### PR TITLE
Add an ID field to the TestRun model.

### DIFF
--- a/api/results_redirect_handler.go
+++ b/api/results_redirect_handler.go
@@ -90,14 +90,18 @@ func getRun(r *http.Request, run string, product string) (latest shared.TestRun,
 	if len(productPieces) > 3 {
 		query = shared.VersionPrefix(query, "OSVersion", productPieces[3], true)
 	}
-	_, err = query.GetAll(ctx, &testRunResults)
+	keys, err := query.GetAll(ctx, &testRunResults)
 	if err != nil {
 		return
+	}
+	// Append the keys as ID
+	for i, key := range keys {
+		testRunResults[i].ID = key.IntID()
 	}
 	if len(testRunResults) > 0 {
 		latest = testRunResults[0]
 	}
-	return
+	return latest, err
 }
 
 func getResultsURL(run shared.TestRun, testFile string) (resultsURL string) {

--- a/shared/datastore.go
+++ b/shared/datastore.go
@@ -53,6 +53,10 @@ func LoadTestRuns(
 		if err = datastore.GetMulti(ctx, keys, testRunResults); err != nil {
 			return nil, err
 		}
+		// Append the keys as ID
+		for i, key := range keys {
+			testRunResults[i].ID = key.IntID()
+		}
 		testRuns = append(testRuns, testRunResults...)
 	}
 	return testRuns, nil

--- a/shared/datastore_medium_test.go
+++ b/shared/datastore_medium_test.go
@@ -1,0 +1,46 @@
+// +build medium
+
+package shared
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/appengine"
+	"google.golang.org/appengine/aetest"
+	"google.golang.org/appengine/datastore"
+)
+
+func TestLoadTestRuns(t *testing.T) {
+	testRun := TestRun{
+		ProductAtRevision: ProductAtRevision{
+			Product: Product{
+				BrowserName:    "chrome",
+				BrowserVersion: "63.0",
+				OSName:         "linux",
+				OSVersion:      "3.16",
+			},
+			Revision: "1234567890",
+		},
+		ResultsURL: "/static/chrome-63.0-linux-summary.json.gz",
+		CreatedAt:  time.Now(),
+	}
+
+	i, err := aetest.NewInstance(&aetest.Options{StronglyConsistentDatastore: true})
+	assert.Nil(t, err)
+	defer i.Close()
+	r, err := i.NewRequest("GET", "/api/run?product=chrome-66.0", nil)
+	assert.Nil(t, err)
+
+	// 'Yesterday', v66...139 earlier version.
+	ctx := appengine.NewContext(r)
+	key := datastore.NewIncompleteKey(ctx, "TestRun", nil)
+	key, _ = datastore.Put(ctx, key, &testRun)
+
+	chrome, _ := ParseProduct("chrome")
+	loaded, err := LoadTestRuns(ctx, []Product{chrome}, "latest", nil, 1)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(loaded))
+	assert.Equalf(t, key.IntID(), loaded[0].ID, "ID field should be populated.")
+}

--- a/shared/models.go
+++ b/shared/models.go
@@ -70,6 +70,8 @@ func (p ProductAtRevision) String() string {
 
 // TestRun stores metadata for a test run (produced by run/run.py)
 type TestRun struct {
+	ID int64 `json:"id" datastore:"-"`
+
 	ProductAtRevision
 
 	// URL for summary of results, which is derived from raw results.

--- a/shared/routing.go
+++ b/shared/routing.go
@@ -10,22 +10,22 @@ import (
 	"github.com/gorilla/mux"
 )
 
-var globalRouter = mux.NewRouter()
-
-func init() {
-	globalRouter.StrictSlash(true)
-	http.Handle("/", globalRouter)
-}
+var globalRouter *mux.Router
 
 // Router returns the global mux.Router used for handling all requests.
 func Router() *mux.Router {
+	if globalRouter == nil {
+		globalRouter = mux.NewRouter()
+		globalRouter.StrictSlash(true)
+		http.Handle("/", globalRouter)
+	}
 	return globalRouter
 }
 
 // AddRoute is a helper for registering a handler for an http path (route).
 // Note that it adds an HSTS header to the response.
 func AddRoute(route, name string, handler func(http.ResponseWriter, *http.Request)) *mux.Route {
-	return globalRouter.HandleFunc(route, WrapHSTS(handler)).Name(name)
+	return Router().HandleFunc(route, WrapHSTS(handler)).Name(name)
 }
 
 // WrapHSTS wraps the given handler func in one that sets the


### PR DESCRIPTION
Working towards #213 

## Description

Adds an `ID` field to the `TestRun` struct, which is manually populated after loading from datastore, and ignored by datastore (to avoid duplicating the field).

## Review Information
Load https://test-run-id-field-dot-wptdashboard-staging.appspot.com/api/runs and witness `id` in the JSON.