### PR TITLE
Announcer: Perform time-based logic in terms of UTC timestamps

### DIFF
--- a/revisions/epoch/fractional.go
+++ b/revisions/epoch/fractional.go
@@ -33,7 +33,7 @@ func (EightHourly) GetData() Data {
 
 // IsEpochal indicates whether or not an every-eight-hours epochal change occur between prev and next.
 func (e EightHourly) IsEpochal(prev time.Time, next time.Time) bool {
-	return nHourly(e, 8, prev, next)
+	return nHourly(e, 8, prev.UTC(), next.UTC())
 }
 
 // FourHourly models an epoch that changes every four hours.
@@ -51,7 +51,7 @@ func (FourHourly) GetData() Data {
 
 // IsEpochal indicates whether or not an every-four-hours epochal change occur between prev and next.
 func (e FourHourly) IsEpochal(prev time.Time, next time.Time) bool {
-	return nHourly(e, 4, prev, next)
+	return nHourly(e, 4, prev.UTC(), next.UTC())
 }
 
 // TwoHourly models an epoch that changes every two hours.
@@ -69,5 +69,5 @@ func (TwoHourly) GetData() Data {
 
 // IsEpochal indicates whether or not an every-two-hours epochal change occur between prev and next.
 func (e TwoHourly) IsEpochal(prev time.Time, next time.Time) bool {
-	return nHourly(e, 2, prev, next)
+	return nHourly(e, 2, prev.UTC(), next.UTC())
 }

--- a/revisions/epoch/fractional_test.go
+++ b/revisions/epoch/fractional_test.go
@@ -33,8 +33,17 @@ func testFarPositive(t *testing.T, e epoch.Epoch) {
 	assert.True(t, e.IsEpochal(thisYear, lastYear))
 }
 
+func testTZPositive(t *testing.T, e epoch.Epoch) {
+	n := int(e.GetData().MaxDuration.Hours())
+	justPrior := time.Date(2018, 4, 1, n-1, 59, 59, 999999999, time.UTC)
+	justAfter := time.Date(2018, 4, 1, n-1, 0, 0, 0, time.FixedZone("UTC-1", -60*60))
+	assert.True(t, e.IsEpochal(justPrior, justAfter))
+	assert.True(t, e.IsEpochal(justAfter, justPrior))
+}
+
 var startDay = time.Date(2018, 4, 1, 0, 0, 0, 0, time.UTC)
 var justAfterStartDay = time.Date(2018, 4, 1, 0, 0, 0, 1, time.UTC)
+var justAfterStartDayTZ = time.Date(2018, 3, 31, 23, 0, 0, 1, time.FixedZone("UTC-1", -60*60))
 
 func testCloseNegative(t *testing.T, e epoch.Epoch) {
 	assert.False(t, e.IsEpochal(startDay, justAfterStartDay))
@@ -49,6 +58,11 @@ func testFarNegative(t *testing.T, e epoch.Epoch) {
 	assert.False(t, e.IsEpochal(justBeforeEnd, start))
 }
 
+func testTZNegative(t *testing.T, e epoch.Epoch) {
+	assert.False(t, e.IsEpochal(startDay, justAfterStartDayTZ))
+	assert.False(t, e.IsEpochal(justAfterStartDayTZ, startDay))
+}
+
 //
 // EightHourly
 //
@@ -61,10 +75,74 @@ func TestIsEightHourly_Far(t *testing.T) {
 	testFarPositive(t, eightHourly)
 }
 
+func TestIsEightHourly_TZ(t *testing.T) {
+	testTZPositive(t, eightHourly)
+}
+
 func TestIsNotEightHourly_Close(t *testing.T) {
 	testCloseNegative(t, eightHourly)
 }
 
 func TestIsNotEightHourly_Far(t *testing.T) {
 	testFarNegative(t, eightHourly)
+}
+
+func TestIsNotEightHourly_TZ(t *testing.T) {
+	testTZNegative(t, eightHourly)
+}
+
+//
+// FourHourly
+//
+
+func TestIsFourHourly_Close(t *testing.T) {
+	testClosePositive(t, fourHourly)
+}
+
+func TestIsFourHourly_Far(t *testing.T) {
+	testFarPositive(t, fourHourly)
+}
+
+func TestIsFourHourly_TZ(t *testing.T) {
+	testTZPositive(t, fourHourly)
+}
+
+func TestIsNotFourHourly_Close(t *testing.T) {
+	testCloseNegative(t, fourHourly)
+}
+
+func TestIsNotFourHourly_Far(t *testing.T) {
+	testFarNegative(t, fourHourly)
+}
+
+func TestIsNotFourHourly_TZ(t *testing.T) {
+	testTZNegative(t, fourHourly)
+}
+
+//
+// TwoHourly
+//
+
+func TestIsTwoHourly_Close(t *testing.T) {
+	testClosePositive(t, twoHourly)
+}
+
+func TestIsTwoHourly_Far(t *testing.T) {
+	testFarPositive(t, twoHourly)
+}
+
+func TestIsTwoHourly_TZ(t *testing.T) {
+	testTZPositive(t, twoHourly)
+}
+
+func TestIsNotTwoHourly_Close(t *testing.T) {
+	testCloseNegative(t, twoHourly)
+}
+
+func TestIsNotTwoHourly_Far(t *testing.T) {
+	testFarNegative(t, twoHourly)
+}
+
+func TestIsNotTwoHourly_TZ(t *testing.T) {
+	testTZNegative(t, twoHourly)
 }

--- a/revisions/epoch/gregorian.go
+++ b/revisions/epoch/gregorian.go
@@ -23,10 +23,12 @@ func (Monthly) GetData() Data {
 
 // IsEpochal indicates whether or not a monthly epochal change occur between prev and next.
 func (Monthly) IsEpochal(prev time.Time, next time.Time) bool {
-	if prev.Year() != next.Year() {
+	pu := prev.UTC()
+	pn := next.UTC()
+	if pu.Year() != pn.Year() {
 		return true
 	}
-	return prev.Month() != next.Month()
+	return pu.Month() != pn.Month()
 }
 
 // Weekly models an epoch that changes at the beginning of every week. Weeks begin on Sundays.
@@ -44,13 +46,15 @@ func (Weekly) GetData() Data {
 
 // IsEpochal indicates whether or not a weekly epochal change occur between prev and next.
 func (e Weekly) IsEpochal(prev time.Time, next time.Time) bool {
-	if prev.After(next) {
-		return e.IsEpochal(next, prev)
+	pu := prev.UTC()
+	pn := next.UTC()
+	if pu.After(pn) {
+		return e.IsEpochal(pn, pu)
 	}
-	if next.Sub(prev).Hours() >= 24*7 {
+	if pn.Sub(pu).Hours() >= 24*7 {
 		return true
 	}
-	return prev.Weekday() > next.Weekday()
+	return pu.Weekday() > pn.Weekday()
 }
 
 // Daily models an epoch that changes at the beginning of every day.
@@ -68,13 +72,15 @@ func (Daily) GetData() Data {
 
 // IsEpochal indicates whether or not a daily epochal change occur between prev and next.
 func (e Daily) IsEpochal(prev time.Time, next time.Time) bool {
-	if prev.After(next) {
-		return e.IsEpochal(next, prev)
+	pu := prev.UTC()
+	pn := next.UTC()
+	if pu.After(pn) {
+		return e.IsEpochal(pn, pu)
 	}
-	if next.Sub(prev).Hours() >= 24 {
+	if pn.Sub(pu).Hours() >= 24 {
 		return true
 	}
-	return prev.Day() != next.Day()
+	return pu.Day() != pn.Day()
 }
 
 // Hourly models an epoch that changes at the beginning of every hour.
@@ -92,11 +98,13 @@ func (Hourly) GetData() Data {
 
 // IsEpochal indicates whether or not an hourly epochal change occur between prev and next.
 func (e Hourly) IsEpochal(prev time.Time, next time.Time) bool {
-	if prev.After(next) {
-		return e.IsEpochal(next, prev)
+	pu := prev.UTC()
+	pn := next.UTC()
+	if pu.After(pn) {
+		return e.IsEpochal(pn, pu)
 	}
-	if next.Sub(prev).Hours() >= 1 {
+	if pn.Sub(pu).Hours() >= 1 {
 		return true
 	}
-	return prev.Hour() != next.Hour()
+	return pu.Hour() != pn.Hour()
 }

--- a/revisions/epoch/gregorian_test.go
+++ b/revisions/epoch/gregorian_test.go
@@ -18,12 +18,16 @@ var monthly epoch.Epoch
 var weekly epoch.Epoch
 var daily epoch.Epoch
 var hourly epoch.Epoch
+var oneHourEastOfUTC *time.Location
+var oneHourWestOfUTC *time.Location
 
 func init() {
 	monthly = epoch.Monthly{}
 	weekly = epoch.Weekly{}
 	daily = epoch.Daily{}
 	hourly = epoch.Hourly{}
+	oneHourEastOfUTC = time.FixedZone("UTC+1", 60*60)
+	oneHourWestOfUTC = time.FixedZone("UTC-1", -60*60)
 }
 
 //
@@ -44,6 +48,13 @@ func TestIsMonthly_Far(t *testing.T) {
 	assert.True(t, monthly.IsEpochal(thisYear, lastYear))
 }
 
+func TestIsMonthly_TZ(t *testing.T) {
+	justPrior := time.Date(2018, 3, 31, 23, 59, 59, 999999999, time.UTC)
+	justAfter := time.Date(2018, 3, 31, 23, 59, 59, 999999999, oneHourWestOfUTC)
+	assert.True(t, monthly.IsEpochal(justPrior, justAfter))
+	assert.True(t, monthly.IsEpochal(justAfter, justPrior))
+}
+
 func TestIsNotMonthly_Close(t *testing.T) {
 	lastInstant := time.Date(2018, 5, 1, 0, 0, 0, 0, time.UTC)
 	nextInstant := time.Date(2018, 5, 1, 0, 0, 0, 1, time.UTC)
@@ -54,6 +65,13 @@ func TestIsNotMonthly_Close(t *testing.T) {
 func TestIsNotMonthly_Far(t *testing.T) {
 	monthStart := time.Date(2018, 3, 1, 0, 0, 0, 0, time.UTC)
 	monthEnd := time.Date(2018, 3, 31, 23, 59, 59, 999999999, time.UTC)
+	assert.False(t, monthly.IsEpochal(monthStart, monthEnd))
+	assert.False(t, monthly.IsEpochal(monthEnd, monthStart))
+}
+
+func TestIsNotMonthly_TZ(t *testing.T) {
+	monthStart := time.Date(2018, 3, 1, 0, 0, 0, 0, time.UTC)
+	monthEnd := time.Date(2018, 4, 1, 0, 0, 0, 0, oneHourEastOfUTC)
 	assert.False(t, monthly.IsEpochal(monthStart, monthEnd))
 	assert.False(t, monthly.IsEpochal(monthEnd, monthStart))
 }
@@ -76,6 +94,13 @@ func TestIsWeekly_Far(t *testing.T) {
 	assert.True(t, weekly.IsEpochal(thisYear, lastYear))
 }
 
+func TestIsWeekly_TZ(t *testing.T) {
+	justPrior := time.Date(2018, 3, 31, 23, 59, 59, 999999999, time.UTC)
+	justAfter := time.Date(2018, 3, 31, 23, 59, 59, 999999999, oneHourWestOfUTC)
+	assert.True(t, weekly.IsEpochal(justPrior, justAfter))
+	assert.True(t, weekly.IsEpochal(justAfter, justPrior))
+}
+
 func TestIsNotWeekly_Close(t *testing.T) {
 	lastInstant := time.Date(2018, 4, 1, 0, 0, 0, 0, time.UTC)
 	nextInstant := time.Date(2018, 4, 1, 0, 0, 0, 1, time.UTC)
@@ -86,6 +111,13 @@ func TestIsNotWeekly_Close(t *testing.T) {
 func TestIsNotWeekly_Far(t *testing.T) {
 	weekStart := time.Date(2018, 4, 1, 0, 0, 0, 0, time.UTC)
 	weekEnd := time.Date(2018, 4, 7, 23, 59, 59, 999999999, time.UTC)
+	assert.False(t, weekly.IsEpochal(weekStart, weekEnd))
+	assert.False(t, weekly.IsEpochal(weekEnd, weekStart))
+}
+
+func TestIsNotWeekly_TZ(t *testing.T) {
+	weekStart := time.Date(2018, 4, 1, 0, 0, 0, 0, time.UTC)
+	weekEnd := time.Date(2018, 4, 8, 0, 0, 0, 0, oneHourEastOfUTC)
 	assert.False(t, weekly.IsEpochal(weekStart, weekEnd))
 	assert.False(t, weekly.IsEpochal(weekEnd, weekStart))
 }
@@ -108,6 +140,13 @@ func TestIsDaily_Far(t *testing.T) {
 	assert.True(t, daily.IsEpochal(thisYear, lastYear))
 }
 
+func TestIsDaily_TZ(t *testing.T) {
+	justPrior := time.Date(2018, 4, 1, 23, 59, 59, 999999999, time.UTC)
+	justAfter := time.Date(2018, 4, 1, 23, 59, 59, 999999999, oneHourWestOfUTC)
+	assert.True(t, daily.IsEpochal(justPrior, justAfter))
+	assert.True(t, daily.IsEpochal(justAfter, justPrior))
+}
+
 func TestIsNotDaily_Close(t *testing.T) {
 	lastInstant := time.Date(2018, 4, 1, 0, 0, 0, 0, time.UTC)
 	nextInstant := time.Date(2018, 4, 1, 0, 0, 0, 1, time.UTC)
@@ -118,6 +157,13 @@ func TestIsNotDaily_Close(t *testing.T) {
 func TestIsNotDaily_Far(t *testing.T) {
 	dayStart := time.Date(2018, 4, 1, 0, 0, 0, 0, time.UTC)
 	dayEnd := time.Date(2018, 4, 1, 23, 59, 59, 999999999, time.UTC)
+	assert.False(t, daily.IsEpochal(dayStart, dayEnd))
+	assert.False(t, daily.IsEpochal(dayEnd, dayStart))
+}
+
+func TestIsNotDaily_TZ(t *testing.T) {
+	dayStart := time.Date(2018, 4, 1, 0, 0, 0, 0, time.UTC)
+	dayEnd := time.Date(2018, 4, 2, 0, 0, 0, 0, oneHourEastOfUTC)
 	assert.False(t, daily.IsEpochal(dayStart, dayEnd))
 	assert.False(t, daily.IsEpochal(dayEnd, dayStart))
 }
@@ -140,6 +186,13 @@ func TestIsHourly_Far(t *testing.T) {
 	assert.True(t, hourly.IsEpochal(thisYear, lastYear))
 }
 
+func TestIsHourly_TZ(t *testing.T) {
+	justPrior := time.Date(2018, 4, 1, 0, 59, 59, 999999999, time.UTC)
+	justAfter := time.Date(2018, 4, 1, 0, 59, 59, 999999999, oneHourWestOfUTC)
+	assert.True(t, hourly.IsEpochal(justPrior, justAfter))
+	assert.True(t, hourly.IsEpochal(justAfter, justPrior))
+}
+
 func TestIsNotHourly_Close(t *testing.T) {
 	lastInstant := time.Date(2018, 4, 1, 0, 0, 0, 0, time.UTC)
 	nextInstant := time.Date(2018, 4, 1, 0, 0, 0, 1, time.UTC)
@@ -150,6 +203,13 @@ func TestIsNotHourly_Close(t *testing.T) {
 func TestIsNotHourly_Far(t *testing.T) {
 	hourStart := time.Date(2018, 4, 1, 1, 0, 0, 0, time.UTC)
 	hourEnd := time.Date(2018, 4, 1, 1, 59, 59, 999999999, time.UTC)
+	assert.False(t, hourly.IsEpochal(hourStart, hourEnd))
+	assert.False(t, hourly.IsEpochal(hourEnd, hourStart))
+}
+
+func TestIsNotHourly_TZ(t *testing.T) {
+	hourStart := time.Date(2018, 4, 1, 1, 0, 0, 0, time.UTC)
+	hourEnd := time.Date(2018, 4, 1, 2, 0, 0, 0, oneHourEastOfUTC)
 	assert.False(t, hourly.IsEpochal(hourStart, hourEnd))
 	assert.False(t, hourly.IsEpochal(hourEnd, hourStart))
 }


### PR DESCRIPTION
## Description

Announcer: Convert times to UTC before executing `IsEpochal(a, b)` logic.