### PR TITLE
Add Labels to the TestRun entity

### DIFF
--- a/api/results_redirect_handler.go
+++ b/api/results_redirect_handler.go
@@ -55,18 +55,18 @@ func apiResultsRedirectHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	if (shared.TestRun{}) == run {
+	if run == nil {
 		http.Error(w, fmt.Sprintf("404 - Test run '%s' not found", runSHA), http.StatusNotFound)
 		return
 	}
 
 	test := params.Get("test")
-	resultsURL := getResultsURL(run, test)
+	resultsURL := getResultsURL(*run, test)
 
 	http.Redirect(w, r, resultsURL, http.StatusFound)
 }
 
-func getRun(r *http.Request, run string, product string) (latest shared.TestRun, err error) {
+func getRun(r *http.Request, run string, product string) (latest *shared.TestRun, err error) {
 	productPieces := strings.Split(product, "-")
 	if len(productPieces) < 1 || len(productPieces) > 4 {
 		err = errors.New("Invalid path")
@@ -99,7 +99,7 @@ func getRun(r *http.Request, run string, product string) (latest shared.TestRun,
 		testRunResults[i].ID = key.IntID()
 	}
 	if len(testRunResults) > 0 {
-		latest = testRunResults[0]
+		latest = &testRunResults[0]
 	}
 	return latest, err
 }

--- a/api/test_run.go
+++ b/api/test_run.go
@@ -56,7 +56,6 @@ func apiTestRunGetHandler(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Invalid query params", http.StatusBadRequest)
 			return
 		}
-
 		var browser, product *shared.Product
 		product, err = shared.ParseProductParam(r)
 		if err != nil {
@@ -75,7 +74,8 @@ func apiTestRunGetHandler(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Missing required 'product' param", http.StatusBadRequest)
 			return
 		}
-		testRuns, err := shared.LoadTestRuns(ctx, []shared.Product{*product}, runSHA, nil, 1)
+		labels := shared.ParseLabelsParam(r)
+		testRuns, err := shared.LoadTestRuns(ctx, []shared.Product{*product}, labels, runSHA, nil, 1)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/api/test_runs.go
+++ b/api/test_runs.go
@@ -62,8 +62,8 @@ func apiTestRunsHandler(w http.ResponseWriter, r *http.Request) {
 		// Default to a single, latest run when from & max-count both empty.
 		limit = 1
 	}
-
-	testRuns, err := shared.LoadTestRuns(ctx, products, runSHA, from, limit)
+	labels := shared.ParseLabelsParam(r)
+	testRuns, err := shared.LoadTestRuns(ctx, products, labels, runSHA, from, limit)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/shared/datastore.go
+++ b/shared/datastore.go
@@ -16,6 +16,7 @@ import (
 func LoadTestRuns(
 	ctx context.Context,
 	products []Product,
+	labels mapset.Set,
 	sha string,
 	from *time.Time,
 	limit int) (result []TestRun, err error) {
@@ -23,6 +24,15 @@ func LoadTestRuns(
 	baseQuery := datastore.NewQuery("TestRun")
 	if sha != "" && sha != "latest" {
 		baseQuery = baseQuery.Filter("Revision =", sha)
+	}
+	if labels != nil {
+		for i := range labels.Iter() {
+			label := i.(string)
+			if label == "experimental" || IsBrowserName(label) {
+				continue // Special-cased in GetProductsForRequest
+			}
+			baseQuery = baseQuery.Filter("Labels =", label)
+		}
 	}
 	for _, product := range products {
 		var prefiltered *mapset.Set

--- a/shared/datastore_medium_test.go
+++ b/shared/datastore_medium_test.go
@@ -39,7 +39,7 @@ func TestLoadTestRuns(t *testing.T) {
 	key, _ = datastore.Put(ctx, key, &testRun)
 
 	chrome, _ := ParseProduct("chrome")
-	loaded, err := LoadTestRuns(ctx, []Product{chrome}, "latest", nil, 1)
+	loaded, err := LoadTestRuns(ctx, []Product{chrome}, nil, "latest", nil, 1)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(loaded))
 	assert.Equalf(t, key.IntID(), loaded[0].ID, "ID field should be populated.")

--- a/shared/models.go
+++ b/shared/models.go
@@ -85,6 +85,9 @@ type TestRun struct {
 	// URL for raw results JSON object. Resembles the JSON output of the
 	// wpt report tool.
 	RawResultsURL string `json:"raw_results_url"`
+
+	// Labels for the test run.
+	Labels []string `json:"labels"`
 }
 
 // TestRuns is a helper type for an array of TestRun entities.

--- a/shared/run_diff.go
+++ b/shared/run_diff.go
@@ -49,7 +49,7 @@ func FetchRunResultsJSONForSpec(
 
 // FetchRunForSpec loads the wpt.fyi TestRun metadata for the given spec.
 func FetchRunForSpec(ctx context.Context, revision ProductAtRevision) (*TestRun, error) {
-	testRuns, err := LoadTestRuns(ctx, []Product{revision.Product}, revision.Revision, nil, 1)
+	testRuns, err := LoadTestRuns(ctx, []Product{revision.Product}, nil, revision.Revision, nil, 1)
 	if err != nil {
 		return nil, err
 	}

--- a/util/populate_dev_data.go
+++ b/util/populate_dev_data.go
@@ -101,6 +101,7 @@ func main() {
 			CreatedAt:  staticDataTime,
 		},
 	}
+	labelRuns(staticTestRuns, "test", "static")
 
 	timeZero := time.Unix(0, 0)
 	// Follow pattern established in metrics/run/*.go data collection code.
@@ -188,6 +189,7 @@ func main() {
 
 	log.Print("Adding latest production TestRun data...")
 	prodTestRuns := shared.FetchLatestRuns(*host)
+	labelRuns(prodTestRuns, "prod")
 	latestProductionTestRunMetadata := make([]interface{}, len(prodTestRuns))
 	for i := range prodTestRuns {
 		latestProductionTestRunMetadata[i] = &prodTestRuns[i]
@@ -196,11 +198,21 @@ func main() {
 
 	log.Print("Adding latest experimental TestRun data...")
 	prodTestRuns = shared.FetchRuns(*host, "latest", mapset.NewSet("experimental"))
+	labelRuns(prodTestRuns, "prod")
+
 	latestProductionTestRunMetadata = make([]interface{}, len(prodTestRuns))
 	for i := range prodTestRuns {
 		latestProductionTestRunMetadata[i] = &prodTestRuns[i]
 	}
 	addData(ctx, testRunKindName, latestProductionTestRunMetadata)
+}
+
+func labelRuns(runs []shared.TestRun, labels ...string) {
+	for i := range runs {
+		for _, label := range labels {
+			runs[i].Labels = append(runs[i].Labels, label)
+		}
+	}
 }
 
 func addSecretToken(ctx context.Context, id string, data interface{}) {


### PR DESCRIPTION
## Description
Resolves #212 

Adds the field `Labels []string` to the TestRun entity, for arbitrary label assignment that can be used to query with the `?label=foo` param in the `/api/runs` endpoint.

## Review Information
To verify, we'll have to combine #240 with the auto-deployed environment, uploading a run that includes a `labels` field (with an array of strings).

Then, `/api/runs?label=[uploader]` should display a result.