### PR TITLE
Add /api/shas endpoint and handle ?complete for multiple complete runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/node_modules
 webapp/bower_components/*
+debug.test

--- a/api/README.md
+++ b/api/README.md
@@ -104,24 +104,36 @@ __Example JSON__
       "raw_results_url": "https://storage.googleapis.com/wptd-results/2bd11b91d490ddd5237bcb6d8149a7f25faaa101/chrome_67.0.3396.62_linux_4.4/report.json"
     }
 
-### /api/diff
+### /api/shas
 
-Computes a TestRun summary JSON blob of the differences between two TestRun
-summary blobs.
+Gets an array of revisions (SHA[0:10]), in reverse chronological order.
+This method behaves similarly to [/api/runs](#apiruns) above, but projects the `revision` field's value.
 
 __Parameters__
 
-__`before`__ : [product]@[sha] spec for the TestRun to use as the before state.
+__`complete`__ : boolean for whether to get only SHAs which were executed across all four of the default (stable) browsers. Not compatible with `product`.
 
-__`after`__ : [product]@[sha] spec for the TestRun to use as the after state.
+__`product`__ : Product(s) to include (repeated param), e.g. `chrome` or `firefox-60`
 
-__`path`__ : Test path to filter by. `path` is a repeatable query parameter.
+__`from`__ : RFC3339 timestamp, for which to include runs that occured after the given time.
 
-__`filter`__ : Differences to include in the summary.
- - `A` : Added - tests which are present after, but not before.
- - `D` : Deleted - tests which are present before, but not after.
- - `C` : Changed - tests which are present before and after, but the results summary is different.
- - `U` : Unchanged - tests which are present before and after, and the results summary count is not different.
+__`max-count`__ : Maximum number of runs to get (for each browser). Maximum of 500.
+
+#### Example
+
+https://wpt.fyi/api/shas?product=chrome
+
+__Example JSON__
+
+    [
+      "98530fb944",
+      "2bd11b91d4"//, ...
+    ]
+
+## Results summaries
+
+The following methods apply to the results summaries JSON blobs, which are linked to from
+[TestRun entities](#test-run-entities).
 
 ### /results
 
@@ -154,6 +166,30 @@ __Example JSON__ (from the summary.json.gz output):
       "/css/css-writing-modes/table-progression-vrl-001.html": [1, 1],
       // ...
     }
+
+### /api/diff
+
+Computes a TestRun summary JSON blob of the differences between two TestRun
+summary blobs.
+
+__Parameters__
+
+__`before`__ : [product]@[sha] spec for the TestRun to use as the before state.
+
+__`after`__ : [product]@[sha] spec for the TestRun to use as the after state.
+
+__`path`__ : Test path to filter by. `path` is a repeatable query parameter.
+
+__`filter`__ : Differences to include in the summary.
+ - `A` : Added - tests which are present after, but not before.
+ - `D` : Deleted - tests which are present before, but not after.
+ - `C` : Changed - tests which are present before and after, but the results summary is different.
+ - `U` : Unchanged - tests which are present before and after, and the results summary count is not different.
+
+## Test Manifest
+
+The following methods apply to the retrieval and filtering of the Test Manifest in [WPT](https://github.com/web-platform-tests/wpt),
+which contains metadata about each test.
 
 ### /api/manifest
 

--- a/api/routes.go
+++ b/api/routes.go
@@ -17,6 +17,9 @@ func RegisterRoutes() {
 	// API endpoint for listing all test runs for a given SHA.
 	shared.AddRoute("/api/runs", "api-test-runs", apiTestRunsHandler)
 
+	// API endpoint for listing SHAs for the test runs.
+	shared.AddRoute("/api/shas", "api-shas", apiSHAsHandler)
+
 	// API endpoints for a single test run, by
 	// ID:
 	shared.AddRoute("/api/runs/{id}", "api-test-run", apiTestRunHandler)

--- a/api/shas.go
+++ b/api/shas.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/deckarep/golang-set"
@@ -45,7 +44,7 @@ func apiSHAsHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := appengine.NewContext(r)
 
 	var shas []string
-	if complete, err := strconv.ParseBool(r.URL.Query().Get("complete")); err == nil && complete {
+	if complete, err := shared.ParseCompleteParam(r); err != nil && complete {
 		if shas, err = getCompleteRunSHAs(ctx, from, limit); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
@@ -103,7 +102,7 @@ func getCompleteRunSHAs(ctx context.Context, from *time.Time, limit *int) (shas 
 			break
 		} else if err != nil {
 			return nil, err
-		} else if !shared.IsBrowserName(testRun.BrowserName) {
+		} else if !shared.IsStableBrowserName(testRun.BrowserName) {
 			continue
 		}
 		set, ok := bySHA[testRun.Revision]

--- a/api/shas.go
+++ b/api/shas.go
@@ -1,0 +1,124 @@
+// Copyright 2017 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/deckarep/golang-set"
+
+	"github.com/web-platform-tests/wpt.fyi/shared"
+	"google.golang.org/appengine"
+	"google.golang.org/appengine/datastore"
+)
+
+// apiSHAsHandler is responsible for emitting just the revision SHAs for test runs.
+//
+// URL Params:
+//     sha: SHA[0:10] of the repo when the tests were executed (or 'latest')
+func apiSHAsHandler(w http.ResponseWriter, r *http.Request) {
+	var products []shared.Product
+	var err error
+	if products, err = shared.GetProductsForRequest(r); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	limit, err := shared.ParseMaxCountParam(r)
+	if err != nil {
+		http.Error(w, "Invalid 'max-count' param: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	var from *time.Time
+	if from, err = shared.ParseFromParam(r); err != nil {
+		http.Error(w, fmt.Sprintf("Invalid 'from' param: %s", err.Error()), http.StatusBadRequest)
+		return
+	}
+
+	ctx := appengine.NewContext(r)
+
+	var shas []string
+	if complete, err := strconv.ParseBool(r.URL.Query().Get("complete")); err == nil && complete {
+		if shas, err = getCompleteRunSHAs(ctx, from, limit); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	} else {
+		labels := shared.ParseLabelsParam(r)
+		testRuns, err := shared.LoadTestRuns(ctx, products, labels, shas, from, limit)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		seen := mapset.NewSet()
+		for _, testRun := range testRuns {
+			if !seen.Contains(testRun.Revision) {
+				shas = append(shas, testRun.Revision)
+				seen.Add(testRun.Revision)
+			}
+		}
+	}
+	shasBytes, err := json.Marshal(shas)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Write(shasBytes)
+}
+
+// getCompleteRunSHAs returns an array of the SHA[0:10] for runs that
+// exists for all initially-loaded browser names (see GetBrowserNames),
+// ordered by most-recent.
+func getCompleteRunSHAs(ctx context.Context, from *time.Time, limit *int) (shas []string, err error) {
+	query := datastore.
+		NewQuery("TestRun").
+		Order("-CreatedAt").
+		Project("Revision", "BrowserName")
+
+	var browserNames []string
+	if browserNames, err = shared.GetBrowserNames(); err != nil {
+		return nil, err
+	}
+
+	if from != nil {
+		query = query.Filter("CreatedAt >=", *from)
+	}
+
+	bySHA := make(map[string]mapset.Set)
+	done := mapset.NewSet()
+	it := query.Run(ctx)
+	for {
+		var testRun shared.TestRun
+		_, err := it.Next(&testRun)
+		if err == datastore.Done {
+			break
+		} else if err != nil {
+			return nil, err
+		} else if !shared.IsBrowserName(testRun.BrowserName) {
+			continue
+		}
+		set, ok := bySHA[testRun.Revision]
+		if !ok {
+			bySHA[testRun.Revision] = mapset.NewSetWith(testRun.BrowserName)
+		} else {
+			set.Add(testRun.BrowserName)
+			if set.Cardinality() == len(browserNames) && !done.Contains(testRun.Revision) {
+				done.Add(testRun.Revision)
+				shas = append(shas, testRun.Revision)
+				if limit != nil && len(shas) >= *limit {
+					return shas, nil
+				}
+			}
+		}
+	}
+	return shas, err
+}

--- a/api/shas.go
+++ b/api/shas.go
@@ -19,9 +19,6 @@ import (
 )
 
 // apiSHAsHandler is responsible for emitting just the revision SHAs for test runs.
-//
-// URL Params:
-//     sha: SHA[0:10] of the repo when the tests were executed (or 'latest')
 func apiSHAsHandler(w http.ResponseWriter, r *http.Request) {
 	var products []shared.Product
 	var err error

--- a/api/shas_medium_test.go
+++ b/api/shas_medium_test.go
@@ -1,0 +1,94 @@
+// +build medium
+
+package api
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/web-platform-tests/wpt.fyi/shared"
+	"google.golang.org/appengine"
+	"google.golang.org/appengine/aetest"
+	"google.golang.org/appengine/datastore"
+)
+
+func TestCompleteSHAs(t *testing.T) {
+	i, err := aetest.NewInstance(&aetest.Options{StronglyConsistentDatastore: true})
+	assert.Nil(t, err)
+	defer i.Close()
+	r, err := i.NewRequest("GET", "/api/shas?complete", nil)
+	assert.Nil(t, err)
+
+	ctx := appengine.NewContext(r)
+	browserNames, _ := shared.GetBrowserNames()
+
+	// Nothing in datastore.
+	shas, _ := getCompleteRunSHAs(ctx, nil, nil)
+	assert.Equal(t, 0, len(shas))
+
+	// Only 3 browsers.
+	run := shared.TestRun{
+		ProductAtRevision: shared.ProductAtRevision{
+			Revision: "abcdef0000",
+		},
+		CreatedAt: time.Now().AddDate(0, 0, -1),
+	}
+	for _, browser := range browserNames[:len(browserNames)-1] {
+		run.BrowserName = browser
+		datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
+	}
+	shas, _ = getCompleteRunSHAs(ctx, nil, nil)
+	assert.Equal(t, 0, len(shas))
+
+	// All 4 browsers, but experimental.
+	run.Revision = "abcdef0111"
+	run.CreatedAt = time.Now().AddDate(0, 0, -2)
+	for _, browser := range browserNames {
+		run.BrowserName = browser + "-" + shared.ExperimentalLabel
+		datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
+	}
+	shas, _ = getCompleteRunSHAs(ctx, nil, nil)
+	assert.Equal(t, 0, len(shas))
+
+	// 2 browsers, and other 2, but experimental.
+	run.Revision = "abcdef0222"
+	run.CreatedAt = time.Now().AddDate(0, 0, -2)
+	for i, browser := range browserNames {
+		run.BrowserName = browser
+		if i > 1 {
+			run.BrowserName += "-" + shared.ExperimentalLabel
+		}
+		datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
+	}
+	shas, _ = getCompleteRunSHAs(ctx, nil, nil)
+	assert.Equal(t, 0, len(shas))
+
+	// All 4 browsers.
+	run.Revision = "abcdef0123"
+	run.CreatedAt = time.Now()
+	for _, browser := range browserNames {
+		run.BrowserName = browser
+		datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
+	}
+	shas, _ = getCompleteRunSHAs(ctx, nil, nil)
+	assert.Equal(t, []string{"abcdef0123"}, shas)
+
+	// Another (earlier) run, all 4 browsers.
+	run.Revision = "abcdef9999"
+	run.CreatedAt = time.Now().AddDate(0, 0, -5)
+	for _, browser := range browserNames {
+		run.BrowserName = browser
+		datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
+	}
+	shas, _ = getCompleteRunSHAs(ctx, nil, nil)
+	assert.Equal(t, []string{"abcdef0123", "abcdef9999"}, shas)
+	// Limit 1
+	one := 1
+	shas, _ = getCompleteRunSHAs(ctx, nil, &one)
+	assert.Equal(t, []string{"abcdef0123"}, shas)
+	// From yesterday.
+	from := time.Now().AddDate(0, 0, -1)
+	shas, _ = getCompleteRunSHAs(ctx, &from, nil)
+	assert.Equal(t, []string{"abcdef0123"}, shas)
+}

--- a/api/test_run.go
+++ b/api/test_run.go
@@ -75,7 +75,12 @@ func apiTestRunGetHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		labels := shared.ParseLabelsParam(r)
-		testRuns, err := shared.LoadTestRuns(ctx, []shared.Product{*product}, labels, runSHA, nil, 1)
+		var shas []string
+		if runSHA != "" && runSHA != "latest" {
+			shas = []string{runSHA}
+		}
+		one := 1
+		testRuns, err := shared.LoadTestRuns(ctx, []shared.Product{*product}, labels, shas, nil, &one)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/api/test_runs.go
+++ b/api/test_runs.go
@@ -24,7 +24,6 @@ func apiTestRunsHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	shas := []string{runSHA}
 
 	var products []shared.Product
 	if products, err = shared.GetProductsForRequest(r); err != nil {
@@ -52,6 +51,7 @@ func apiTestRunsHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := appengine.NewContext(r)
 	// When ?complete=true, make sure to show results for the same complete run (executed for all browsers).
 
+	var shas []string
 	if complete, err := shared.ParseCompleteParam(r); err == nil && complete {
 		if runSHA == "latest" {
 			shas, err = getCompleteRunSHAs(ctx, from, limit)
@@ -65,6 +65,8 @@ func apiTestRunsHandler(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		}
+	} else if !shared.IsLatest(runSHA) {
+		shas = []string{runSHA}
 	}
 	labels := shared.ParseLabelsParam(r)
 	testRuns, err := shared.LoadTestRuns(ctx, products, labels, shas, from, limit)

--- a/api/test_runs.go
+++ b/api/test_runs.go
@@ -5,7 +5,6 @@
 package api
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -14,7 +13,6 @@ import (
 
 	"github.com/web-platform-tests/wpt.fyi/shared"
 	"google.golang.org/appengine"
-	"google.golang.org/appengine/datastore"
 )
 
 // apiTestRunsHandler is responsible for emitting test-run JSON for all the runs at a given SHA.
@@ -27,18 +25,7 @@ func apiTestRunsHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-
-	ctx := appengine.NewContext(r)
-	// When ?complete=true, make sure to show results for the same complete run (executed for all browsers).
-	if complete, err := strconv.ParseBool(r.URL.Query().Get("complete")); err == nil && complete {
-		if runSHA == "latest" {
-			runSHA, err = getLastCompleteRunSHA(ctx)
-			if err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-				return
-			}
-		}
-	}
+	shas := []string{runSHA}
 
 	var products []shared.Product
 	if products, err = shared.GetProductsForRequest(r); err != nil {
@@ -46,24 +33,42 @@ func apiTestRunsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var limit int
-	if parsed, err := shared.ParseMaxCountParam(r); err != nil {
+	limit, err := shared.ParseMaxCountParam(r)
+	if err != nil {
 		http.Error(w, "Invalid 'max-count' param: "+err.Error(), http.StatusBadRequest)
 		return
-	} else if parsed != nil {
-		limit = *parsed
 	}
 	var from *time.Time
 	if from, err = shared.ParseFromParam(r); err != nil {
 		http.Error(w, fmt.Sprintf("Invalid 'from' param: %s", err.Error()), http.StatusBadRequest)
 		return
 	}
-	if limit == 0 && from == nil {
+
+	if limit == nil && from == nil {
 		// Default to a single, latest run when from & max-count both empty.
-		limit = 1
+		one := 1
+		limit = &one
+	}
+
+	ctx := appengine.NewContext(r)
+	// When ?complete=true, make sure to show results for the same complete run (executed for all browsers).
+
+	if complete, err := strconv.ParseBool(r.URL.Query().Get("complete")); err == nil && complete {
+		if runSHA == "latest" {
+			shas, err = getCompleteRunSHAs(ctx, from, limit)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			if len(shas) < 1 {
+				// Bail out early - can't find any complete runs.
+				w.Write([]byte("[]"))
+				return
+			}
+		}
 	}
 	labels := shared.ParseLabelsParam(r)
-	testRuns, err := shared.LoadTestRuns(ctx, products, labels, runSHA, from, limit)
+	testRuns, err := shared.LoadTestRuns(ctx, products, labels, shas, from, limit)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -75,44 +80,4 @@ func apiTestRunsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Write(testRunsBytes)
-}
-
-// getLastCompleteRunSHA returns the SHA[0:10] for the most recent run that exists for all initially-loaded browser
-// names (see GetBrowserNames).
-func getLastCompleteRunSHA(ctx context.Context) (sha string, err error) {
-	baseQuery := datastore.
-		NewQuery("TestRun").
-		Order("-CreatedAt").
-		Limit(100).
-		Project("Revision")
-
-	// Map is sha -> browser -> seen yet?  - this prevents over-counting dupes.
-	runSHAs := make(map[string]map[string]bool)
-	var browserNames []string
-	if browserNames, err = shared.GetBrowserNames(); err != nil {
-		return sha, err
-	}
-
-	for _, browser := range browserNames {
-		it := baseQuery.Filter("BrowserName = ", browser).Run(ctx)
-		for {
-			var testRun shared.TestRun
-			_, err := it.Next(&testRun)
-			if err == datastore.Done {
-				break
-			}
-			if err != nil {
-				return "latest", err
-			}
-			if _, ok := runSHAs[testRun.Revision]; !ok {
-				runSHAs[testRun.Revision] = make(map[string]bool)
-			}
-			browsersSeen := runSHAs[testRun.Revision]
-			browsersSeen[browser] = true
-			if len(browsersSeen) == len(browserNames) {
-				return testRun.Revision, nil
-			}
-		}
-	}
-	return "latest", nil
 }

--- a/api/test_runs.go
+++ b/api/test_runs.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/web-platform-tests/wpt.fyi/shared"
@@ -53,7 +52,7 @@ func apiTestRunsHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := appengine.NewContext(r)
 	// When ?complete=true, make sure to show results for the same complete run (executed for all browsers).
 
-	if complete, err := strconv.ParseBool(r.URL.Query().Get("complete")); err == nil && complete {
+	if complete, err := shared.ParseCompleteParam(r); err == nil && complete {
 		if runSHA == "latest" {
 			shas, err = getCompleteRunSHAs(ctx, from, limit)
 			if err != nil {

--- a/shared/datastore.go
+++ b/shared/datastore.go
@@ -2,7 +2,6 @@ package shared
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	mapset "github.com/deckarep/golang-set"
@@ -32,7 +31,7 @@ func LoadTestRuns(
 	if labels != nil {
 		for i := range labels.Iter() {
 			label := i.(string)
-			if IsBrowserName(label) {
+			if IsStableBrowserName(label) {
 				// Browser name labels are already handled in GetProductsForRequest (which produces `products`).
 				continue
 			}
@@ -87,9 +86,7 @@ func LoadTestRuns(
 			// label; instead, their browser names have the suffix. We'd
 			// like to support both the suffix and the label.
 			// TODO(Hexcles): Remove this once we convert history runs.
-			if experimentalOnly &&
-				!contains(testRun.Labels, ExperimentalLabel) &&
-				!strings.HasSuffix(testRun.BrowserName, "-"+ExperimentalLabel) {
+			if experimentalOnly && !testRun.IsExperimental() {
 				continue
 			}
 			if len(shas) > 1 && !contains(shas, testRun.Revision) {

--- a/shared/datastore_medium_test.go
+++ b/shared/datastore_medium_test.go
@@ -40,7 +40,7 @@ func TestLoadTestRuns(t *testing.T) {
 	key, _ = datastore.Put(ctx, key, &testRun)
 
 	chrome, _ := ParseProduct("chrome")
-	loaded, err := LoadTestRuns(ctx, []Product{chrome}, nil, "latest", nil, 1)
+	loaded, err := LoadTestRuns(ctx, []Product{chrome}, nil, nil, nil, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(loaded))
 	assert.Equalf(t, key.IntID(), loaded[0].ID, "ID field should be populated.")
@@ -105,7 +105,8 @@ func TestLoadTestRuns_Experimental_Only(t *testing.T) {
 	products := []Product{Product{BrowserName: "chrome"}, Product{BrowserName: "chrome-experimental"}}
 	labels := mapset.NewSet()
 	labels.Add("experimental")
-	loaded, err := LoadTestRuns(ctx, products, labels, "latest", nil, 10)
+	ten := 10
+	loaded, err := LoadTestRuns(ctx, products, labels, nil, nil, &ten)
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(loaded))
 	assert.Equal(t, "experimental", loaded[0].Labels[0])

--- a/shared/datastore_medium_test.go
+++ b/shared/datastore_medium_test.go
@@ -3,6 +3,8 @@
 package shared
 
 import (
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -111,4 +113,37 @@ func TestLoadTestRuns_Experimental_Only(t *testing.T) {
 	assert.Equal(t, 2, len(loaded))
 	assert.Equal(t, "experimental", loaded[0].Labels[0])
 	assert.Equal(t, "chrome-experimental", loaded[1].BrowserName)
+}
+
+func TestLoadTestRuns_MultipleSHAs(t *testing.T) {
+	var testRuns TestRuns
+	for i := 0; i < 3; i++ {
+		testRun := TestRun{}
+		testRun.BrowserName = "chrome"
+		testRun.Revision = strings.Repeat(strconv.FormatInt(int64(i), 10), 10)
+		testRuns = append(testRuns, testRun)
+	}
+
+	i, err := aetest.NewInstance(&aetest.Options{StronglyConsistentDatastore: true})
+	assert.Nil(t, err)
+	defer i.Close()
+	// URL is a placeholder and is not used in this test.
+	r, err := i.NewRequest("GET", "/api/runs", nil)
+	assert.Nil(t, err)
+
+	ctx := appengine.NewContext(r)
+	keys := make([]*datastore.Key, len(testRuns))
+	for i := range testRuns {
+		keys[i] = datastore.NewIncompleteKey(ctx, "TestRun", nil)
+	}
+	keys, err = datastore.PutMulti(ctx, keys, testRuns)
+	assert.Nil(t, err)
+
+	products := []Product{Product{BrowserName: "chrome"}}
+	shas := []string{"1111111111", "2222222222"}
+	loaded, err := LoadTestRuns(ctx, products, nil, shas, nil, nil)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(loaded))
+	assert.Equal(t, shas[0], loaded[0].Revision)
+	assert.Equal(t, shas[1], loaded[1].Revision)
 }

--- a/shared/models.go
+++ b/shared/models.go
@@ -90,6 +90,13 @@ type TestRun struct {
 	Labels []string `json:"labels"`
 }
 
+// IsExperimental returns whether the run is experimental, for both the legacy
+// behaviour (-experimental suffix on browser name) and the new behaviour
+// (experimental label).
+func (run TestRun) IsExperimental() bool {
+	return contains(run.Labels, ExperimentalLabel) || strings.HasSuffix(run.BrowserName, "-"+ExperimentalLabel)
+}
+
 // TestRuns is a helper type for an array of TestRun entities.
 type TestRuns []TestRun
 

--- a/shared/params.go
+++ b/shared/params.go
@@ -415,3 +415,17 @@ func ParseQueryParamInt(r *http.Request, key string) (int, error) {
 	}
 	return i, err
 }
+
+// ParseCompleteParam parses the "complete" param, returning
+// true if it's present with no value, otherwise the parsed
+// bool value.
+func ParseCompleteParam(r *http.Request) (bool, error) {
+	q := r.URL.Query()
+	if _, ok := q["complete"]; !ok {
+		return false, nil
+	} else if val := q.Get("complete"); val == "" {
+		return true, nil
+	} else {
+		return strconv.ParseBool(val)
+	}
+}

--- a/shared/params_test.go
+++ b/shared/params_test.go
@@ -377,3 +377,17 @@ func TestParseProductAtRevision_OSVersion(t *testing.T) {
 	assert.Equal(t, "4.4", productAtRevision.OSVersion)
 	assert.Equal(t, "latest", productAtRevision.Revision)
 }
+
+func TestParseComplete(t *testing.T) {
+	r := httptest.NewRequest("GET", "http://wpt.fyi/api/runs?complete", nil)
+	complete, _ := ParseCompleteParam(r)
+	assert.True(t, complete)
+
+	r = httptest.NewRequest("GET", "http://wpt.fyi/api/runs?complete=true", nil)
+	complete, _ = ParseCompleteParam(r)
+	assert.True(t, complete)
+
+	r = httptest.NewRequest("GET", "http://wpt.fyi/api/runs?complete=false", nil)
+	complete, _ = ParseCompleteParam(r)
+	assert.False(t, complete)
+}

--- a/shared/run_diff.go
+++ b/shared/run_diff.go
@@ -49,7 +49,8 @@ func FetchRunResultsJSONForSpec(
 
 // FetchRunForSpec loads the wpt.fyi TestRun metadata for the given spec.
 func FetchRunForSpec(ctx context.Context, revision ProductAtRevision) (*TestRun, error) {
-	testRuns, err := LoadTestRuns(ctx, []Product{revision.Product}, nil, revision.Revision, nil, 1)
+	one := 1
+	testRuns, err := LoadTestRuns(ctx, []Product{revision.Product}, nil, []string{revision.Revision}, nil, &one)
 	if err != nil {
 		return nil, err
 	}

--- a/shared/util.go
+++ b/shared/util.go
@@ -74,3 +74,9 @@ func ToStringSlice(set mapset.Set) []string {
 	}
 	return result
 }
+
+// IsLatest returns whether a SHA[0:10] is empty or "latest", both
+// of which are treated as looking up the latest run for each browser.
+func IsLatest(sha string) bool {
+	return sha == "" || sha == "latest"
+}

--- a/shared/util.go
+++ b/shared/util.go
@@ -34,6 +34,12 @@ func IsBrowserName(name string) bool {
 	if strings.HasSuffix(name, "-"+ExperimentalLabel) {
 		name = name[0 : len(name)-1-len(ExperimentalLabel)] // Trim suffix.
 	}
+	return IsStableBrowserName(name)
+}
+
+// IsStableBrowserName determines whether the given name string is a valid browser name
+// of a stable browser (i.e. not using the -experimental suffix).
+func IsStableBrowserName(name string) bool {
 	_, ok := browserNames[name]
 	return ok
 }

--- a/webapp/index.yaml
+++ b/webapp/index.yaml
@@ -68,3 +68,8 @@ indexes:
     direction: desc
   - name: BrowserName
   - name: Revision
+- kind: TestRun
+  properties:
+  - name: Labels
+  - name: CreatedAt
+    direction: desc

--- a/webapp/index.yaml
+++ b/webapp/index.yaml
@@ -62,3 +62,9 @@ indexes:
   - name: BrowserName
   - name: BrowserVersion
     direction: desc
+- kind: TestRun
+  properties:
+  - name: CreatedAt
+    direction: desc
+  - name: BrowserName
+  - name: Revision


### PR DESCRIPTION
## Description
Prior to this PR, fetching `?complete=true&max-count=5` didn't work.

This PR fixes that, and adds `/api/shas`, which simple enumerates a list of revision SHA[0:10] hashes (mostly for debugging purposes).

## Review Information
Multiple complete runs, with complete and max-count, e.g.
https://multiple-complete-dot-wptdashboard-staging.appspot.com/api/runs?complete=true&max-count=5

SHAs endpoint
https://multiple-complete-dot-wptdashboard-staging.appspot.com/api/shas
https://multiple-complete-dot-wptdashboard-staging.appspot.com/api/shas?complete=true
