### PR TITLE
Use correct scheme in w3c-test.org link

### DIFF
--- a/webapp/components/interop.html
+++ b/webapp/components/interop.html
@@ -218,7 +218,7 @@ found in the LICENSE file.
         },
         scheme: {
           type: String,
-          value: window.location.pathname.indexOf('.https.') !== -1 ? 'https' : 'http'
+          computed: 'computeTestScheme(path)'
         },
         path: {
           type: String,
@@ -326,6 +326,10 @@ found in the LICENSE file.
       }
       const encodedQuery = window.encodeURIComponent(query);
       stateFunc(state, '', `/interop${path}?q=${encodedQuery}`);
+    }
+
+    computeTestScheme(path) {
+      return path.indexOf('.https.') !== -1 ? 'https' : 'http';
     }
 
     computePathIsATestFile(path) {

--- a/webapp/components/interop.html
+++ b/webapp/components/interop.html
@@ -144,7 +144,7 @@ found in the LICENSE file.
         <li>
           <a href$="https://github.com/w3c/web-platform-tests/blob/master[[path]]"
              target="_blank">View source on GitHub</a></li>
-        <li><a href$="https://w3c-test.org[[path]]" target="_blank">Run in your
+        <li><a href$="[[scheme]]://w3c-test.org[[path]]" target="_blank">Run in your
           browser on w3c-test.org</a></li>
       </ul>
     </div>
@@ -215,6 +215,10 @@ found in the LICENSE file.
         metrics: {
           type: Object,
           computed: 'computeMetrics(path, query, allMetrics)'
+        },
+        scheme: {
+          type: String,
+          value: window.location.pathname.indexOf('.https.') !== -1 ? 'https' : 'http'
         },
         path: {
           type: String,

--- a/webapp/components/interop.html
+++ b/webapp/components/interop.html
@@ -329,6 +329,9 @@ found in the LICENSE file.
     }
 
     computeTestScheme(path) {
+      // This should (close enough) match up with the logic in:
+      // https://github.com/w3c/web-platform-tests/blob/master/tools/manifest/item.py
+      // https://github.com/w3c/web-platform-tests/blob/master/tools/wptrunner/wptrunner/wpttest.py
       return path.indexOf('.https.') !== -1 ? 'https' : 'http';
     }
 

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -197,6 +197,9 @@ found in the LICENSE file.
       }
 
       computeTestScheme(path) {
+        // This should (close enough) match up with the logic in:
+        // https://github.com/w3c/web-platform-tests/blob/master/tools/manifest/item.py
+        // https://github.com/w3c/web-platform-tests/blob/master/tools/wptrunner/wptrunner/wpttest.py
         return path.indexOf('.https.') !== -1 ? 'https' : 'http';
       }
 

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -99,7 +99,7 @@ found in the LICENSE file.
       <div class="links">
         <ul>
           <li><a href$="https://github.com/w3c/web-platform-tests/blob/master[[path]]" target="_blank">View source on GitHub</a></li>
-          <li><a href$="https://w3c-test.org[[path]]" target="_blank">Run in your browser on w3c-test.org</a></li>
+          <li><a href$="[[scheme]]://w3c-test.org[[path]]" target="_blank">Run in your browser on w3c-test.org</a></li>
         </ul>
       </div>
 
@@ -168,6 +168,10 @@ found in the LICENSE file.
           isLatest: {
             type: Boolean,
             computed: 'computeIsLatest(sha)'
+          },
+          scheme: {
+            type: String,
+            value: window.location.pathname.indexOf('.https.') !== -1 ? 'https' : 'http'
           },
           path: {
             type: String,

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -171,7 +171,7 @@ found in the LICENSE file.
           },
           scheme: {
             type: String,
-            value: window.location.pathname.indexOf('.https.') !== -1 ? 'https' : 'http'
+            computed: 'computeTestScheme(path)'
           },
           path: {
             type: String,
@@ -194,6 +194,10 @@ found in the LICENSE file.
 
       computeIsLatest(sha) {
         return !sha || sha === 'latest';
+      }
+
+      computeTestScheme(path) {
+        return path.indexOf('.https.') !== -1 ? 'https' : 'http';
       }
 
       computePathIsATestFile(path) {


### PR DESCRIPTION
Tests should use http scheme by default and https scheme if the path has ".https.".

(This is rebased on current master. Please "squash and merge".)