### PR TITLE
[processor] Implement GCS upload & task handler

### DIFF
--- a/results-processor/Dockerfile
+++ b/results-processor/Dockerfile
@@ -20,4 +20,4 @@ ADD requirements.txt /app/
 RUN pip install -r requirements.txt
 
 ADD . /app/
-CMD exec gunicorn -b :$PORT test:app
+CMD exec gunicorn -b :$PORT main:app

--- a/results-processor/Dockerfile
+++ b/results-processor/Dockerfile
@@ -20,4 +20,4 @@ ADD requirements.txt /app/
 RUN pip install -r requirements.txt
 
 ADD . /app/
-CMD exec gunicorn -b :$PORT main:app
+CMD exec gunicorn -b :$PORT -t 3600 main:app

--- a/results-processor/gsutil.py
+++ b/results-processor/gsutil.py
@@ -1,0 +1,32 @@
+# Copyright 2018 The WPT Dashboard Project. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import logging
+import subprocess
+
+
+_log = logging.getLogger(__name__)
+_log.setLevel(logging.INFO)
+
+
+def gs_to_public_url(gcs_path):
+    assert gcs_path.startswith('gs://')
+    return gcs_path.replace('gs://', 'https://storage.googleapis.com/', 1)
+
+
+def rsync(path1, path2):
+    command = [
+        'gsutil', '-m', '-h', 'Content-Encoding:gzip', 'rsync', '-r',
+        path1, path2
+    ]
+    _log.info(' '.join(command))
+    subprocess.check_call(command)
+
+
+def copy(path1, path2):
+    command = [
+        'gsutil', '-m', 'cp', '-r', path1, path2
+    ]
+    _log.info(' '.join(command))
+    subprocess.check_call(command)

--- a/results-processor/gsutil.py
+++ b/results-processor/gsutil.py
@@ -10,23 +10,29 @@ _log = logging.getLogger(__name__)
 _log.setLevel(logging.INFO)
 
 
+def _call(command, quiet=False):
+    _log.info(' '.join(command))
+    if quiet:
+        subprocess.check_call(command, stdout=subprocess.DEVNULL)
+    else:
+        subprocess.check_call(command)
+
+
 def gs_to_public_url(gcs_path):
     assert gcs_path.startswith('gs://')
     return gcs_path.replace('gs://', 'https://storage.googleapis.com/', 1)
 
 
-def rsync(path1, path2):
+def rsync(path1, path2, quiet=False):
     command = [
         'gsutil', '-m', '-h', 'Content-Encoding:gzip', 'rsync', '-r',
         path1, path2
     ]
-    _log.info(' '.join(command))
-    subprocess.check_call(command)
+    _call(command, quiet)
 
 
-def copy(path1, path2):
+def copy(path1, path2, quiet=False):
     command = [
         'gsutil', '-m', 'cp', '-r', path1, path2
     ]
-    _log.info(' '.join(command))
-    subprocess.check_call(command)
+    _call(command, quiet)

--- a/results-processor/gsutil.py
+++ b/results-processor/gsutil.py
@@ -7,13 +7,16 @@ import subprocess
 
 
 _log = logging.getLogger(__name__)
-_log.setLevel(logging.INFO)
 
 
 def _call(command, quiet=False):
-    _log.info(' '.join(command))
+    _log.info('EXEC%s: %s',
+              '(quiet)' if quiet else '',
+              ' '.join(command))
     if quiet:
-        subprocess.check_call(command, stdout=subprocess.DEVNULL)
+        subprocess.check_call(command,
+                              stdout=subprocess.DEVNULL,
+                              stderr=subprocess.DEVNULL)
     else:
         subprocess.check_call(command)
 

--- a/results-processor/main.py
+++ b/results-processor/main.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import logging
 import re
 import shutil
 import tempfile
@@ -13,6 +14,7 @@ import gsutil
 APPENGINE_INTERNAL_IP = '10.0.0.1'
 
 
+logging.basicConfig(level=logging.INFO)
 app = flask.Flask(__name__)
 
 
@@ -75,4 +77,5 @@ def task_handler():
 
 # Run the script directly locally to start Flask dev server.
 if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
     app.run(debug=True)

--- a/results-processor/main.py
+++ b/results-processor/main.py
@@ -57,8 +57,10 @@ def task_handler():
 
     resp = "{} results loaded from {}".format(len(report.results), gcs_path)
 
-    gsutil.copy(gcs_path, 'gs://wptd-results/{}/{}/report.json'.format(
-        revision, browser))
+    gsutil.copy(
+        'gs:/' + gcs_path,
+        'gs://wptd-results/{}/{}/report.json'.format(revision, browser)
+    )
 
     tempdir = report.populate_upload_directory(
         browser=browser, revision=revision)

