### PR TITLE
Fix read nesting bugs in pre-push

### DIFF
--- a/git/hooks/pre-push
+++ b/git/hooks/pre-push
@@ -7,15 +7,8 @@ source "${REPO_DIR}/util/path.sh"
 source "${REPO_DIR}/util/commands.sh"
 WPTD_PATH=${WPTD_PATH:-$(absdir "${REPO_DIR}")}
 
-# Check for uncommitted changes.
-! git diff . 2>&1 | read > /dev/null 2>&1
-DIFF_STATUS="${?}"
-if [ "${DIFF_STATUS}" != "0" ]; then
-  confirm "You have uncommitted local changes. Push committed changes anyway?"
-  if [ ${?} != 0 ]; then fatal "User cancelled the push"; fi
-fi
-
 info "Checking where we're pushing..."
+IS_MASTER="false"
 while read local_ref local_sha remote_ref remote_sha
 do
   debug "$local_ref $local_sha $remote_ref $remote_sha"
@@ -23,11 +16,24 @@ do
   then
     if [[ "$(echo $remote_ref | sed -e 's,.*/\(.*\),\1,')" == "master" ]]
     then
-      confirm "Are you sure you want to push master?"
-      if [ ${?} != 0 ]; then fatal "User cancelled the push"; fi
+      IS_MASTER="true"
     fi
   fi
 done
+
+if [[ "${IS_MASTER}" == "true" ]]
+then
+  confirm "Are you sure you want to push master?" || fatal "User cancelled the push"
+fi
+
+# Check for uncommitted changes.
+info "Checking for uncommitted changes..."
+! git diff . 2>&1 | read > /dev/null 2>&1
+DIFF_STATUS="${?}"
+if [ "${DIFF_STATUS}" != "0" ]; then
+  confirm "You have uncommitted local changes. Push committed changes anyway?" \
+      || fatal "User cancelled the push"
+fi
 
 info "Running lint task in docker..."
 docker inspect wptd-dev-instance > /dev/null 2>&1
@@ -51,9 +57,7 @@ docker exec -t -u $(id -u $USER):$(id -g $USER) wptd-dev-instance make lint
 LINT_STATUS="${?}"
 FINAL_STATUS="${LINT_STATUS}"
 if [ "${LINT_STATUS}" != "0" ]; then
-  confirm "Lint failed. Push anyway?"
-  if [ ${?} != 0 ]; then fatal "User cancelled the push"; fi
-
+  confirm "Lint failed. Push anyway?" || fatal "User cancelled the push"
   info "Pushing in spite of lint errors..."
   FINAL_STATUS="0"
 fi


### PR DESCRIPTION
## Description
When a read occurs before the read for the pre-push params, it causes an infinite loop. Similarly, when we use the `confirm` logging helper, which reads file desc 1, we get caught in the loop.