### PR TITLE
Simplify path collapse code, fix WPT navigate hook

### DIFF
--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -80,7 +80,7 @@ found in the LICENSE file.
         class="query"
         placeholder="Search test files, like cors/allow-headers.htm">
       <div class="path">
-        <a href="/" on-click="navigate">WPT</a>
+        <a href="/" onclick="{{ bindNavigate() }}">WPT</a>
         <template is="dom-repeat" items="{{ splitPathIntoLinkedParts(path) }}" as="part">
           <span class="path-separator">/</span>
           <a href="{{ part.path }}" on-click="navigate">{{ part.name }}</a>
@@ -243,7 +243,8 @@ found in the LICENSE file.
         /* Recomputes the list of displayed directories and test files. */
         const displayedNodeMap = new Map();
         const currentPathParts = this.splitPathIntoLinkedParts(this.path);
-
+        const partCountIfTestFile = this.path == '/' ? 1 : currentPathParts.length + 1;
+        const nextSubdirIndex = this.path == '/' ? 0 : currentPathParts.length;
 
         const updateResults = (testFileName, dirPath, isDir) => {
           if (!displayedNodeMap.has(dirPath)) {
@@ -271,26 +272,14 @@ found in the LICENSE file.
           }
 
           let parts = this.splitPathIntoLinkedParts(testFileName);
-
-          if (this.path === '/' && parts.length === 2) {
-            let dirParts = [parts[0]];
-            let dirPath = dirParts[dirParts.length - 1].path;
-            updateResults(testFileName, dirPath, true);
-
-            // Add test files in current directory
-          } else if (parts.length === currentPathParts.length + 1) {
+          // Add test files in current directory
+          if (parts.length == partCountIfTestFile) {
             let path = parts[parts.length - 1].path;
             updateResults(testFileName, path, false);
 
             // Add subdirectories in current directory
-          } else if (parts.length > currentPathParts.length + 1) {
-            let dirParts;
-            if (this.path === '/') {
-              dirParts = [parts[0]];
-            } else {
-              dirParts = parts.slice(0, currentPathParts.length + 1);
-            }
-            let dirPath = dirParts[dirParts.length - 1].path;
+          } else if (parts.length > partCountIfTestFile) {
+            let dirPath = parts[nextSubdirIndex].path;
             updateResults(testFileName, dirPath, true);
           }
         });


### PR DESCRIPTION
Code was unnecessarily complex; In particular, the following was essentially just parts[0].path:

        let dirParts = [parts[0]];	
        let dirPath = dirParts[dirParts.length - 1].path;