### PR TITLE
Use 'from' param for /api/runs & /test-runs

### DIFF
--- a/shared/params.go
+++ b/shared/params.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/deckarep/golang-set"
 )
@@ -269,19 +270,12 @@ func GetProductsForRequest(r *http.Request) (products []Product, err error) {
 	return products, nil
 }
 
-// ParseMaxCountParam parses the 'max-count' parameter as an integer, or returns 1 if no param
-// is present, or on error.
-func ParseMaxCountParam(r *http.Request) (count int, err error) {
-	return ParseMaxCountParamWithDefault(r, MaxCountDefaultValue)
-}
-
-// ParseMaxCountParamWithDefault parses the 'max-count' parameter as an integer, or returns the
-// default when no param is present, or on error.
-func ParseMaxCountParamWithDefault(r *http.Request, defaultValue int) (count int, err error) {
-	count = defaultValue
+// ParseMaxCountParam parses the 'max-count' parameter as an integer
+func ParseMaxCountParam(r *http.Request) (*int, error) {
 	if maxCountParam := r.URL.Query().Get("max-count"); maxCountParam != "" {
-		if count, err = strconv.Atoi(maxCountParam); err != nil {
-			return defaultValue, err
+		count, err := strconv.Atoi(maxCountParam)
+		if err != nil {
+			return nil, err
 		}
 		if count < MaxCountMinValue {
 			count = MaxCountMinValue
@@ -289,8 +283,30 @@ func ParseMaxCountParamWithDefault(r *http.Request, defaultValue int) (count int
 		if count > MaxCountMaxValue {
 			count = MaxCountMaxValue
 		}
+		return &count, nil
 	}
-	return count, err
+	return nil, nil
+}
+
+// ParseMaxCountParamWithDefault parses the 'max-count' parameter as an integer, or returns the
+// default when no param is present, or on error.
+func ParseMaxCountParamWithDefault(r *http.Request, defaultValue int) (count int, err error) {
+	if maxCountParam, err := ParseMaxCountParam(r); maxCountParam != nil || err != nil {
+		return *maxCountParam, err
+	}
+	return defaultValue, nil
+}
+
+// ParseFromParam parses the "from" param as a timestamp.
+func ParseFromParam(r *http.Request) (*time.Time, error) {
+	if fromParam := r.URL.Query().Get("from"); fromParam != "" {
+		parsed, err := time.Parse(time.RFC3339, fromParam)
+		if err != nil {
+			return nil, err
+		}
+		return &parsed, nil
+	}
+	return nil, nil
 }
 
 // DiffFilterParam represents the types of changed test paths to include.

--- a/shared/params_test.go
+++ b/shared/params_test.go
@@ -197,38 +197,42 @@ func TestParseMaxCountParam_Missing(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/", nil)
 	count, err := ParseMaxCountParam(r)
 	assert.Nil(t, err)
-	assert.Equal(t, MaxCountDefaultValue, count)
+	assert.Nil(t, count)
+
+	d, err := ParseMaxCountParamWithDefault(r, 5)
+	assert.Nil(t, err)
+	assert.Equal(t, 5, d)
 }
 
 func TestParseMaxCountParam_TooSmall(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?max-count=0", nil)
 	count, err := ParseMaxCountParam(r)
 	assert.Nil(t, err)
-	assert.Equal(t, MaxCountMinValue, count)
+	assert.Equal(t, MaxCountMinValue, *count)
 
 	r = httptest.NewRequest("GET", "http://wpt.fyi/?max-count=-1", nil)
 	count, err = ParseMaxCountParam(r)
 	assert.Nil(t, err)
-	assert.Equal(t, MaxCountMinValue, count)
+	assert.Equal(t, MaxCountMinValue, *count)
 }
 
 func TestParseMaxCountParam_TooLarge(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?max-count=123456789", nil)
 	count, err := ParseMaxCountParam(r)
 	assert.Nil(t, err)
-	assert.Equal(t, MaxCountMaxValue, count)
+	assert.Equal(t, MaxCountMaxValue, *count)
 
 	r = httptest.NewRequest("GET", "http://wpt.fyi/?max-count=100000000", nil)
 	count, err = ParseMaxCountParam(r)
 	assert.Nil(t, err)
-	assert.Equal(t, MaxCountMaxValue, count)
+	assert.Equal(t, MaxCountMaxValue, *count)
 }
 
 func TestParseMaxCountParam(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?max-count=2", nil)
 	count, err := ParseMaxCountParam(r)
 	assert.Nil(t, err)
-	assert.Equal(t, 2, count)
+	assert.Equal(t, 2, *count)
 }
 
 func TestParsePathsParam_Missing(t *testing.T) {

--- a/webapp/components/wpt-runs.html
+++ b/webapp/components/wpt-runs.html
@@ -54,7 +54,7 @@ found in the LICENSE file.
     </style>
 
     <section class="info">
-      Showing the last 100 runs per browser.
+      Showing the last 3 months of test runs.
     </section>
 
     <table>


### PR DESCRIPTION
## Description
Fixes https://github.com/web-platform-tests/wpt.fyi/issues/3

Currently, we load 100 of each browser and try to 'match' them in the UI, which causes a misleading appearance after the first 100 runs of the most-frequent browsers.

This PR changes it to be all runs in the last 3 months.

## Review Information
https://runs-after-time-dot-wptdashboard.appspot.com/test-runs