### PR TITLE
Always use --no-promote (even for prod deploy)

### DIFF
--- a/util/deploy.sh
+++ b/util/deploy.sh
@@ -9,7 +9,7 @@ WPTD_PATH=${WPTD_PATH:-$(absdir ${REPO_DIR})}
 
 usage() {
   USAGE="Usage: deploy.sh [-p] [-q] [-b] [-h] [app path]
-    -p : Production deploy
+    -p : Production deploy (to wptdashboard, no-promote)
     -q : Quiet (no user prompts, debugging off)
     -b : Branch name - defaults to current Git branch
     -h : Show (this) help information
@@ -61,7 +61,6 @@ then
   fi
   # Use SHA for prod-pushes.
   VERSION="$(git rev-parse --short HEAD)"
-  PROMOTE="--promote"
 fi
 
 if [[ -n "${QUIET}" ]]


### PR DESCRIPTION
It's almost always a good idea to separate deployment and promotion.
Setting traffic split is very easy (with either the dashboard or CLI),
so let's always use --no-promote and then require a manual promotion.