### PR TITLE
Include eslint in git pre-push hook

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -21,7 +21,7 @@ RUN apt-get install -y nodejs
 
 # Install wct
 # Note that --unsafe-perm bypasses a post install script issue.
-# See https://github.com/Polymer/polymer-cli/issues/832#issuecomment-320238339
+# See https://github.com/npm/npm/issues/17346
 RUN npm install -g web-component-tester --unsafe-perm
 
 # Put wpt.fyi code in GOPATH

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -15,6 +15,21 @@ RUN gcloud components install \
     gsutil \
     app-engine-python
 
+# Install npm, and use a user-relative global path.
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash
+RUN apt-get install -y nodejs
+
+# Change global install path to be user-relative.
+ENV NPM_GLOBAL_PATH="${USER_HOME}/.npm-global"
+RUN mkdir ${NPM_GLOBAL_PATH}
+RUN npm config set prefix "${NPM_GLOBAL_PATH}"
+RUN export PATH=$PATH:${NPM_GLOBAL_PATH}/bin
+
+# Install wct
+# Note that --unsafe-perm bypasses a post install script issue.
+# See https://github.com/Polymer/polymer-cli/issues/832#issuecomment-320238339
+RUN npm install -g web-component-tester --unsafe-perm
+
 # Put wpt.fyi code in GOPATH
 RUN mkdir -p "${GOPATH}/src/github.com/web-platform-tests"
 RUN ln -s "${WPTD_PATH}" "${GOPATH}/src/github.com/web-platform-tests/wpt.fyi"

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -19,12 +19,6 @@ RUN gcloud components install \
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash
 RUN apt-get install -y nodejs
 
-# Change global install path to be user-relative.
-ENV NPM_GLOBAL_PATH="${USER_HOME}/.npm-global"
-RUN mkdir ${NPM_GLOBAL_PATH}
-RUN npm config set prefix "${NPM_GLOBAL_PATH}"
-RUN export PATH=$PATH:${NPM_GLOBAL_PATH}/bin
-
 # Install wct
 # Note that --unsafe-perm bypasses a post install script issue.
 # See https://github.com/Polymer/polymer-cli/issues/832#issuecomment-320238339

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ build: go_deps
 
 test: go_test
 
-lint: go_lint
+lint: go_lint eslint
 
 go_lint: go_deps
 	cd $(WPTD_GO_PATH); golint -set_exit_status $(GO_FILES)
@@ -48,6 +48,9 @@ go_test: go_deps
 
 go_deps: $(find .  -type f | grep '\.go$' | grep -v '\.pb.go$')
 	cd $(WPTD_GO_PATH); go get -t ./...
+
+eslint:
+	cd $(WPTD_PATH)webapp; npm run lint
 
 dev_data:
 	cd $(WPTD_GO_PATH)/util; go get -t ./...


### PR DESCRIPTION
## Description
Adds `eslint` as a make rule when running `lint`, which is what we execute during our git pre-push hook.
To support this, we install wct

Note that we don't yet run `wct` from inside docker - I'll cover that in a follow-up PR.