### PR TITLE
[processor] Implement WPTReport and tests

### DIFF
--- a/results-processor/.gitignore
+++ b/results-processor/.gitignore
@@ -1,0 +1,3 @@
+env/
+.tox/
+__pycache__/

--- a/results-processor/requirements-top_level.txt
+++ b/results-processor/requirements-top_level.txt
@@ -1,3 +1,4 @@
 Flask
 google-cloud-storage
 gunicorn
+flake8

--- a/results-processor/requirements.txt
+++ b/results-processor/requirements.txt
@@ -1,7 +1,8 @@
-cachetools==2.0.1
+cachetools==2.1.0
 certifi==2018.4.16
 chardet==3.0.4
 click==6.7
+flake8==3.5.0
 Flask==1.0.2
 google-api-core==1.1.2
 google-auth==1.4.1
@@ -14,9 +15,12 @@ idna==2.6
 itsdangerous==0.24
 Jinja2==2.10
 MarkupSafe==1.0
+mccabe==0.6.1
 protobuf==3.5.2.post1
 pyasn1==0.4.2
 pyasn1-modules==0.2.1
+pycodestyle==2.3.1
+pyflakes==1.6.0
 pytz==2018.4
 requests==2.18.4
 rsa==3.4.2

--- a/results-processor/tox.ini
+++ b/results-processor/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py3
+# We don't have or need setup.py for now.
+skipsdist=True
+
+[testenv]
+deps = -rrequirements.txt
+commands = python -m unittest discover . "*_test.py"

--- a/results-processor/tox.ini
+++ b/results-processor/tox.ini
@@ -5,4 +5,6 @@ skipsdist=True
 
 [testenv]
 deps = -rrequirements.txt
-commands = python -m unittest discover . "*_test.py"
+commands =
+    flake8 *.py
+    python -m unittest discover . "*_test.py"

--- a/results-processor/wptreport.py
+++ b/results-processor/wptreport.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+
+# Copyright 2018 The WPT Dashboard Project. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import argparse
+import gzip
+import io
+import json
+import os
+
+
+class InsufficientData(Exception):
+    """Execption for empty/incomplete WPTReport."""
+    def __init__(self):
+        super(InsufficientData, self).__init__("Zero results available")
+
+
+class WPTReport(object):
+    """An abstraction of wptreport.json with some transformation features."""
+
+    def __init__(self):
+        self._report = dict()
+        self._summary = dict()
+
+    def load_json(self, fileobj):
+        """Loads wptreport from a JSON file.
+
+        Args:
+            fileobj: A JSON file object.
+        """
+        if isinstance(fileobj, io.TextIOBase):
+            self._report = json.load(fileobj, strict=False)
+        else:
+            # Wrap the fileobj in case it's in binary mode.
+            # JSON files are always encoded in UTF-8 (RFC 8529).
+            with io.TextIOWrapper(fileobj, encoding='utf-8') as text_file:
+                self._report = json.load(text_file, strict=False)
+        # Raise when 'results' is either not found or empty.
+        if not self._report.get('results'):
+            raise InsufficientData
+
+    def load_gzip_json(self, fileobj):
+        """Loads wptreport from a gzipped JSON file.
+
+        Args:
+            fileobj: A gzip file object.
+        """
+        # Gzip is always opened in binary mode (in fact, r == rb for gzip).
+        with gzip.GzipFile(fileobj=fileobj, mode='rb') as gzip_file:
+            self.load_json(gzip_file)
+
+    @staticmethod
+    def write_json(filepath, payload):
+        """Encode an object to JSON and writes it to disk.
+
+        Args:
+            filepath: A file path to write to. All intermediate directories
+                in the path will be automatically created.
+            payload: An object that can be JSON encoded.
+        """
+        if os.path.dirname(filepath):
+            os.makedirs(os.path.dirname(filepath), exist_ok=True)
+        # json.dump only produces ASCII characters by default.
+        with io.open(filepath, 'w', encoding='ascii') as json_file:
+            json.dump(payload, json_file)
+
+    @property
+    def results(self):
+        """The 'results' field of the report, or None if it doesn't exists."""
+        return self._report.get('results')
+
+    @property
+    def run_info(self):
+        """The 'run_info' field of the report, or None if it doesn't exists."""
+        return self._report.get('run_info')
+
+    def summarize(self):
+        """Creates a summary of all the test results.
+
+        The summary will be cached after the first call to this method.
+
+        Returns:
+            A summary dictionary.
+
+        Raises:
+            InsufficientData if the dataset contains zero test results.
+        """
+        if self._summary:
+            return self._summary
+
+        if not self.results:
+            raise InsufficientData
+
+        for result in self.results:
+            test_file = result['test']
+
+            assert test_file not in self._summary, (
+                'Found duplicate entries for %s' % test_file)
+
+            if result['status'] in ('OK', 'PASS'):
+                self._summary[test_file] = [1, 1]
+            else:
+                self._summary[test_file] = [0, 1]
+
+            for subtest in result['subtests']:
+                if subtest['status'] == 'PASS':
+                    self._summary[test_file][0] += 1
+                self._summary[test_file][1] += 1
+
+        return self._summary
+
+    def each_result(self):
+        """Iterates over all the individual test results.
+
+        Returns:
+            A generator.
+        """
+        return (result for result in self.results)
+
+    def write_summary(self, filepath):
+        """Writes the summary JSON file to disk.
+
+        Args:
+            filepath: A file path to write to.
+        """
+        self.write_json(filepath, self.summarize())
+
+    def write_result_directory(self, directory):
+        """Writes individual test results to a directory.
+
+        Args:
+            directory: The base directory to write to.
+        """
+        if directory.endswith('/'):
+            directory = directory[:-1]
+        for result in self.each_result():
+            test_file = result['test']
+            assert test_file.startswith('/')
+            filepath = directory + test_file
+            self.write_json(filepath, result)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Parse and transform JSON wptreport.')
+    parser.add_argument('report', metavar='REPORT', type=str,
+                        help='path to a JSON wptreport (gzipped files are '
+                        'supported as long as the extension is .gz)')
+    parser.add_argument('--summary', type=str,
+                        help='if specified, write a JSON summary to this file')
+    parser.add_argument('--results-directory', type=str,
+                        help='if specified, split the full report into tests '
+                        'and write individual results to this directory')
+    args = parser.parse_args()
+
+    report = WPTReport()
+    if args.report.endswith('.gz'):
+        with open(args.report, 'rb') as f:
+            report.load_gzip_json(f)
+    else:
+        with open(args.report, 'rt') as f:
+            report.load_json(f)
+    if args.summary:
+        report.write_summary(args.summary)
+    if args.results_directory:
+        report.write_result_directory(args.results_directory)
+
+
+if __name__ == '__main__':
+    main()

