### PR TITLE
Fix results paths with slashes

### DIFF
--- a/webapp/routes.go
+++ b/webapp/routes.go
@@ -29,7 +29,7 @@ func RegisterRoutes() {
 
 	// Test run results, viewed by pass-rate across the browsers
 	shared.AddRoute("/interop/", "interop", interopHandler)
-	shared.AddRoute("/interop/{path}", "interop", interopHandler)
+	shared.AddRoute("/interop/{path:.*}", "interop", interopHandler)
 
 	// List of all test runs, by SHA[0:10]
 	shared.AddRoute("/test-runs", "test-runs", testRunsHandler)
@@ -40,9 +40,9 @@ func RegisterRoutes() {
 	// Test run results, viewed by browser (default view)
 	// For run results diff view, 'before' and 'after' params can be given.
 	shared.AddRoute("/results/", "results", testResultsHandler)
-	shared.AddRoute("/results/{path}", "results", testResultsHandler)
+	shared.AddRoute("/results/{path:.*}", "results", testResultsHandler)
 
 	// Legacy wildcard match
 	shared.AddRoute("/", "results-legacy", testResultsHandler)
-	shared.AddRoute("/{path}", "results-legacy", testResultsHandler)
+	shared.AddRoute("/{path:.*}", "results-legacy", testResultsHandler)
 }

--- a/webapp/routes_test.go
+++ b/webapp/routes_test.go
@@ -22,6 +22,7 @@ func TestLandingPageBound(t *testing.T) {
 	assertHandlerIs(t, "/", "results-legacy")
 	assertHSTS(t, "/")
 	assertHandlerIs(t, "/2dcontext", "results-legacy")
+	assertHandlerIs(t, "/BackgroundSync/interfaces.any.html", "results-legacy")
 }
 
 func TestAboutBound(t *testing.T) {
@@ -32,6 +33,7 @@ func TestInteropBound(t *testing.T) {
 	assertHandlerIs(t, "/interop", "interop")
 	assertHandlerIs(t, "/interop/", "interop")
 	assertHandlerIs(t, "/interop/2dcontext", "interop")
+	assertHandlerIs(t, "/interop/BackgroundSync/interfaces.any.html", "interop")
 }
 
 func TestInteropAnomaliesBound(t *testing.T) {
@@ -65,6 +67,10 @@ func TestApiResultsUploadBound(t *testing.T) {
 
 func TestResultsBound(t *testing.T) {
 	assertBound(t, "/results")
+	assertHandlerIs(t, "/results", "results")
+	assertHandlerIs(t, "/results/", "results")
+	assertHandlerIs(t, "/results/2dcontext", "results")
+	assertHandlerIs(t, "/results/BackgroundSync/interfaces.any.html", "results")
 }
 
 func TestAdminResultsUploadBound(t *testing.T) {


### PR DESCRIPTION
Default regex is `[^/]*`, which doesn't work for paths containing a slash.