### PR TITLE
Replace / and _ with - in automatic branch naming

### DIFF
--- a/util/deploy.sh
+++ b/util/deploy.sh
@@ -39,7 +39,7 @@ cd ${WPTD_PATH}
 make webserver_deps || fatal "Error installing deps"
 
 # Create a name for this version
-BRANCH_NAME=${BRANCH_NAME:-"$(git rev-parse --abbrev-ref HEAD)"}
+BRANCH_NAME=${BRANCH_NAME:-"$(git rev-parse --abbrev-ref HEAD | tr /_ - | cut -c 1-63)"}
 USER="$(git remote -v get-url origin | sed -E 's#(https?:\/\/|git@)github.com(\/|:)##' | sed 's#/.*$##')-"
 if [[ "${USER}" == "web-platform-tests-" ]]; then USER=""; fi
 


### PR DESCRIPTION
Example failed deployment build: https://travis-ci.org/web-platform-tests/wpt.fyi/jobs/387942807

> ERROR: (gcloud.app.deploy) argument --version/-v: Bad value [zcorpan/clarify-browsers-passing]: May only contain lowercase letters, digits, and hyphens. Must begin and end with a letter or digit. Must not exceed 63 characters.