### PR TITLE
Ensure ID set for /api/runs/[ID] response

### DIFF
--- a/api/test_run.go
+++ b/api/test_run.go
@@ -41,8 +41,8 @@ func apiTestRunGetHandler(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, fmt.Sprintf("Invalid id '%s'", idParam), http.StatusBadRequest)
 			return
 		}
-		key := datastore.NewKey(ctx, "TestRun", "", id, nil)
-		if err = datastore.Get(ctx, key, &testRun); err != nil {
+		run, err := shared.LoadTestRun(ctx, id)
+		if err != nil {
 			if err == datastore.ErrNoSuchEntity {
 				http.NotFound(w, r)
 				return
@@ -50,6 +50,7 @@ func apiTestRunGetHandler(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+		testRun = *run
 	} else {
 		runSHA, err := shared.ParseSHAParam(r)
 		if err != nil {

--- a/api/test_run_medium_test.go
+++ b/api/test_run_medium_test.go
@@ -19,7 +19,7 @@ import (
 	"google.golang.org/appengine/datastore"
 )
 
-func TestGetTestRuns(t *testing.T) {
+func TestGetTestRunByID(t *testing.T) {
 	i, err := aetest.NewInstance(&aetest.Options{StronglyConsistentDatastore: true})
 	assert.Nil(t, err)
 	defer i.Close()
@@ -45,6 +45,10 @@ func TestGetTestRuns(t *testing.T) {
 	resp = httptest.NewRecorder()
 	apiTestRunGetHandler(resp, r)
 	assert.Equal(t, http.StatusOK, resp.Code)
+	var bodyTestRun shared.TestRun
+	bodyBytes, _ := ioutil.ReadAll(resp.Body)
+	json.Unmarshal(bodyBytes, &bodyTestRun)
+	assert.Equal(t, int64(123), bodyTestRun.ID)
 }
 
 func TestGetTestRuns_VersionPrefix(t *testing.T) {

--- a/shared/datastore.go
+++ b/shared/datastore.go
@@ -10,6 +10,17 @@ import (
 	"google.golang.org/appengine/datastore"
 )
 
+// LoadTestRun loads the TestRun entity for the given key.
+func LoadTestRun(ctx context.Context, id int64) (*TestRun, error) {
+	var testRun TestRun
+	key := datastore.NewKey(ctx, "TestRun", "", id, nil)
+	if err := datastore.Get(ctx, key, &testRun); err != nil {
+		return nil, err
+	}
+	testRun.ID = key.IntID()
+	return &testRun, nil
+}
+
 // LoadTestRuns loads the TestRun entities for the given parameters.
 // It is encapsulated because we cannot run single queries with multiple inequality
 // filters, so must load the keys and merge the results.


### PR DESCRIPTION
Currently `id` is `0` for runs fetched by their ID (e.g. https://staging.wpt.fyi/api/runs/5089364245741568)