### PR TITLE
Check whether in PR outside travis-staging-deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,8 +49,12 @@ script:
     # Deploy PR to staging environment (only when Travis secrets are available).
     # Note: Travis 'deploy' task is skipped for PRs, so can't be used for this.
     if [ ${DEPLOY_STAGING} == true ]; then
-      bash util/travis-deploy-staging.sh webapp
-      bash util/travis-deploy-staging.sh results-processor
+      if [ -z "${TRAVIS_PULL_REQUEST_BRANCH}" ];
+      then info "Not on a PR. Skipping ${APP_PATH} deployment.";
+      else
+        bash util/travis-deploy-staging.sh webapp;
+        bash util/travis-deploy-staging.sh results-processor;
+      fi;
     fi
   - | # Run tests
     if [ "${MAKE_TEST_TARGET}" != "" ]; then

--- a/util/travis-deploy-staging.sh
+++ b/util/travis-deploy-staging.sh
@@ -28,11 +28,6 @@ if [ "${TRAVIS_SECURE_ENV_VARS}" == "false" ]; then
   exit 0
 fi
 
-if [ -z "${TRAVIS_PULL_REQUEST_BRANCH}" ]; then
-  info "Not on a PR. Skipping ${APP_PATH} deployment."
-  exit 0
-fi
-
 # Skip if nothing under $APP_PATH was modified.
 if [ "${FORCE_PUSH}" != "true" ];
 then
@@ -44,7 +39,11 @@ fi
 
 echo "Copying output to ${TEMP_FILE:=$(mktemp)}"
 # NOTE: Most gcloud output is stderr, so need to redirect it to stdout.
-docker exec -t -u $(id -u $USER):$(id -g $USER) "${DOCKER_INSTANCE}" make deploy_staging APP_PATH=${APP_PATH} BRANCH_NAME=${TRAVIS_PULL_REQUEST_BRANCH} 2>&1 | tee ${TEMP_FILE}
+docker exec -t -u $(id -u $USER):$(id -g $USER) "${DOCKER_INSTANCE}" \
+    make deploy_staging \
+        APP_PATH=${APP_PATH} \
+        BRANCH_NAME=${TRAVIS_PULL_REQUEST_BRANCH:-TRAVIS_BRANCH} 2>&1 \
+            | tee ${TEMP_FILE}
 if [ "${EXIT_CODE:=${PIPESTATUS[0]}}" != "0" ]; then exit ${EXIT_CODE}; fi
 DEPLOYED_URL="$(grep -Po 'Deployed to \K[^\s]+' ${TEMP_FILE} | tr -d '\n')"
 ${UTIL_DIR}/deploy-comment.sh "${DEPLOYED_URL}"


### PR DESCRIPTION
## Description
Re-using `travis-deploy-staging.sh` from PRs and master has stopped master deploying (since the script checks for `$TRAVIS_PULL_REQUEST_BRANCH`).

This changes that condition to be for the PR deploy in `.travis.yml`, and makes the script fall back to `$TRAVIS_BRANCH` when `$TRAVIS_PULL_REQUEST_BRANCH` isn't set.