### PR TITLE
Add /api/manifest endpoint

### DIFF
--- a/webapp/api_handlers.go
+++ b/webapp/api_handlers.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	models "github.com/web-platform-tests/wpt.fyi/shared"
@@ -381,8 +382,6 @@ func apiManifestHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := appengine.NewContext(r)
 	if manifest, err := getManifestForSHA(ctx, sha); err != nil {
 		http.Error(w, err.Error(), http.StatusNotFound)
-	} else if manifest == nil {
-		http.NotFound(w, r)
 	} else {
 		w.Header().Add("content-type", "application/json")
 		w.Write(manifest)
@@ -463,7 +462,7 @@ func getManifestForSHA(ctx context.Context, sha string) (manifest []byte, err er
 			return body, nil
 		}
 	}
-	return nil, nil
+	return nil, fmt.Errorf("No manifest asset found for release %s", releaseTag)
 }
 
 func fetchGitHubURL(ctx context.Context, url string, githubToken string) ([]byte, error) {

--- a/webapp/api_handlers_test.go
+++ b/webapp/api_handlers_test.go
@@ -1,0 +1,96 @@
+// Copyright 2017 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package webapp
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockGitHubClient struct {
+	Responses map[string][]byte
+}
+
+func (m *mockGitHubClient) fetch(url string) ([]byte, error) {
+	if _, ok := m.Responses[url]; !ok {
+		return nil, fmt.Errorf("fore! oh; for: %s", url)
+	}
+	return m.Responses[url], nil
+}
+
+func TestGetGitHubReleaseAssetForSHA_SHANotFound(t *testing.T) {
+	client := mockGitHubClient{}
+	const sha = "abcdef1234"
+	manifest, err := getGitHubReleaseAssetForSHA(&client, sha)
+	assert.Nil(t, manifest)
+	assert.NotNil(t, err)
+}
+
+func TestGetGitHubReleaseAssetForSHA(t *testing.T) {
+	const sha = "abcdef1234"
+	searchResults, _ := json.Marshal(
+		object{
+			"items": []object{
+				object{
+					"number": 123,
+				},
+			},
+		},
+	)
+	downloadURL := "http://github.com/magic_url"
+
+	releasesJSON := object{
+		"assets": []object{
+			object{
+				"name":                 "MANIFEST-abcdef1234.json.gz",
+				"browser_download_url": downloadURL,
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	zw.Write([]byte("magic data"))
+	zw.Close()
+	data := buf.Bytes()
+
+	client := mockGitHubClient{
+		Responses: map[string][]byte{
+			gitHubSHASearchURL(sha):          searchResults,
+			gitHubReleaseURL("merge_pr_123"): unsafeMarshal(releasesJSON),
+			downloadURL:                      data,
+		},
+	}
+
+	// 1) Data is unzipped.
+	manifest, err := getGitHubReleaseAssetForSHA(&client, sha)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte("magic data"), manifest)
+
+	// 2) Correct asset picked when first asset is some other asset.
+	releasesJSON["assets"] = []object{
+		object{
+			"name":                 "Some other asset.txt",
+			"browser_download_url": "http://huh.com?",
+		},
+		releasesJSON["assets"].([]object)[0],
+	}
+	client.Responses[gitHubReleaseURL("merge_pr_123")] = unsafeMarshal(releasesJSON)
+	manifest, err = getGitHubReleaseAssetForSHA(&client, sha)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte("magic data"), manifest)
+
+	// 3) Error when no matching asset found.
+	releasesJSON["assets"] = releasesJSON["assets"].([]object)[0:1] // Just the other asset
+	client.Responses[gitHubReleaseURL("merge_pr_123")] = unsafeMarshal(releasesJSON)
+	manifest, err = getGitHubReleaseAssetForSHA(&client, sha)
+	assert.NotNil(t, err)
+	assert.Nil(t, manifest)
+}

--- a/webapp/github_client.go
+++ b/webapp/github_client.go
@@ -1,0 +1,41 @@
+package webapp
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	models "github.com/web-platform-tests/wpt.fyi/shared"
+	"golang.org/x/net/context"
+	"google.golang.org/appengine/urlfetch"
+)
+
+type gitHubClientImpl struct {
+	Token   *models.Token
+	Context context.Context
+}
+
+func (g *gitHubClientImpl) fetch(url string) ([]byte, error) {
+	client := urlfetch.Client(g.Context)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	if g.Token != nil {
+		req.Header.Add("Authorization", fmt.Sprintf("token %s", g.Token.Secret))
+	}
+	var resp *http.Response
+	if resp, err = client.Do(req); err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	var body []byte
+	if body, err = ioutil.ReadAll(resp.Body); err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("%s returned HTTP status %d:\n%s", url, resp.StatusCode, string(body))
+	}
+	return body, nil
+}

