### PR TITLE
Add Python tests to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,17 +17,15 @@ services:
 
 matrix:
   include:
-    - language: go
-      env:
+    - env:
+        - MAKE_TEST_TARGET=python_test
+    - env:
         - MAKE_TEST_TARGET=integration_test
-    - language: go
-      env:
+    - env:
         - MAKE_TEST_TARGET=lint
-    - language: go
-      env:
+    - env:
         - MAKE_TEST_TARGET=go_test
-    - language: go
-      env:
+    - env:
         - secure: "UuTZnGD+HSB+EYQFg2+lKhDwxlDUtU/uz4XdUG8/8F7Us9G7e7w/DL0jhnzpHjK13ig7Yafj83zZmNszpfaXhNdNp2glhiIeuupODODd24tRA4e9DBIoEToJEyjkXD7RttK4H7SaRp12yVEnE+gnUTiDCOJQHmkDl6DHwwUfeTG3P+dKgHsybdrXcUZG+ff4DPrwq9B6NU7izKC3QqByfcxhfxv+SE9e6vi8LKs6qdRbg4PnPEOc85kiqMmtqNHQ7hph3Np3oEaEeZqMylo2hKh/gXxWgNjH3uFwEtJx7sWYL/c3HpiNRMTPUFVJmGaU/xQqH3gGqEbt0QIjrQVFGJZ0wjJoha1+TigIB9LjJ3eSJCtUwj6naWwi0laOZJyR4L/+XCWpNRH2SjLvakIjims7ZEKbE3rVA/Vr0mY67NLnEm0fh6xglN2Jlm5Mag5hw3bHcOi72sQthjQofEtUE0fElAEGc4wBVCd87LzcLyCvZhg6VeJ/M+kC4uJuiMQJ6qkO92UDaV0bvY9svLlGBuBbd/PH0YPh0kkTUlH5IzJx/wymE2mSwtP8af1n0IBIItVfq6uuzct5IhEZvMoZsDv1pU5pqM/ucRuuvb6rtZedGpGjBZacM1uNa/MbvnF5imAHxfY7783saGaIpdNr6k4cxmHglelxwSR0zqujU2Q="
         - DEPLOY_STAGING=true
 

--- a/Makefile
+++ b/Makefile
@@ -31,11 +31,14 @@ GO_TEST_FILES := $(shell find $(WPTD_PATH) -type f -name '*_test.go')
 
 build: go_build
 
-test: go_test
+test: go_test python_test
 
 lint: go_lint eslint
 
 prepush: go_build test lint
+
+python_test: python3 tox
+	cd $(WPTD_PATH)results-processor; tox
 
 go_build: go_deps
 	cd $(WPTD_GO_PATH); go build ./...
@@ -124,8 +127,10 @@ golint_deps: git go_deps
 sys_deps: curl gpg node gcloud git
 
 curl: apt-get-curl
-python: apt-get-python
 git: apt-get-git
+python3: apt-get-python3
+python: apt-get-python
+tox: apt-get-tox
 wget: apt-get-wget
 
 java:


### PR DESCRIPTION
Integrate Python unit tests and lints (both managed by `tox`) into Makefile & Travis.

Also, since we are running everything inside Docker now, we don't need to specify `language`, which supposedly saves some time installing the language-specific dependencies on Travis outside Docker.