### PR TITLE
Rename the "Spec" column to "Path"

### DIFF
--- a/webapp/components/interop.html
+++ b/webapp/components/interop.html
@@ -153,7 +153,7 @@ found in the LICENSE file.
   <table>
     <thead>
       <tr>
-        <th>Spec</th>
+        <th>Path</th>
         <template is="dom-if" if="{{ thLabels.length }}">
           <th colspan="100">Browsers Passing</th>
           <!--

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -114,7 +114,7 @@ found in the LICENSE file.
       <table>
         <thead>
           <tr>
-            <th>Spec</th>
+            <th>Path</th>
             <template is="dom-repeat" items="{{testRuns}}" as="testRun">
               <!-- Repeats for as many different browser test runs are available -->
               <th><test-run test-run="[[testRun]]"></test-run></th>


### PR DESCRIPTION
This <th> is used at all levels. At the top level most directories
correspond to a spec, but not all, in particular HTML is split across
directories. And except for in css/, tests and directories that aren't
at the top level never correspond to specs. So just call it path.