### PR TITLE
Always use '-' as the separator in report URLs

### DIFF
--- a/results-processor/main.py
+++ b/results-processor/main.py
@@ -146,14 +146,10 @@ def task_handler():
         os_version=params.get('os_version'),
     )
 
-    revision = report.run_info['revision']
-    # For consistency, use underscores in wptd-results.
-    product = report.product_id('_', sanitize=True)
-
     resp = "{} results loaded from {}\n".format(len(report.results), gcs_path)
 
-    raw_results_gcs_path = '/{}/{}/{}/report.json'.format(
-        config.raw_results_bucket(), revision, product)
+    raw_results_gcs_path = '/{}/{}/report.json'.format(
+        config.raw_results_bucket(), report.sha_product_path)
     gsutil.copy('gs:/' + gcs_path, 'gs:/' + raw_results_gcs_path)
 
     tempdir = tempfile.mkdtemp()

--- a/results-processor/wptreport.py
+++ b/results-processor/wptreport.py
@@ -226,7 +226,7 @@ class WPTReport(object):
             filepath = directory + test_file
             self.write_gzip_json(filepath, result)
 
-    def product_id(self, separator, sanitize=False):
+    def product_id(self, separator='-', sanitize=False):
         """Returns an ID string for the product configuration.
 
         Args:
@@ -280,7 +280,7 @@ class WPTReport(object):
         """A relative path: sha/product_id"""
         try:
             return os.path.join(self.run_info['revision'],
-                                self.product_id('-', sanitize=True))
+                                self.product_id(separator='-', sanitize=True))
         except KeyError as e:
             raise MissingMetadataError(str(e)) from e
 
@@ -356,7 +356,7 @@ def create_test_run(report, labels_str, uploader, secret,
         results_gcs_path: The GCS path to the gzipped summary file.
             (e.g. '/wptd/0123456789/chrome-62.0-linux-summary.json.gz')
         raw_results_gcs_path: The GCS path to the raw full report.
-            (e.g. '/wptd-results/[full SHA]/chrome_62.0_linux/report.json')
+            (e.g. '/wptd-results/[full SHA]/chrome-62.0-linux/report.json')
     """
     assert results_gcs_path.startswith('/')
     assert raw_results_gcs_path.startswith('/')

--- a/results-processor/wptreport_test.py
+++ b/results-processor/wptreport_test.py
@@ -266,10 +266,10 @@ class WPTReportTest(unittest.TestCase):
             }
         }
         r.hashsum = 'afa59408e1797c7091d7e89de5561612f7da440d'
-        self.assertEqual(r.product_id('-'), 'firefox-59.0-linux-afa59408e1')
+        self.assertEqual(r.product_id(), 'firefox-59.0-linux-afa59408e1')
 
         r._report['run_info']['os_version'] = '4.4'
-        self.assertEqual(r.product_id('_'),
+        self.assertEqual(r.product_id(separator='_'),
                          'firefox_59.0_linux_4.4_afa59408e1')
 
     def test_product_id_sanitize(self):
@@ -282,7 +282,7 @@ class WPTReportTest(unittest.TestCase):
             }
         }
         r.hashsum = 'afa59408e1797c7091d7e89de5561612f7da440d'
-        self.assertEqual(r.product_id('-', sanitize=True),
+        self.assertEqual(r.product_id(separator='-', sanitize=True),
                          'chrome_-1.2.3_dev-1-linux-afa59408e1')
 
     def test_sha_product_path(self):


### PR DESCRIPTION
With https://github.com/web-platform-tests/data-migration/pull/6 , the
unshard script will also start to use '-' as the separator, which is
more consistent with the naming convention in the frontend serving
bucket (wptd) and design docs. And there is no need for the processor to
special case this any more.

This change has no user-facing effect. And existing historical reports
will be renamed in batch later.

## Review Information

Small non-user-visible change for code health and consistency.