### PR TITLE
Use Fetch's response.ok instead of checking for status 200

### DIFF
--- a/webapp/components/runs.html
+++ b/webapp/components/runs.html
@@ -38,8 +38,9 @@ found in the LICENSE file.
           const fetches = await Promise.all(
             this.testRunResources.map(async url => {
               const response = await window.fetch(url);
-              if (response.status !== 200) {
-                return Promise.resolve();
+              if (!response.ok) {
+                console.error(`Got non-OK status ${response.status} for url: ${url}`);
+                return null;
               }
               return response.json();
             })

--- a/webapp/components/test-file-results.html
+++ b/webapp/components/test-file-results.html
@@ -126,9 +126,9 @@ found in the LICENSE file.
       async loadResultFile(testRun) {
         const url = this.resultsURL(testRun, this.testFile);
         const response = await window.fetch(url);
-        if (response.status !== 200) {
-          console.error(`Got non-200 status for url: ${url}`);
-          return Promise.resolve(null);
+        if (!response.ok) {
+          console.error(`Got non-OK status ${response.status} for url: ${url}`);
+          return null;
         }
         return response.json();
       }


### PR DESCRIPTION
Also log the non-OK fetches in a consistent way.

Note that in runs.html the resolved value changes from undefined to
null, but that doesn't matter as both are falsy and filter soon after
into `nonEmpty`.