### PR TITLE
Fix staging deployment and tweak some logging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ script:
     # Deploy PR to staging environment (only when Travis secrets are available).
     # Note: Done here (in 'script', not 'deploy') because we need deploy to happen before staging webdriver test.
     if [ ${DEPLOY_STAGING} == true ]; then
-      if [ "${TRAVIS_BRANCH}" == "master" ]; then
+      if [ "${TRAVIS_PULL_REQUEST}" == "false" -a "${TRAVIS_BRANCH}" == "master" ]; then
         bash util/travis-deploy-staging.sh -f "webapp results-processor";
       elif [ -n "${TRAVIS_PULL_REQUEST_BRANCH}" ]; then
         bash util/travis-deploy-staging.sh webapp;

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ web_components_test: xvfb firefox chrome node-web-component-tester webserver_dep
 	$(STOP_XVFB)
 
 sys_update: sys_deps
-	sudo apt-get update
+	sudo apt-get --quiet update
 	gcloud components update
 	npm install -g npm
 
@@ -115,7 +115,7 @@ firefox: browser_deps
 	fi
 
 browser_deps: wget java
-	sudo apt-get install --assume-yes --no-install-suggests $$(apt-cache depends firefox-esr chromedriver |  grep Depends | sed "s/.*ends:\ //" | tr '\n' ' ')
+	sudo apt-get install -qy --no-install-suggests $$(apt-cache depends firefox-esr chromedriver |  grep Depends | sed "s/.*ends:\ //" | tr '\n' ' ')
 
 go_deps: gcloud go_packages $(GO_FILES)
 
@@ -142,19 +142,19 @@ wget: apt-get-wget
 java:
 	@ # java has a different apt-get package name.
 	if [[ "$$(which java)" == "" ]]; then \
-		sudo apt-get install --assume-yes --no-install-suggests openjdk-8-jdk; \
+		sudo apt-get install -qy --no-install-suggests openjdk-8-jdk; \
 	fi
 
 gpg:
 	@ # gpg has a different apt-get package name.
 	if [[ "$$(which gpg)" == "" ]]; then \
-		sudo apt-get install --assume-yes --no-install-suggests gnupg; \
+		sudo apt-get install -qy --no-install-suggests gnupg; \
 	fi
 
 node: curl gpg
 	if [[ "$$(which node)" == "" ]]; then \
 		curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -; \
-		sudo apt-get install -y nodejs; \
+		sudo apt-get install -qy nodejs; \
 	fi
 
 gcloud: python curl gpg
@@ -183,7 +183,7 @@ bower_components: git node-bower
 
 xvfb:
 	if [[ "$(USE_FRAME_BUFFER)" == "true" && "$$(which Xvfb)" == "" ]]; then \
-		sudo apt-get install --assume-yes --no-install-suggests xvfb; \
+		sudo apt-get install -qy --no-install-suggests xvfb; \
 	fi
 
 gcloud-%: gcloud

--- a/util/deploy-comment.sh
+++ b/util/deploy-comment.sh
@@ -47,7 +47,7 @@ then
     curl -H "Authorization: token ${GITHUB_TOKEN}" \
           -X "POST" \
           -d "${POST_BODY}" \
-          -vv \
+          -s \
           "https://api.github.com/repos/${TRAVIS_REPO_SLUG}/issues/${TRAVIS_PULL_REQUEST}/comments"
 else
     info "Found existing comment mentioning link:\n${STAGING_URL}"

--- a/util/travis-deploy-staging.sh
+++ b/util/travis-deploy-staging.sh
@@ -27,7 +27,7 @@ APP_DEPS_REGEX="^(${APP_DEPS})/"
 UTIL_DIR="$(dirname "${BASH_SOURCE[0]}")"
 source "${UTIL_DIR}/logging.sh"
 
-if [ "${TRAVIS_SECURE_ENV_VARS}" == "false" ]; then
+if [ "${TRAVIS_SECURE_ENV_VARS}" != "true" ]; then
   info "Travis secrets unavaible. Skipping ${APP_PATH} deployment."
   exit 0
 fi

--- a/util/travis-deploy-staging.sh
+++ b/util/travis-deploy-staging.sh
@@ -46,8 +46,8 @@ debug "Copying output to ${TEMP_FILE:=$(mktemp)}"
 docker exec -t -u $(id -u $USER):$(id -g $USER) "${DOCKER_INSTANCE}" \
     make deploy_staging \
         PROJECT=wptdashboard-staging \
-        APP_PATH=${APP_PATH} \
-        BRANCH_NAME=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH} 2>&1 \
+        APP_PATH="${APP_PATH}" \
+        BRANCH_NAME="${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}" 2>&1 \
             | tee ${TEMP_FILE}
 if [ "${EXIT_CODE:=${PIPESTATUS[0]}}" != "0" ]; then exit ${EXIT_CODE}; fi
 DEPLOYED_URL="$(grep -Po 'Deployed to \K[^\s]+' ${TEMP_FILE} | tr -d '\n')"

--- a/util/travis-deploy-staging.sh
+++ b/util/travis-deploy-staging.sh
@@ -36,7 +36,7 @@ fi
 if [ "${FORCE_PUSH}" != "true" ];
 then
   git diff --name-only ${TRAVIS_BRANCH}..HEAD | egrep "${APP_DEPS_REGEX}" || {
-    info "No changes detected under ${APP_PATH}. Skipping deployment."
+    info "No changes detected under ${APP_DEPS}. Skipping deploying ${APP_PATH}."
     exit 0
   }
 fi


### PR DESCRIPTION
## Description

This PR tries to fix the staging deployment for `results-processor` (by quoting some variables that might contain spaces), as well as to fix #229 (by inverting the check for `TRAVIS_SECURE_ENV_VARS` so that it also works when the env var doesn't exist).

## Changes

I also made some drive-by changes to improve logging, mostly to make `curl` and `apt-get` quieter.