### PR TITLE
Add HSTS header to every request

### DIFF
--- a/webapp/routes.go
+++ b/webapp/routes.go
@@ -54,7 +54,7 @@ func init() {
 
 func wrapHSTS(h http.HandlerFunc) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		value := "max-age=31536000; includeSubDomains; preload"
+		value := "max-age=31536000; preload"
 		w.Header().Add("Strict-Transport-Security", value)
 		h(w, r)
 	})

--- a/webapp/routes.go
+++ b/webapp/routes.go
@@ -33,18 +33,6 @@ func init() {
 
 		// Admin-only manual results upload.
 		"/admin/results/upload": adminUploadHandler,
-
-		// API endpoint for diff of two test run summary JSON blobs.
-		"/api/diff": apiDiffHandler,
-
-		// API endpoint for listing all test runs for a given SHA.
-		"/api/runs": apiTestRunsHandler,
-
-		// API endpoint for a single test run.
-		"/api/run": apiTestRunHandler,
-
-		// API endpoint for redirecting to a run's summary JSON blob.
-		"/api/results": apiResultsRedirectHandler,
 	}
 
 	for route, handler := range routes {

--- a/webapp/routes.go
+++ b/webapp/routes.go
@@ -12,24 +12,50 @@ import (
 var templates = template.Must(template.ParseGlob("templates/*.html"))
 
 func init() {
-	// Test run results, viewed by browser (default view)
-	// For run results diff view, 'before' and 'after' params can be given.
-	http.HandleFunc("/", testResultsHandler)
-	http.HandleFunc("/results", testResultsHandler) // Prevent default redirect
-	http.HandleFunc("/results/", testResultsHandler)
+	routes := map[string]http.HandlerFunc{
+		// Test run results, viewed by browser (default view)
+		// For run results diff view, 'before' and 'after' params can be given.
+		"/": testResultsHandler,
+		"/results": testResultsHandler, // Prevent default redirect
+		"/results/": testResultsHandler,
 
-	// About wpt.fyi
-	http.HandleFunc("/about", aboutHandler)
+		// About wpt.fyi
+		"/about": aboutHandler,
 
-	// Test run results, viewed by pass-rate across the browsers
-	http.HandleFunc("/interop/", interopHandler)
+		// Test run results, viewed by pass-rate across the browsers
+		"/interop/": interopHandler,
 
-	// Lists of test run results which have poor interoperability
-	http.HandleFunc("/interop/anomalies", anomalyHandler)
+		// Lists of test run results which have poor interoperability
+		"/interop/anomalies": anomalyHandler,
 
-	// List of all test runs, by SHA[0:10]
-	http.HandleFunc("/test-runs", testRunsHandler)
+		// List of all test runs, by SHA[0:10]
+		"/test-runs": testRunsHandler,
 
-	// Admin-only manual results upload.
-	http.HandleFunc("/admin/results/upload", adminUploadHandler)
+		// Admin-only manual results upload.
+		"/admin/results/upload": adminUploadHandler,
+
+		// API endpoint for diff of two test run summary JSON blobs.
+		"/api/diff": apiDiffHandler,
+
+		// API endpoint for listing all test runs for a given SHA.
+		"/api/runs": apiTestRunsHandler,
+
+		// API endpoint for a single test run.
+		"/api/run": apiTestRunHandler,
+
+		// API endpoint for redirecting to a run's summary JSON blob.
+		"/api/results": apiResultsRedirectHandler,
+	}
+
+	for route, handler := range routes {
+		http.HandleFunc(route, wrapHSTS(handler))
+	}
+}
+
+func wrapHSTS(h http.HandlerFunc) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		value := "max-age=31536000; includeSubDomains; preload"
+		w.Header().Add("Strict-Transport-Security", value)
+		h(w, r)
+	})
 }

--- a/webapp/routes_test.go
+++ b/webapp/routes_test.go
@@ -21,6 +21,10 @@ func TestLandingPageBound(t *testing.T) {
 	assertHandlerMatch(t, "/2dcontext", "/")
 }
 
+func TestLandingPageHSTS(t *testing.T) {
+	assertHSTS(t, "/")
+}
+
 func TestAboutBound(t *testing.T) {
 	assertBound(t, "/about")
 	assertHandlerMatch(t, "/about", "/about")
@@ -44,6 +48,10 @@ func TestInteropAnomaliesBound(t *testing.T) {
 
 func TestRunsBound(t *testing.T) {
 	assertBound(t, "/test-runs")
+}
+
+func TestRunsBoundHSTS(t *testing.T) {
+	assertHSTS(t, "/test-runs")
 }
 
 func TestApiDiffBound(t *testing.T) {
@@ -81,4 +89,13 @@ func assertHandlerMatch(t *testing.T, path string, pattern string) {
 	handler, handlerPattern := http.DefaultServeMux.Handler(req)
 	assert.NotNil(t, handler)
 	assert.Equal(t, pattern, handlerPattern)
+}
+
+func assertHSTS(t *testing.T, path string) {
+	req := httptest.NewRequest("GET", path, nil)
+	rr := httptest.NewRecorder()
+	handler, _ := http.DefaultServeMux.Handler(req)
+	handler.ServeHTTP(rr, req)
+	assert.Equal(t, "max-age=31536000; includeSubDomains; preload",
+		rr.HeaderMap["Strict-Transport-Security"][0])
 }

--- a/webapp/routes_test.go
+++ b/webapp/routes_test.go
@@ -96,6 +96,6 @@ func assertHSTS(t *testing.T, path string) {
 	rr := httptest.NewRecorder()
 	handler, _ := http.DefaultServeMux.Handler(req)
 	handler.ServeHTTP(rr, req)
-	assert.Equal(t, "max-age=31536000; includeSubDomains; preload",
+	assert.Equal(t, "max-age=31536000; preload",
 		rr.HeaderMap["Strict-Transport-Security"][0])
 }


### PR DESCRIPTION
This adds an HSTS header to every request that expires after 1 year.
It also applies the rule to all subdomains (we should check if this is
feasible) and opts-in to the HSTS preload list.

Resolves #58