--- a/results-processor/wptreport_test.py
+++ b/results-processor/wptreport_test.py
@@ -1,0 +1,189 @@
+# Copyright 2018 The WPT Dashboard Project. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import gzip
+import json
+import os
+import shutil
+import tempfile
+import unittest
+
+from wptreport import WPTReport, InsufficientData
+
+
+class WPTReportTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp_dir)
+
+    def test_write_json(self):
+        obj = {'results': [{
+            'test': 'ABC~‾¥≈¤･・•∙·☼★星🌟星★☼·∙•・･¤≈¥‾~XYZ',
+            'message': None,
+            'status': 'PASS'
+        }]}
+        tmp_path = os.path.join(self.tmp_dir, 'foo', 'bar.json')
+        WPTReport.write_json(tmp_path, obj)
+        with open(tmp_path, 'r') as f:
+            round_trip = json.load(f)
+        self.assertDictEqual(obj, round_trip)
+
+    def test_load_json_binary_mode(self):
+        tmp_path = os.path.join(self.tmp_dir, 'test.json')
+        with open(tmp_path, 'wt') as f:
+            f.write('{"results": [{"test": "foo"}]}')
+        r = WPTReport()
+        with open(tmp_path, 'rb') as f:
+            r.load_json(f)
+        self.assertEqual(len(r.results), 1)
+
+    def test_load_json_text_mode(self):
+        tmp_path = os.path.join(self.tmp_dir, 'test.json')
+        with open(tmp_path, 'wt') as f:
+            f.write('{"results": [{"test": "foo"}]}')
+        r = WPTReport()
+        with open(tmp_path, 'rt') as f:
+            r.load_json(f)
+        self.assertEqual(len(r.results), 1)
+
+    def test_load_json_empty_report(self):
+        tmp_path = os.path.join(self.tmp_dir, 'test.json')
+        with open(tmp_path, 'wt') as f:
+            f.write('{}')
+        r = WPTReport()
+        with open(tmp_path, 'rt') as f:
+            with self.assertRaises(InsufficientData):
+                r.load_json(f)
+
+    def test_load_gzip_json(self):
+        # This case also covers the Unicode testing of load_json.
+        obj = {'results': [{
+            'test': 'ABC~‾¥≈¤･・•∙·☼★星🌟星★☼·∙•・･¤≈¥‾~XYZ',
+            'message': None,
+            'status': 'PASS'
+        }]}
+        json_s = json.dumps(obj, ensure_ascii=False)
+        tmp_path = os.path.join(self.tmp_dir, 'test.json.gz')
+        with open(tmp_path, 'wb') as f:
+            gzip_file = gzip.GzipFile(fileobj=f, mode='wb')
+            gzip_file.write(json_s.encode('utf-8'))
+            gzip_file.close()
+
+        r = WPTReport()
+        with open(tmp_path, 'rb') as f:
+            r.load_gzip_json(f)
+        self.assertDictEqual(r._report, obj)
+
+    def test_summarize(self):
+        r = WPTReport()
+        r._report = {'results': [
+            {
+                'test': '/js/with-statement.html',
+                'status': 'OK',
+                'message': None,
+                'subtests': [
+                    {'status': 'PASS', 'message': None, 'name': 'first'},
+                    {'status': 'FAIL', 'message': 'bad', 'name': 'second'}
+                ]
+            },
+            {
+                'test': '/js/isNaN.html',
+                'status': 'OK',
+                'message': None,
+                'subtests': [
+                    {'status': 'PASS', 'message': None, 'name': 'first'},
+                    {'status': 'FAIL', 'message': 'bad', 'name': 'second'},
+                    {'status': 'PASS', 'message': None, 'name': 'third'}
+                ]
+            }
+        ]}
+        self.assertEqual(r.summarize(), {
+            '/js/with-statement.html': [2, 3],
+            '/js/isNaN.html': [3, 4]
+        })
+
+    def test_summarize_zero_results(self):
+        r = WPTReport()
+        with self.assertRaises(InsufficientData):
+            r.summarize()
+
+    def test_summarize_duplicate_results(self):
+        r = WPTReport()
+        r._report = {'results': [
+            {
+                'test': '/js/with-statement.html',
+                'status': 'OK',
+                'message': None,
+                'subtests': [
+                    {'status': 'PASS', 'message': None, 'name': 'first'},
+                    {'status': 'FAIL', 'message': 'bad', 'name': 'second'}
+                ]
+            },
+            {
+                'test': '/js/with-statement.html',
+                'status': 'OK',
+                'message': None,
+                'subtests': [
+                    {'status': 'PASS', 'message': None, 'name': 'first'},
+                    {'status': 'FAIL', 'message': 'bad', 'name': 'second'},
+                    {'status': 'FAIL', 'message': 'bad', 'name': 'third'},
+                    {'status': 'FAIL', 'message': 'bad', 'name': 'fourth'}
+                ]
+            }
+        ]}
+        with self.assertRaises(AssertionError):
+            r.summarize()
+
+    def test_each_result(self):
+        expected_results = [
+            {
+                'test': '/js/with-statement.html',
+                'status': 'OK',
+                'message': None,
+                'subtests': [
+                    {'status': 'PASS', 'message': None, 'name': 'first'},
+                    {'status': 'FAIL', 'message': 'bad', 'name': 'second'}
+                ]
+            },
+            {
+                'test': '/js/isNaN.html',
+                'status': 'OK',
+                'message': None,
+                'subtests': [
+                    {'status': 'PASS', 'message': None, 'name': 'first'},
+                    {'status': 'FAIL', 'message': 'bad', 'name': 'second'},
+                    {'status': 'PASS', 'message': None, 'name': 'third'}
+                ]
+            },
+            {
+                'test': '/js/do-while-statement.html',
+                'status': 'OK',
+                'message': None,
+                'subtests': [
+                    {'status': 'PASS', 'message': None, 'name': 'first'}
+                ]
+            },
+            {
+                'test': '/js/symbol-unscopables.html',
+                'status': 'TIMEOUT',
+                'message': None,
+                'subtests': []
+            },
+            {
+                'test': '/js/void-statement.html',
+                'status': 'OK',
+                'message': None,
+                'subtests': [
+                    {'status': 'PASS', 'message': None, 'name': 'first'},
+                    {'status': 'FAIL', 'message': 'bad', 'name': 'second'},
+                    {'status': 'FAIL', 'message': 'bad', 'name': 'third'},
+                    {'status': 'FAIL', 'message': 'bad', 'name': 'fourth'}
+                ]
+            }
+        ]
+        r = WPTReport()
+        r._report = {'results': expected_results}
+        self.assertListEqual(list(r.each_result()), expected_results)


### PR DESCRIPTION
WPTReport abstracts wptreport.json and provides some helper functions to
summarize and split the full report (the split output is needed by the
current frontend).

The code is largely based on
https://github.com/web-platform-tests/results-collection/blob/master/src/scripts/upload-wpt-results.py
but without any sharding support.

wptreport.py is also an executable (requires Python 3), a handy script
to summarize and/or split a wptreport JSON locally. See its help message
for detailed usage.

The plan is to run unit tests via `tox`, which takes care of creating
virtualenv and installing dependencies. The setup currently works
locally as long as Python 3 and tox are available. It hasn't been
integrated into Travis or the project Makefile yet; the integration will
happen soon later.
