### PR TITLE
Silence gloud install script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,15 +158,13 @@ node: curl gpg
 	fi
 
 gcloud: python curl gpg
-	@ echo "travis_fold:start:gcloud_install"
 	if [[ "$$(which gcloud)" == "" ]]; then \
 		curl -s https://sdk.cloud.google.com > ./install-gcloud.sh; \
-		bash ./install-gcloud.sh --disable-prompts --install-dir=$(HOME); \
+		bash ./install-gcloud.sh --disable-prompts --install-dir=$(HOME) > /dev/null; \
 		rm -f ./install-gcloud.sh; \
 		gcloud components install --quiet core gsutil; \
 		gcloud config set disable_usage_reporting false; \
 	fi
-	@ echo "travis_fold:end:gcloud_install"
 
 eslint: node-babel-eslint node-eslint node-eslint-plugin-html
 	cd $(WPTD_PATH)webapp; npm run lint


### PR DESCRIPTION
The script prints out a few thousand lines of logs. They were put inside
a pair of Travis folding marks, but are still too noisy (e.g. folding
doesn't take effect when logs are still being streamed, or when Makefile
is used locally).

In the Dockerfile of results receiver, the stdout of this script is
directed to /dev/null, which seems to be a good compromise so far as
some of the more useful information is in stderr, so let's do this in
the project Makefile, too.
