### PR TITLE
Set response code correctly in POST /api/run

### DIFF
--- a/api/test_run.go
+++ b/api/test_run.go
@@ -154,6 +154,6 @@ func TestRunPostHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	w.Write(jsonOutput)
 	w.WriteHeader(http.StatusCreated)
+	w.Write(jsonOutput)
 }

--- a/api/test_run_medium_test.go
+++ b/api/test_run_medium_test.go
@@ -140,5 +140,5 @@ func TestTestRunPostHandler(t *testing.T) {
 	resp := httptest.NewRecorder()
 
 	TestRunPostHandler(resp, r)
-	assert.Equal(t, http.StatusOK, resp.Code)
+	assert.Equal(t, http.StatusCreated, resp.Code)
 }


### PR DESCRIPTION
Fixes #278

(`WriteHeader` must be called before `Write` otherwise the clients will receive the default status code.)