--- a/webapp/main.go
+++ b/webapp/main.go
@@ -33,6 +33,9 @@ func init() {
 	// API endpoint for diff of two test run summary JSON blobs.
 	http.HandleFunc("/api/diff", apiDiffHandler)
 
+	// API endpoint for fetching a manifest for a commit SHA.
+	http.HandleFunc("/api/manifest", apiManifestHandler)
+
 	// API endpoint for listing all test runs for a given SHA.
 	http.HandleFunc("/api/runs", apiTestRunsHandler)
 

--- a/webapp/params.go
+++ b/webapp/params.go
@@ -48,6 +48,10 @@ func ParseSHAParam(r *http.Request) (runSHA string, err error) {
 	return runSHA, err
 }
 
+// ParseSHAParam parses and validates the 'sha' param for the request.
+// It returns "latest" by default (and in error cases).
+func ParseSHAParamFull(r *http.Request)
+
 // ParseBrowserParam parses and validates the 'browser' param for the request.
 // It returns "" by default (and in error cases).
 func ParseBrowserParam(r *http.Request) (browser string, err error) {

--- a/webapp/params.go
+++ b/webapp/params.go
@@ -28,9 +28,19 @@ const MaxCountMinValue = 1
 // SHARegex is a regex for SHA[0:10] slice of a git hash.
 var SHARegex = regexp.MustCompile("[0-9a-fA-F]{10,40}")
 
-// ParseSHAParam parses and validates the 'sha' param for the request.
-// It returns "latest" by default (and in error cases).
+// ParseSHAParam parses and validates the 'sha' param for the request,
+// cropping it to 10 chars. It returns "latest" by default. (and in error cases).
 func ParseSHAParam(r *http.Request) (runSHA string, err error) {
+	sha, err := ParseSHAParamFull(r)
+	if err != nil || !SHARegex.MatchString(sha) {
+		return sha, err
+	}
+	return sha[:10], nil
+}
+
+// ParseSHAParamFull parses and validates the 'sha' param for the request.
+// It returns "latest" by default (and in error cases).
+func ParseSHAParamFull(r *http.Request) (runSHA string, err error) {
 	// Get the SHA for the run being loaded (the first part of the path.)
 	runSHA = "latest"
 	params, err := url.ParseQuery(r.URL.RawQuery)
@@ -41,16 +51,11 @@ func ParseSHAParam(r *http.Request) (runSHA string, err error) {
 	runParam := params.Get("sha")
 	if runParam != "" && runParam != "latest" {
 		if !SHARegex.MatchString(runParam) {
-			return "", fmt.Errorf("Invalid sha param value: %s", runParam)
+			return "latest", fmt.Errorf("Invalid sha param value: %s", runParam)
 		}
-		runSHA = runParam[:10]
 	}
-	return runSHA, err
+	return runParam, err
 }
-
-// ParseSHAParam parses and validates the 'sha' param for the request.
-// It returns "latest" by default (and in error cases).
-func ParseSHAParamFull(r *http.Request)
 
 // ParseBrowserParam parses and validates the 'browser' param for the request.
 // It returns "" by default (and in error cases).

--- a/webapp/params.go
+++ b/webapp/params.go
@@ -50,11 +50,12 @@ func ParseSHAParamFull(r *http.Request) (runSHA string, err error) {
 
 	runParam := params.Get("sha")
 	if runParam != "" && runParam != "latest" {
+		runSHA = runParam
 		if !SHARegex.MatchString(runParam) {
 			return "latest", fmt.Errorf("Invalid sha param value: %s", runParam)
 		}
 	}
-	return runParam, err
+	return runSHA, err
 }
 
 // ParseBrowserParam parses and validates the 'browser' param for the request.

--- a/webapp/util_test.go
+++ b/webapp/util_test.go
@@ -5,11 +5,19 @@
 package webapp
 
 import (
+	"encoding/json"
 	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+type object map[string]interface{}
+
+func unsafeMarshal(i interface{}) []byte {
+	result, _ := json.Marshal(i)
+	return result
+}
 
 func TestGetBrowserNames(t *testing.T) {
 	names, _ := GetBrowserNames()


### PR DESCRIPTION
## Description
WIP - request for feedback

Adds an endpoint for getting a manifest for a given SHA.
To achieve this, it does:
- GitHub search for the PR associated with the SHA
- GitHub fetch for the release by tag-name `merge_pr_[PR number]`
- GitHub download of the release's asset with the name `MANIFEST-[sha].json.gz`

@gsnedders @jgraham if there is a better way to do this (without a local git clone) I'd be happy to know about it

@tabatkins - Haven't done `latest` behaviour yet, needs to be given a SHA param, but it's running here if you want to play around and point out any major flaws. AppEngine seems to behave nicely if you allow gzip encoding, but defaults to raw JSON @ ~20MB.

https://manifest-api-dot-wptdashboard.appspot.com/api/manifest?sha=ae34fb2b39f8b2cf9c3989a566ab938cde45dec0

## Context
There are some UI features (e.g. linking to w3c-test.org) which require manifest context, so we'd like to eventually cache manifests by SHA and support lookup of manifest info for a single test file.