### PR TITLE
Strip trailing slashes

### DIFF
--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -214,8 +214,8 @@ found in the LICENSE file.
 
       urlToResultsPath(location) {
         return location.pathname
-            .replace(/^\/results\/(.+)?$/, '/$1') // Strip '/results' prefix
-            .replace(/\/$/, ''); // Strip trailing slash
+          .replace(/^\/results\/(.+)?$/, '/$1') // Strip '/results' prefix
+          .replace(/\/$/, ''); // Strip trailing slash
       }
 
       async connectedCallback() {

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -213,7 +213,9 @@ found in the LICENSE file.
       }
 
       urlToResultsPath(location) {
-        return location.pathname.replace(/\/results\/(.+)?$/, '/$1');
+        return location.pathname
+            .replace(/^\/results\/(.+)?$/, '/$1') // Strip '/results' prefix
+            .replace(/\/$/, ''); // Strip trailing slash
       }
 
       async connectedCallback() {

--- a/webapp/test/wpt-results.html
+++ b/webapp/test/wpt-results.html
@@ -32,6 +32,7 @@
               assert.equal(trf.urlToResultsPath(url('/results/')), '/');
               assert.equal(trf.urlToResultsPath(url('/results/abc')), '/abc');
               assert.equal(trf.urlToResultsPath(url('/results/abc/')), '/abc');
+              assert.equal(trf.urlToResultsPath(url('/results/abc/def/')), '/abc/def');
               assert.equal(trf.urlToResultsPath(url('/results/abc/def.html')), '/abc/def.html');
             });
           });


### PR DESCRIPTION
## Description
Trim any trailing slash on the URL path when computing the test-path.

Fixes https://github.com/web-platform-tests/wpt.fyi/issues/93 (sometimes the user will manually tweak the URL and leave a trailing slash).