### PR TITLE
Don't run deploy on forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,8 +90,11 @@ install:
     fi
 
 script:
-  - | # Deploy PR to staging environment
-    if [ "${MAKE_DEPLOY_TARGET}" != "" ]; then
+  - | # Deploy PR to staging environment (only when Travis secrets are available)
+    if [ "${MAKE_DEPLOY_TARGET}" != "" ] \
+        && [ "${TRAVIS_SECURE_ENV_VARS}" != "false" ] \
+        && [ "${TRAVIS_PULL_REQUEST_BRANCH}" != "" ];
+    then
       echo "Copying output to ${TEMP_FILE:=$(mktemp)}"
       # NOTE: Most gcloud output is stderr, so need to redirect it to stdout.
       docker exec -t -u $(id -u $USER):$(id -g $USER) "${DOCKER_INSTANCE}" make "${MAKE_DEPLOY_TARGET}" BRANCH_NAME=${TRAVIS_PULL_REQUEST_BRANCH} 2>&1 | tee ${TEMP_FILE}


### PR DESCRIPTION
Forks can't access Travis CI secrets (by design), so the creds needed for a staging deploy are not available. Bypass the task.