### PR TITLE
Cull any runs older than the youngest 100th run

### DIFF
--- a/api/test_runs.go
+++ b/api/test_runs.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/web-platform-tests/wpt.fyi/shared"
 	"google.golang.org/appengine"
@@ -47,7 +48,7 @@ func apiTestRunsHandler(w http.ResponseWriter, r *http.Request) {
 	labels := shared.ParseLabelsParam(r)
 	experimentalBrowsers := labels != nil && labels.Contains(shared.ExperimentalLabel)
 
-	var testRuns []shared.TestRun
+	var testRuns [][]shared.TestRun
 	var limit int
 	if limit, err = shared.ParseMaxCountParam(r); err != nil {
 		http.Error(w, "Invalid 'max-count' param: "+err.Error(), http.StatusBadRequest)
@@ -71,10 +72,25 @@ func apiTestRunsHandler(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		testRuns = append(testRuns, testRunResults...)
+		testRuns = append(testRuns, testRunResults)
 	}
 
-	testRunsBytes, err := json.Marshal(testRuns)
+	// Crop at `limit` runs - whichever is the youngest `limit`th run.
+	youngestRun := time.Unix(0, 0)
+	for _, runs := range testRuns {
+		if len(runs) == limit && runs[limit-1].CreatedAt.After(youngestRun) {
+			youngestRun = runs[limit-1].CreatedAt
+		}
+	}
+
+	var allRuns []shared.TestRun
+	for _, runs := range testRuns {
+		for len(runs) > 0 && runs[len(runs)-1].CreatedAt.Before(youngestRun) {
+			runs = runs[0 : len(runs)-1]
+		}
+		allRuns = append(allRuns, runs...)
+	}
+	testRunsBytes, err := json.Marshal(allRuns)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return


### PR DESCRIPTION
## Description
Fixes https://github.com/web-platform-tests/wpt.fyi/issues/3

If multiple browsers return `max-count` / `limit` runs, find out which has the youngest `limit`th run, and cull anything older than that, so that the number of SHAs (i.e. "rows" in the UI) matches `max-count`.

## Review Information
https://runs-dot-wptdashboard.appspot.com/test-runs