### PR TITLE
Add staging.wpt.fyi continuous webdriver test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,11 @@ matrix:
         - MAKE_TEST_TARGET=lint
     - env:
         - MAKE_TEST_TARGET=go_test
-    - if: type = pull_request
+    - if: type IS pull_request
       env:
         - secure: "UuTZnGD+HSB+EYQFg2+lKhDwxlDUtU/uz4XdUG8/8F7Us9G7e7w/DL0jhnzpHjK13ig7Yafj83zZmNszpfaXhNdNp2glhiIeuupODODd24tRA4e9DBIoEToJEyjkXD7RttK4H7SaRp12yVEnE+gnUTiDCOJQHmkDl6DHwwUfeTG3P+dKgHsybdrXcUZG+ff4DPrwq9B6NU7izKC3QqByfcxhfxv+SE9e6vi8LKs6qdRbg4PnPEOc85kiqMmtqNHQ7hph3Np3oEaEeZqMylo2hKh/gXxWgNjH3uFwEtJx7sWYL/c3HpiNRMTPUFVJmGaU/xQqH3gGqEbt0QIjrQVFGJZ0wjJoha1+TigIB9LjJ3eSJCtUwj6naWwi0laOZJyR4L/+XCWpNRH2SjLvakIjims7ZEKbE3rVA/Vr0mY67NLnEm0fh6xglN2Jlm5Mag5hw3bHcOi72sQthjQofEtUE0fElAEGc4wBVCd87LzcLyCvZhg6VeJ/M+kC4uJuiMQJ6qkO92UDaV0bvY9svLlGBuBbd/PH0YPh0kkTUlH5IzJx/wymE2mSwtP8af1n0IBIItVfq6uuzct5IhEZvMoZsDv1pU5pqM/ucRuuvb6rtZedGpGjBZacM1uNa/MbvnF5imAHxfY7783saGaIpdNr6k4cxmHglelxwSR0zqujU2Q="
         - DEPLOY_STAGING=true
-    - if: branch = master
+    - if: type IS push AND branch IS master
       env:
         - secure: "UuTZnGD+HSB+EYQFg2+lKhDwxlDUtU/uz4XdUG8/8F7Us9G7e7w/DL0jhnzpHjK13ig7Yafj83zZmNszpfaXhNdNp2glhiIeuupODODd24tRA4e9DBIoEToJEyjkXD7RttK4H7SaRp12yVEnE+gnUTiDCOJQHmkDl6DHwwUfeTG3P+dKgHsybdrXcUZG+ff4DPrwq9B6NU7izKC3QqByfcxhfxv+SE9e6vi8LKs6qdRbg4PnPEOc85kiqMmtqNHQ7hph3Np3oEaEeZqMylo2hKh/gXxWgNjH3uFwEtJx7sWYL/c3HpiNRMTPUFVJmGaU/xQqH3gGqEbt0QIjrQVFGJZ0wjJoha1+TigIB9LjJ3eSJCtUwj6naWwi0laOZJyR4L/+XCWpNRH2SjLvakIjims7ZEKbE3rVA/Vr0mY67NLnEm0fh6xglN2Jlm5Mag5hw3bHcOi72sQthjQofEtUE0fElAEGc4wBVCd87LzcLyCvZhg6VeJ/M+kC4uJuiMQJ6qkO92UDaV0bvY9svLlGBuBbd/PH0YPh0kkTUlH5IzJx/wymE2mSwtP8af1n0IBIItVfq6uuzct5IhEZvMoZsDv1pU5pqM/ucRuuvb6rtZedGpGjBZacM1uNa/MbvnF5imAHxfY7783saGaIpdNr6k4cxmHglelxwSR0zqujU2Q="
         - DEPLOY_STAGING=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,16 @@ matrix:
         - MAKE_TEST_TARGET=lint
     - env:
         - MAKE_TEST_TARGET=go_test
-    - env:
+    - if: type = pull_request
+      env:
         - secure: "UuTZnGD+HSB+EYQFg2+lKhDwxlDUtU/uz4XdUG8/8F7Us9G7e7w/DL0jhnzpHjK13ig7Yafj83zZmNszpfaXhNdNp2glhiIeuupODODd24tRA4e9DBIoEToJEyjkXD7RttK4H7SaRp12yVEnE+gnUTiDCOJQHmkDl6DHwwUfeTG3P+dKgHsybdrXcUZG+ff4DPrwq9B6NU7izKC3QqByfcxhfxv+SE9e6vi8LKs6qdRbg4PnPEOc85kiqMmtqNHQ7hph3Np3oEaEeZqMylo2hKh/gXxWgNjH3uFwEtJx7sWYL/c3HpiNRMTPUFVJmGaU/xQqH3gGqEbt0QIjrQVFGJZ0wjJoha1+TigIB9LjJ3eSJCtUwj6naWwi0laOZJyR4L/+XCWpNRH2SjLvakIjims7ZEKbE3rVA/Vr0mY67NLnEm0fh6xglN2Jlm5Mag5hw3bHcOi72sQthjQofEtUE0fElAEGc4wBVCd87LzcLyCvZhg6VeJ/M+kC4uJuiMQJ6qkO92UDaV0bvY9svLlGBuBbd/PH0YPh0kkTUlH5IzJx/wymE2mSwtP8af1n0IBIItVfq6uuzct5IhEZvMoZsDv1pU5pqM/ucRuuvb6rtZedGpGjBZacM1uNa/MbvnF5imAHxfY7783saGaIpdNr6k4cxmHglelxwSR0zqujU2Q="
         - DEPLOY_STAGING=true
