### PR TITLE
Sanitize special characters in report URLs

### DIFF
--- a/results-processor/main.py
+++ b/results-processor/main.py
@@ -144,7 +144,7 @@ def task_handler():
 
     revision = report.run_info['revision']
     # For consistency, use underscores in wptd-results.
-    product = report.product_id('_')
+    product = report.product_id('_', sanitize=True)
 
     resp = "{} results loaded from {}".format(len(report.results), gcs_path)
 

--- a/results-processor/wptreport_test.py
+++ b/results-processor/wptreport_test.py
@@ -272,6 +272,19 @@ class WPTReportTest(unittest.TestCase):
         self.assertEqual(r.product_id('_'),
                          'firefox_59.0_linux_4.4_afa59408e1')
 
+    def test_product_id_sanitize(self):
+        r = WPTReport()
+        r._report = {
+            'run_info': {
+                'product': 'chrome!',
+                'browser_version': '1.2.3 dev-1',
+                'os': 'linux',
+            }
+        }
+        r.hashsum = 'afa59408e1797c7091d7e89de5561612f7da440d'
+        self.assertEqual(r.product_id('-', sanitize=True),
+                         'chrome_-1.2.3_dev-1-linux-afa59408e1')
+
     def test_sha_product_path(self):
         r = WPTReport()
         r._report = {


### PR DESCRIPTION
Fixes #259

Replace non-URL-safe characters with underscores in URLs. e.g. `chrome-69.0 dev-linux.json` will now become `chrome-69.0_dev-linux.json`.

I didn't use percent encoding because I'd like to keep the URLs short and easily readable. These fields can be found inside the report anyway, so we are not losing any information.

The fields in Datastore are kept intact, i.e. they may still contain spaces. Only the URLs (of the full report, summary, and sharded results) are sanitized.