### PR TITLE
Add experimental runs when adding dev data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ go_deps: $(find .  -type f | grep '\.go$' | grep -v '\.pb.go$')
 
 dev_data:
 	cd $(WPTD_GO_PATH)/util; go get -t ./...
-	go run util/populate_dev_data.go
+	go run util/populate_dev_data.go $(FLAGS)
 
 webapp_deploy_staging: env-BRANCH_NAME
 	gcloud config set project wptdashboard

--- a/shared/fetch_runs.go
+++ b/shared/fetch_runs.go
@@ -7,16 +7,34 @@ package shared
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"strconv"
+
+	"github.com/deckarep/golang-set"
 )
 
 // FetchLatestRuns fetches the TestRun metadata for the latest runs, using the
 // API on the given host.
 func FetchLatestRuns(wptdHost string) []TestRun {
+	return FetchRuns(wptdHost, "latest", nil)
+}
+
+// FetchRuns fetches the TestRun metadata for the given sha / labels, using the
+// API on the given host.
+func FetchRuns(wptdHost, sha string, labels mapset.Set) []TestRun {
 	url := "https://" + wptdHost + "/api/runs"
+	if labels != nil && labels.Cardinality() > 0 {
+		sep := "?"
+		for label := range labels.Iter() {
+			url += sep + fmt.Sprintf("label=%s", label.(string))
+			sep = "&"
+		}
+	}
+	log.Printf("Fetching %s...", url)
+
 	resp, err := http.Get(url)
 	if err != nil {
 		log.Fatal(err)

--- a/util/docker-dev/dev_data.sh
+++ b/util/docker-dev/dev_data.sh
@@ -27,4 +27,4 @@ else
     ${COPY_COMMAND}
 fi
 
-wptd_exec "make dev_data"
+wptd_exec "make dev_data FLAGS=$@"


### PR DESCRIPTION
## Description
Adds a fetch for `?label=experimental` when populating dev data locally, so that experimental related UI features are easier to test (e.g. https://github.com/web-platform-tests/wpt.fyi/pull/99)

Also adds a flag for the `wpt.fyi` host to use, because the experimental label isn't supported in prod yet.