### PR TITLE
Cleanup deployment script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,33 @@ matrix:
     - language: go
       env:
         - secure: "UuTZnGD+HSB+EYQFg2+lKhDwxlDUtU/uz4XdUG8/8F7Us9G7e7w/DL0jhnzpHjK13ig7Yafj83zZmNszpfaXhNdNp2glhiIeuupODODd24tRA4e9DBIoEToJEyjkXD7RttK4H7SaRp12yVEnE+gnUTiDCOJQHmkDl6DHwwUfeTG3P+dKgHsybdrXcUZG+ff4DPrwq9B6NU7izKC3QqByfcxhfxv+SE9e6vi8LKs6qdRbg4PnPEOc85kiqMmtqNHQ7hph3Np3oEaEeZqMylo2hKh/gXxWgNjH3uFwEtJx7sWYL/c3HpiNRMTPUFVJmGaU/xQqH3gGqEbt0QIjrQVFGJZ0wjJoha1+TigIB9LjJ3eSJCtUwj6naWwi0laOZJyR4L/+XCWpNRH2SjLvakIjims7ZEKbE3rVA/Vr0mY67NLnEm0fh6xglN2Jlm5Mag5hw3bHcOi72sQthjQofEtUE0fElAEGc4wBVCd87LzcLyCvZhg6VeJ/M+kC4uJuiMQJ6qkO92UDaV0bvY9svLlGBuBbd/PH0YPh0kkTUlH5IzJx/wymE2mSwtP8af1n0IBIItVfq6uuzct5IhEZvMoZsDv1pU5pqM/ucRuuvb6rtZedGpGjBZacM1uNa/MbvnF5imAHxfY7783saGaIpdNr6k4cxmHglelxwSR0zqujU2Q="
-        - MAKE_DEPLOY_TARGET=webapp_deploy_staging
+      deploy:
+        # Deploy PRs to branch-named staging environment.
+        - provider: script
+          on:
+            all_branches: true
+            repo: web-platform-tests/wpt.fyi
+            condition: "${TRAVIS_PULL_REQUEST_BRANCH}" != ""
+          script: |
+            # Skip if webapp isn't modified.
+            git diff --name-only FETCH_HEAD...${TRAVIS_BRANCH} | grep ^webapp/ || {
+              echo "No webapp updates, skipping staging deployment."
+              exit 0
+            }
+
+            echo "Copying output to ${TEMP_FILE:=$(mktemp)}"
+            # NOTE: Most gcloud output is stderr, so need to redirect it to stdout.
+            docker exec -t -u $(id -u $USER):$(id -g $USER) "${DOCKER_INSTANCE}" make webapp_deploy_staging BRANCH_NAME=${TRAVIS_PULL_REQUEST_BRANCH} 2>&1 | tee ${TEMP_FILE}
+            if [ "${EXIT_CODE:=${PIPESTATUS[0]}}" != "0" ]; then exit ${EXIT_CODE}; fi
+            DEPLOYED_URL="$(grep -Po 'Deployed to \K[^\s]+' ${TEMP_FILE} | tr -d '\n')"
+            util/deploy-comment.sh "${DEPLOYED_URL}"
+        # Silently, continuously deploy master.
+        - provider: script
+          on:
+            branch: master
+            repo: web-platform-tests/wpt.fyi
+          script: |
+            docker exec -t -u $(id -u $USER):$(id -g $USER) "${DOCKER_INSTANCE}" make webapp_deploy_staging BRANCH_NAME=master
 
 before_install: |
   export DOCKER_FILE=Dockerfile.dev
@@ -76,24 +102,6 @@ install:
     fi
 
 script:
-  - | # Deploy PR to staging environment (only when Travis secrets are available)
-    if [ "${MAKE_DEPLOY_TARGET}" != "" ] \
-        && [ "${TRAVIS_SECURE_ENV_VARS}" != "false" ] \
-        && [ "${TRAVIS_PULL_REQUEST_BRANCH}" != "" ];
-    then
-      # Skip if webapp isn't modified.
-      git diff --name-only FETCH_HEAD...${TRAVIS_BRANCH} | grep ^webapp/ || {
-        echo "No webapp updates, skipping staging deployment."
-        exit 0
-      }
-
-      echo "Copying output to ${TEMP_FILE:=$(mktemp)}"
-      # NOTE: Most gcloud output is stderr, so need to redirect it to stdout.
-      docker exec -t -u $(id -u $USER):$(id -g $USER) "${DOCKER_INSTANCE}" make "${MAKE_DEPLOY_TARGET}" BRANCH_NAME=${TRAVIS_PULL_REQUEST_BRANCH} 2>&1 | tee ${TEMP_FILE}
-      if [ "${EXIT_CODE:=${PIPESTATUS[0]}}" != "0" ]; then exit ${EXIT_CODE}; fi
-      DEPLOYED_URL="$(grep -Po 'Deployed to \K[^\s]+' ${TEMP_FILE} | tr -d '\n')"
-      util/deploy-comment.sh "${DEPLOYED_URL}"
-    fi
   - | # Run tests
     if [ "${MAKE_TEST_TARGET}" != "" ]; then
       docker exec -t -u $(id -u $USER):$(id -g $USER) "${DOCKER_INSTANCE}" make "${MAKE_TEST_TARGET}"


### PR DESCRIPTION
## Description
Cleans up the deployment script to use the more-standard `deploy` lifecycle events in Travis.

Also changes Travis to push the `master` branch when it builds.