### PR TITLE
Accept labels from runners in results receiver

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -212,6 +212,9 @@ __Parameters__
 
 __`result_file`__: A gzipped JSON file produced by `wpt run --log-wptreport`.
 
+__`labels`__: (Optional) A comma-separated string of labels for this test run. Currently recognized
+labels are "experimental" and "stable" (the release channel of the tested browser).
+
 The JSON file roughly looks like this:
 
 ```json

--- a/api/receiver/results_receiver.go
+++ b/api/receiver/results_receiver.go
@@ -53,6 +53,8 @@ func HandleResultsUpload(a AppEngineAPI, w http.ResponseWriter, r *http.Request)
 	// Non-existent keys will have empty values, which will later be
 	// filtered out by scheduleResultsTask.
 	extraParams := map[string]string{
+		"labels": r.PostFormValue("labels"),
+		// The following fields will be deprecated when all runners embed metadata in the report.
 		"revision":        r.PostFormValue("revision"),
 		"browser_name":    r.PostFormValue("browser_name"),
 		"browser_version": r.PostFormValue("browser_version"),

--- a/results-processor/main.py
+++ b/results-processor/main.py
@@ -116,6 +116,9 @@ def task_handler():
     uploader = params['uploader']
     gcs_path = params['gcs']
     result_type = params['type']
+    # Optional fields:
+    labels = params.get('labels', '')
+
     # TODO(Hexcles): Support multiple results.
     assert result_type == 'single'
 
@@ -161,7 +164,7 @@ def task_handler():
 
     ds = datastore.Client()
     upload_token = ds.get(ds.key('Token', 'upload-token'))['Secret']
-    wptreport.create_test_run(report, uploader, upload_token,
+    wptreport.create_test_run(report, labels, uploader, upload_token,
                               results_gcs_path, raw_results_gcs_path)
 
     return resp

--- a/results-processor/wptreport_test.py
+++ b/results-processor/wptreport_test.py
@@ -9,7 +9,7 @@ import shutil
 import tempfile
 import unittest
 
-from wptreport import WPTReport, InsufficientDataError
+from wptreport import WPTReport, InsufficientDataError, prepare_labels
 
 
 class WPTReportTest(unittest.TestCase):
@@ -301,3 +301,29 @@ class WPTReportTest(unittest.TestCase):
         self.assertEqual(r.sha_summary_path,
                          '0bdaaf9c1622ca49eb140381af1ece6d8001c934/'
                          'firefox-59.0-linux-afa59408e1-summary.json.gz')
+
+
+class HelpersTest(unittest.TestCase):
+    def test_prepare_labels_from_empty_str(self):
+        r = WPTReport()
+        r.update_metadata(browser_name='firefox')
+        self.assertListEqual(
+            prepare_labels(r, '', 'blade-runner'),
+            ['blade-runner', 'firefox', 'stable']
+        )
+
+    def test_prepare_labels_from_custom_labels(self):
+        r = WPTReport()
+        r.update_metadata(browser_name='firefox')
+        self.assertListEqual(
+            prepare_labels(r, 'foo,bar', 'blade-runner'),
+            ['bar', 'blade-runner', 'firefox', 'foo', 'stable']
+        )
+
+    def test_prepare_labels_from_experimental_label(self):
+        r = WPTReport()
+        r.update_metadata(browser_name='firefox')
+        self.assertListEqual(
+            prepare_labels(r, 'experimental', 'blade-runner'),
+            ['blade-runner', 'experimental', 'firefox']
+        )


### PR DESCRIPTION
## Description

An optional parameter is added to the payload of the results receiving API: `labels`. The main purpose is to fix #245 , but the runner can add arbitrary labels and filter test runs on wpt.fyi by these labels.

Re #245: In order to keep the number of required parameters minimal, we will automatically add a "stable" label if neither "stable" or "experimental" is present (i.e. we assume test runs are from stable browsers by default), which is compatible with the current behaviour.

## Changes

1. An optional parameter `labels` is added to the API endpoint. It's a comma-separated string. The receiver (Go) does not touch this parameter, but simply passes it along to the processor.
2. The processor now has a new method `prepare_labels` which includes all the magics and heuristics.
3. Both new pieces come with unit tests.