### PR TITLE
Throw errors for invalid params

### DIFF
--- a/webapp/api_handlers.go
+++ b/webapp/api_handlers.go
@@ -26,7 +26,7 @@ import (
 func apiTestRunsHandler(w http.ResponseWriter, r *http.Request) {
 	runSHA, err := ParseSHAParam(r)
 	if err != nil {
-		http.Error(w, "Invalid query params", http.StatusBadRequest)
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 

--- a/webapp/params.go
+++ b/webapp/params.go
@@ -39,7 +39,10 @@ func ParseSHAParam(r *http.Request) (runSHA string, err error) {
 	}
 
 	runParam := params.Get("sha")
-	if SHARegex.MatchString(runParam) {
+	if runParam != "" && runParam != "latest" {
+		if !SHARegex.MatchString(runParam) {
+			return "", fmt.Errorf("Invalid sha param value: %s", runParam)
+		}
 		runSHA = runParam[:10]
 	}
 	return runSHA, err
@@ -55,7 +58,7 @@ func ParseBrowserParam(r *http.Request) (browser string, err error) {
 	if IsBrowserName(browser) {
 		return browser, nil
 	}
-	return "", fmt.Errorf("invalid browser param %s", browser)
+	return "", fmt.Errorf("Invalid browser param value: %s", browser)
 }
 
 // ParseBrowsersParam returns a sorted list of browsers to include.
@@ -77,10 +80,14 @@ func ParseBrowsersParam(r *http.Request) (browsers []string, err error) {
 	// Otherwise filter to valid browser names.
 	for i := 0; i < len(browsers); {
 		if !IsBrowserName(browsers[i]) {
-			// 'Remove' browser by switching to end and cropping.
-			browsers[len(browsers)-1], browsers[i] = browsers[i], browsers[len(browsers)-1]
-			browsers = browsers[:len(browsers)-1]
-			continue
+			if browsers[i] == "" {
+				// 'Remove' empty browser by switching to end and cropping.
+				browsers[len(browsers)-1], browsers[i] = browsers[i], browsers[len(browsers)-1]
+				browsers = browsers[:len(browsers)-1]
+				continue
+			} else {
+				return nil, fmt.Errorf("Invalid browser param value %s", browsers[i])
+			}
 		}
 		i++
 	}

--- a/webapp/params_test.go
+++ b/webapp/params_test.go
@@ -18,7 +18,14 @@ func TestParseSHAParam(t *testing.T) {
 	assert.Equal(t, "latest", runSHA)
 }
 
-func TestParseSHAParam_2(t *testing.T) {
+func TestParseSHAParam_Latest(t *testing.T) {
+	r := httptest.NewRequest("GET", "http://wpt.fyi/?sha=latest", nil)
+	runSHA, err := ParseSHAParam(r)
+	assert.Nil(t, err)
+	assert.Equal(t, "latest", runSHA)
+}
+
+func TestParseSHAParam_ShortSHA(t *testing.T) {
 	sha := "0123456789"
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?sha="+sha, nil)
 	runSHA, err := ParseSHAParam(r)
@@ -43,16 +50,14 @@ func TestParseSHAParam_BadRequest(t *testing.T) {
 
 func TestParseSHAParam_NonSHA(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?sha=123", nil)
-	runSHA, err := ParseSHAParam(r)
-	assert.Nil(t, err)
-	assert.Equal(t, "latest", runSHA)
+	_, err := ParseSHAParam(r)
+	assert.NotNil(t, err)
 }
 
 func TestParseSHAParam_NonSHA_2(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?sha=zapper0123", nil)
-	runSHA, err := ParseSHAParam(r)
-	assert.Nil(t, err)
-	assert.Equal(t, "latest", runSHA)
+	_, err := ParseSHAParam(r)
+	assert.NotNil(t, err)
 }
 
 func TestParseBrowserParam(t *testing.T) {
@@ -93,30 +98,22 @@ func TestParseBrowsersParam_ChromeSafari(t *testing.T) {
 
 func TestParseBrowsersParam_ChromeInvalid(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?browsers=chrome,invalid", nil)
-	browsers, err := ParseBrowsersParam(r)
-	assert.Nil(t, err)
-	assert.Equal(t, []string{"chrome"}, browsers)
-}
-
-func TestParseBrowsersParam_AllInvalid(t *testing.T) {
-	r := httptest.NewRequest("GET", "http://wpt.fyi/?browsers=notabrowser,invalid", nil)
-	browsers, err := ParseBrowsersParam(r)
-	assert.Nil(t, err)
-	assert.Empty(t, browsers)
+	_, err := ParseBrowsersParam(r)
+	assert.NotNil(t, err)
 }
 
 func TestParseBrowsersParam_EmptyCommas(t *testing.T) {
-	r := httptest.NewRequest("GET", "http://wpt.fyi/?browsers=,notabrowser,,,,invalid,,", nil)
+	r := httptest.NewRequest("GET", "http://wpt.fyi/?browsers=,chrome,,,,safari,,", nil)
 	browsers, err := ParseBrowsersParam(r)
 	assert.Nil(t, err)
-	assert.Empty(t, browsers)
+	assert.Equal(t, []string{"chrome", "safari"}, browsers)
 }
 
 func TestParseBrowsersParam_SafariChrome(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?browsers=safari,chrome", nil)
 	browsers, err := ParseBrowsersParam(r)
 	assert.Nil(t, err)
-	assert.Equal(t, []string{"chrome", "safari"}, browsers)
+	assert.Equal(t, []string{"chrome", "safari"}, browsers) // Alphabetical
 }
 
 func TestParseBrowsersParam_MultiBrowserParam_SafariChrome(t *testing.T) {
@@ -128,16 +125,8 @@ func TestParseBrowsersParam_MultiBrowserParam_SafariChrome(t *testing.T) {
 
 func TestParseBrowsersParam_MultiBrowserParam_SafariInvalid(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?browser=safari&browser=invalid", nil)
-	browsers, err := ParseBrowsersParam(r)
-	assert.Nil(t, err)
-	assert.Equal(t, []string{"safari"}, browsers)
-}
-
-func TestParseBrowsersParam_MultiBrowserParam_AllInvalid(t *testing.T) {
-	r := httptest.NewRequest("GET", "http://wpt.fyi/?browser=invalid&browser=notabrowser", nil)
-	browsers, err := ParseBrowsersParam(r)
-	assert.Nil(t, err)
-	assert.Empty(t, browsers)
+	_, err := ParseBrowsersParam(r)
+	assert.NotNil(t, err)
 }
 
 func TestParseMaxCountParam_Missing(t *testing.T) {


### PR DESCRIPTION
## Description
Changes the silent-fallback behaviour of `?browser=invalid-name` and `?sha=invalid-sha` to throw 400's instead of falling back to default values.

Resolves https://github.com/web-platform-tests/wpt.fyi/issues/71

Running at https://lukebjerring-error-bad-params-dot-wptdashboard.appspot.com
Examples:
- https://lukebjerring-error-bad-params-dot-wptdashboard.appspot.com/results?sha=not-a-sha
- https://lukebjerring-error-bad-params-dot-wptdashboard.appspot.com/api/runs?browser=not-a-browser