### PR TITLE
Add support for latest manifest

### DIFF
--- a/api/github_client.go
+++ b/api/github_client.go
@@ -25,7 +25,7 @@ func (g *gitHubClientImpl) fetch(url string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	if g.Token != nil {
+	if g.Token != nil && g.Token.Secret != "" {
 		req.Header.Add("Authorization", fmt.Sprintf("token %s", g.Token.Secret))
 	}
 	var resp *http.Response

--- a/api/manifest.go
+++ b/api/manifest.go
@@ -119,7 +119,7 @@ func getGitHubReleaseAssetForSHA(client gitHubClient, sha string) (manifest []by
 	// Get (and unzip) the asset with name "MANIFEST-{sha}.json.gz"
 	shaMatch := sha
 	if sha == "" || sha == "latest" {
-		shaMatch = "[0-9a-f]{1,40}"
+		shaMatch = "[0-9a-f]{40}"
 	}
 	assetRegex := regexp.MustCompile(fmt.Sprintf("MANIFEST-%s.json.gz", shaMatch))
 	for _, asset := range assets {

--- a/api/results_redirect_handler_test.go
+++ b/api/results_redirect_handler_test.go
@@ -16,8 +16,8 @@ type Case struct {
 	expected string
 }
 
-const sha = "abcdef0123"
-const resultsURLBase = "https://storage.googleapis.com/wptd/" + sha + "/"
+const shortSHA = "abcdef0123"
+const resultsURLBase = "https://storage.googleapis.com/wptd/" + shortSHA + "/"
 const platform = "chrome-63.0-linux"
 const resultsURL = resultsURLBase + "/" + platform + "-summary.json.gz"
 
@@ -27,7 +27,7 @@ func TestGetResultsURL_EmptyFile(t *testing.T) {
 		Case{
 			base.TestRun{
 				ResultsURL: resultsURL,
-				Revision:   sha,
+				Revision:   shortSHA,
 			},
 			"",
 			resultsURL,
@@ -41,7 +41,7 @@ func TestGetResultsURL_TestFile(t *testing.T) {
 		Case{
 			base.TestRun{
 				ResultsURL: resultsURL,
-				Revision:   sha,
+				Revision:   shortSHA,
 			},
 			file,
 			resultsURLBase + platform + "/" + file,
@@ -54,7 +54,7 @@ func TestGetResultsURL_TrailingSlash(t *testing.T) {
 		Case{
 			base.TestRun{
 				ResultsURL: resultsURL,
-				Revision:   sha,
+				Revision:   shortSHA,
 			},
 			"/",
 			resultsURL,


### PR DESCRIPTION
## Description
Special-case `latest` as a SHA (which is the default when no SHA is provided) and fetch the latest release using [GitHub's latest release API](https://developer.github.com/v3/repos/releases/#get-the-latest-release)

@tabatkins - as I understand it, this is a step in the direction you wanted.

## Review Information
See https://manifest-latest-dot-wptdashboard.appspot.com/api/manifest