### PR TITLE
Add Content-Encoding:gzip back to summary files

### DIFF
--- a/results-processor/gsutil.py
+++ b/results-processor/gsutil.py
@@ -26,7 +26,15 @@ def gs_to_public_url(gcs_path):
     return gcs_path.replace('gs://', 'https://storage.googleapis.com/', 1)
 
 
-def rsync(path1, path2, quiet=False):
+def rsync_gzip(path1, path2, quiet=False):
+    """Syncs path1 to path2 with gsutil rsync.
+
+    All files in path1 are considered gzipped, and the 'Content-Encoding:gzip'
+    header will be set for all files.
+
+    Args:
+        path1, path2: The source and destination paths (must be directories).
+    """
     # Use parallel processes and no multithreading to avoid Python GIL.
     # https://cloud.google.com/storage/docs/gsutil/commands/rsync#options
     command = [
@@ -38,8 +46,16 @@ def rsync(path1, path2, quiet=False):
     _call(command, quiet)
 
 
-def copy(path1, path2, quiet=False):
-    command = [
-        'gsutil', '-m', 'cp', '-r', path1, path2
-    ]
+def copy(path1, path2, gzipped=False, quiet=False):
+    """Copies path1 to path2 with gsutil cp.
+
+    Args:
+        path1, path2: The source and destination paths.
+        gzipped: Whether path1 is gzipped (if True, 'Content-Encoding:gzip'
+            will be added to the headers).
+    """
+    command = ['gsutil', '-m']
+    if gzipped:
+        command += ['-h', 'Content-Encoding:gzip']
+    command += ['cp', '-r', path1, path2]
     _call(command, quiet)

--- a/results-processor/main.py
+++ b/results-processor/main.py
@@ -161,13 +161,16 @@ def task_handler():
         report.populate_upload_directory(output_dir=tempdir)
         results_gcs_path = '/{}/{}'.format(
             config.results_bucket(), report.sha_summary_path)
-        gsutil.copy(os.path.join(tempdir, report.sha_summary_path),
-                    'gs:/' + results_gcs_path)
-        gsutil.rsync(os.path.join(tempdir, report.sha_product_path),
-                     # The trailing slash is crucial.
-                     'gs://{}/{}/'.format(config.results_bucket(),
-                                          report.sha_product_path),
-                     quiet=True)
+        gsutil.copy(
+            os.path.join(tempdir, report.sha_summary_path),
+            'gs:/' + results_gcs_path,
+            gzipped=True)
+        gsutil.rsync_gzip(
+            os.path.join(tempdir, report.sha_product_path),
+            # The trailing slash is crucial (wpt.fyi#275).
+            'gs://{}/{}/'.format(config.results_bucket(),
+                                 report.sha_product_path),
+            quiet=True)
         resp += "Uploaded to gs:/{}\n".format(results_gcs_path)
     finally:
         shutil.rmtree(tempdir)


### PR DESCRIPTION
This was accidentally dropped in #276 because of switching from rsync to cp.
This PR adds an option to gsutil.copy to set the gzip header, changes the
method name and adds documentation to gsutil.rsync make it clear that it will
set the encoding header.