### PR TITLE
Return an HTTP header with the manifest's SHA

### DIFF
--- a/api/manifest_test.go
+++ b/api/manifest_test.go
@@ -37,7 +37,7 @@ func unsafeMarshal(i interface{}) []byte {
 
 func TestGetGitHubReleaseAssetForSHA_SHANotFound(t *testing.T) {
 	client := mockGitHubClient{}
-	manifest, err := getGitHubReleaseAssetForSHA(&client, fullSHA)
+	_, manifest, err := getGitHubReleaseAssetForSHA(&client, fullSHA)
 	assert.Nil(t, manifest)
 	assert.NotNil(t, err)
 }
@@ -74,7 +74,7 @@ func TestGetGitHubReleaseAssetForSHA(t *testing.T) {
 	}
 
 	// 1) Data is unzipped.
-	manifest, err := getGitHubReleaseAssetForSHA(&client, fullSHA)
+	_, manifest, err := getGitHubReleaseAssetForSHA(&client, fullSHA)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(content), manifest)
 
@@ -87,14 +87,14 @@ func TestGetGitHubReleaseAssetForSHA(t *testing.T) {
 		releaseJSON["assets"].([]object)[0],
 	}
 	client.Responses[gitHubReleaseURL("merge_pr_123")] = unsafeMarshal(releaseJSON)
-	manifest, err = getGitHubReleaseAssetForSHA(&client, fullSHA)
+	_, manifest, err = getGitHubReleaseAssetForSHA(&client, fullSHA)
 	assert.Nil(t, err)
 	assert.Equal(t, []byte(content), manifest)
 
 	// 3) Error when no matching asset found.
 	releaseJSON["assets"] = releaseJSON["assets"].([]object)[0:1] // Just the other asset
 	client.Responses[gitHubReleaseURL("merge_pr_123")] = unsafeMarshal(releaseJSON)
-	manifest, err = getGitHubReleaseAssetForSHA(&client, fullSHA)
+	_, manifest, err = getGitHubReleaseAssetForSHA(&client, fullSHA)
 	assert.NotNil(t, err)
 	assert.Nil(t, manifest)
 }
@@ -120,10 +120,12 @@ func TestGetGitHubReleaseAssetLatest(t *testing.T) {
 	}
 
 	// Release by empty SHA or "latest" match.
-	latestManifest, _ := getGitHubReleaseAssetForSHA(&client, "")
+	sha, latestManifest, _ := getGitHubReleaseAssetForSHA(&client, "")
 	assert.Equal(t, []byte(content), latestManifest)
-	latestManifest, _ = getGitHubReleaseAssetForSHA(&client, "latest")
+	assert.Equal(t, fullSHA, sha)
+	sha, latestManifest, _ = getGitHubReleaseAssetForSHA(&client, "latest")
 	assert.Equal(t, []byte(content), latestManifest)
+	assert.Equal(t, fullSHA, sha)
 }
 
 func getManifestPayload(data string) []byte {


### PR DESCRIPTION
## Description
Adds a header `x-wpt-sha` to the response which contains the full SHA of the manifest that is returned.

Fixes https://github.com/web-platform-tests/wpt.fyi/issues/133

cc: @tabatkins 

## Review
Header is present for requests to
https://sha-header-dot-wptdashboard.appspot.com/api/manifest?sha=latest