### PR TITLE
Deploy to wptdashboard-staging instead

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,8 +169,8 @@ dev_data:
 	cd $(WPTD_GO_PATH)/util; go get -t ./...
 	go run util/populate_dev_data.go $(FLAGS)
 
-deploy_staging: gcloud webapp_deps env-BRANCH_NAME env-APP_PATH $(WPTD_PATH)client-secret.json
-	gcloud config set project wptdashboard
+deploy_staging: gcloud webapp_deps var-BRANCH_NAME var-APP_PATH var-PROJECT $(WPTD_PATH)client-secret.json
+	gcloud config set project $(PROJECT)
 	gcloud auth activate-service-account --key-file $(WPTD_PATH)client-secret.json
 	cd $(WPTD_PATH); util/deploy.sh -q -b $(BRANCH_NAME) $(APP_PATH)
 
@@ -196,3 +196,6 @@ apt-get-%:
 
 env-%:
 	@ if [[ "${${*}}" = "" ]]; then echo "Environment variable $* not set"; exit 1; fi
+
+var-%:
+	@ if [[ "$($*)" = "" ]]; then echo "Make variable $* not set"; exit 1; fi

--- a/util/travis-deploy-staging.sh
+++ b/util/travis-deploy-staging.sh
@@ -41,6 +41,7 @@ debug "Copying output to ${TEMP_FILE:=$(mktemp)}"
 # NOTE: Most gcloud output is stderr, so need to redirect it to stdout.
 docker exec -t -u $(id -u $USER):$(id -g $USER) "${DOCKER_INSTANCE}" \
     make deploy_staging \
+        PROJECT=wptdashboard-staging \
         APP_PATH=${APP_PATH} \
         BRANCH_NAME=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH} 2>&1 \
             | tee ${TEMP_FILE}


### PR DESCRIPTION
## Description
Changes the deploy script to use the `wptdashboard-staging` project instead.

Applies to https://github.com/web-platform-tests/wpt.fyi/issues/161