### PR TITLE
Fix flaky golang test by sorting products

### DIFF
--- a/shared/models.go
+++ b/shared/models.go
@@ -35,6 +35,13 @@ func (p Product) String() string {
 	return s
 }
 
+// ByBrowserName is a []Product sortable by BrowserName values.
+type ByBrowserName []Product
+
+func (e ByBrowserName) Len() int           { return len(e) }
+func (e ByBrowserName) Swap(i, j int)      { e[i], e[j] = e[j], e[i] }
+func (e ByBrowserName) Less(i, j int) bool { return e[i].BrowserName < e[j].BrowserName }
+
 // Version is a struct for a parsed semantic version string.
 type Version struct {
 	Major    string

--- a/shared/params.go
+++ b/shared/params.go
@@ -200,7 +200,7 @@ func ParseProductsParam(r *http.Request) (products []Product, err error) {
 }
 
 // GetProductsForRequest parses the 'products' (and legacy 'browsers') params, returning
-// the list of products to include, or a default list.
+// the sorted list of products to include, or a default list.
 func GetProductsForRequest(r *http.Request) (products []Product, err error) {
 	if products, err = ParseProductsParam(r); err != nil {
 		return nil, err
@@ -265,6 +265,7 @@ func GetProductsForRequest(r *http.Request) (products []Product, err error) {
 		}
 	}
 
+	sort.Sort(ByBrowserName(products))
 	return products, nil
 }
 

--- a/shared/params_test.go
+++ b/shared/params_test.go
@@ -176,9 +176,9 @@ func TestGetProductsForRequest_BrowserAndProductParam(t *testing.T) {
 	products, err := GetProductsForRequest(r)
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(products))
-	assert.Equal(t, "edge", products[0].BrowserName)
-	assert.Equal(t, "16", products[0].BrowserVersion)
-	assert.Equal(t, "chrome", products[1].BrowserName)
+	assert.Equal(t, "chrome", products[0].BrowserName)
+	assert.Equal(t, "edge", products[1].BrowserName)
+	assert.Equal(t, "16", products[1].BrowserVersion)
 }
 
 func TestGetProductsForRequest_BrowsersAndProductsParam(t *testing.T) {
@@ -186,11 +186,11 @@ func TestGetProductsForRequest_BrowsersAndProductsParam(t *testing.T) {
 	products, err := GetProductsForRequest(r)
 	assert.Nil(t, err)
 	assert.Equal(t, 4, len(products))
-	assert.Equal(t, "edge", products[0].BrowserName)
-	assert.Equal(t, "16", products[0].BrowserVersion)
-	assert.Equal(t, "safari", products[1].BrowserName)
-	assert.Equal(t, "chrome", products[2].BrowserName)
-	assert.Equal(t, "firefox", products[3].BrowserName)
+	assert.Equal(t, "chrome", products[0].BrowserName)
+	assert.Equal(t, "edge", products[1].BrowserName)
+	assert.Equal(t, "16", products[1].BrowserVersion)
+	assert.Equal(t, "firefox", products[2].BrowserName)
+	assert.Equal(t, "safari", products[3].BrowserName)
 }
 
 func TestParseMaxCountParam_Missing(t *testing.T) {


### PR DESCRIPTION
## Description
Tests were sometimes failing, because order of enumerating a mapset is non-deterministic.
This PR explicitly sorts the set (by BrowserName alphabetically).