### PR TITLE
Add support for platform param in /api/runs

### DIFF
--- a/api/results_redirect_handler_test.go
+++ b/api/results_redirect_handler_test.go
@@ -7,11 +7,11 @@ package api
 import (
 	"testing"
 
-	base "github.com/web-platform-tests/wpt.fyi/shared"
+	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
 type Case struct {
-	testRun  base.TestRun
+	testRun  shared.TestRun
 	testFile string
 	expected string
 }
@@ -25,9 +25,11 @@ func TestGetResultsURL_EmptyFile(t *testing.T) {
 	checkResult(
 		t,
 		Case{
-			base.TestRun{
+			shared.TestRun{
+				PlatformAtRevision: shared.PlatformAtRevision{
+					Revision: shortSHA,
+				},
 				ResultsURL: resultsURL,
-				Revision:   shortSHA,
 			},
 			"",
 			resultsURL,
@@ -39,9 +41,11 @@ func TestGetResultsURL_TestFile(t *testing.T) {
 	checkResult(
 		t,
 		Case{
-			base.TestRun{
+			shared.TestRun{
+				PlatformAtRevision: shared.PlatformAtRevision{
+					Revision: shortSHA,
+				},
 				ResultsURL: resultsURL,
-				Revision:   shortSHA,
 			},
 			file,
 			resultsURLBase + platform + "/" + file,
@@ -52,9 +56,11 @@ func TestGetResultsURL_TrailingSlash(t *testing.T) {
 	checkResult(
 		t,
 		Case{
-			base.TestRun{
+			shared.TestRun{
+				PlatformAtRevision: shared.PlatformAtRevision{
+					Revision: shortSHA,
+				},
 				ResultsURL: resultsURL,
-				Revision:   shortSHA,
 			},
 			"/",
 			resultsURL,

--- a/api/test_runs.go
+++ b/api/test_runs.go
@@ -38,8 +38,8 @@ func apiTestRunsHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	var browserNames []string
-	if browserNames, err = shared.GetBrowsersForRequest(r); err != nil {
+	var platforms []shared.Platform
+	if platforms, err = shared.GetPlatformsForRequest(r); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -55,9 +55,13 @@ func apiTestRunsHandler(w http.ResponseWriter, r *http.Request) {
 		Order("-CreatedAt").
 		Limit(limit)
 
-	for _, browserName := range browserNames {
+	for _, platform := range platforms {
 		var testRunResults []shared.TestRun
-		query := baseQuery.Filter("BrowserName =", browserName)
+		query := baseQuery.Filter("BrowserName =", platform.BrowserName)
+		if platform.BrowserVersion != "" {
+			query = query.Filter("BrowserVersion =", platform.BrowserVersion)
+		}
+		// TODO(lukebjerring): Indexes + filtering for OS + version.
 		if runSHA != "" && runSHA != "latest" {
 			query = query.Filter("Revision =", runSHA)
 		}

--- a/shared/models.go
+++ b/shared/models.go
@@ -6,22 +6,58 @@ package shared
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"time"
 
 	mapset "github.com/deckarep/golang-set"
 )
 
-// TestRun stores metadata for a test run (produced by run/run.py)
-type TestRun struct {
-	// Platform information
+// Platform uniquely defines a browser version, running on an OS version.
+type Platform struct {
 	BrowserName    string `json:"browser_name"`
 	BrowserVersion string `json:"browser_version"`
 	OSName         string `json:"os_name"`
 	OSVersion      string `json:"os_version"`
+}
+
+func (p Platform) String() string {
+	s := p.BrowserName
+	if p.BrowserVersion != "" {
+		s = fmt.Sprintf("%s-%s", s, p.BrowserVersion)
+	}
+	if p.OSName != "" {
+		s = fmt.Sprintf("%s-%s", s, p.OSName)
+		if p.OSVersion != "" {
+			s = fmt.Sprintf("%s-%s", s, p.OSVersion)
+		}
+	}
+	return s
+}
+
+// Version is a struct for a parsed semantic version string.
+type Version struct {
+	Major    string
+	Minor    string
+	Revision string
+}
+
+// PlatformAtRevision defines a WPT run for a specific platform, at a
+// specific hash of the WPT repo.
+type PlatformAtRevision struct {
+	Platform
 
 	// The first 10 characters of the SHA1 of the tested WPT revision
 	Revision string `json:"revision"`
+}
+
+func (p PlatformAtRevision) String() string {
+	return fmt.Sprintf("%s@%s", p.Platform.String(), p.Revision)
+}
+
+// TestRun stores metadata for a test run (produced by run/run.py)
+type TestRun struct {
+	PlatformAtRevision
 
 	// Results URL
 	ResultsURL string `json:"results_url"`

--- a/shared/params.go
+++ b/shared/params.go
@@ -127,17 +127,32 @@ func ParseVersion(version string) (result *Version, err error) {
 	return result, nil
 }
 
+// ParsePlatformParam parses and validates the 'platform' param for the request.
+func ParsePlatformParam(r *http.Request) (platform *Platform, err error) {
+	platformParam := r.URL.Query().Get("platform")
+	if "" == platformParam {
+		return nil, nil
+	}
+	parsed, err := ParsePlatform(platformParam)
+	if err != nil {
+		return nil, err
+	}
+	return &parsed, nil
+}
+
 // ParseBrowserParam parses and validates the 'browser' param for the request.
 // It returns "" by default (and in error cases).
-func ParseBrowserParam(r *http.Request) (browser string, err error) {
-	browser = r.URL.Query().Get("browser")
+func ParseBrowserParam(r *http.Request) (platform *Platform, err error) {
+	browser := r.URL.Query().Get("browser")
 	if "" == browser {
-		return "", nil
+		return nil, nil
 	}
 	if IsBrowserName(browser) {
-		return browser, nil
+		return &Platform{
+			BrowserName: browser,
+		}, nil
 	}
-	return "", fmt.Errorf("Invalid browser param value: %s", browser)
+	return nil, fmt.Errorf("Invalid browser param value: %s", browser)
 }
 
 // ParseBrowsersParam returns a sorted list of browser params for the request.

--- a/shared/params_test.go
+++ b/shared/params_test.go
@@ -81,77 +81,91 @@ func TestParseBrowserParam_Invalid(t *testing.T) {
 	assert.Equal(t, "", browser)
 }
 
-func TestGetBrowsersForRequest(t *testing.T) {
+func TestGetPlatformsForRequest_Default(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/", nil)
-	browsers, err := GetBrowsersForRequest(r)
+	platforms, err := GetPlatformsForRequest(r)
 	assert.Nil(t, err)
 	defaultBrowsers, err := GetBrowserNames()
-	assert.Equal(t, defaultBrowsers, browsers)
+	assert.Equal(t, len(defaultBrowsers), len(platforms))
+	for i := range defaultBrowsers {
+		assert.Equal(t, defaultBrowsers[i], platforms[i].BrowserName)
+	}
 }
 
-func TestGetBrowsersForRequest_ChromeSafari(t *testing.T) {
+func TestGetPlatformsForRequest_BrowserParam_ChromeSafari(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?browsers=chrome,safari", nil)
-	browsers, err := GetBrowsersForRequest(r)
+	browsers, err := GetPlatformsForRequest(r)
 	assert.Nil(t, err)
-	assert.Equal(t, []string{"chrome", "safari"}, browsers)
+	assert.Equal(t, 2, len(browsers))
+	assert.Equal(t, "chrome", browsers[0].BrowserName)
+	assert.Equal(t, "safari", browsers[1].BrowserName)
 }
 
-func TestGetBrowsersForRequest_ChromeInvalid(t *testing.T) {
+func TestGetPlatformsForRequest_BrowserParam_ChromeInvalid(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?browsers=chrome,invalid", nil)
-	_, err := GetBrowsersForRequest(r)
+	_, err := GetPlatformsForRequest(r)
 	assert.NotNil(t, err)
 }
 
-func TestGetBrowsersForRequest_EmptyCommas(t *testing.T) {
+func TestGetPlatformsForRequest_BrowserParam_EmptyCommas(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?browsers=,chrome,,,,safari,,", nil)
-	browsers, err := GetBrowsersForRequest(r)
+	platforms, err := GetPlatformsForRequest(r)
 	assert.Nil(t, err)
-	assert.Equal(t, []string{"chrome", "safari"}, browsers)
+	assert.Equal(t, 2, len(platforms))
+	assert.Equal(t, "chrome", platforms[0].BrowserName) // Alphabetical
+	assert.Equal(t, "safari", platforms[1].BrowserName)
 }
 
-func TestGetBrowsersForRequest_SafariChrome(t *testing.T) {
+func TestGetPlatformsForRequest_BrowserParam_SafariChrome(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?browsers=safari,chrome", nil)
-	browsers, err := GetBrowsersForRequest(r)
+	platforms, err := GetPlatformsForRequest(r)
 	assert.Nil(t, err)
-	assert.Equal(t, []string{"chrome", "safari"}, browsers) // Alphabetical
+	assert.Equal(t, 2, len(platforms))
+	assert.Equal(t, "chrome", platforms[0].BrowserName) // Alphabetical
+	assert.Equal(t, "safari", platforms[1].BrowserName)
 }
 
-func TestGetBrowsersForRequest_MultiBrowserParam_SafariChrome(t *testing.T) {
+func TestGetPlatformsForRequest_BrowserParam_MultiBrowserParam_SafariChrome(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?browser=safari&browser=chrome", nil)
-	browsers, err := GetBrowsersForRequest(r)
+	platforms, err := GetPlatformsForRequest(r)
 	assert.Nil(t, err)
-	assert.Equal(t, []string{"chrome", "safari"}, browsers)
+	assert.Equal(t, 2, len(platforms))
+	assert.Equal(t, "chrome", platforms[0].BrowserName) // Alphabetical
+	assert.Equal(t, "safari", platforms[1].BrowserName)
 }
 
-func TestGetBrowsersForRequest_MultiBrowserParam_SafariInvalid(t *testing.T) {
+func TestGetPlatformsForRequest_BrowserParam_MultiBrowserParam_SafariInvalid(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?browser=safari&browser=invalid", nil)
-	_, err := GetBrowsersForRequest(r)
+	_, err := GetPlatformsForRequest(r)
 	assert.NotNil(t, err)
 }
 
-func TestGetBrowsersForRequest_ChromeLabel(t *testing.T) {
+func TestGetPlatformsForRequest_BrowserParam_ChromeLabel(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?label=chrome", nil)
-	browsers, err := GetBrowsersForRequest(r)
+	platforms, err := GetPlatformsForRequest(r)
 	assert.Nil(t, err)
-	assert.Equal(t, []string{"chrome", "chrome-experimental"}, browsers)
+	assert.Equal(t, 2, len(platforms))
+	assert.Equal(t, "chrome", platforms[0].BrowserName)
+	assert.Equal(t, "chrome-experimental", platforms[1].BrowserName)
 }
 
-func TestGetBrowsersForRequest_ExperimentalLabel(t *testing.T) {
+func TestGetPlatformsForRequest_BrowserParam_ExperimentalLabel(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?labels=experimental", nil)
-	browsers, err := GetBrowsersForRequest(r)
+	platforms, err := GetPlatformsForRequest(r)
 	assert.Nil(t, err)
 	names, _ := GetBrowserNames()
+	assert.Equal(t, len(names), len(platforms))
 	for i := range names {
-		names[i] = names[i] + "-" + ExperimentalLabel
+		assert.Equal(t, names[i]+"-"+ExperimentalLabel, platforms[i].BrowserName)
 	}
-	assert.Equal(t, names, browsers)
 }
 
-func TestGetBrowsersForRequest_ChromeAndExperimentalLabel(t *testing.T) {
+func TestGetPlatformsForRequest_BrowserParam_ChromeAndExperimentalLabel(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?labels=chrome,experimental", nil)
-	browsers, err := GetBrowsersForRequest(r)
+	platforms, err := GetPlatformsForRequest(r)
 	assert.Nil(t, err)
-	assert.Equal(t, []string{"chrome-experimental"}, browsers)
+	assert.Equal(t, 1, len(platforms))
+	assert.Equal(t, "chrome-experimental", platforms[0].BrowserName)
 }
 
 func TestParseMaxCountParam_Missing(t *testing.T) {
@@ -308,4 +322,38 @@ func TestParseLabelsParam_LabelsAndLabel_Duplicate(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/api/runs?labels=experimental&label=experimental", nil)
 	labels := ParseLabelsParam(r)
 	assert.Equal(t, 1, labels.Cardinality())
+}
+
+func TestParsePlatformAtRevision(t *testing.T) {
+	platformAtRevision, err := ParsePlatformAtRevision("chrome@latest")
+	assert.Nil(t, err)
+	assert.Equal(t, "chrome", platformAtRevision.BrowserName)
+	assert.Equal(t, "latest", platformAtRevision.Revision)
+}
+
+func TestParsePlatformAtRevision_BrowserVersion(t *testing.T) {
+	platformAtRevision, err := ParsePlatformAtRevision("chrome-63.0@latest")
+	assert.Nil(t, err)
+	assert.Equal(t, "chrome", platformAtRevision.BrowserName)
+	assert.Equal(t, "63.0", platformAtRevision.BrowserVersion)
+	assert.Equal(t, "latest", platformAtRevision.Revision)
+}
+
+func TestParsePlatformAtRevision_OS(t *testing.T) {
+	platformAtRevision, err := ParsePlatformAtRevision("chrome-63.0-linux@latest")
+	assert.Nil(t, err)
+	assert.Equal(t, "chrome", platformAtRevision.BrowserName)
+	assert.Equal(t, "63.0", platformAtRevision.BrowserVersion)
+	assert.Equal(t, "linux", platformAtRevision.OSName)
+	assert.Equal(t, "latest", platformAtRevision.Revision)
+}
+
+func TestParsePlatformAtRevision_OSVersion(t *testing.T) {
+	platformAtRevision, err := ParsePlatformAtRevision("chrome-63.0-linux-4.4@latest")
+	assert.Nil(t, err)
+	assert.Equal(t, "chrome", platformAtRevision.BrowserName)
+	assert.Equal(t, "63.0", platformAtRevision.BrowserVersion)
+	assert.Equal(t, "linux", platformAtRevision.OSName)
+	assert.Equal(t, "4.4", platformAtRevision.OSVersion)
+	assert.Equal(t, "latest", platformAtRevision.Revision)
 }

--- a/shared/params_test.go
+++ b/shared/params_test.go
@@ -64,21 +64,22 @@ func TestParseBrowserParam(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/", nil)
 	browser, err := ParseBrowserParam(r)
 	assert.Nil(t, err)
-	assert.Equal(t, "", browser)
+	assert.Nil(t, browser)
 }
 
 func TestParseBrowserParam_Chrome(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?browser=chrome", nil)
 	browser, err := ParseBrowserParam(r)
 	assert.Nil(t, err)
-	assert.Equal(t, "chrome", browser)
+	assert.NotNil(t, browser)
+	assert.Equal(t, "chrome", browser.BrowserName)
 }
 
 func TestParseBrowserParam_Invalid(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?browser=invalid", nil)
 	browser, err := ParseBrowserParam(r)
 	assert.NotNil(t, err)
-	assert.Equal(t, "", browser)
+	assert.Nil(t, browser)
 }
 
 func TestGetPlatformsForRequest_Default(t *testing.T) {

--- a/shared/run_diff.go
+++ b/shared/run_diff.go
@@ -7,7 +7,6 @@ package shared
 import (
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -18,36 +17,6 @@ import (
 	"google.golang.org/appengine/datastore"
 	"google.golang.org/appengine/urlfetch"
 )
-
-// PlatformAtRevision is represents a test-run spec, of [platform]@[SHA],
-// e.g. 'chrome@latest' or 'safari-10@abcdef1234'
-type PlatformAtRevision struct {
-	// Platform is the string representing browser (+ version), and OS (+ version).
-	Platform string
-
-	// Revision is the SHA[0:10] of the git repo.
-	Revision string
-}
-
-// ParsePlatformAtRevisionSpec parses a test-run spec into a PlatformAtRevision struct.
-func ParsePlatformAtRevisionSpec(spec string) (platformAtRevision PlatformAtRevision, err error) {
-	pieces := strings.Split(spec, "@")
-	if len(pieces) > 2 {
-		return platformAtRevision, errors.New("invalid platform@revision spec: " + spec)
-	}
-	platformAtRevision.Platform = pieces[0]
-	if len(pieces) < 2 {
-		// No @ is assumed to be the platform only.
-		platformAtRevision.Revision = "latest"
-	} else {
-		platformAtRevision.Revision = pieces[1]
-	}
-	// TODO(lukebjerring): Also handle actual platforms (with version + os)
-	if IsBrowserName(platformAtRevision.Platform) {
-		return platformAtRevision, nil
-	}
-	return platformAtRevision, errors.New("Platform " + platformAtRevision.Platform + " not found")
-}
 
 func FetchRunResultsJSONForParam(
 	ctx context.Context, r *http.Request, param string) (results map[string][]int, err error) {
@@ -60,7 +29,7 @@ func FetchRunResultsJSONForParam(
 		return FetchRunResultsJSON(ctx, r, run)
 	}
 	var spec PlatformAtRevision
-	if spec, err = ParsePlatformAtRevisionSpec(param); err != nil {
+	if spec, err = ParsePlatformAtRevision(param); err != nil {
 		return nil, err
 	}
 	return FetchRunResultsJSONForSpec(ctx, r, spec)

--- a/util/populate_dev_data.go
+++ b/util/populate_dev_data.go
@@ -13,7 +13,7 @@ import (
 	"github.com/deckarep/golang-set"
 
 	"github.com/web-platform-tests/results-analysis/metrics"
-	base "github.com/web-platform-tests/wpt.fyi/shared"
+	"github.com/web-platform-tests/wpt.fyi/shared"
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/appengine/datastore"
@@ -41,48 +41,64 @@ func main() {
 		log.Fatal(err)
 	}
 
-	emptySecretToken := &base.Token{}
+	emptySecretToken := &shared.Token{}
 	staticDataTime, _ := time.Parse(time.RFC3339, "2017-10-18T00:00:00Z")
 
 	// Follow pattern established in run/*.py data collection code.
 	const staticRunSHA = "b952881825"
 	const summaryURLFmtString = "/static/" + staticRunSHA + "/%s"
-	staticTestRuns := []base.TestRun{
+	staticTestRuns := []shared.TestRun{
 		{
-			BrowserName:    "chrome",
-			BrowserVersion: "63.0",
-			OSName:         "linux",
-			OSVersion:      "3.16",
-			Revision:       staticRunSHA,
-			ResultsURL:     fmt.Sprintf(summaryURLFmtString, "chrome-63.0-linux-summary.json.gz"),
-			CreatedAt:      staticDataTime,
+			PlatformAtRevision: shared.PlatformAtRevision{
+				Platform: shared.Platform{
+					BrowserName:    "chrome",
+					BrowserVersion: "63.0",
+					OSName:         "linux",
+					OSVersion:      "3.16",
+				},
+				Revision: staticRunSHA,
+			},
+			ResultsURL: fmt.Sprintf(summaryURLFmtString, "chrome-63.0-linux-summary.json.gz"),
+			CreatedAt:  staticDataTime,
 		},
 		{
-			BrowserName:    "edge",
-			BrowserVersion: "15",
-			OSName:         "windows",
-			OSVersion:      "10",
-			Revision:       staticRunSHA,
-			ResultsURL:     fmt.Sprintf(summaryURLFmtString, "edge-15-windows-10-sauce-summary.json.gz"),
-			CreatedAt:      staticDataTime,
+			PlatformAtRevision: shared.PlatformAtRevision{
+				Platform: shared.Platform{
+					BrowserName:    "edge",
+					BrowserVersion: "15",
+					OSName:         "windows",
+					OSVersion:      "10",
+				},
+				Revision: staticRunSHA,
+			},
+			ResultsURL: fmt.Sprintf(summaryURLFmtString, "edge-15-windows-10-sauce-summary.json.gz"),
+			CreatedAt:  staticDataTime,
 		},
 		{
-			BrowserName:    "firefox",
-			BrowserVersion: "57.0",
-			OSName:         "linux",
-			OSVersion:      "*",
-			Revision:       staticRunSHA,
-			ResultsURL:     fmt.Sprintf(summaryURLFmtString, "firefox-57.0-linux-summary.json.gz"),
-			CreatedAt:      staticDataTime,
+			PlatformAtRevision: shared.PlatformAtRevision{
+				Platform: shared.Platform{
+					BrowserName:    "firefox",
+					BrowserVersion: "57.0",
+					OSName:         "linux",
+					OSVersion:      "*",
+				},
+				Revision: staticRunSHA,
+			},
+			ResultsURL: fmt.Sprintf(summaryURLFmtString, "firefox-57.0-linux-summary.json.gz"),
+			CreatedAt:  staticDataTime,
 		},
 		{
-			BrowserName:    "safari",
-			BrowserVersion: "10",
-			OSName:         "macos",
-			OSVersion:      "10.12",
-			Revision:       staticRunSHA,
-			ResultsURL:     fmt.Sprintf(summaryURLFmtString, "safari-10-macos-10.12-sauce-summary.json.gz"),
-			CreatedAt:      staticDataTime,
+			PlatformAtRevision: shared.PlatformAtRevision{
+				Platform: shared.Platform{
+					BrowserName:    "safari",
+					BrowserVersion: "10",
+					OSName:         "macos",
+					OSVersion:      "10.12",
+				},
+				Revision: staticRunSHA,
+			},
+			ResultsURL: fmt.Sprintf(summaryURLFmtString, "safari-10-macos-10.12-sauce-summary.json.gz"),
+			CreatedAt:  staticDataTime,
 		},
 	}
 
@@ -150,7 +166,7 @@ func main() {
 	addData(ctx, failuresMetadataKindName, staticFailuresMetadata)
 
 	log.Print("Adding latest production TestRun data...")
-	prodTestRuns := base.FetchLatestRuns(*host)
+	prodTestRuns := shared.FetchLatestRuns(*host)
 	latestProductionTestRunMetadata := make([]interface{}, len(prodTestRuns))
 	for i := range prodTestRuns {
 		latestProductionTestRunMetadata[i] = &prodTestRuns[i]
@@ -158,7 +174,7 @@ func main() {
 	addData(ctx, testRunKindName, latestProductionTestRunMetadata)
 
 	log.Print("Adding latest experimental TestRun data...")
-	prodTestRuns = base.FetchRuns(*host, "latest", mapset.NewSet("experimental"))
+	prodTestRuns = shared.FetchRuns(*host, "latest", mapset.NewSet("experimental"))
 	latestProductionTestRunMetadata = make([]interface{}, len(prodTestRuns))
 	for i := range prodTestRuns {
 		latestProductionTestRunMetadata[i] = &prodTestRuns[i]

--- a/webapp/anomaly_handler.go
+++ b/webapp/anomaly_handler.go
@@ -23,12 +23,12 @@ type AnomalyData struct {
 // anomalyHandler handles the view of test results showing which tests pass in
 // some, but not all, browsers.
 func anomalyHandler(w http.ResponseWriter, r *http.Request) {
-	browser, err := shared.ParseBrowserParam(r)
+	platform, err := shared.ParseBrowserParam(r)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
-	} else if browser != "" {
-		browserAnomalyHandler(w, r, browser)
+	} else if platform != nil {
+		browserAnomalyHandler(w, r, platform.BrowserName)
 		return
 	}
 

--- a/webapp/test_results_handler.go
+++ b/webapp/test_results_handler.go
@@ -116,10 +116,10 @@ func getTestRunsAndSources(r *http.Request, runSHA string) (testRunSources []str
 			testRuns = append(testRuns, run)
 		} else {
 			var beforeSpec shared.PlatformAtRevision
-			if beforeSpec, err = shared.ParsePlatformAtRevisionSpec(before); err != nil {
+			if beforeSpec, err = shared.ParsePlatformAtRevision(before); err != nil {
 				return nil, nil, errors.New("invalid before param")
 			}
-			testRunSources = append(testRunSources, fmt.Sprintf(singleRunURL, beforeSpec.Revision, beforeSpec.Platform))
+			testRunSources = append(testRunSources, fmt.Sprintf(singleRunURL, beforeSpec.Revision, beforeSpec.Platform.String()))
 		}
 
 		if afterDecoded, err := base64.URLEncoding.DecodeString(after); err == nil {
@@ -130,10 +130,10 @@ func getTestRunsAndSources(r *http.Request, runSHA string) (testRunSources []str
 			testRuns = append(testRuns, run)
 		} else {
 			var afterSpec shared.PlatformAtRevision
-			if afterSpec, err = shared.ParsePlatformAtRevisionSpec(after); err != nil {
+			if afterSpec, err = shared.ParsePlatformAtRevision(after); err != nil {
 				return nil, nil, errors.New("invalid after param")
 			}
-			testRunSources = append(testRunSources, fmt.Sprintf(singleRunURL, afterSpec.Revision, afterSpec.Platform))
+			testRunSources = append(testRunSources, fmt.Sprintf(singleRunURL, afterSpec.Revision, afterSpec.Platform.String()))
 		}
 	} else {
 		var sourceURL = `/api/runs?sha=%s`

--- a/webapp/test_results_handler.go
+++ b/webapp/test_results_handler.go
@@ -106,7 +106,7 @@ func getTestRunsAndSources(r *http.Request, runSHA string) (testRunSources []str
 			return nil, nil, errors.New("before param provided, but after param missing")
 		}
 
-		const singleRunURL = `/api/run?sha=%s&browser=%s`
+		const singleRunURL = `/api/run?sha=%s&platform=%s`
 
 		if beforeDecoded, err := base64.URLEncoding.DecodeString(before); err == nil {
 			var run shared.TestRun


### PR DESCRIPTION
## Description
Currently, we can't distinguish between different versions of browsers, making it impossible to compare, say, the latest run of Edge 16 and Edge 17.

This PR extracts the `Platform` struct, for re-use in `PlatformAtRevision`, which is used in `TestRun`.
We treat the existing `?browser=chrome` as the equivalent of `?platform=chrome` (which does not specify a version or OS.).

## Review
Deployed to https://browser-param-dot-wptdashboard.appspot.com/

### Example uses
Fetching specific edge version
https://browser-param-dot-wptdashboard.appspot.com/api/runs?platform=edge-15

Diffing edge-15 and edge-16
https://browser-param-dot-wptdashboard.appspot.com/results/?before=edge-15&after=edge-16