### PR TITLE
[processor] Send labels when creating test runs

### DIFF
--- a/results-processor/main.py
+++ b/results-processor/main.py
@@ -113,7 +113,7 @@ def task_handler():
 
     params = flask.request.form
     # Mandatory fields:
-    # uploader = params['uploader']
+    uploader = params['uploader']
     gcs_path = params['gcs']
     result_type = params['type']
     # TODO(Hexcles): Support multiple results.
@@ -161,7 +161,7 @@ def task_handler():
 
     ds = datastore.Client()
     upload_token = ds.get(ds.key('Token', 'upload-token'))['Secret']
-    wptreport.create_test_run(report, upload_token,
+    wptreport.create_test_run(report, uploader, upload_token,
                               results_gcs_path, raw_results_gcs_path)
 
     return resp

--- a/results-processor/wptreport.py
+++ b/results-processor/wptreport.py
@@ -324,7 +324,7 @@ def create_test_run(report, uploader, secret,
     payload = report.test_run_metadata
     payload['results_url'] = GCS_PUBLIC_DOMAIN + results_gcs_path
     payload['raw_results_url'] = GCS_PUBLIC_DOMAIN + raw_results_gcs_path
-    payload['labels'] = [uploader]
+    payload['labels'] = [uploader, report.run_info['product']]
 
     response = requests.post(
         config.project_baseurl() + '/api/run',

--- a/results-processor/wptreport.py
+++ b/results-processor/wptreport.py
@@ -303,13 +303,15 @@ class WPTReport(object):
         return payload
 
 
-def create_test_run(report, secret, results_gcs_path, raw_results_gcs_path):
+def create_test_run(report, uploader, secret,
+                    results_gcs_path, raw_results_gcs_path):
     """Creates a TestRun on the dashboard.
 
     By posting to the /api/run endpoint.
 
     Args:
         report: A WPTReport.
+        uploader: The name of the uploader.
         secret: An upload token.
         results_gcs_path: The GCS path to the gzipped summary file.
             (e.g. '/wptd/0123456789/chrome-62.0-linux-summary.json.gz')
@@ -322,6 +324,7 @@ def create_test_run(report, secret, results_gcs_path, raw_results_gcs_path):
     payload = report.test_run_metadata
     payload['results_url'] = GCS_PUBLIC_DOMAIN + results_gcs_path
     payload['raw_results_url'] = GCS_PUBLIC_DOMAIN + raw_results_gcs_path
+    payload['labels'] = [uploader]
 
     response = requests.post(
         config.project_baseurl() + '/api/run',


### PR DESCRIPTION
Currently, there is only one label: uploader.

The test run creation API doesn't handle labels at the moment, but extra params are safely ignored.

Part of #212 .

The JSON payload now has one extra field: `labels`, which is an array of strings.