--- a/results-processor/main.py
+++ b/results-processor/main.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+import re
+import shutil
+import tempfile
+
+from flask import Flask, request
+from google.cloud import storage
+
+import wptreport
+
+
+app = Flask(__name__)
+
+
+@app.route('/api/results/process', methods=['POST'])
+def task_handler():
+    params = request.get_json() if request.is_json else request.form
+    # uploader = params['uploader']
+    gcs_path = params['gcs']
+    result_type = params['type']
+    # TODO(Hexcles): Support multiple results.
+    assert result_type == 'single'
+
+    match = re.match(r'/([^/]+)/(.*)', gcs_path)
+    bucket_name, blob_path = match.groups()
+
+    gcs = storage.Client()
+    bucket = gcs.get_bucket(bucket_name)
+    blob = bucket.blob(blob_path)
+
+    with tempfile.NamedTemporaryFile(suffix='.json') as temp:
+        blob.download_to_file(temp)
+        temp.seek(0)
+        report = wptreport.WPTReport()
+        report.load_json(temp)
+
+    resp = "{} results loaded from {}".format(len(report.results), gcs_path)
+
+    tempdir = report.populate_upload_directory()
+    # TODO(Hexcles): Switch to prod.
+    wptreport.gcs_upload(tempdir, 'gs://robertma-wptd-dev/')
+    # TODO(Hexcles): Get secret from Datastore and create the test run.
+    # wptreport.create_test_run(report, secret)
+    shutil.rmtree(tempdir)
+
+    return resp
+
+
+# Run the script directly locally to start Flask dev server.
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/results-processor/main.py
+++ b/results-processor/main.py
@@ -65,7 +65,7 @@ def task_handler():
     tempdir = report.populate_upload_directory(
         browser=browser, revision=revision)
     # TODO(Hexcles): Switch to prod.
-    gsutil.rsync(tempdir, 'gs://robertma-wptd-dev/')
+    gsutil.rsync(tempdir, 'gs://robertma-wptd-dev/', quiet=True)
     # TODO(Hexcles): Get secret from Datastore and create the test run.
     # wptreport.create_test_run(report, secret)
     shutil.rmtree(tempdir)

--- a/results-processor/main.py
+++ b/results-processor/main.py
@@ -18,8 +18,12 @@ app = flask.Flask(__name__)
 
 @app.route('/api/results/process', methods=['POST'])
 def task_handler():
-    if flask.request.remote_addr != APPENGINE_INTERNAL_IP:
-        return 'External requests not allowed', 403
+    if not app.debug:
+        # Only allow access from other services.
+        # https://cloud.google.com/appengine/docs/standard/python/creating-firewalls#allowing_requests_from_your_services
+        remote_ip = flask.request.access_route[0]
+        if remote_ip != APPENGINE_INTERNAL_IP:
+            return 'External requests not allowed', 403
 
     params = flask.request.form
     # Mandatory fields:

--- a/results-processor/requirements-top_level.txt
+++ b/results-processor/requirements-top_level.txt
@@ -2,3 +2,4 @@ Flask
 google-cloud-storage
 gunicorn
 flake8
+requests

--- a/results-processor/requirements.txt
+++ b/results-processor/requirements.txt
@@ -7,7 +7,7 @@ Flask==1.0.2
 google-api-core==1.1.2
 google-auth==1.4.1
 google-cloud-core==0.28.1
-google-cloud-storage==1.9.0
+google-cloud-storage==1.10.0
 google-resumable-media==0.3.1
 googleapis-common-protos==1.5.3
 gunicorn==19.8.1
@@ -17,7 +17,7 @@ Jinja2==2.10
 MarkupSafe==1.0
 mccabe==0.6.1
 protobuf==3.5.2.post1
-pyasn1==0.4.2
+pyasn1==0.4.3
 pyasn1-modules==0.2.1
 pycodestyle==2.3.1
 pyflakes==1.6.0

--- a/results-processor/test.py
+++ b/results-processor/test.py
@@ -1,7 +1,0 @@
-from flask import Flask
-
-app = Flask(__name__)
-
-@app.route('/api/hello')
-def test():
-    return "Hello, world!"

--- a/results-processor/wptreport.py
+++ b/results-processor/wptreport.py
@@ -16,8 +16,8 @@ import requests
 
 import gsutil
 
+
 _log = logging.getLogger(__name__)
-_log.setLevel(logging.INFO)
 
 
 class MissingMetadataError(Exception):
@@ -307,4 +307,5 @@ def main():
 
 
 if __name__ == '__main__':
+    _log.setLevel(logging.INFO)
     main()


### PR DESCRIPTION
This PR is part of #146 and implements all basic functionalities except creating the task run, namely:

1. `wptreport` can now create a full results directory that contains both the summary and split test results (both gzipped), which is ready to be uploaded to the GCS bucket that backs the current frontend.
2. Create a new `gsutil` module that abstracts external calls out to `gsutil` which does all the parallel recursive upload. It's much simpler than implementing ourselves using the Python GCS library.
3. We now have a simple Flask-based web server which handles the tasks from TaskQueue. The handler currently uploads the processed results to a temporary dev bucket.

The next step is to upload to the prod bucket, and create test runs by calling a HTTP API on wpt.fyi.