### PR TITLE
Processor creates test runs after uploading processed results

### DIFF
--- a/results-processor/config.py
+++ b/results-processor/config.py
@@ -17,3 +17,11 @@ def results_bucket():
     if _is_prod():
         return 'wptd'
     return 'wptd-staging'
+
+
+def project_baseurl():
+    """Returns the base URL of the current project."""
+    # Defaults to staging to prevent accidental access of prod.
+    # TODO(Hexcles): Support local dev_appserver.
+    project = os.getenv('GOOGLE_CLOUD_PROJECT') or 'wptdashboard-staging'
+    return 'https://%s.appspot.com' % project

--- a/results-processor/config.py
+++ b/results-processor/config.py
@@ -1,0 +1,19 @@
+import os
+
+
+def _is_prod():
+    return os.getenv('GOOGLE_CLOUD_PROJECT') == 'wptdashboard'
+
+
+def raw_results_bucket():
+    """Returns the bucket name for storing raw, full results."""
+    if _is_prod():
+        return 'wptd-results'
+    return 'wptd-results-staging'
+
+
+def results_bucket():
+    """Returns the bucket name for storing split results."""
+    if _is_prod():
+        return 'wptd'
+    return 'wptd-staging'

--- a/results-processor/main.py
+++ b/results-processor/main.py
@@ -11,6 +11,7 @@ import filelock
 import flask
 from google.cloud import datastore, storage
 
+import config
 import wptreport
 import gsutil
 
@@ -146,13 +147,15 @@ def task_handler():
 
     resp = "{} results loaded from {}".format(len(report.results), gcs_path)
 
-    raw_results_gcs_path = '/wptd-results/{}/{}/report.json'.format(
-        revision, product)
+    raw_results_gcs_path = '/{}/{}/{}/report.json'.format(
+        config.raw_results_bucket(), revision, product)
     gsutil.copy('gs:/' + gcs_path, 'gs:/' + raw_results_gcs_path)
 
     tempdir = report.populate_upload_directory()
-    results_gcs_path = '/wptd/' + report.sha_summary_path
-    gsutil.rsync(tempdir, 'gs://wptd/', quiet=True)
+    results_gcs_path = '/{}/{}'.format(
+        config.results_bucket(), report.sha_summary_path)
+    gsutil.rsync(tempdir, 'gs://{}/'.format(config.results_bucket()),
+                 quiet=True)
     shutil.rmtree(tempdir)
 
     ds = datastore.Client()

--- a/results-processor/requirements-top_level.txt
+++ b/results-processor/requirements-top_level.txt
@@ -1,6 +1,7 @@
 Flask
 filelock
 flake8
+google-cloud-datastore
 google-cloud-storage
 gunicorn
 requests

--- a/results-processor/requirements.txt
+++ b/results-processor/requirements.txt
@@ -8,9 +8,11 @@ Flask==1.0.2
 google-api-core==1.1.2
 google-auth==1.4.1
 google-cloud-core==0.28.1
+google-cloud-datastore==1.6.0
 google-cloud-storage==1.10.0
 google-resumable-media==0.3.1
 googleapis-common-protos==1.5.3
+grpcio==1.12.0
 gunicorn==19.8.1
 idna==2.6
 itsdangerous==0.24

--- a/results-processor/wptreport.py
+++ b/results-processor/wptreport.py
@@ -14,6 +14,7 @@ import tempfile
 
 import requests
 
+import config
 import gsutil
 
 
@@ -282,11 +283,8 @@ def create_test_run(report, secret, results_gcs_path, raw_results_gcs_path):
     payload['results_url'] = GCS_PUBLIC_DOMAIN + results_gcs_path
     payload['raw_results_url'] = GCS_PUBLIC_DOMAIN + raw_results_gcs_path
 
-    # If we are running in cloud, post to the current project.
-    project = os.getenv('GOOGLE_CLOUD_PROJECT') or DEFAULT_PROJECT
-
     response = requests.post(
-        "https://%s.appspot.com/api/run" % project,
+        config.project_baseurl() + '/api/run',
         params={'secret': secret},
         data=json.dumps(payload)
     )

--- a/results-processor/wptreport.py
+++ b/results-processor/wptreport.py
@@ -17,6 +17,7 @@ import requests
 import gsutil
 
 
+DEFAULT_PROJECT = 'wptdashboard'
 GCS_PUBLIC_DOMAIN = 'https://storage.googleapis.com'
 
 _log = logging.getLogger(__name__)
@@ -262,7 +263,7 @@ class WPTReport(object):
 def create_test_run(report, secret, results_gcs_path, raw_results_gcs_path):
     """Creates a TestRun on the dashboard.
 
-    By posting to the https://wpt.fyi/api/run endpoint.
+    By posting to the /api/run endpoint.
 
     Args:
         report: A WPTReport.
@@ -279,8 +280,11 @@ def create_test_run(report, secret, results_gcs_path, raw_results_gcs_path):
     payload['results_url'] = GCS_PUBLIC_DOMAIN + results_gcs_path
     payload['raw_results_url'] = GCS_PUBLIC_DOMAIN + raw_results_gcs_path
 
+    # If we are running in cloud, post to the current project.
+    project = os.getenv('GOOGLE_CLOUD_PROJECT') or DEFAULT_PROJECT
+
     response = requests.post(
-        "https://wpt.fyi/api/run",
+        "https://%s.appspot.com/api/run" % project,
         params={'secret': secret},
         data=json.dumps(payload)
     )

--- a/results-processor/wptreport.py
+++ b/results-processor/wptreport.py
@@ -17,6 +17,8 @@ import requests
 import gsutil
 
 
+GCS_PUBLIC_DOMAIN = 'https://storage.googleapis.com'
+
 _log = logging.getLogger(__name__)
 
 
@@ -247,7 +249,7 @@ class WPTReport(object):
                 'browser_version': self.run_info['browser_version'],
                 'os_name': self.run_info['os'],
                 'revision': self.run_info['revision'][:10],
-                'full_revision': self.run_info['revision'],
+                'full_revision_hash': self.run_info['revision'],
             }
         except KeyError as e:
             raise MissingMetadataError(str(e)) from e
@@ -257,15 +259,26 @@ class WPTReport(object):
             payload['os_version'] = self.run_info['os_version']
 
 
-def create_test_run(report, secret):
-    if not report.sha_summary_path:
-        raise MissingMetadataError('results_url')
+def create_test_run(report, secret, results_gcs_path, raw_results_gcs_path):
+    """Creates a TestRun on the dashboard.
 
