### PR TITLE
Fix the revision selection in deployment script

### DIFF
--- a/util/travis-deploy-staging.sh
+++ b/util/travis-deploy-staging.sh
@@ -19,7 +19,7 @@ if [ -z "${TRAVIS_PULL_REQUEST_BRANCH}" ]; then
 fi
 
 # Skip if webapp isn't modified.
-git diff --name-only HEAD...${TRAVIS_BRANCH} | grep "^$APP_PATH/" || {
+git diff --name-only ${TRAVIS_BRANCH}..HEAD | grep "^$APP_PATH/" || {
   info "No changes detected under ${APP_PATH}. Skipping deployment."
   exit 0
 }


### PR DESCRIPTION
We should us the [double dot syntax](https://git-scm.com/book/en/v2/Git-Tools-Revision-Selection#double_dot) to select revisions reachable from `HEAD` (i.e. the PR branch) but not from `TRAVIS_BRANCH` (i.e. the base branch), which is equivalent to the effect of rebase+merge.

@lukebjerring was the previous triple dot a typo or intended?