### PR TITLE
Add a copy of wptd/shared Go code

### DIFF
--- a/shared/fetch_runs.go
+++ b/shared/fetch_runs.go
@@ -1,0 +1,38 @@
+// Copyright 2017 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package shared
+
+import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"strconv"
+)
+
+// FetchLatestRuns fetches the TestRun metadata for the latest runs, using the
+// API on the given host.
+func FetchLatestRuns(wptdHost string) []TestRun {
+	url := "https://" + wptdHost + "/api/runs"
+	resp, err := http.Get(url)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		log.Fatal(errors.New("Bad response code from " + url + ": " +
+			strconv.Itoa(resp.StatusCode)))
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+	var runs []TestRun
+	if err := json.Unmarshal(body, &runs); err != nil {
+		log.Fatal(err)
+	}
+	return runs
+}

--- a/shared/models.go
+++ b/shared/models.go
@@ -1,0 +1,42 @@
+// Copyright 2017 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package shared
+
+import (
+	"time"
+)
+
+// TestRun stores metadata for a test run (produced by run/run.py)
+type TestRun struct {
+	// Platform information
+	BrowserName    string `json:"browser_name"`
+	BrowserVersion string `json:"browser_version"`
+	OSName         string `json:"os_name"`
+	OSVersion      string `json:"os_version"`
+
+	// The first 10 characters of the SHA1 of the tested WPT revision
+	Revision string `json:"revision"`
+
+	// Results URL
+	ResultsURL string `json:"results_url"`
+
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// Browser holds objects that appear in browsers.json
+type Browser struct {
+	InitiallyLoaded bool   `json:"initially_loaded"`
+	CurrentlyRun    bool   `json:"currently_run"`
+	BrowserName     string `json:"browser_name"`
+	BrowserVersion  string `json:"browser_version"`
+	OSName          string `json:"os_name"`
+	OSVersion       string `json:"os_version"`
+	Sauce           bool   `json:"sauce"`
+}
+
+// Token is used for test result uploads.
+type Token struct {
+	Secret string `json:"secret"`
+}

--- a/webapp/api_handlers.go
+++ b/webapp/api_handlers.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 	"time"
 
-	models "github.com/w3c/wptdashboard/shared"
+	models "github.com/web-platform-tests/wpt.fyi/shared"
 	"golang.org/x/net/context"
 	"google.golang.org/appengine"
 	"google.golang.org/appengine/datastore"

--- a/webapp/results_redirect_handler.go
+++ b/webapp/results_redirect_handler.go
@@ -12,7 +12,7 @@ import (
 	"regexp"
 	"strings"
 
-	models "github.com/w3c/wptdashboard/shared"
+	models "github.com/web-platform-tests/wpt.fyi/shared"
 	"google.golang.org/appengine"
 	"google.golang.org/appengine/datastore"
 )

--- a/webapp/results_redirect_handler_test.go
+++ b/webapp/results_redirect_handler_test.go
@@ -7,7 +7,7 @@ package webapp
 import (
 	"testing"
 
-	base "github.com/w3c/wptdashboard/shared"
+	base "github.com/web-platform-tests/wpt.fyi/shared"
 )
 
 type Case struct {

--- a/webapp/run_diff.go
+++ b/webapp/run_diff.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 
 	mapset "github.com/deckarep/golang-set"
-	models "github.com/w3c/wptdashboard/shared"
+	models "github.com/web-platform-tests/wpt.fyi/shared"
 	"golang.org/x/net/context"
 	"google.golang.org/appengine/datastore"
 	"google.golang.org/appengine/urlfetch"

--- a/webapp/test_handler.go
+++ b/webapp/test_handler.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"net/http"
 
-	models "github.com/w3c/wptdashboard/shared"
+	models "github.com/web-platform-tests/wpt.fyi/shared"
 )
 
 // This handler is responsible for all pages that display test results.

--- a/webapp/util.go
+++ b/webapp/util.go
@@ -9,7 +9,7 @@ import (
 	"io/ioutil"
 	"sort"
 
-	models "github.com/w3c/wptdashboard/shared"
+	models "github.com/web-platform-tests/wpt.fyi/shared"
 )
 
 // All errors are considered fatal


### PR DESCRIPTION
Works towards https://github.com/web-platform-tests/wpt.fyi/issues/44

Note that the existing `wptdashboard/metrics` refs will can't be migrated in a single step.