### PR TITLE
Write general handling for TestRun filter params

### DIFF
--- a/shared/params.go
+++ b/shared/params.go
@@ -29,9 +29,9 @@ type TestRunFilter struct {
 }
 
 // ToQuery converts the filter set to a url.Values (set of query params).
-// defaultQuery is whether the params should fall back to the default query
-// (on the homepage).
-func (filter TestRunFilter) ToQuery(defaultQuery bool) (q url.Values) {
+// complete is whether the params should fall back to a complete run
+// (the default on the homepage).
+func (filter TestRunFilter) ToQuery(complete bool) (q url.Values) {
 	u := url.URL{}
 	q = u.Query()
 	if !IsLatest(filter.SHA) {
@@ -47,7 +47,7 @@ func (filter TestRunFilter) ToQuery(defaultQuery bool) (q url.Values) {
 			q.Add("product", p.String())
 		}
 	}
-	if filter.Complete || (defaultQuery && len(q) == 0) {
+	if filter.Complete || (complete && len(q) == 0) {
 		q.Set("complete", "true")
 	}
 	if filter.MaxCount != nil {
@@ -55,9 +55,6 @@ func (filter TestRunFilter) ToQuery(defaultQuery bool) (q url.Values) {
 	}
 	return q
 }
-
-// MaxCountDefaultValue is the default value returned by ParseMaxCountParam for the max-count param.
-const MaxCountDefaultValue = 1
 
 // MaxCountMaxValue is the maximum allowed value for the max-count param.
 const MaxCountMaxValue = 500

--- a/shared/params.go
+++ b/shared/params.go
@@ -18,6 +18,44 @@ import (
 	mapset "github.com/deckarep/golang-set"
 )
 
+// TestRunFilter represents the ways TestRun entities can be filtered in
+// the webapp and api.
+type TestRunFilter struct {
+	SHA      string
+	Labels   mapset.Set
+	Complete bool
+	MaxCount *int
+	Products []Product
+}
+
+// ToQuery converts the filter set to a url.Values (set of query params).
+// defaultQuery is whether the params should fall back to the default query
+// (on the homepage).
+func (filter TestRunFilter) ToQuery(defaultQuery bool) (q url.Values) {
+	u := url.URL{}
+	q = u.Query()
+	if !IsLatest(filter.SHA) {
+		q.Set("sha", filter.SHA)
+	}
+	if filter.Labels != nil && filter.Labels.Cardinality() > 0 {
+		for label := range filter.Labels.Iter() {
+			q.Add("label", label.(string))
+		}
+	}
+	if len(filter.Products) > 0 {
+		for _, p := range filter.Products {
+			q.Add("product", p.String())
+		}
+	}
+	if filter.Complete || (defaultQuery && len(q) == 0) {
+		q.Set("complete", "true")
+	}
+	if filter.MaxCount != nil {
+		q.Set("max-count", fmt.Sprintf("%v", *filter.MaxCount))
+	}
+	return q
+}
+
 // MaxCountDefaultValue is the default value returned by ParseMaxCountParam for the max-count param.
 const MaxCountDefaultValue = 1
 
@@ -205,9 +243,9 @@ func ParseProductsParam(r *http.Request) (products []Product, err error) {
 	return products, nil
 }
 
-// GetProductsForRequest parses the 'products' (and legacy 'browsers') params, returning
-// the sorted list of products to include, or a default list.
-func GetProductsForRequest(r *http.Request) (products []Product, err error) {
+// ParseProductOrBrowserParams parses the product (or, browser) params present in the given
+// request.
+func ParseProductOrBrowserParams(r *http.Request) (products []Product, err error) {
 	if products, err = ParseProductsParam(r); err != nil {
 		return nil, err
 	}
@@ -221,10 +259,19 @@ func GetProductsForRequest(r *http.Request) (products []Product, err error) {
 			BrowserName: browser,
 		})
 	}
+	return products, nil
+}
 
+// GetProductsForRequest parses the 'products' (and legacy 'browsers') params, returning
+// the sorted list of products to include, or a default list.
+func GetProductsForRequest(r *http.Request) (products []Product, err error) {
+	products, err = ParseProductOrBrowserParams(r)
+	if err != nil {
+		return nil, err
+	}
 	browserNames, err := GetBrowserNames()
 	// Fall back to default browser set.
-	if products == nil && browserParams == nil {
+	if products == nil {
 		products = GetDefaultProducts()
 	}
 
@@ -424,4 +471,21 @@ func ParseCompleteParam(r *http.Request) (bool, error) {
 	} else {
 		return strconv.ParseBool(val)
 	}
+}
+
+// ParseTestRunFilterParams parses all of the filter params for a TestRun query.
+func ParseTestRunFilterParams(r *http.Request) (filter TestRunFilter, err error) {
+	runSHA, err := ParseSHAParam(r)
+	if err != nil {
+		return filter, err
+	}
+	filter.SHA = runSHA
+	filter.Labels = ParseLabelsParam(r)
+	if filter.Complete, err = ParseCompleteParam(r); err != nil {
+		return filter, err
+	}
+	if filter.Products, err = ParseProductOrBrowserParams(r); err != nil {
+		return filter, err
+	}
+	return filter, nil
 }

--- a/shared/params_test.go
+++ b/shared/params_test.go
@@ -391,3 +391,17 @@ func TestParseComplete(t *testing.T) {
 	complete, _ = ParseCompleteParam(r)
 	assert.False(t, complete)
 }
+
+func TestParseTestRunFilterParams(t *testing.T) {
+	r := httptest.NewRequest("GET", "http://wpt.fyi/", nil)
+	filter, _ := ParseTestRunFilterParams(r)
+	assert.False(t, filter.Complete)
+	assert.Equal(t, "?complete=true", filter.ToQuery(true).Encode())
+	assert.Equal(t, "", filter.ToQuery(false).Encode())
+
+	r = httptest.NewRequest("GET", "http://wpt.fyi/?label=stable", nil)
+	filter, _ = ParseTestRunFilterParams(r)
+	assert.False(t, filter.Complete)
+	assert.Equal(t, "label=stable", filter.ToQuery(true).Encode())
+	assert.Equal(t, "label=stable", filter.ToQuery(false).Encode())
+}

--- a/shared/params_test.go
+++ b/shared/params_test.go
@@ -396,7 +396,7 @@ func TestParseTestRunFilterParams(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/", nil)
 	filter, _ := ParseTestRunFilterParams(r)
 	assert.False(t, filter.Complete)
-	assert.Equal(t, "?complete=true", filter.ToQuery(true).Encode())
+	assert.Equal(t, "complete=true", filter.ToQuery(true).Encode())
 	assert.Equal(t, "", filter.ToQuery(false).Encode())
 
 	r = httptest.NewRequest("GET", "http://wpt.fyi/?label=stable", nil)

--- a/webapp/test_results_handler.go
+++ b/webapp/test_results_handler.go
@@ -107,9 +107,10 @@ func testResultsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// getTestRunsAndSources gets the arrays of source urls and placeholder-TestRun-shared from the parameters for the
-// current request. When diffing, 'before' and 'after' parameters can be test-run specs (i.e. [product]@[sha]), or
-// base64 encoded TestRun JSON blobs for the results summaries.
+// getTestRunsAndSources gets source urls (api endpoints), and any placeholder TestRun entities from the parameters
+// for the current request.
+// When diffing, 'before' and 'after' parameters can be test-run specs (i.e. [product]@[sha]), or base64 encoded
+// TestRun JSON blobs for the results summaries.
 func getTestRunsAndSources(r *http.Request, runSHA string) (testRunSources []string, testRuns []shared.TestRun, err error) {
 	before := r.URL.Query().Get("before")
 	after := r.URL.Query().Get("after")


### PR DESCRIPTION
This fixes the `?complete=true` behaviour when combined with a `?label=experimental` flag.