### PR TITLE
Migrate webapp to use a gorilla/mux Router

### DIFF
--- a/api/routes.go
+++ b/api/routes.go
@@ -6,7 +6,8 @@ package api
 
 import "github.com/web-platform-tests/wpt.fyi/shared"
 
-func init() {
+// RegisterRoutes adds all the api route handlers.
+func RegisterRoutes() {
 	// API endpoint for diff of two test run summary JSON blobs.
 	shared.AddRoute("/api/diff", "api-diff", apiDiffHandler)
 

--- a/api/routes.go
+++ b/api/routes.go
@@ -8,20 +8,20 @@ import "github.com/web-platform-tests/wpt.fyi/shared"
 
 func init() {
 	// API endpoint for diff of two test run summary JSON blobs.
-	shared.AddRoute("/api/diff", apiDiffHandler)
+	shared.AddRoute("/api/diff", "api-diff", apiDiffHandler)
 
 	// API endpoint for fetching a manifest for a commit SHA.
-	shared.AddRoute("/api/manifest", apiManifestHandler)
+	shared.AddRoute("/api/manifest", "api-manifest", apiManifestHandler)
 
 	// API endpoint for listing all test runs for a given SHA.
-	shared.AddRoute("/api/runs", apiTestRunsHandler)
+	shared.AddRoute("/api/runs", "api-test-runs", apiTestRunsHandler)
 
 	// API endpoint for a single test run.
-	shared.AddRoute("/api/run", apiTestRunHandler)
+	shared.AddRoute("/api/run", "api-test-run", apiTestRunHandler)
 
 	// API endpoint for redirecting to a run's summary JSON blob.
-	shared.AddRoute("/api/results", apiResultsRedirectHandler)
+	shared.AddRoute("/api/results", "api-results", apiResultsRedirectHandler)
 
 	// API endpoint for receiving test results (wptreport) from runners.
-	shared.AddRoute("/api/results/upload", apiResultsReceiveHandler)
+	shared.AddRoute("/api/results/upload", "api-results-upload", apiResultsReceiveHandler)
 }

--- a/shared/routing.go
+++ b/shared/routing.go
@@ -23,11 +23,13 @@ func Router() *mux.Router {
 
 // AddRoute is a helper for registering a handler for an http path (route).
 // Note that it adds an HSTS header to the response.
-func AddRoute(route string, handler func(http.ResponseWriter, *http.Request)) {
-	globalRouter.HandleFunc(route, wrapHSTS(handler))
+func AddRoute(route, name string, handler func(http.ResponseWriter, *http.Request)) *mux.Route {
+	return globalRouter.HandleFunc(route, WrapHSTS(handler)).Name(name)
 }
 
-func wrapHSTS(h http.HandlerFunc) http.HandlerFunc {
+// WrapHSTS wraps the given handler func in one that sets the
+// Strict-Transport-Security header on the response.
+func WrapHSTS(h http.HandlerFunc) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		value := "max-age=31536000; preload"
 		w.Header().Add("Strict-Transport-Security", value)

--- a/shared/routing.go
+++ b/shared/routing.go
@@ -13,6 +13,7 @@ import (
 var globalRouter = mux.NewRouter()
 
 func init() {
+	globalRouter.StrictSlash(true)
 	http.Handle("/", globalRouter)
 }
 

--- a/shared/routing.go
+++ b/shared/routing.go
@@ -1,0 +1,36 @@
+// Copyright 2018 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package shared
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+var globalRouter = mux.NewRouter()
+
+func init() {
+	http.Handle("/", globalRouter)
+}
+
+// Router returns the global mux.Router used for handling all requests.
+func Router() *mux.Router {
+	return globalRouter
+}
+
+// AddRoute is a helper for registering a handler for an http path (route).
+// Note that it adds an HSTS header to the response.
+func AddRoute(route string, handler func(http.ResponseWriter, *http.Request)) {
+	globalRouter.HandleFunc(route, wrapHSTS(handler))
+}
+
+func wrapHSTS(h http.HandlerFunc) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		value := "max-age=31536000; preload"
+		w.Header().Add("Strict-Transport-Security", value)
+		h(w, r)
+	})
+}

--- a/shared/util.go
+++ b/shared/util.go
@@ -6,7 +6,6 @@ package shared
 
 import (
 	"encoding/json"
-	"net/http"
 	"sort"
 	"strings"
 
@@ -61,20 +60,6 @@ func loadBrowsers() (map[string]bool, []string) {
 	sort.Strings(browserNamesAlphabetical)
 
 	return browserNames, browserNamesAlphabetical
-}
-
-// AddRoute registers a handler for an http path (route).
-// Note that it adds an HSTS header to the response.
-func AddRoute(route string, handler func(http.ResponseWriter, *http.Request)) {
-	http.HandleFunc(route, wrapHSTS(handler))
-}
-
-func wrapHSTS(h http.HandlerFunc) http.HandlerFunc {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		value := "max-age=31536000; preload"
-		w.Header().Add("Strict-Transport-Security", value)
-		h(w, r)
-	})
 }
 
 // ToStringSlice converts a set to a typed string slice.

--- a/webapp/routes.go
+++ b/webapp/routes.go
@@ -7,12 +7,20 @@ package webapp
 import (
 	"html/template"
 
+	"github.com/web-platform-tests/wpt.fyi/api"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
 var templates = template.Must(template.ParseGlob("templates/*.html"))
 
 func init() {
+	// webapp.RegisterRoutes has a catch-all, so needs to go last.
+	api.RegisterRoutes()
+	RegisterRoutes()
+}
+
+// RegisterRoutes adds the route handlers for the webapp.
+func RegisterRoutes() {
 	// About wpt.fyi
 	shared.AddRoute("/about", "about", aboutHandler)
 
@@ -27,10 +35,11 @@ func init() {
 	shared.AddRoute("/test-runs", "test-runs", testRunsHandler)
 
 	// Admin-only manual results upload.
-	shared.AddRoute("/admin/results/upload", "upload", adminUploadHandler)
+	shared.AddRoute("/admin/results/upload", "admin-results-upload", adminUploadHandler)
 
 	// Test run results, viewed by browser (default view)
 	// For run results diff view, 'before' and 'after' params can be given.
+	shared.AddRoute("/results/", "results", testResultsHandler)
 	shared.AddRoute("/results/{path}", "results", testResultsHandler)
 
 	// Legacy wildcard match

--- a/webapp/routes.go
+++ b/webapp/routes.go
@@ -20,7 +20,6 @@ func init() {
 	shared.AddRoute("/anomalies", "anomaly", anomalyHandler)
 
 	// Test run results, viewed by pass-rate across the browsers
-	shared.AddRoute("/interop", "interop", interopHandler)
 	shared.AddRoute("/interop/", "interop", interopHandler)
 	shared.AddRoute("/interop/{path}", "interop", interopHandler)
 

--- a/webapp/routes.go
+++ b/webapp/routes.go
@@ -13,24 +13,28 @@ import (
 var templates = template.Must(template.ParseGlob("templates/*.html"))
 
 func init() {
-	// Test run results, viewed by browser (default view)
-	// For run results diff view, 'before' and 'after' params can be given.
-	shared.AddRoute("/", testResultsHandler)
-	shared.AddRoute("/results", testResultsHandler) // Prevent default redirect
-	shared.AddRoute("/results/", testResultsHandler)
-
 	// About wpt.fyi
-	shared.AddRoute("/about", aboutHandler)
-
-	// Test run results, viewed by pass-rate across the browsers
-	shared.AddRoute("/interop/", interopHandler)
+	shared.AddRoute("/about", "about", aboutHandler)
 
 	// Lists of test run results which have poor interoperability
-	shared.AddRoute("/interop/anomalies", anomalyHandler)
+	shared.AddRoute("/anomalies", "anomaly", anomalyHandler)
+
+	// Test run results, viewed by pass-rate across the browsers
+	shared.AddRoute("/interop", "interop", interopHandler)
+	shared.AddRoute("/interop/", "interop", interopHandler)
+	shared.AddRoute("/interop/{path}", "interop", interopHandler)
 
 	// List of all test runs, by SHA[0:10]
-	shared.AddRoute("/test-runs", testRunsHandler)
+	shared.AddRoute("/test-runs", "test-runs", testRunsHandler)
 
 	// Admin-only manual results upload.
-	shared.AddRoute("/admin/results/upload", adminUploadHandler)
+	shared.AddRoute("/admin/results/upload", "upload", adminUploadHandler)
+
+	// Test run results, viewed by browser (default view)
+	// For run results diff view, 'before' and 'after' params can be given.
+	shared.AddRoute("/results/{path}", "results", testResultsHandler)
+
+	// Legacy wildcard match
+	shared.AddRoute("/", "results-legacy", testResultsHandler)
+	shared.AddRoute("/{path}", "results-legacy", testResultsHandler)
 }

--- a/webapp/routes_test.go
+++ b/webapp/routes_test.go
@@ -7,43 +7,35 @@
 package webapp
 
 import (
-	"testing"
-
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"testing"
 
+	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
+	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
 func TestLandingPageBound(t *testing.T) {
 	// Note that init() is always called by the Golang runtime.
-	assertBound(t, "/")
-	assertHandlerMatch(t, "/2dcontext", "/")
-}
-
-func TestLandingPageHSTS(t *testing.T) {
+	assertHandlerIs(t, "/", "results-legacy")
 	assertHSTS(t, "/")
+	assertHandlerIs(t, "/2dcontext", "results-legacy")
 }
 
 func TestAboutBound(t *testing.T) {
-	assertBound(t, "/about")
-	assertHandlerMatch(t, "/about", "/about")
+	assertHandlerIs(t, "/about", "about")
 }
 
 func TestInteropBound(t *testing.T) {
-	const pattern = "/interop/"
-	assertBound(t, pattern)
-	assertHandlerMatch(t, pattern, pattern)
-	assertHandlerMatch(t, "/interop/2dcontext", pattern)
-	// NOTE(lukebjerring): Trailing slash makes it a path.
-	assertHandlerMatch(t, "/interop/anomalies/", pattern)
-	assertHandlerMatch(t, "/interop/anomalies/2dcontext", pattern)
+	assertHandlerIs(t, "/interop", "interop")
+	assertHandlerIs(t, "/interop/", "interop")
+	assertHandlerIs(t, "/interop/2dcontext", "interop")
 }
 
 func TestInteropAnomaliesBound(t *testing.T) {
-	const pattern = "/interop/anomalies"
-	assertBound(t, pattern)
-	assertHandlerMatch(t, pattern, pattern)
+	assertHandlerIs(t, "/anomalies", "anomaly")
 }
 
 func TestRunsBound(t *testing.T) {
@@ -75,20 +67,23 @@ func TestResultsBound(t *testing.T) {
 }
 
 func TestAdminResultsUploadBound(t *testing.T) {
+	assertHandlerIs(t, "/admin/results/upload", "upload")
 	assertHSTS(t, "/admin/results/upload")
 }
 
-func assertBound(t *testing.T, path string) {
+func assertBound(t *testing.T, path string) mux.RouteMatch {
 	req := httptest.NewRequest("GET", path, nil)
-	handler, _ := http.DefaultServeMux.Handler(req)
-	assert.NotNil(t, handler)
+	router := shared.Router()
+	match := mux.RouteMatch{}
+	assert.Truef(t, router.Match(req, &match), "%s should match a route", path)
+	return match
 }
 
-func assertHandlerMatch(t *testing.T, path string, pattern string) {
-	req := httptest.NewRequest("GET", path, nil)
-	handler, handlerPattern := http.DefaultServeMux.Handler(req)
-	assert.NotNil(t, handler)
-	assert.Equal(t, pattern, handlerPattern)
+func assertHandlerIs(t *testing.T, path string, name string) {
+	match := assertBound(t, path)
+	if match.Route != nil {
+		assert.Equal(t, name, match.Route.GetName())
+	}
 }
 
 func assertHSTS(t *testing.T, path string) {
@@ -96,6 +91,8 @@ func assertHSTS(t *testing.T, path string) {
 	rr := httptest.NewRecorder()
 	handler, _ := http.DefaultServeMux.Handler(req)
 	handler.ServeHTTP(rr, req)
-	assert.Equal(t, "max-age=31536000; preload",
-		rr.HeaderMap["Strict-Transport-Security"][0])
+	assert.Equal(
+		t,
+		"[max-age=31536000; preload]",
+		fmt.Sprintf("%s", rr.HeaderMap["Strict-Transport-Security"]))
 }

--- a/webapp/routes_test.go
+++ b/webapp/routes_test.go
@@ -67,7 +67,7 @@ func TestResultsBound(t *testing.T) {
 }
 
 func TestAdminResultsUploadBound(t *testing.T) {
-	assertHandlerIs(t, "/admin/results/upload", "upload")
+	assertHandlerIs(t, "/admin/results/upload", "admin-results-upload")
 	assertHSTS(t, "/admin/results/upload")
 }
 

--- a/webapp/test_results_handler.go
+++ b/webapp/test_results_handler.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/gorilla/mux"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
@@ -24,19 +25,19 @@ import (
 // The JSON property "initially_loaded" is what controls this.
 func testResultsHandler(w http.ResponseWriter, r *http.Request) {
 	// Redirect legacy paths.
-	testPath := ""
-	if r.URL.Path == "/" || r.URL.Path == "/results" {
-		testPath = "/"
-	} else if strings.Index(r.URL.Path, "/results/") != 0 {
-		testPath = r.URL.Path
+	path := mux.Vars(r)["path"]
+	var redir string
+	if path == "results" {
+		redir = "/results/"
+	} else if path != "" && strings.Index(r.URL.Path, "/results/") != 0 {
+		redir = fmt.Sprintf("/results/%s", path)
 	}
-	if testPath != "" {
+	if redir != "" {
 		params := ""
 		if r.URL.RawQuery != "" {
 			params = "?" + r.URL.RawQuery
 		}
-		url := fmt.Sprintf("/results%s%s", testPath, params)
-		http.Redirect(w, r, url, http.StatusTemporaryRedirect)
+		http.Redirect(w, r, redir+params, http.StatusTemporaryRedirect)
 		return
 	}
 

--- a/webapp/test_results_handler.go
+++ b/webapp/test_results_handler.go
@@ -29,7 +29,7 @@ func testResultsHandler(w http.ResponseWriter, r *http.Request) {
 	var redir string
 	if path == "results" {
 		redir = "/results/"
-	} else if path != "" && strings.Index(r.URL.Path, "/results/") != 0 {
+	} else if strings.Index(r.URL.Path, "/results/") != 0 {
 		redir = fmt.Sprintf("/results/%s", path)
 	}
 	if redir != "" {


### PR DESCRIPTION
## Description
Migrate the webapp's routing to leverage gorilla/mux, a more powerful routing library. Unblocks #213 by supporting an `{id}` in the path.

@foolip - note that this highlighted a poor choice of nesting `/interop/anomalies` and thus migrates it to `/anomalies`

## Review Information
See auto-deployed environment.