### PR TITLE
Run build + test on prepush

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,11 +32,16 @@ GO_FILES := $(wildcard $(WPTD_PATH)**/*.go)
 GO_FILES := $(filter-out $(wildcard $(WPTD_PATH)generated/**/*.go), $(GO_FILES))
 GO_FILES := $(filter-out $(wildcard $(WPTD_PATH)vendor/**/*.go), $(GO_FILES))
 
-build: go_deps
+build: go_build
 
 test: go_test
 
 lint: go_lint eslint
+
+prepush: build test lint
+
+go_build: go_deps
+	cd $(WPTD_GO_PATH); go build ./...
 
 go_lint: go_deps
 	cd $(WPTD_GO_PATH); golint -set_exit_status $(GO_FILES)

--- a/git/hooks/pre-push
+++ b/git/hooks/pre-push
@@ -35,7 +35,7 @@ if [ "${DIFF_STATUS}" != "0" ]; then
       || fatal "User cancelled the push"
 fi
 
-info "Running lint task in docker..."
+info "Running pre-push checks in docker..."
 docker inspect wptd-dev-instance > /dev/null 2>&1
 INSPECT_STATUS="${?}"
 
@@ -53,7 +53,7 @@ fi
 # Ensure rights.
 wptd_chown "/home/jenkins"
 
-docker exec -t -u $(id -u $USER):$(id -g $USER) wptd-dev-instance make lint
+docker exec -t -u $(id -u $USER):$(id -g $USER) wptd-dev-instance make prepush
 LINT_STATUS="${?}"
 FINAL_STATUS="${LINT_STATUS}"
 if [ "${LINT_STATUS}" != "0" ]; then


### PR DESCRIPTION
## Description
Adds `go build` and `go test` during prepush, since they are super fast to execute, and can catch silly errors when prepping for a PR.

Note that `make build` was previously only grabbing the `go_deps`, but not actually building.