-    # TODO(Hexcles): Do not hardcode the URLs.
+    By posting to the https://wpt.fyi/api/run endpoint.
+
+    Args:
+        report: A WPTReport.
+        secret: An upload token.
+        results_gcs_path: The GCS path to the gzipped summary file.
+            (e.g. '/wptd/0123456789/chrome-62.0-linux-summary.json.gz')
+        raw_results_gcs_path: The GCS path to the raw full report.
+            (e.g. '/wptd-results/[full SHA]/chrome-62.0-linux/report.json')
+    """
+    assert results_gcs_path.startswith('/')
+    assert raw_results_gcs_path.startswith('/')
+
     payload = report.test_run_metadata
-    payload['results_url'] = "https://storage.googleapis.com/wptd/%s".format(
-        report.sha_summary_path
-    )
+    payload['results_url'] = GCS_PUBLIC_DOMAIN + results_gcs_path
+    payload['raw_results_url'] = GCS_PUBLIC_DOMAIN + raw_results_gcs_path
+
     response = requests.post(
         "https://wpt.fyi/api/run",
         params={'secret': secret},
@@ -309,8 +322,7 @@ def main():
     if args.upload:
         assert args.upload.startswith('gs://')
         gsutil.rsync(upload_dir, args.upload)
-        _log.info('Uploaded to: https://storage.googleapis.com/wptd/%s',
-                  report.sha_summary_path)
+        _log.info('Uploaded to: %s/%s', args.upload, report.sha_summary_path)
 
 
 if __name__ == '__main__':

--- a/results-processor/wptreport.py
+++ b/results-processor/wptreport.py
@@ -259,6 +259,8 @@ class WPTReport(object):
         if self.run_info.get('os_version'):
             payload['os_version'] = self.run_info['os_version']
 
+        return payload
+
 
 def create_test_run(report, secret, results_gcs_path, raw_results_gcs_path):
     """Creates a TestRun on the dashboard.

--- a/results-processor/wptreport_test.py
+++ b/results-processor/wptreport_test.py
@@ -241,3 +241,21 @@ class WPTReportTest(unittest.TestCase):
             'os': 'linux',
             'os_version': '4.4'
         })
+
+    def test_test_run_metadata(self):
+        r = WPTReport()
+        r._report = {
+            'run_info': {
+                'revision': '0bdaaf9c1622ca49eb140381af1ece6d8001c934',
+                'product': 'firefox',
+                'browser_version': '59.0',
+                'os': 'linux'
+            }
+        }
+        self.assertDictEqual(r.test_run_metadata, {
+            'browser_name': 'firefox',
+            'browser_version': '59.0',
+            'os_name': 'linux',
+            'revision': '0bdaaf9c16',
+            'full_revision_hash': '0bdaaf9c1622ca49eb140381af1ece6d8001c934',
+        })

--- a/webapp/queue.yaml
+++ b/webapp/queue.yaml
@@ -2,3 +2,4 @@ queue:
 - name: results-arrival
   target: processor
   max_concurrent_requests: 1
+  rate: 1/m


### PR DESCRIPTION
## Description

This PR implements the final piece of #146 , i.e. creating test runs.

We now have a fully isolated staging project (which gives us a separate Datastore) so we don't need to worry about polluting prod data. The processor now decides which GCS buckets to upload the processed results to depending on which project it's running in. And then the it will send a POST request to the `/api/run` endpoint of the *current* project, which is handled by the default Go app and will eventually create a test run in the Datastore of the project.

Also see #192 for the migration plan.

### GCS buckets Permissions

Since GCS buckets are all in a global namespace, we need to create separate buckets for the staging deployment.

* `wptd-staging` (in `wptdashboard-staging` project) is the staging counterpart of `wptd`, and is similarly publicly readable.
* `wptd-results-staging` (in `wptdashboard-staging` project) is the staging counterpart of `wptd-results`, and is similarly publicly readable.
* `wptd-results-buffer` (in **`wptdashboard`** project) is still used as the results buffer (when a task is in the queue) for the staging deployment: since we only need to append new data to and read existing data from the bucket, it's safe to share the bucket across prod and staging projects. The service account for `wptdashboard-staging` is given create-and-read permissions (no delete) to the bucket.

## Review Information

The PR is ready for review now. Try uploading results at https://wptdashboard-staging.appspot.com/admin/results/upload and the whole pipeline should work. You should see new runs at https://wptdashboard-staging.appspot.com/test-runs eventually (after ~20 minutes).