### PR TITLE
Add TimeStart and TimeEnd to TestRun

### DIFF
--- a/api/test_run.go
+++ b/api/test_run.go
@@ -137,10 +137,13 @@ func TestRunPostHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Use 'now' as created time, unless flagged as retroactive.
-	if retro, err := strconv.ParseBool(r.URL.Query().Get("retroactive")); err != nil || !retro {
-		testRun.CreatedAt = time.Now()
+	if testRun.TimeStart.IsZero() {
+		testRun.TimeStart = time.Now()
 	}
+	if testRun.TimeEnd.IsZero() {
+		testRun.TimeEnd = testRun.TimeStart
+	}
+	testRun.CreatedAt = time.Now()
 
 	// Create a new shared.TestRun out of the JSON body of the request.
 	key := datastore.NewIncompleteKey(ctx, "TestRun", nil)

--- a/api/test_run_medium_test.go
+++ b/api/test_run_medium_test.go
@@ -119,12 +119,15 @@ func TestTestRunPostHandler(t *testing.T) {
 	i, err := aetest.NewInstance(&aetest.Options{StronglyConsistentDatastore: true})
 	assert.Nil(t, err)
 	defer i.Close()
-	payload := map[string]string{
+	payload := map[string]interface{}{
 		"browser_name":    "firefox",
 		"browser_version": "59.0",
 		"os_name":         "linux",
 		"os_version":      "4.4",
 		"revision":        "0123456789",
+		"labels":          []string{"foo", "bar"},
+		"time_start":      "2018-06-21T18:39:54.218000+00:00",
+		"time_end":        "2018-06-21T20:03:49Z",
 		// Intentionally missing full_revision_hash; no error should be raised.
 		// Unknown parameters should be ignored.
 		"_random_extra_key_": "some_value",
@@ -141,4 +144,41 @@ func TestTestRunPostHandler(t *testing.T) {
 
 	TestRunPostHandler(resp, r)
 	assert.Equal(t, http.StatusCreated, resp.Code)
+
+	var testRuns []shared.TestRun
+	datastore.NewQuery("TestRun").Limit(1).GetAll(ctx, &testRuns)
+	assert.Equal(t, "firefox", testRuns[0].BrowserName)
+	assert.Equal(t, []string{"foo", "bar"}, testRuns[0].Labels)
+	assert.False(t, testRuns[0].TimeStart.IsZero())
+	assert.False(t, testRuns[0].TimeEnd.IsZero())
+}
+
+func TestTestRunPostHandler_NoTimestamps(t *testing.T) {
+	i, err := aetest.NewInstance(&aetest.Options{StronglyConsistentDatastore: true})
+	assert.Nil(t, err)
+	defer i.Close()
+	payload := map[string]interface{}{
+		"browser_name":    "firefox",
+		"browser_version": "59.0",
+		"os_name":         "linux",
+		"revision":        "0123456789",
+	}
+	body, err := json.Marshal(payload)
+	assert.Nil(t, err)
+	r, err := i.NewRequest("POST", "/api/runs?secret=secret-token", strings.NewReader(string(body)))
+	assert.Nil(t, err)
+
+	ctx := appengine.NewContext(r)
+	token := &shared.Token{Secret: "secret-token"}
+	datastore.Put(ctx, datastore.NewKey(ctx, "Token", "upload-token", 0, nil), token)
+	resp := httptest.NewRecorder()
+
+	TestRunPostHandler(resp, r)
+	assert.Equal(t, http.StatusCreated, resp.Code)
+
+	var testRuns []shared.TestRun
+	datastore.NewQuery("TestRun").Limit(1).GetAll(ctx, &testRuns)
+	assert.False(t, testRuns[0].CreatedAt.IsZero())
+	assert.False(t, testRuns[0].TimeStart.IsZero())
+	assert.Equal(t, testRuns[0].TimeStart, testRuns[0].TimeEnd)
 }

--- a/results-processor/wptreport.py
+++ b/results-processor/wptreport.py
@@ -13,6 +13,7 @@ import logging
 import os
 import re
 import tempfile
+from datetime import datetime, timezone
 
 import requests
 
@@ -304,8 +305,20 @@ class WPTReport(object):
             raise MissingMetadataError(str(e)) from e
 
         # Optional fields:
+
         if self.run_info.get('os_version'):
             payload['os_version'] = self.run_info['os_version']
+
+        def microseconds_to_iso(ms_since_epoch):
+            dt = datetime.fromtimestamp(ms_since_epoch / 1000, timezone.utc)
+            return dt.isoformat()
+
+        if self._report.get('time_start'):
+            payload['time_start'] = microseconds_to_iso(
+                self._report['time_start'])
+        if self._report.get('time_end'):
+            payload['time_end'] = microseconds_to_iso(
+                self._report['time_end'])
 
         return payload
 

--- a/results-processor/wptreport_test.py
+++ b/results-processor/wptreport_test.py
@@ -238,7 +238,7 @@ class WPTReportTest(unittest.TestCase):
             'os_version': '4.4'
         })
 
-    def test_test_run_metadata(self):
+    def test_test_run_metadata_required_fields(self):
         r = WPTReport()
         r._report = {
             'run_info': {
@@ -254,6 +254,30 @@ class WPTReportTest(unittest.TestCase):
             'os_name': 'linux',
             'revision': '0bdaaf9c16',
             'full_revision_hash': '0bdaaf9c1622ca49eb140381af1ece6d8001c934',
+        })
+
+    def test_test_run_metadata_optional_fields(self):
+        r = WPTReport()
+        r._report = {
+            'run_info': {
+                'revision': '0bdaaf9c1622ca49eb140381af1ece6d8001c934',
+                'product': 'firefox',
+                'browser_version': '59.0',
+                'os': 'windows',
+                'os_version': '10'
+            },
+            'time_start': 1529606394218,
+            'time_end': 1529611429000,
+        }
+        self.assertDictEqual(r.test_run_metadata, {
+            'browser_name': 'firefox',
+            'browser_version': '59.0',
+            'os_name': 'windows',
+            'os_version': '10',
+            'revision': '0bdaaf9c16',
+            'full_revision_hash': '0bdaaf9c1622ca49eb140381af1ece6d8001c934',
+            'time_start': '2018-06-21T18:39:54.218000+00:00',
+            'time_end': '2018-06-21T20:03:49+00:00',
         })
 
     def test_product_id(self):

--- a/shared/models.go
+++ b/shared/models.go
@@ -82,6 +82,12 @@ type TestRun struct {
 	// Time when the test run metadata was first created.
 	CreatedAt time.Time `json:"created_at"`
 
+	// Time when the test run started.
+	TimeStart time.Time `json:"time_start"`
+
+	// Time when the test run ended.
+	TimeEnd time.Time `json:"time_end"`
+
 	// URL for raw results JSON object. Resembles the JSON output of the
 	// wpt report tool.
 	RawResultsURL string `json:"raw_results_url"`


### PR DESCRIPTION
First step of #310

Results processor will extract 'time_start' and 'time_end' from reports,
which are microseconds since epochs, convert them into ISO UTC time
strings, and send them to /api/run.

The API handler will unmarshal them into TimeStart and TimeEnd in
TestRun, which are two newly added fields in this PR. In the absence of
the two fields, the API handler will use the current timestamp as
TimeStart and TimeEnd.

CreatedAt continues to be the current timestamp when the API handler
receives the request, but the "retro" mode is now removed.