### PR TITLE
Use manifest test source for source and w3c-test links

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -86,7 +86,8 @@ The high-level structure of the `v4` manifest is as follows:
             ...
         },
         "reftest": {...},
-        "testharness": {...}
+        "testharness": {...},
+        "wdspec": {...},
       },
     }
 

--- a/shared/models.go
+++ b/shared/models.go
@@ -60,6 +60,9 @@ func (m Manifest) FilterByPath(paths mapset.Set) (result Manifest, err error) {
 	if result.Items.TestHarness, err = m.Items.TestHarness.FilterByPath(paths); err != nil {
 		return result, err
 	}
+	if result.Items.WDSpec, err = m.Items.WDSpec.FilterByPath(paths); err != nil {
+		return result, err
+	}
 	return result, nil
 }
 
@@ -67,6 +70,7 @@ type ManifestItems struct {
 	Manual      *ManifestItem `json:"manual,omitempty"`
 	Reftest     *ManifestItem `json:"reftest,omitempty"`
 	TestHarness *ManifestItem `json:"testharness,omitempty"`
+	WDSpec      *ManifestItem `json:"wdspec,omitempty"`
 }
 
 type ManifestItem map[string][][]*json.RawMessage

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -181,9 +181,8 @@ found in the LICENSE file.
   </template>
 
   <script>
+    const TEST_TYPES = ['manual', 'reftest', 'testharness', 'wdspec'];
 
