### PR TITLE
Add results/ prefix to landing page

### DIFF
--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -151,10 +151,6 @@ found in the LICENSE file.
   <script>
     /* global TestRunsBase */
     class WPTResults extends TestRunsBase {
-      static get UrlToResultsPath() {
-        return location => location.pathname.replace(/\/results(.+)(\/)?$/, '$1');
-      }
-
       static get is() {
         return 'wpt-results';
       }
@@ -177,10 +173,7 @@ found in the LICENSE file.
             type: String,
             computed: 'computeTestScheme(path)'
           },
-          path: {
-            type: String,
-            value: WPTResults.UrlToResultsPath(location)
-          },
+          path: String,
           pathIsATestFile: {
             type: Boolean,
             computed: 'computePathIsATestFile(path)'
@@ -194,6 +187,11 @@ found in the LICENSE file.
             value: []
           }
         };
+      }
+
+      ready() {
+        super.ready();
+        this.path = this.urlToResultsPath(window.location);
       }
 
       computeIsLatest(sha) {
@@ -211,11 +209,16 @@ found in the LICENSE file.
         return /(\.(html|htm|py|svg|xhtml|xht|xml)$)/.test(path);
       }
 
+      urlToResultsPath(location) {
+        return location.pathname.replace(/\/results\/(.+)?$/, '/$1');
+      }
+
       async connectedCallback() {
         await super.connectedCallback();
 
+        const that = this;
         window.onpopstate = () => {
-          this.path = WPTResults.UrlToResultsPath(window.location);
+          this.path = that.urlToResultsPath(window.location);
           this.refreshDisplayedNodes();
         };
 
@@ -318,7 +321,7 @@ found in the LICENSE file.
 
       navigate(event) {
         event.preventDefault();
-        let path = WPTResults.UrlToResultsPath(event.target);
+        let path = this.urlToResultsPath(event.target);
         if (path === this.path) {
           return;
         }

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -126,7 +126,7 @@ found in the LICENSE file.
           <template is="dom-repeat" items="{{displayedNodes}}" as="node">
             <tr>
               <td>
-                <path-part path="{{ node.path }}" is-dir="{{ node.isDir }}" navigate="{{ bindNavigate() }}"></path-part>
+                <path-part prefix="/results" path="{{ node.path }}" is-dir="{{ node.isDir }}" navigate="{{ bindNavigate() }}"></path-part>
               </td>
 
               <template is="dom-repeat" items="{{testRuns}}" as="testRun">
@@ -151,6 +151,10 @@ found in the LICENSE file.
   <script>
     /* global TestRunsBase */
     class WPTResults extends TestRunsBase {
+      static get UrlToResultsPath() {
+        return location => location.pathname.replace(/\/results(.+)(\/)?$/, '$1');
+      }
+
       static get is() {
         return 'wpt-results';
       }
@@ -175,7 +179,7 @@ found in the LICENSE file.
           },
           path: {
             type: String,
-            value: window.location.pathname.replace(/(.+)(\/)$/, '$1')
+            value: WPTResults.UrlToResultsPath(location)
           },
           pathIsATestFile: {
             type: Boolean,
@@ -211,7 +215,7 @@ found in the LICENSE file.
         await super.connectedCallback();
 
         window.onpopstate = () => {
-          this.path = window.location.pathname.replace(/(.+)(\/)$/, '$1');
+          this.path = WPTResults.UrlToResultsPath(window.location);
           this.refreshDisplayedNodes();
         };
 
@@ -314,7 +318,7 @@ found in the LICENSE file.
 
       navigate(event) {
         event.preventDefault();
-        let path = event.target.pathname.replace(/(.+)(\/)$/, '$1');
+        let path = WPTResults.UrlToResultsPath(event.target);
         if (path === this.path) {
           return;
         }
@@ -332,7 +336,7 @@ found in the LICENSE file.
             .map(btoa);
           path += `before=${before}&after=${after}`;
         }
-        window.history.pushState({}, '', path);
+        window.history.pushState({}, '', `/results${path}`);
 
         // Send Google Analytics pageview event
         if ('ga' in window) {

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -173,7 +173,10 @@ found in the LICENSE file.
             type: String,
             computed: 'computeTestScheme(path)'
           },
-          path: String,
+          path: {
+            type: String,
+            value: '',
+          },
           pathIsATestFile: {
             type: Boolean,
             computed: 'computePathIsATestFile(path)'
@@ -202,7 +205,7 @@ found in the LICENSE file.
         // This should (close enough) match up with the logic in:
         // https://github.com/w3c/web-platform-tests/blob/master/tools/manifest/item.py
         // https://github.com/w3c/web-platform-tests/blob/master/tools/wptrunner/wptrunner/wpttest.py
-        return path.indexOf('.https.') !== -1 ? 'https' : 'http';
+        return (path || '').indexOf('.https.') !== -1 ? 'https' : 'http';
       }
 
       computePathIsATestFile(path) {
@@ -348,7 +351,7 @@ found in the LICENSE file.
       }
 
       splitPathIntoLinkedParts(input) {
-        const parts = input.split('/').slice(1);
+        const parts = (input || '').split('/').slice(1);
         let path = '';
         return parts.map(name => {
           path += `/${name}`;

--- a/webapp/main.go
+++ b/webapp/main.go
@@ -14,7 +14,8 @@ var templates = template.Must(template.ParseGlob("templates/*.html"))
 func init() {
 	// Test run results, viewed by browser (default view)
 	// For run results diff view, 'before' and 'after' params can be given.
-	http.HandleFunc("/", testHandler)
+	http.HandleFunc("/", testResultsHandler)
+	http.HandleFunc("/results/", testResultsHandler)
 
 	// About wpt.fyi
 	http.HandleFunc("/about", aboutHandler)
@@ -38,5 +39,5 @@ func init() {
 	http.HandleFunc("/api/run", apiTestRunHandler)
 
 	// API endpoint for redirecting to a run's summary JSON blob.
-	http.HandleFunc("/results", resultsRedirectHandler)
+	http.HandleFunc("/api/results", apiResultsRedirectHandler)
 }

--- a/webapp/results_redirect_handler.go
+++ b/webapp/results_redirect_handler.go
@@ -17,7 +17,7 @@ import (
 	"google.golang.org/appengine/datastore"
 )
 
-// resultsRedirectHandler is responsible for redirecting to the Google Cloud Storage API
+// apiResultsRedirectHandler is responsible for redirecting to the Google Cloud Storage API
 // JSON blob for the given SHA (or latest) models.TestRun for the given browser.
 //
 // URL format:
@@ -27,7 +27,7 @@ import (
 //   platform: Browser (and OS) of the run, e.g. "chrome-63.0" or "safari"
 //   (optional) run: SHA[0:10] of the test run, or "latest" (latest is the default)
 //   (optional) test: Path of the test, e.g. "/css/css-images-3/gradient-button.html"
-func resultsRedirectHandler(w http.ResponseWriter, r *http.Request) {
+func apiResultsRedirectHandler(w http.ResponseWriter, r *http.Request) {
 	params, err := url.ParseQuery(r.URL.RawQuery)
 	if err != nil {
 		http.Error(w, "Invalid path", http.StatusBadRequest)

--- a/webapp/test/wpt-results.html
+++ b/webapp/test/wpt-results.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <script src="../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../bower_components/web-component-tester/browser.js"></script>
+
+  <link rel="import" href="../components/wpt-results.html">
+</head>
+
+<body>
+  <test-fixture id="wpt-results-fixture">
+    <template>
+      <wpt-results></wpt-results>
+    </template>
+  </test-fixture>
+  
+  <script>
+    suite('<wpt-results>', () => {
+      let trf = null;
+
+      setup(() => {
+        trf = fixture('wpt-results-fixture');
+      });
+
+      suite('WPTResults.prototype.*', () => {
+        suite('urlToResultsPath()', () => {
+          test('urlToResultsPath(location Location)', () => {
+            test('Path regex', () => {
+              const url = s => new URL(`https://wpt.fyi${s}`);
+              assert.equal(trf.urlToResultsPath(url('/results/')), '/');
+              assert.equal(trf.urlToResultsPath(url('/results/abc')), '/abc');
+              assert.equal(trf.urlToResultsPath(url('/results/abc/')), '/abc');
+              assert.equal(trf.urlToResultsPath(url('/results/abc/def.html')), '/abc/def.html');
+            });
+          });
+        });
+      });
+    });
+  </script>
+</body>
+
+</html>

--- a/webapp/test/wpt-results.html
+++ b/webapp/test/wpt-results.html
@@ -15,7 +15,7 @@
       <wpt-results></wpt-results>
     </template>
   </test-fixture>
-  
+
   <script>
     suite('<wpt-results>', () => {
       let trf = null;

--- a/webapp/test_results_handler.go
+++ b/webapp/test_results_handler.go
@@ -24,7 +24,7 @@ import (
 // The JSON property "initially_loaded" is what controls this.
 func testResultsHandler(w http.ResponseWriter, r *http.Request) {
 	if strings.Index(r.URL.Path, "/results/") != 0 {
-		http.Redirect(w, r, fmt.Sprintf("/results%s", r.URL.Path), 308)
+		http.Redirect(w, r, fmt.Sprintf("/results%s", r.URL.Path), http.StatusTemporaryRedirect)
 		return
 	}
 

--- a/webapp/test_results_handler.go
+++ b/webapp/test_results_handler.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	models "github.com/web-platform-tests/wpt.fyi/shared"
 )
@@ -21,7 +22,12 @@ import (
 //
 // The browsers initially displayed to the user are defined in browsers.json.
 // The JSON property "initially_loaded" is what controls this.
-func testHandler(w http.ResponseWriter, r *http.Request) {
+func testResultsHandler(w http.ResponseWriter, r *http.Request) {
+	if strings.Index(r.URL.Path, "/results/") != 0 {
+		http.Redirect(w, r, fmt.Sprintf("/results%s", r.URL.Path), 308)
+		return
+	}
+
 	runSHA, err := ParseSHAParam(r)
 	if err != nil {
 		http.Error(w, "Invalid query params", http.StatusBadRequest)

--- a/webapp/wct.conf.json
+++ b/webapp/wct.conf.json
@@ -1,10 +1,6 @@
 {
   "suites": [
-    "test/interop.html",
-    "test/path-part.html",
-    "test/runs.html",
-    "test/test-run.html",
-    "test/test-file-results.html"
+    "test/*.html"
   ],
   "verbose": true,
   "plugins": {


### PR DESCRIPTION
Working towards https://github.com/web-platform-tests/wpt.fyi/issues/13 (current path scheme is future-hostile) and https://github.com/web-platform-tests/wpt.fyi/issues/39 (interop focus)

Redirects the `/*` path wildcards to `/results/*`, which will be _mooooostly_ backward-compatible for existing links, except for the clashes which are possible (and hence the change moving forward).