### PR TITLE
Change the filtering of experimental runs

### DIFF
--- a/shared/datastore_medium_test.go
+++ b/shared/datastore_medium_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	mapset "github.com/deckarep/golang-set"
+
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/appengine"
 	"google.golang.org/appengine/aetest"
@@ -19,7 +21,6 @@ func TestLoadTestRuns(t *testing.T) {
 				BrowserName:    "chrome",
 				BrowserVersion: "63.0",
 				OSName:         "linux",
-				OSVersion:      "3.16",
 			},
 			Revision: "1234567890",
 		},
@@ -30,10 +31,9 @@ func TestLoadTestRuns(t *testing.T) {
 	i, err := aetest.NewInstance(&aetest.Options{StronglyConsistentDatastore: true})
 	assert.Nil(t, err)
 	defer i.Close()
-	r, err := i.NewRequest("GET", "/api/run?product=chrome-66.0", nil)
+	r, err := i.NewRequest("GET", "/api/run?product=chrome", nil)
 	assert.Nil(t, err)
 
-	// 'Yesterday', v66...139 earlier version.
 	ctx := appengine.NewContext(r)
 	key := datastore.NewIncompleteKey(ctx, "TestRun", nil)
 	key, _ = datastore.Put(ctx, key, &testRun)
@@ -43,4 +43,69 @@ func TestLoadTestRuns(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(loaded))
 	assert.Equalf(t, key.IntID(), loaded[0].ID, "ID field should be populated.")
+}
+
+func TestLoadTestRuns_Experimental_Only(t *testing.T) {
+	testRuns := TestRuns{
+		TestRun{
+			ProductAtRevision: ProductAtRevision{
+				Product: Product{
+					BrowserName:    "chrome",
+					BrowserVersion: "63.0",
+					OSName:         "linux",
+				},
+				Revision: "1234567890",
+			},
+			ResultsURL: "/static/chrome-63.0-linux-summary.json.gz",
+			CreatedAt:  time.Now(),
+		},
+		TestRun{
+			ProductAtRevision: ProductAtRevision{
+				Product: Product{
+					BrowserName:    "chrome-experimental",
+					BrowserVersion: "63.0",
+					OSName:         "linux",
+				},
+				Revision: "1234567890",
+			},
+			ResultsURL: "/static/chrome-experimental-63.0-linux-summary.json.gz",
+			CreatedAt:  time.Now(),
+		},
+		TestRun{
+			ProductAtRevision: ProductAtRevision{
+				Product: Product{
+					BrowserName:    "chrome",
+					BrowserVersion: "64.0",
+					OSName:         "linux",
+				},
+				Revision: "1234567890",
+			},
+			ResultsURL: "/static/chrome-64.0-linux-summary.json.gz",
+			CreatedAt:  time.Now(),
+			Labels:     []string{"experimental"},
+		},
+	}
+
+	i, err := aetest.NewInstance(&aetest.Options{StronglyConsistentDatastore: true})
+	assert.Nil(t, err)
+	defer i.Close()
+	r, err := i.NewRequest("GET", "/api/run?product=chrome-66.0&labels=experimental", nil)
+	assert.Nil(t, err)
+
+	ctx := appengine.NewContext(r)
+	keys := make([]*datastore.Key, len(testRuns))
+	for i := range testRuns {
+		keys[i] = datastore.NewIncompleteKey(ctx, "TestRun", nil)
+	}
+	keys, err = datastore.PutMulti(ctx, keys, testRuns)
+	assert.Nil(t, err)
+
+	products := []Product{Product{BrowserName: "chrome"}, Product{BrowserName: "chrome-experimental"}}
+	labels := mapset.NewSet()
+	labels.Add("experimental")
+	loaded, err := LoadTestRuns(ctx, products, labels, "latest", nil, 10)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(loaded))
+	assert.Equal(t, "experimental", loaded[0].Labels[0])
+	assert.Equal(t, "chrome-experimental", loaded[1].BrowserName)
 }

