### PR TITLE
Attempt to fix timeout and low disk space issues

### DIFF
--- a/results-processor/Dockerfile
+++ b/results-processor/Dockerfile
@@ -28,4 +28,8 @@ ADD . /app/
 # The number of workers should always be 2: one for processing tasks, the other
 # for responding health checks. Scale the service by increasing the number of
 # instances instead.
-CMD exec gunicorn --bind :$PORT --timeout 3600 --workers 2 main:app
+# The timeout for gunicorn should be significantly longer than the timeout in
+# main.py for liveness checks, because when things go wrong we'd like AppEngine
+# to restart a fresh Docker instance instead of having gunicorn to restart the
+# worker (which would require extra cleanup/recovery logic).
+CMD exec gunicorn --bind :$PORT --timeout 7200 --workers 2 main:app

--- a/results-processor/Dockerfile
+++ b/results-processor/Dockerfile
@@ -4,7 +4,10 @@ FROM gcr.io/google-appengine/python
 
 # Install curl & gcloud SDK.
 RUN apt-get update -q
-RUN apt-get install -qy curl
+# curl needed by install-gcloud.sh
+# python-crcmod for faster gsutil checksum
+# https://cloud.google.com/storage/docs/gsutil/commands/rsync#slow-checksums
+RUN apt-get install -qy curl python-crcmod
 RUN curl -s https://sdk.cloud.google.com > install-gcloud.sh
 RUN bash install-gcloud.sh --disable-prompts --install-dir=/opt > /dev/null
 ENV PATH=/opt/google-cloud-sdk/bin:$PATH

--- a/results-processor/gsutil.py
+++ b/results-processor/gsutil.py
@@ -27,8 +27,12 @@ def gs_to_public_url(gcs_path):
 
 
 def rsync(path1, path2, quiet=False):
+    # Use parallel processes and no multithreading to avoid Python GIL.
+    # https://cloud.google.com/storage/docs/gsutil/commands/rsync#options
     command = [
-        'gsutil', '-m', '-h', 'Content-Encoding:gzip', 'rsync', '-r',
+        'gsutil', '-o', 'GSUtil:parallel_process_count=10',
+        '-o', 'GSUtil:parallel_thread_count=1',
+        '-m', '-h', 'Content-Encoding:gzip', 'rsync', '-r',
         path1, path2
     ]
     _call(command, quiet)

--- a/results-processor/main.py
+++ b/results-processor/main.py
@@ -27,8 +27,9 @@ LOCK_FILE = '/tmp/results-processor.lock'
 # because the attempts to acquire a file lock invoke open() in truncate mode.
 TIMESTAMP_FILE = '/tmp/results-processor.last'
 # If the processing takes more than this timeout (in seconds), the instance is
-# considered unhealthy and will be restarted by AppEngine.
-TIMEOUT = 5400
+# considered unhealthy and will be restarted by AppEngine. We set it to be
+# smaller than the 60-minute timeout of AppEngine to give a safe margin.
+TIMEOUT = 3500
 
 
 logging.basicConfig(level=logging.INFO)

--- a/results-processor/main.py
+++ b/results-processor/main.py
@@ -28,7 +28,7 @@ LOCK_FILE = '/tmp/results-processor.lock'
 TIMESTAMP_FILE = '/tmp/results-processor.last'
 # If the processing takes more than this timeout (in seconds), the instance is
 # considered unhealthy and will be restarted by AppEngine.
-TIMEOUT = 3600
+TIMEOUT = 5400
 
 
 logging.basicConfig(level=logging.INFO)

--- a/results-processor/main.py
+++ b/results-processor/main.py
@@ -158,7 +158,12 @@ def task_handler():
     tempdir = report.populate_upload_directory()
     results_gcs_path = '/{}/{}'.format(
         config.results_bucket(), report.sha_summary_path)
-    gsutil.rsync(tempdir, 'gs://{}/'.format(config.results_bucket()),
+    gsutil.copy(os.path.join(tempdir, report.sha_summary_path),
+                'gs://{}/{}'.format(config.results_bucket(),
+                                    report.sha_summary_path))
+    gsutil.rsync(os.path.join(tempdir, report.sha_product_path),
+                 'gs://{}/{}'.format(config.results_bucket(),
+                                     report.sha_product_path),
                  quiet=True)
     shutil.rmtree(tempdir)
 


### PR DESCRIPTION
First of all, this fixes the out-of-disk-space issue by forcing AppEngine to restart the Docker instance when things go wrong as described in https://github.com/web-platform-tests/wpt.fyi/issues/271#issuecomment-397394519 ("problem 2").

Secondly (but perhaps more importantly), this PR fixes the root issue: `gsutil rsync` timeout. There are three fixes in total, in the decreasing order of effectiveness/importance:

1. Change the paths used in `gsutil rsync` to reduce the length of remote file lists (see https://github.com/web-platform-tests/wpt.fyi/issues/271#issuecomment-397502130 for further explanation).
2. Install `python-crcmod` so that `gsutil rsync` can use the compiled `crcmod` C extension https://cloud.google.com/storage/docs/gsutil/commands/rsync#slow-checksums
3. Explicitly use multiprocessing instead of multithreading to avoid the impact of Python GIL.

Fixes #271 .