### PR TITLE
[processor] Take optional parameters from the admin upload form

### DIFF
--- a/api/receiver/appengine_mock.go
+++ b/api/receiver/appengine_mock.go
@@ -110,16 +110,16 @@ func (mr *MockAppEngineAPIMockRecorder) uploadToGCS(fileName, f, gzipped interfa
 }
 
 // scheduleResultsTask mocks base method
-func (m *MockAppEngineAPI) scheduleResultsTask(uploader string, gcsPaths []string, payloadType string) (*taskqueue.Task, error) {
-	ret := m.ctrl.Call(m, "scheduleResultsTask", uploader, gcsPaths, payloadType)
+func (m *MockAppEngineAPI) scheduleResultsTask(uploader string, gcsPaths []string, payloadType string, extraParams map[string]string) (*taskqueue.Task, error) {
+	ret := m.ctrl.Call(m, "scheduleResultsTask", uploader, gcsPaths, payloadType, extraParams)
 	ret0, _ := ret[0].(*taskqueue.Task)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // scheduleResultsTask indicates an expected call of scheduleResultsTask
-func (mr *MockAppEngineAPIMockRecorder) scheduleResultsTask(uploader, gcsPaths, payloadType interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "scheduleResultsTask", reflect.TypeOf((*MockAppEngineAPI)(nil).scheduleResultsTask), uploader, gcsPaths, payloadType)
+func (mr *MockAppEngineAPIMockRecorder) scheduleResultsTask(uploader, gcsPaths, payloadType, extraParams interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "scheduleResultsTask", reflect.TypeOf((*MockAppEngineAPI)(nil).scheduleResultsTask), uploader, gcsPaths, payloadType, extraParams)
 }
 
 // fetchURL mocks base method

--- a/api/receiver/appengine_test.go
+++ b/api/receiver/appengine_test.go
@@ -62,13 +62,31 @@ func TestScheduleResultsTask(t *testing.T) {
 	assert.Equal(t, stats[0].Tasks, 0)
 
 	a := appEngineAPIImpl{ctx: ctx}
-	_, err = a.scheduleResultsTask("blade-runner", []string{"/blade-runner/test.json"}, "single")
+	_, err = a.scheduleResultsTask("blade-runner", []string{"/blade-runner/test.json"}, "single", nil)
 	assert.Nil(t, err)
 
 	stats, err = taskqueue.QueueStats(ctx, []string{""})
 	assert.Nil(t, err)
 	assert.Equal(t, stats[0].Tasks, 1)
+}
 
+func TestScheduleResultsTask_error(t *testing.T) {
+	ctx, done, err := aetest.NewContext()
+	assert.Nil(t, err)
+	defer done()
+	a := appEngineAPIImpl{ctx: ctx}
+
+	_, err = a.scheduleResultsTask("", []string{"/blade-runner/test.json"}, "single", nil)
+	assert.NotNil(t, err)
+
+	_, err = a.scheduleResultsTask("blade-runner", []string{""}, "single", nil)
+	assert.NotNil(t, err)
+
+	_, err = a.scheduleResultsTask("blade-runner", nil, "single", nil)
+	assert.NotNil(t, err)
+
+	_, err = a.scheduleResultsTask("blade-runner", []string{"/blade-runner/test.json"}, "", nil)
+	assert.NotNil(t, err)
 }
 
 func TestAuthenticateUploader(t *testing.T) {

--- a/api/receiver/results_receiver_test.go
+++ b/api/receiver/results_receiver_test.go
@@ -54,13 +54,17 @@ func TestHandleFilePayload(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	f := &os.File{}
+	extraParams := map[string]string{
+		"browser_name": "firefox",
+	}
+
 	mockAE := NewMockAppEngineAPI(mockCtrl)
 	gomock.InOrder(
 		mockAE.EXPECT().uploadToGCS(gomock.Any(), f, true).Return("/blade-runner/test.json", nil),
-		mockAE.EXPECT().scheduleResultsTask("blade-runner", []string{"/blade-runner/test.json"}, "single"),
+		mockAE.EXPECT().scheduleResultsTask("blade-runner", []string{"/blade-runner/test.json"}, "single", extraParams),
 	)
 
-	handleFilePayload(mockAE, "blade-runner", f)
+	handleFilePayload(mockAE, "blade-runner", f, extraParams)
 }
 
 func TestHandleURLPayload_single(t *testing.T) {
@@ -68,32 +72,36 @@ func TestHandleURLPayload_single(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	f := &os.File{}
+	extraParams := map[string]string{
+		"browser_name": "firefox",
+	}
+
 	mockAE := NewMockAppEngineAPI(mockCtrl)
 	gomock.InOrder(
 		mockAE.EXPECT().fetchURL("http://wpt.fyi/test.json.gz").Return(f, nil),
 		mockAE.EXPECT().uploadToGCS(gomock.Any(), f, true).Return("/blade-runner/test.json", nil),
-		mockAE.EXPECT().scheduleResultsTask("blade-runner", []string{"/blade-runner/test.json"}, "single"),
+		mockAE.EXPECT().scheduleResultsTask("blade-runner", []string{"/blade-runner/test.json"}, "single", extraParams),
 	)
 
-	handleURLPayload(mockAE, "blade-runner", []string{"http://wpt.fyi/test.json.gz"})
+	handleURLPayload(mockAE, "blade-runner", []string{"http://wpt.fyi/test.json.gz"}, extraParams)
 }
 
 func TestHandleURLPayload_multiple(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
+	f := &os.File{}
 	urls := []string{"http://wpt.fyi/foo.json.gz", "http://wpt.fyi/bar.json.gz"}
 	gcs := []string{"/blade-runner/foo.json", "/blade-runner/bar.json"}
 
-	f := &os.File{}
 	mockAE := NewMockAppEngineAPI(mockCtrl)
 	gomock.InOrder(
 		mockAE.EXPECT().fetchURL(urls[0]).Return(f, nil),
 		mockAE.EXPECT().uploadToGCS(gomock.Any(), f, true).Return(gcs[0], nil),
 		mockAE.EXPECT().fetchURL(urls[1]).Return(f, nil),
 		mockAE.EXPECT().uploadToGCS(gomock.Any(), f, true).Return(gcs[1], nil),
-		mockAE.EXPECT().scheduleResultsTask("blade-runner", gcs, "multiple"),
+		mockAE.EXPECT().scheduleResultsTask("blade-runner", gcs, "multiple", nil),
 	)
 
-	handleURLPayload(mockAE, "blade-runner", urls)
+	handleURLPayload(mockAE, "blade-runner", urls, nil)
 }

--- a/results-processor/Dockerfile
+++ b/results-processor/Dockerfile
@@ -6,7 +6,7 @@ FROM gcr.io/google-appengine/python
 RUN apt-get update -q
 RUN apt-get install -qy curl
 RUN curl -s https://sdk.cloud.google.com > install-gcloud.sh
-RUN bash install-gcloud.sh --disable-prompts --install-dir=/opt
+RUN bash install-gcloud.sh --disable-prompts --install-dir=/opt > /dev/null
 ENV PATH=/opt/google-cloud-sdk/bin:$PATH
 RUN gcloud config set disable_usage_reporting false
 

--- a/results-processor/wptreport_test.py
+++ b/results-processor/wptreport_test.py
@@ -225,32 +225,19 @@ class WPTReportTest(unittest.TestCase):
             self.tmp_dir, short_sha, 'firefox-59.0-linux', 'foo', 'bar.html'
         )))
 
