### PR TITLE
Add conditional for polymer attributes

### DIFF
--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -6,11 +6,11 @@
   {{ template "_header.html" }}
   <div>
     <wpt-results
-        test-runs="{{ .TestRuns }}"
-        test-run-resources="{{ .TestRunSources }}"
-        sha="{{ .SHA }}"
-        {{- if .Labels}}labels="{{ .Labels }}"{{end}}
-         {{- if .Diff}}diff{{end}}></wpt-results>
+        {{- if .TestRuns}} test-runs="{{ .TestRuns }}"{{end}}
+        {{- if .TestRunSources}} test-run-resources="{{ .TestRunSources }}"{{end}}
+        {{- if .SHA}} sha="{{ .SHA }}" {{end}}
+        {{- if .Labels}} labels="{{ .Labels }}"{{end}}
+        {{- if .Diff}} diff{{end}}></wpt-results>
   </div>
 </div>
 {{ template "_ga.html" }}


### PR DESCRIPTION
Fixes https://github.com/web-platform-tests/wpt.fyi/issues/294

Spitting out an empty string for the attribute doesn't correctly parse as an empty array.