### PR TITLE
Redirect with query params

### DIFF
--- a/webapp/main.go
+++ b/webapp/main.go
@@ -15,6 +15,7 @@ func init() {
 	// Test run results, viewed by browser (default view)
 	// For run results diff view, 'before' and 'after' params can be given.
 	http.HandleFunc("/", testResultsHandler)
+	http.HandleFunc("/results", testResultsHandler) // Prevent default redirect
 	http.HandleFunc("/results/", testResultsHandler)
 
 	// About wpt.fyi

--- a/webapp/test_results_handler.go
+++ b/webapp/test_results_handler.go
@@ -23,8 +23,20 @@ import (
 // The browsers initially displayed to the user are defined in browsers.json.
 // The JSON property "initially_loaded" is what controls this.
 func testResultsHandler(w http.ResponseWriter, r *http.Request) {
-	if strings.Index(r.URL.Path, "/results/") != 0 {
-		http.Redirect(w, r, fmt.Sprintf("/results%s", r.URL.Path), http.StatusTemporaryRedirect)
+	// Redirect legacy paths.
+	testPath := ""
+	if r.URL.Path == "/" || r.URL.Path == "/results" {
+		testPath = "/"
+	} else if strings.Index(r.URL.Path, "/results/") != 0 {
+		testPath = r.URL.Path
+	}
+	if testPath != "" {
+		params := ""
+		if r.URL.RawQuery != "" {
+			params = "?" + r.URL.RawQuery
+		}
+		url := fmt.Sprintf("/results%s%s", testPath, params)
+		http.Redirect(w, r, url, http.StatusTemporaryRedirect)
 		return
 	}
 


### PR DESCRIPTION
## Description
Preserve the query param when redirecting to `/results/`

Fixes https://github.com/web-platform-tests/wpt.fyi/issues/89