-    def test_populate_upload_directory_overrides(self):
+    def test_update_metadata(self):
         r = WPTReport()
-        r._report = {
-            'results': [{
-                'test': '/foo/bar.html',
-                'status': 'PASS',
-                'message': None,
-                'subtests': []
-            }],
-            'run_info': {
-                'revision': '0bdaaf9c1622ca49eb140381af1ece6d8001c934',
-                'product': 'firefox',
-                'browser_version': '59.0',
-                'os': 'linux'
-            }
-        }
-        short_sha = '0123456789'
-        r.populate_upload_directory(
-            revision=short_sha,
-            browser='chrome-60-macos',
-            output_dir=self.tmp_dir
+        r.update_metadata(
+            revision='0bdaaf9c1622ca49eb140381af1ece6d8001c934',
+            browser_name='firefox',
+            browser_version='59.0',
+            os_name='linux',
+            os_version='4.4'
         )
-
-        self.assertTrue(os.path.isfile(os.path.join(
-            self.tmp_dir, short_sha, 'chrome-60-macos-summary.json.gz'
-        )))
-        self.assertTrue(os.path.isfile(os.path.join(
-            self.tmp_dir, short_sha, 'chrome-60-macos', 'foo', 'bar.html'
-        )))
+        self.assertDictEqual(r.run_info, {
+            'revision': '0bdaaf9c1622ca49eb140381af1ece6d8001c934',
+            'product': 'firefox',
+            'browser_version': '59.0',
+            'os': 'linux',
+            'os_version': '4.4'
+        })

--- a/webapp/templates/admin_upload.html
+++ b/webapp/templates/admin_upload.html
@@ -8,8 +8,16 @@
 <link rel="import" href="/bower_components/paper-input/paper-input.html">
 <link rel="import" href="/bower_components/paper-styles/color.html">
 
+<style>
+  h2 { clear: both; }
+</style>
+
 <custom-style>
   <style>
+    div.note {
+      background-color: var(--paper-blue-100);
+      padding: 5px;
+    }
     form, iron-form {
       max-width: 100%;
       width: 480px;
@@ -34,7 +42,7 @@
 <!-- iron-form doesn't support multipart/form-data -->
 <form method="POST" action="/api/results/upload" enctype="multipart/form-data">
   <paper-input-container>
-    <label slot="label">Name</label>
+    <label slot="label">Uploader</label>
     <iron-input slot="input" class="input-element">
       <input name="user">
     </iron-input>
@@ -43,6 +51,40 @@
     <label slot="label">Results file</label>
     <iron-input slot="input" class="input-element">
       <input name="result_file" type="file">
+    </iron-input>
+  </paper-input-container>
+  <div class="note">
+    The following fields override the metadata included in the report. Generally
+    speaking, you should only fill these fields if the report doesn't have them.
+  </div>
+  <paper-input-container>
+    <label slot="label">Revision</label>
+    <iron-input slot="input" class="input-element">
+      <input name="revision">
+    </iron-input>
+  </paper-input-container>
+  <paper-input-container>
+    <label slot="label">Browser name</label>
+    <iron-input slot="input" class="input-element">
+      <input name="browser_name">
+    </iron-input>
+  </paper-input-container>
+  <paper-input-container>
+    <label slot="label">Browser version</label>
+    <iron-input slot="input" class="input-element">
+      <input name="browser_version">
+    </iron-input>
+  </paper-input-container>
+  <paper-input-container>
+    <label slot="label">OS name</label>
+    <iron-input slot="input" class="input-element">
+      <input name="os_name">
+    </iron-input>
+  </paper-input-container>
+  <paper-input-container>
+    <label slot="label">OS version</label>
+    <iron-input slot="input" class="input-element">
+      <input name="os_version">
     </iron-input>
   </paper-input-container>
 


### PR DESCRIPTION
Old results don't have the required metadata. This change provides admins with a way to fill in (or override) the metadata.

## Review
https://extra-params-dot-wptdashboard.appspot.com/admin/results/upload