+    - if: branch = master
+      env:
+        - secure: "UuTZnGD+HSB+EYQFg2+lKhDwxlDUtU/uz4XdUG8/8F7Us9G7e7w/DL0jhnzpHjK13ig7Yafj83zZmNszpfaXhNdNp2glhiIeuupODODd24tRA4e9DBIoEToJEyjkXD7RttK4H7SaRp12yVEnE+gnUTiDCOJQHmkDl6DHwwUfeTG3P+dKgHsybdrXcUZG+ff4DPrwq9B6NU7izKC3QqByfcxhfxv+SE9e6vi8LKs6qdRbg4PnPEOc85kiqMmtqNHQ7hph3Np3oEaEeZqMylo2hKh/gXxWgNjH3uFwEtJx7sWYL/c3HpiNRMTPUFVJmGaU/xQqH3gGqEbt0QIjrQVFGJZ0wjJoha1+TigIB9LjJ3eSJCtUwj6naWwi0laOZJyR4L/+XCWpNRH2SjLvakIjims7ZEKbE3rVA/Vr0mY67NLnEm0fh6xglN2Jlm5Mag5hw3bHcOi72sQthjQofEtUE0fElAEGc4wBVCd87LzcLyCvZhg6VeJ/M+kC4uJuiMQJ6qkO92UDaV0bvY9svLlGBuBbd/PH0YPh0kkTUlH5IzJx/wymE2mSwtP8af1n0IBIItVfq6uuzct5IhEZvMoZsDv1pU5pqM/ucRuuvb6rtZedGpGjBZacM1uNa/MbvnF5imAHxfY7783saGaIpdNr6k4cxmHglelxwSR0zqujU2Q="
+        - DEPLOY_STAGING=true
+        - MAKE_TEST_TARGET=go_webdriver_test
+        - MAKE_TEST_FLAGS="STAGING=true"
 
 before_install: |
   export DOCKER_IMAGE=wptd-dev
@@ -45,26 +52,18 @@ install:
 script:
   - |
     # Deploy PR to staging environment (only when Travis secrets are available).
-    # Note: Travis 'deploy' task is skipped for PRs, so can't be used for this.
+    # Note: Done here (in 'script', not 'deploy') because we need deploy to happen before staging webdriver test.
     if [ ${DEPLOY_STAGING} == true ]; then
-      if [ -z "${TRAVIS_PULL_REQUEST_BRANCH}" ];
-      then echo "Not on a PR. Skipping ${APP_PATH} deployment.";
-      else
+      if [ "${TRAVIS_BRANCH}" == "master" ]; then
+        bash util/travis-deploy-staging.sh -f "webapp results-processor";
+      elif [ -n "${TRAVIS_PULL_REQUEST_BRANCH}" ]; then
         bash util/travis-deploy-staging.sh webapp;
         bash util/travis-deploy-staging.sh results-processor;
+      else
+        echo "Not on master or a PR. Skipping deployment.";
       fi;
     fi
   - | # Run tests
     if [ "${MAKE_TEST_TARGET}" != "" ]; then
-      docker exec -t -u $(id -u $USER):$(id -g $USER) "${DOCKER_INSTANCE}" make "${MAKE_TEST_TARGET}"
+      docker exec -t -u $(id -u $USER):$(id -g $USER) "${DOCKER_INSTANCE}" make "${MAKE_TEST_TARGET}" ${MAKE_TEST_FLAGS}
     fi
-
-# Continuously deploy master to staging.
-deploy:
-  skip_cleanup: true
-  provider: script
-  on:
-    branch: master
-    repo: web-platform-tests/wpt.fyi
-    condition: ${TRAVIS_SECURE_ENV_VARS} == true && ${DEPLOY_STAGING} == true
-  script: bash util/travis-deploy-staging.sh -f "webapp results-processor"

--- a/Makefile
+++ b/Makefile
@@ -70,14 +70,16 @@ go_large_test: go_webdriver_test
 
 integration_test: go_webdriver_test web_components_test
 
+go_webdriver_test: STAGING := false
 go_webdriver_test: go_deps xvfb firefox node-web-component-tester webserver_deps
-	$(START_XVFB)
+	if [ "$(USE_FRAME_BUFFER)" == "true" ]; then ($(START_XVFB)); fi
 	cd $(WPTD_PATH)webdriver; go test -v -tags=large \
 			--selenium_path=$(SELENIUM_SERVER_PATH) \
 			--firefox_path=$(FIREFOX_PATH) \
 			--geckodriver_path=$(GECKODRIVER_PATH) \
