### PR TITLE
Load interop by SHA

### DIFF
--- a/shared/params.go
+++ b/shared/params.go
@@ -225,11 +225,7 @@ func GetProductsForRequest(r *http.Request) (products []Product, err error) {
 	browserNames, err := GetBrowserNames()
 	// Fall back to default browser set.
 	if products == nil && browserParams == nil {
-		for _, name := range browserNames {
-			products = append(products, Product{
-				BrowserName: name,
-			})
-		}
+		products = GetDefaultProducts()
 	}
 
 	labels := ParseLabelsParam(r)

--- a/shared/util.go
+++ b/shared/util.go
@@ -28,6 +28,17 @@ func GetBrowserNames() ([]string, error) {
 	return tmp, nil
 }
 
+// GetDefaultProducts returns the default set of products to show on wpt.fyi
+func GetDefaultProducts() []Product {
+	products := make([]Product, len(browserNamesAlphabetical))
+	for i, name := range browserNamesAlphabetical {
+		products[i] = Product{
+			BrowserName: name,
+		}
+	}
+	return products
+}
+
 // IsBrowserName determines whether the given name string is a valid browser name.
 // Used for validating user-input params for browsers.
 func IsBrowserName(name string) bool {

--- a/webapp/index.yaml
+++ b/webapp/index.yaml
@@ -73,3 +73,8 @@ indexes:
   - name: Labels
   - name: CreatedAt
     direction: desc
+- kind: github.com.web-platform-tests.results-analysis.metrics.PassRateMetadata
+  properties:
+  - name: TestRunIDs
+  - name: StartTime
+    direction: desc

--- a/webapp/interop_handler.go
+++ b/webapp/interop_handler.go
@@ -33,7 +33,7 @@ func interopHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Try load by SHA, otherwise fall back to latest.
+	// We 'load by SHA' by fetching any interop result with all TestRunIDs for that SHA.
 	if !shared.IsLatest(sha) {
 		// Load default browser runs for SHA.
 		one := 1

--- a/webapp/interop_handler.go
+++ b/webapp/interop_handler.go
@@ -27,11 +27,18 @@ func interopHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	labels := shared.ParseLabelsParam(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
 	// Try load by SHA, otherwise fall back to latest.
 	if !shared.IsLatest(sha) {
 		// Load default browser runs for SHA.
+		one := 1
 		runs, err := shared.LoadTestRuns(
-			ctx, shared.GetDefaultProducts(), nil, []string{sha}, nil, nil)
+			ctx, shared.GetDefaultProducts(), labels, []string{sha}, nil, &one)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return


### PR DESCRIPTION
Fixes #214 

Since we don't actually store a revision on a `PassRateMetadata` entity, this PR loads the default set of products for the given SHA and then finds a `PassRateMetadata` that has all of the run keys (IDs) in its `TestRunIDs` field.