### PR TITLE
Increase the memory limit of webapp

### DIFF
--- a/webapp/app.yaml
+++ b/webapp/app.yaml
@@ -4,6 +4,7 @@
 
 runtime: go
 api_version: go1
+instance_class: F4_1G
 
 builtins:
 - remote_api: on


### PR DESCRIPTION
## Description

Both the results receiver and the manifest API need a lot more memory than the default 128MB:
* The receiver needs to fetch wptreport from a remote URL to memory if the runner provides a URL instead of uploading a file.
* The manifest API needs to deserialize the WPT manifest JSON, which is also pretty big.

1GB is the largest memory AppEngine offers. We might not need that much, but we can scale down later based on monitoring.

This should fix or alleviate #220 .

## Review Information

Once the staging deployment is up, try the manifest API a few times and examine the logs. There should be no OOM.