### PR TITLE
Remove special cases for the experimental label

### DIFF
--- a/shared/datastore.go
+++ b/shared/datastore.go
@@ -38,18 +38,11 @@ func LoadTestRuns(
 	if len(shas) == 1 && !IsLatest(shas[0]) {
 		baseQuery = baseQuery.Filter("Revision =", shas[0])
 	}
-	experimentalOnly := false
 	if labels != nil {
 		for i := range labels.Iter() {
 			label := i.(string)
 			if IsStableBrowserName(label) {
 				// Browser name labels are already handled in GetProductsForRequest (which produces `products`).
-				continue
-			}
-			if label == ExperimentalLabel {
-				// The "experimental" label is handled specially at the end of the function.
-				// TODO(Hexcles): Remove this once we convert all history runs.
-				experimentalOnly = true
 				continue
 			}
 			baseQuery = baseQuery.Filter("Labels =", label)
@@ -92,14 +85,6 @@ func LoadTestRuns(
 		}
 		appended := 0
 		for _, testRun := range testRunResults {
-			// Handle the "experimental" label specially.
-			// Some history experimental runs don't have the experimental
-			// label; instead, their browser names have the suffix. We'd
-			// like to support both the suffix and the label.
-			// TODO(Hexcles): Remove this once we convert history runs.
-			if experimentalOnly && !testRun.IsExperimental() {
-				continue
-			}
 			if len(shas) > 1 && !contains(shas, testRun.Revision) {
 				continue
 			}

--- a/shared/datastore_medium_test.go
+++ b/shared/datastore_medium_test.go
@@ -63,6 +63,8 @@ func TestLoadTestRuns_Experimental_Only(t *testing.T) {
 			CreatedAt:  time.Now(),
 		},
 		TestRun{
+			// We no longer have runs like this (with the "-experimental" suffix but without
+			// the "experimental" label; and it should no longer be considered experimental.
 			ProductAtRevision: ProductAtRevision{
 				Product: Product{
 					BrowserName:    "chrome-experimental",
@@ -84,6 +86,19 @@ func TestLoadTestRuns_Experimental_Only(t *testing.T) {
 				Revision: "1234567890",
 			},
 			ResultsURL: "/static/chrome-64.0-linux-summary.json.gz",
+			CreatedAt:  time.Now(),
+			Labels:     []string{"experimental"},
+		},
+		TestRun{
+			ProductAtRevision: ProductAtRevision{
+				Product: Product{
+					BrowserName:    "chrome-experimental",
+					BrowserVersion: "65.0",
+					OSName:         "linux",
+				},
+				Revision: "1234567890",
+			},
+			ResultsURL: "/static/chrome-experimental-65.0-linux-summary.json.gz",
 			CreatedAt:  time.Now(),
 			Labels:     []string{"experimental"},
 		},
@@ -111,8 +126,8 @@ func TestLoadTestRuns_Experimental_Only(t *testing.T) {
 	loaded, err := LoadTestRuns(ctx, products, labels, nil, nil, &ten)
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(loaded))
-	assert.Equal(t, "experimental", loaded[0].Labels[0])
-	assert.Equal(t, "chrome-experimental", loaded[1].BrowserName)
+	assert.Equal(t, "64.0", loaded[0].BrowserVersion)
+	assert.Equal(t, "65.0", loaded[1].BrowserVersion)
 }
 
 func TestLoadTestRuns_MultipleSHAs(t *testing.T) {

--- a/shared/models.go
+++ b/shared/models.go
@@ -90,13 +90,6 @@ type TestRun struct {
 	Labels []string `json:"labels"`
 }
 
-// IsExperimental returns whether the run is experimental, for both the legacy
-// behaviour (-experimental suffix on browser name) and the new behaviour
-// (experimental label).
-func (run TestRun) IsExperimental() bool {
-	return contains(run.Labels, ExperimentalLabel) || strings.HasSuffix(run.BrowserName, "-"+ExperimentalLabel)
-}
-
 // TestRuns is a helper type for an array of TestRun entities.
 type TestRuns []TestRun
 


### PR DESCRIPTION
Part of #311

## Review Information

"experimental" label should still work in the staging deployment.

## Changes

This removes the special case for handling "experimental" labels. All runs in staging have been tagged with "experimental" and "stable", and the prod runs will be tagged soon (before we release this commit).

This PR doesn't deal with the "*-experimental" browser names. We will need to batch rename those browser names to remove the suffix, and then we can remove more code.