### PR TITLE
Add display names for platforms

### DIFF
--- a/webapp/components/test-run.html
+++ b/webapp/components/test-run.html
@@ -66,6 +66,7 @@ See models.go for more details.
       m.set('edge', 'Edge');
       m.set('linux', 'Linux');
       m.set('macos', 'macOS');
+      m.set('safari', 'Safari');
       m.set('windows', 'Windows');
       return m;
     })();

--- a/webapp/components/test-run.html
+++ b/webapp/components/test-run.html
@@ -61,12 +61,12 @@ See models.go for more details.
   <script>
     const DISPLAY_NAMES = (() => {
       let m = new Map();
-      m.set("chrome", "Chrome");
-      m.set("firefox", "Firefox");
-      m.set("edge", "Edge");
-      m.set("linux", "Linux");
-      m.set("macos", "macOS");
-      m.set("windows", "Windows");
+      m.set('chrome', 'Chrome');
+      m.set('firefox', 'Firefox');
+      m.set('edge', 'Edge');
+      m.set('linux', 'Linux');
+      m.set('macos', 'macOS');
+      m.set('windows', 'Windows');
       return m;
     })();
     

--- a/webapp/components/test-run.html
+++ b/webapp/components/test-run.html
@@ -49,9 +49,9 @@ See models.go for more details.
 
     <div>
       <div><img src="/static/{{testRun.browser_name}}_64x64.png" /></div>
-      <div>{{testRun.browser_name}} {{testRun.browser_version}}</div>
+      <div>{{displayName(testRun.browser_name)}} {{testRun.browser_version}}</div>
       <template is="dom-if" if="{{ !isDiff(testRun.browser_name) }}">
-        <div>{{testRun.os_name}} {{testRun.os_version}}</div>
+        <div>{{displayName(testRun.os_name)}} {{testRun.os_version}}</div>
         <div class="revision">@<a href="?sha={{testRun.revision}}">{{testRun.revision}}</a></div>
         <div>{{dateFormat(testRun.created_at)}}</div>
       </template>
@@ -59,6 +59,17 @@ See models.go for more details.
   </template>
 
   <script>
+    const DISPLAY_NAMES = (() => {
+      let m = new Map();
+      m.set("chrome", "Chrome");
+      m.set("firefox", "Firefox");
+      m.set("edge", "Edge");
+      m.set("linux", "Linux");
+      m.set("macos", "macOS");
+      m.set("windows", "Windows");
+      return m;
+    })();
+    
     class TestRun extends window.Polymer.Element {
       static get is() {
         return 'test-run';
@@ -78,6 +89,10 @@ See models.go for more details.
 
       isDiff(browserName) {
         return browserName.toLowerCase() === 'diff';
+      }
+
+      friendlyName(name) {
+        return DISPLAY_NAMES.get(name) || name;
       }
     }
 

--- a/webapp/components/test-run.html
+++ b/webapp/components/test-run.html
@@ -91,7 +91,7 @@ See models.go for more details.
         return browserName.toLowerCase() === 'diff';
       }
 
-      friendlyName(name) {
+      displayName(name) {
         return DISPLAY_NAMES.get(name) || name;
       }
     }


### PR DESCRIPTION
## Description
Add a map of the dataset names to Canonical Case names, and use them in the UI.

Resolves https://github.com/web-platform-tests/wpt.fyi/issues/6

## Review Information
Running at https://lukebjerring-camel-case-names-dot-wptdashboard.appspot.com