### PR TITLE
Fake-support the label=experimental param

### DIFF
--- a/webapp/params.go
+++ b/webapp/params.go
@@ -190,3 +190,30 @@ func ParsePathsParam(r *http.Request) (paths mapset.Set) {
 	}
 	return paths
 }
+
+// ParseLabelsParam returns a set list of test-run labels to include, or nil if
+// no labels are provided.
+func ParseLabelsParam(r *http.Request) (labels mapset.Set) {
+	labelParams := r.URL.Query()["label"]
+	labelsParam := r.URL.Query().Get("labels")
+	if len(labelParams) == 0 && labelsParam == "" {
+		return nil
+	}
+
+	labels = mapset.NewSet()
+	for _, label := range labelParams {
+		labels.Add(label)
+	}
+	if labelsParam != "" {
+		for _, label := range strings.Split(labelsParam, ",") {
+			labels.Add(label)
+		}
+	}
+	if labels.Contains("") {
+		labels.Remove("")
+	}
+	if labels.Cardinality() == 0 {
+		return nil
+	}
+	return labels
+}

--- a/webapp/params.go
+++ b/webapp/params.go
@@ -164,56 +164,43 @@ func ParseDiffFilterParams(r *http.Request) (param DiffFilterParam, err error) {
 	return param, nil
 }
 
