### PR TITLE
Add a Datastore index

### DIFF
--- a/webapp/index.yaml
+++ b/webapp/index.yaml
@@ -3,6 +3,11 @@
 # found in the LICENSE file.
 
 indexes:
+- kind: github.com.web-platform-tests.results-analysis.metrics.FailuresMetadata
+  properties:
+  - name: BrowserName
+  - name: StartTime
+    direction: desc
 - kind: TestRun
   properties:
   - name: BrowserName
@@ -52,11 +57,6 @@ indexes:
   - name: CreatedAt
     direction: desc
   - name: Revision
-- kind: github.com.web-platform-tests.results-analysis.metrics.FailuresMetadata
-  properties:
-  - name: BrowserName
-  - name: StartTime
-    direction: desc
 - kind: TestRun
   properties:
   - name: BrowserName
@@ -72,4 +72,9 @@ indexes:
   properties:
   - name: Labels
   - name: CreatedAt
+    direction: desc
+- kind: TestRun
+  properties:
+  - name: Revision
+  - name: BrowserVersion
     direction: desc


### PR DESCRIPTION
Fixes #298

## Description

* Added an index as suggested by AppEngine.
* Also moved the only non-TestRun index to the top.

## Review Information

https://staging.wpt.fyi/api/diff?before=chrome@61df0b90ef&after=chrome-69@61df0b90ef is working now. (Datastore indexes aren't versioned, and I've manually deployed the new index to staging.)