### PR TITLE
Add a gcloud update to Dockerfile.dev

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -7,6 +7,9 @@ RUN apt-get install --assume-yes --no-install-suggests \
     --no-install-recommends \
     inotify-tools
 
+# Update the SDK to the latest.
+RUN gcloud components update
+
 # Ensure Google Cloud Platform tools are installed
 RUN gcloud components install \
     app-engine-go \


### PR DESCRIPTION
## Description
The docker base image is v167 of gcloud SDK, which contains some bugs about resolving the Golang version to use for the separated `wpt.fyi/api` package.

This PR adds a `gcloud components update` which bumps us up to v200 (as at time of PR).

We are going to consolidate the docker files/images anyway (see #107), but this is a quick workaround until then.