-    const TEST_TYPES = ["manual", "reftest", "testharness", "wdspec"];
-    
     /* global TestRunsBase */
     class WPTResults extends TestRunsBase {
       static get is() {
@@ -294,7 +293,7 @@ found in the LICENSE file.
         for (const type of TEST_TYPES) {
           const items = manifest.items[type];
           const test = Object.keys(items).find(k => items[k].find(i => i[0] === path));
-          if (test && type == "wdspec") {
+          if (test && type === 'wdspec') {
             return false;
           }
         }
@@ -376,7 +375,7 @@ found in the LICENSE file.
         this.manifest = null;
         const that = this;
         fetch(`/api/manifest?path=${path}`).then(async r => {
-            that.manifest = await r.json()
+          that.manifest = await r.json();
         });
       }
 

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -131,8 +131,10 @@ found in the LICENSE file.
     <template is="dom-if" if="{{ pathIsATestFile }}">
       <div class="links">
         <ul>
-          <li><a href$="https://github.com/w3c/web-platform-tests/blob/master[[path]]" target="_blank">View source on GitHub</a></li>
-          <li><a href$="[[scheme]]://w3c-test.org[[path]]" target="_blank">Run in your browser on w3c-test.org</a></li>
+          <li><a href$="https://github.com/w3c/web-platform-tests/blob/master[[sourcePath]]" target="_blank">View source on GitHub</a></li>
+          <template is="dom-if" if="{{ testCanRunOnW3C }}">
+            <li><a href$="[[scheme]]://w3c-test.org[[path]]" target="_blank">Run in your browser on w3c-test.org</a></li>
+          </template>
         </ul>
       </div>
 
@@ -179,6 +181,9 @@ found in the LICENSE file.
   </template>
 
   <script>
+
+    const TEST_TYPES = ["manual", "reftest", "testharness", "wdspec"];
+    
     /* global TestRunsBase */
     class WPTResults extends TestRunsBase {
       static get is() {
@@ -206,10 +211,19 @@ found in the LICENSE file.
           path: {
             type: String,
             value: '/',
+            observer: 'fetchManifest',
           },
           pathIsATestFile: {
             type: Boolean,
             computed: 'computePathIsATestFile(path)'
+          },
+          sourcePath: {
+            type: String,
+            computed: 'computeSourcePath(path, manifest)',
+          },
+          testCanRunOnW3C: {
+            type: Boolean,
+            computed: 'computeTestCanBeRunOnW3C(path, manifest)',
           },
           testFiles: {
             type: Object,
@@ -256,6 +270,35 @@ found in the LICENSE file.
 
       computePathIsATestFile(path) {
         return /(\.(html|htm|py|svg|xhtml|xht|xml)$)/.test(path);
+      }
+
+      computeSourcePath(path, manifest) {
+        if (!this.computePathIsATestFile(path) || !manifest) {
+          return path;
+        }
+        const itemSets = TEST_TYPES.map(t => manifest.items[t]).filter(i => i);
+        for (const items of itemSets) {
+          const key = Object.keys(items).find(k => items[k].find(i => i[0] === path));
+          if (key) {
+            // Ensure leading slash.
+            return key.indexOf('/') === 0 ? key : `/${key}`;
+          }
+        }
+        return null;
+      }
+
+      computeTestCanBeRunOnW3C(path, manifest) {
+        if (!this.computePathIsATestFile(path) || !manifest) {
+          return true;
+        }
+        for (const type of TEST_TYPES) {
+          const items = manifest.items[type];
+          const test = Object.keys(items).find(k => items[k].find(i => i[0] === path));
+          if (test && type == "wdspec") {
+            return false;
+          }
+        }
+        return true;
       }
 
       urlToResultsPath(location) {
@@ -324,6 +367,17 @@ found in the LICENSE file.
         await this.fetchResults([diffRun]);
         this.push('testRuns', diffRun);
         this.refreshDisplayedNodes();
+      }
+
+      async fetchManifest(path) {
+        if (!this.computePathIsATestFile(path)) {
+          return;
+        }
+        this.manifest = null;
+        const that = this;
+        fetch(`/api/manifest?path=${path}`).then(async r => {
+            that.manifest = await r.json()
+        });
       }
 
       nodeSort(a, b) {

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -275,12 +275,13 @@ found in the LICENSE file.
         if (!this.computePathIsATestFile(path) || !manifest) {
           return path;
         }
+        // Filter in case any types are fully missing.
         const itemSets = TEST_TYPES.map(t => manifest.items[t]).filter(i => i);
         for (const items of itemSets) {
           const key = Object.keys(items).find(k => items[k].find(i => i[0] === path));
           if (key) {
             // Ensure leading slash.
-            return key.indexOf('/') === 0 ? key : `/${key}`;
+            return key.startsWith('/') ? key : `/${key}`;
           }
         }
         return null;
@@ -292,9 +293,11 @@ found in the LICENSE file.
         }
         for (const type of TEST_TYPES) {
           const items = manifest.items[type];
-          const test = Object.keys(items).find(k => items[k].find(i => i[0] === path));
-          if (test && type === 'wdspec') {
-            return false;
+          if (items) {
+            const test = Object.keys(items).find(k => items[k].find(i => i[0] === path));
+            if (test && type === 'wdspec') {
+              return false;
+            }
           }
         }
         return true;
@@ -372,11 +375,8 @@ found in the LICENSE file.
         if (!this.computePathIsATestFile(path)) {
           return;
         }
-        this.manifest = null;
-        const that = this;
-        fetch(`/api/manifest?path=${path}`).then(async r => {
-          that.manifest = await r.json();
-        });
+        this.manifest = null; // Clear ASAP.
+        this.manifest = await fetch(`/api/manifest?path=${path}`).then(r => r.json());
       }
 
       nodeSort(a, b) {


### PR DESCRIPTION
## Description
Fixes https://github.com/web-platform-tests/wpt.fyi/issues/61 and https://github.com/web-platform-tests/wpt.fyi/issues/14 using the `/api/manifest` endpoint.

## Review Information
This example is from an `any.js` source-file:
https://manifest-test-source-dot-wptdashboard.appspot.com/results/console/console-counting-label-conversion.any.html

This example is from a `wdspec` python test:
https://manifest-test-source-dot-wptdashboard.appspot.com/webdriver/tests/element_retrieval/get_active_element.py