-// ParsePathsParam returns a set list of test paths to include, or nil if no filter is provided (and all tests should be
-// included). It parses the 'paths' parameter, split on commas, and also checks for the (repeatable) 'path' params.
+// ParsePathsParam returns a set list of test paths to include, or nil if no
+// filter is provided (and all tests should be included). It parses the 'paths'
+// parameter, split on commas, and also checks for the (repeatable) 'path' params
 func ParsePathsParam(r *http.Request) (paths mapset.Set) {
-	pathParams := r.URL.Query()["path"]
-	pathsParam := r.URL.Query().Get("paths")
-	if len(pathParams) == 0 && pathsParam == "" {
-		return nil
-	}
-
-	paths = mapset.NewSet()
-	for _, path := range pathParams {
-		paths.Add(path)
-	}
-	if pathsParam != "" {
-		for _, path := range strings.Split(pathsParam, ",") {
-			paths.Add(path)
-		}
-	}
-	if paths.Contains("") {
-		paths.Remove("")
-	}
-	if paths.Cardinality() == 0 {
-		return nil
-	}
-	return paths
+	return ParseRepeatedParam(r, "path", "paths")
 }
 
 // ParseLabelsParam returns a set list of test-run labels to include, or nil if
 // no labels are provided.
 func ParseLabelsParam(r *http.Request) (labels mapset.Set) {
-	labelParams := r.URL.Query()["label"]
-	labelsParam := r.URL.Query().Get("labels")
-	if len(labelParams) == 0 && labelsParam == "" {
+	return ParseRepeatedParam(r, "label", "labels")
+}
+
+// ParseRepeatedParam parses a param that may be a plural name, with all values
+// comma-separated, or a repeated singular param.
+// e.g. ?label=foo&label=bar vs ?labels=foo,bar
+func ParseRepeatedParam(r *http.Request, singular string, plural string) (params mapset.Set) {
+	repeatedParam := r.URL.Query()[singular]
+	pluralParam := r.URL.Query().Get(plural)
+	if len(repeatedParam) == 0 && pluralParam == "" {
 		return nil
 	}
 
-	labels = mapset.NewSet()
-	for _, label := range labelParams {
-		labels.Add(label)
+	params = mapset.NewSet()
+	for _, label := range repeatedParam {
+		params.Add(label)
 	}
-	if labelsParam != "" {
-		for _, label := range strings.Split(labelsParam, ",") {
-			labels.Add(label)
+	if pluralParam != "" {
+		for _, label := range strings.Split(pluralParam, ",") {
+			params.Add(label)
 		}
 	}
-	if labels.Contains("") {
-		labels.Remove("")
+	if params.Contains("") {
+		params.Remove("")
 	}
-	if labels.Cardinality() == 0 {
+	if params.Cardinality() == 0 {
 		return nil
 	}
-	return labels
+	return params
 }

--- a/webapp/params_test.go
+++ b/webapp/params_test.go
@@ -279,19 +279,19 @@ func TestParseLabelsParam_Empty(t *testing.T) {
 }
 
 func TestParseLabelsParam_Label_Duplicate(t *testing.T) {
-	r := httptest.NewRequest("GET", "http://wpt.fyi/api/runs?label=unstable&label=unstable", nil)
+	r := httptest.NewRequest("GET", "http://wpt.fyi/api/runs?label=experimental&label=experimental", nil)
 	labels := ParseLabelsParam(r)
 	assert.Equal(t, 1, labels.Cardinality())
 }
 
 func TestParseLabelsParam_Labels_Duplicate(t *testing.T) {
-	r := httptest.NewRequest("GET", "http://wpt.fyi/api/runs?labels=unstable,unstable", nil)
+	r := httptest.NewRequest("GET", "http://wpt.fyi/api/runs?labels=experimental,experimental", nil)
 	labels := ParseLabelsParam(r)
 	assert.Equal(t, 1, labels.Cardinality())
 }
 
 func TestParseLabelsParam_LabelsAndLabel_Duplicate(t *testing.T) {
-	r := httptest.NewRequest("GET", "http://wpt.fyi/api/runs?labels=unstable&label=unstable", nil)
+	r := httptest.NewRequest("GET", "http://wpt.fyi/api/runs?labels=experimental&label=experimental", nil)
 	labels := ParseLabelsParam(r)
 	assert.Equal(t, 1, labels.Cardinality())
 }

--- a/webapp/params_test.go
+++ b/webapp/params_test.go
@@ -261,3 +261,37 @@ func TestParseDiffFilterParam_Invalid(t *testing.T) {
 	_, err := ParseDiffFilterParams(r)
 	assert.NotNil(t, err)
 }
+
+func TestParseLabelsParam_Missing(t *testing.T) {
+	r := httptest.NewRequest("GET", "http://wpt.fyi/api/runs", nil)
+	labels := ParseLabelsParam(r)
+	assert.Nil(t, labels)
+}
+
+func TestParseLabelsParam_Empty(t *testing.T) {
+	r := httptest.NewRequest("GET", "http://wpt.fyi/api/runs?label=", nil)
+	labels := ParseLabelsParam(r)
+	assert.Nil(t, labels)
+
+	r = httptest.NewRequest("GET", "http://wpt.fyi/api/runs?labels=", nil)
+	labels = ParseLabelsParam(r)
+	assert.Nil(t, labels)
+}
+
+func TestParseLabelsParam_Label_Duplicate(t *testing.T) {
+	r := httptest.NewRequest("GET", "http://wpt.fyi/api/runs?label=unstable&label=unstable", nil)
+	labels := ParseLabelsParam(r)
+	assert.Equal(t, 1, labels.Cardinality())
+}
+
+func TestParseLabelsParam_Labels_Duplicate(t *testing.T) {
+	r := httptest.NewRequest("GET", "http://wpt.fyi/api/runs?labels=unstable,unstable", nil)
+	labels := ParseLabelsParam(r)
+	assert.Equal(t, 1, labels.Cardinality())
+}
+
+func TestParseLabelsParam_LabelsAndLabel_Duplicate(t *testing.T) {
+	r := httptest.NewRequest("GET", "http://wpt.fyi/api/runs?labels=unstable&label=unstable", nil)
+	labels := ParseLabelsParam(r)
+	assert.Equal(t, 1, labels.Cardinality())
+}

--- a/webapp/test_results_handler.go
+++ b/webapp/test_results_handler.go
@@ -119,7 +119,13 @@ func getTestRunsAndSources(r *http.Request, runSHA string) (testRunSources []str
 			testRunSources = append(testRunSources, fmt.Sprintf(singleRunURL, afterSpec.Revision, afterSpec.Platform))
 		}
 	} else {
-		const sourceURL = `/api/runs?sha=%s`
+		var sourceURL = `/api/runs?sha=%s`
+		labels := ParseLabelsParam(r)
+		if labels != nil {
+			for label := range labels.Iterator().C {
+				sourceURL = sourceURL + "&label=" + label.(string)
+			}
+		}
 		testRunSources = []string{fmt.Sprintf(sourceURL, runSHA)}
 	}
 

--- a/webapp/test_run_handler.go
+++ b/webapp/test_run_handler.go
@@ -31,6 +31,13 @@ func handleTestRunGet(w http.ResponseWriter, r *http.Request) {
 	}
 	sourceURL := fmt.Sprintf(`/api/runs?max-count=%d`, maxCount)
 
+	labels := ParseLabelsParam(r)
+	if labels != nil {
+		for label := range labels.Iterator().C {
+			sourceURL = sourceURL + "&label=" + label.(string)
+		}
+	}
+
 	// Serialize the data + pipe through the test-runs.html template.
 	testRunSourcesBytes, err := json.Marshal([]string{sourceURL})
 	if err != nil {


### PR DESCRIPTION
Working towards https://github.com/web-platform-tests/wpt.fyi/issues/60

Spoofs the `?label=unstable` functionality support by querying for `[browser]-experimental` during query execution. This is to ensure that when we develop real labels, the UI doesn't need to change behaviour (just the datastore query).

Notes:
- `?labels=A,B,C` and `?label=A&label=B` forms of the param are both supported.
- Param is supported by both the `/api/runs` and the `/results` endpoints (and bubbles through).

CC @jugglinmike who may be happy to be able to view the experimental runs in the UI.