-			--frame_buffer=$(USE_FRAME_BUFFER)
-	$(STOP_XVFB)
+			--frame_buffer=$(USE_FRAME_BUFFER) \
+			--staging=$(STAGING)
+	if [[ "$(USE_FRAME_BUFFER)" == "true" ]]; then $(STOP_XVFB); fi
 
 web_components_test: xvfb firefox chrome node-web-component-tester webserver_deps
 	$(START_XVFB)

--- a/webdriver/search_test.go
+++ b/webdriver/search_test.go
@@ -3,17 +3,11 @@
 package webdriver
 
 import (
-	"context"
-	"fmt"
 	"testing"
 	"time"
 
-	"log"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/tebeka/selenium"
-	"github.com/web-platform-tests/wpt.fyi/shared"
-	"google.golang.org/appengine/datastore"
 )
 
 func TestSearch(t *testing.T) {
@@ -22,20 +16,13 @@ func TestSearch(t *testing.T) {
 		panic(err)
 	}
 	defer devAppserverInstance.Close()
-	if err = devAppserverInstance.AwaitReady(); err != nil {
-		panic(err)
-	}
-
-	if err = addStaticData(devAppserverInstance); err != nil {
-		panic(err)
-	}
 
 	service, wd, err := FirefoxWebDriver()
 	defer service.Stop()
 	defer wd.Quit()
 
 	// Navigate to the wpt.fyi homepage.
-	if err := wd.Get(devAppserverInstance.GetWebappUrl("/")); err != nil {
+	if err := wd.Get(devAppserverInstance.GetWebappURL("/")); err != nil {
 		panic(err)
 	}
 
@@ -70,80 +57,4 @@ func TestSearch(t *testing.T) {
 		assert.Fail(t, err.Error())
 	}
 	assert.Equal(t, "2dcontext/", text)
-}
-
-func addStaticData(i WebserverInstance) (err error) {
-	var ctx context.Context
-	if ctx, err = i.NewContext(); err != nil {
-		return err
-	}
-
-	staticDataTime, _ := time.Parse(time.RFC3339, "2017-10-18T00:00:00Z")
-	// Follow pattern established in run/*.py data collection code.
-	const sha = "b952881825"
-	const summaryURLFmtString = "/static/" + sha + "/%s"
-	staticTestRuns := []shared.TestRun{
-		{
-			ProductAtRevision: shared.ProductAtRevision{
-				Product: shared.Product{
-					BrowserName:    "chrome",
-					BrowserVersion: "63.0",
-					OSName:         "linux",
-					OSVersion:      "3.16",
-				},
-				Revision: sha,
-			},
-			ResultsURL: fmt.Sprintf(summaryURLFmtString, "chrome-63.0-linux-summary.json.gz"),
-			CreatedAt:  staticDataTime,
-		},
-		{
-			ProductAtRevision: shared.ProductAtRevision{
-				Product: shared.Product{
-					BrowserName:    "edge",
-					BrowserVersion: "15",
-					OSName:         "windows",
-					OSVersion:      "10",
-				},
-				Revision: sha,
-			},
-			ResultsURL: fmt.Sprintf(summaryURLFmtString, "edge-15-windows-10-sauce-summary.json.gz"),
-			CreatedAt:  staticDataTime,
-		},
-		{
-			ProductAtRevision: shared.ProductAtRevision{
-				Product: shared.Product{
-					BrowserName:    "firefox",
-					BrowserVersion: "57.0",
-					OSName:         "linux",
-					OSVersion:      "*",
-				},
-				Revision: sha,
-			},
-			ResultsURL: fmt.Sprintf(summaryURLFmtString, "firefox-57.0-linux-summary.json.gz"),
-			CreatedAt:  staticDataTime,
-		},
-		{
-			ProductAtRevision: shared.ProductAtRevision{
-				Product: shared.Product{
-					BrowserName:    "safari",
-					BrowserVersion: "10",
-					OSName:         "macos",
-					OSVersion:      "10.12",
-				},
-				Revision: sha,
-			},
-			ResultsURL: fmt.Sprintf(summaryURLFmtString, "safari-10.0-macos-10.12-sauce-summary.json.gz"),
-			CreatedAt:  staticDataTime,
-		},
-	}
-
-	log.Println("Adding static TestRun data...")
-	for i := range staticTestRuns {
-		key := datastore.NewIncompleteKey(ctx, "TestRun", nil)
-		if _, err := datastore.Put(ctx, key, &staticTestRuns[i]); err != nil {
-			return err
-		}
-		fmt.Printf("Added static run for %s\n", staticTestRuns[i].BrowserName)
-	}
-	return nil
 }


### PR DESCRIPTION
## Description
Changes the webdriver test to take a `--staging=true` flag (and optional `--remote_host` for the wpt.fyi address).

Also re-jigged .travis.yml to run the continuous master deployment in `script` so that it occurs before the `MAKE_TEST_TARGET`.

Resolves https://github.com/web-platform-tests/wpt.fyi/issues/199