### PR TITLE
Initialize dev database with "complete" runs

### DIFF
--- a/shared/fetch_runs.go
+++ b/shared/fetch_runs.go
@@ -16,7 +16,7 @@ import (
 // FetchLatestRuns fetches the TestRun metadata for the latest runs, using the
 // API on the given host.
 func FetchLatestRuns(wptdHost string) []TestRun {
-	url := "https://" + wptdHost + "/api/runs"
+	url := "https://" + wptdHost + "/api/runs?complete=true"
 	resp, err := http.Get(url)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
The modified function is labeled as "shared," but it is only referenced from a script intended for local development. That leads me to believe the change won't effect any other aspects of the system. (If that's correct, it might be wise to re-locate it.)