### PR TITLE
Load interop + anomalies data with backward compatible struct

### DIFF
--- a/webapp/anomaly_handler.go
+++ b/webapp/anomaly_handler.go
@@ -36,7 +36,7 @@ func anomalyHandler(w http.ResponseWriter, r *http.Request) {
 	passRateType := metrics.GetDatastoreKindName(metrics.PassRateMetadata{})
 	query := datastore.NewQuery(passRateType).Order("-StartTime").Limit(1)
 
-	var metadataSlice []metrics.PassRateMetadata
+	var metadataSlice []metrics.PassRateMetadataLegacy
 	if _, err := query.GetAll(ctx, &metadataSlice); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/webapp/interop_handler.go
+++ b/webapp/interop_handler.go
@@ -19,8 +19,8 @@ func interopHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := appengine.NewContext(r)
 	passRateType := metrics.GetDatastoreKindName(metrics.PassRateMetadata{})
 	query := datastore.NewQuery(passRateType).Order("-StartTime").Limit(1)
-	var metadataSlice []metrics.PassRateMetadata
 
+	var metadataSlice []metrics.PassRateMetadataLegacy
 	if _, err := query.GetAll(ctx, &metadataSlice); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return


### PR DESCRIPTION
Relies on https://github.com/web-platform-tests/results-analysis/pull/40

Change the datastore-reading struct to be the Legacy formats, which don't ignore the nested `TestRun` entities.