--- a/shared/datastore_medium_test.go
+++ b/shared/datastore_medium_test.go
@@ -31,7 +31,8 @@ func TestLoadTestRuns(t *testing.T) {
 	i, err := aetest.NewInstance(&aetest.Options{StronglyConsistentDatastore: true})
 	assert.Nil(t, err)
 	defer i.Close()
-	r, err := i.NewRequest("GET", "/api/run?product=chrome", nil)
+	// URL is a placeholder and is not used in this test.
+	r, err := i.NewRequest("GET", "/api/run", nil)
 	assert.Nil(t, err)
 
 	ctx := appengine.NewContext(r)
@@ -89,7 +90,8 @@ func TestLoadTestRuns_Experimental_Only(t *testing.T) {
 	i, err := aetest.NewInstance(&aetest.Options{StronglyConsistentDatastore: true})
 	assert.Nil(t, err)
 	defer i.Close()
-	r, err := i.NewRequest("GET", "/api/run?product=chrome-66.0&labels=experimental", nil)
+	// URL is a placeholder and is not used in this test.
+	r, err := i.NewRequest("GET", "/api/run", nil)
 	assert.Nil(t, err)
 
 	ctx := appengine.NewContext(r)

--- a/shared/params.go
+++ b/shared/params.go
@@ -231,7 +231,6 @@ func GetProductsForRequest(r *http.Request) (products []Product, err error) {
 
 	labels := ParseLabelsParam(r)
 	if labels != nil {
-		experimental := labels.Contains(ExperimentalLabel)
 		if err != nil {
 			return nil, err
 		}
@@ -252,19 +251,13 @@ func GetProductsForRequest(r *http.Request) (products []Product, err error) {
 					BrowserName: name,
 				},
 			}
-			// For a browser label (e.g. "chrome"), we also include experimental, unless we explicitly only
-			// want experimental, which is handled below.
-			if !experimental {
-				products = append(products, Product{
-					BrowserName: name + "-" + ExperimentalLabel,
-				})
-			}
-		}
-
-		if experimental {
-			for i := range products {
-				products[i].BrowserName = products[i].BrowserName + "-" + ExperimentalLabel
-			}
+			// For a browser label (e.g. "chrome"), we also include its -experimental variant because
+			// we used to spoof the experimental label by adding it as a suffix to browser names.
+			// The experimental label filtering will happen later in datastore.go.
+			// TODO(Hexcles): remove this once we convert all history -experimental runs.
+			products = append(products, Product{
+				BrowserName: name + "-" + ExperimentalLabel,
+			})
 		}
 	}
 

--- a/shared/params_test.go
+++ b/shared/params_test.go
@@ -152,23 +152,14 @@ func TestGetProductsForRequest_BrowserParam_ChromeLabel(t *testing.T) {
 	assert.Equal(t, "chrome-experimental", products[1].BrowserName)
 }
 
-func TestGetProductsForRequest_BrowserParam_ExperimentalLabel(t *testing.T) {
-	r := httptest.NewRequest("GET", "http://wpt.fyi/?labels=experimental", nil)
-	products, err := GetProductsForRequest(r)
-	assert.Nil(t, err)
-	names, _ := GetBrowserNames()
-	assert.Equal(t, len(names), len(products))
-	for i := range names {
-		assert.Equal(t, names[i]+"-"+ExperimentalLabel, products[i].BrowserName)
-	}
-}
-
 func TestGetProductsForRequest_BrowserParam_ChromeAndExperimentalLabel(t *testing.T) {
+	// The experimental label is no longer handled in params.go.
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?labels=chrome,experimental", nil)
 	products, err := GetProductsForRequest(r)
 	assert.Nil(t, err)
-	assert.Equal(t, 1, len(products))
-	assert.Equal(t, "chrome-experimental", products[0].BrowserName)
+	assert.Equal(t, 2, len(products))
+	assert.Equal(t, "chrome", products[0].BrowserName)
+	assert.Equal(t, "chrome-experimental", products[1].BrowserName)
 }
 
 func TestGetProductsForRequest_BrowserAndProductParam(t *testing.T) {


### PR DESCRIPTION
## Description

This is part of #245. With this change, two kinds of runs will be considered as experimental and show up in `labels=experimental` queries: those with the `-experimental` suffix in the browser names, and those with the "experimental" label.

The implementation isn't the most efficient. Filtering happens in the app instead of in Datastore, because the union of the two conditions can't be expressed as Datastore queries. However, once we no longer create those spoofed `*-experimental` runs (i.e. once the results receiver is in prod), we can batch convert the existing `*-experimental` runs to have an `experimental` label and remove a whole bunch of special cases in the code.

## Review Information

Please verify in staging deployment that various label/browser params (especially `labels=experimental`) still filter runs correctly.

## Changes

I've cleaned up the branch history. See the commit titles.