### PR TITLE
Refactor api methods to re-use the TestRunFilter struct

### DIFF
--- a/api/shas.go
+++ b/api/shas.go
@@ -28,7 +28,7 @@ func apiSHAsHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := appengine.NewContext(r)
 
 	var shas []string
-	if filters.Complete {
+	if filters.Complete != nil && *filters.Complete {
 		if shas, err = getCompleteRunSHAs(ctx, filters.From, filters.MaxCount); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/api/shas.go
+++ b/api/shas.go
@@ -7,7 +7,6 @@ package api
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -20,38 +19,23 @@ import (
 
 // apiSHAsHandler is responsible for emitting just the revision SHAs for test runs.
 func apiSHAsHandler(w http.ResponseWriter, r *http.Request) {
-	var products []shared.Product
-	var err error
-	if products, err = shared.GetProductsForRequest(r); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	limit, err := shared.ParseMaxCountParam(r)
+	filters, err := shared.ParseTestRunFilterParams(r)
 	if err != nil {
-		http.Error(w, "Invalid 'max-count' param: "+err.Error(), http.StatusBadRequest)
-		return
-	}
-	var from *time.Time
-	if from, err = shared.ParseFromParam(r); err != nil {
-		http.Error(w, fmt.Sprintf("Invalid 'from' param: %s", err.Error()), http.StatusBadRequest)
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
 	ctx := appengine.NewContext(r)
 
 	var shas []string
-	if complete, err := shared.ParseCompleteParam(r); err != nil {
-		http.Error(w, fmt.Sprintf("Invalid 'complete' param: %s", r.URL.Query().Get("complete")), http.StatusBadRequest)
-		return
-	} else if complete {
-		if shas, err = getCompleteRunSHAs(ctx, from, limit); err != nil {
+	if filters.Complete {
+		if shas, err = getCompleteRunSHAs(ctx, filters.From, filters.MaxCount); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 	} else {
-		labels := shared.ParseLabelsParam(r)
-		testRuns, err := shared.LoadTestRuns(ctx, products, labels, shas, from, limit)
+		products := filters.GetProductsOrDefault()
+		testRuns, err := shared.LoadTestRuns(ctx, products, filters.Labels, nil, filters.From, filters.MaxCount)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/api/test_run_medium_test.go
+++ b/api/test_run_medium_test.go
@@ -9,7 +9,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
@@ -49,70 +48,6 @@ func TestGetTestRunByID(t *testing.T) {
 	bodyBytes, _ := ioutil.ReadAll(resp.Body)
 	json.Unmarshal(bodyBytes, &bodyTestRun)
 	assert.Equal(t, int64(123), bodyTestRun.ID)
-}
-
-func TestGetTestRuns_VersionPrefix(t *testing.T) {
-	i, err := aetest.NewInstance(&aetest.Options{StronglyConsistentDatastore: true})
-	assert.Nil(t, err)
-	defer i.Close()
-	r, err := i.NewRequest("GET", "/api/run?product=chrome-66.0", nil)
-	assert.Nil(t, err)
-
-	// 'Yesterday', v66...139 earlier version.
-	ctx := appengine.NewContext(r)
-	now := time.Now()
-	chrome := shared.TestRun{
-		ProductAtRevision: shared.ProductAtRevision{
-			Product: shared.Product{
-				BrowserName:    "chrome",
-				BrowserVersion: "66.0.3359.139",
-			},
-			Revision: "abcdef0123",
-		},
-		CreatedAt: now.AddDate(0, 0, -1),
-	}
-	datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &chrome)
-
-	// 'Today', v66...181 (revision increased)
-	chrome.BrowserVersion = "66.0.3359.181"
-	chrome.CreatedAt = now
-	datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &chrome)
-
-	// Also 'today', a v68 run.
-	chrome.BrowserVersion = "68.0.3432.3"
-	datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &chrome)
-
-	r, _ = i.NewRequest("GET", "/api/run?product=chrome-6", nil)
-	resp := httptest.NewRecorder()
-	apiTestRunGetHandler(resp, r)
-	assert.Equal(t, http.StatusNotFound, resp.Code)
-
-	r, _ = i.NewRequest("GET", "/api/run?product=chrome-66.0", nil)
-	resp = httptest.NewRecorder()
-	apiTestRunGetHandler(resp, r)
-	body, _ := ioutil.ReadAll(resp.Result().Body)
-	assert.Equalf(t, http.StatusOK, resp.Code, string(body))
-	var result66 shared.TestRun
-	json.Unmarshal(body, &result66)
-	assert.Equal(t, "66.0.3359.181", result66.BrowserVersion)
-
-	r, _ = i.NewRequest("GET", "/api/run?product=chrome-66.0.3359.139", nil)
-	resp = httptest.NewRecorder()
-	apiTestRunGetHandler(resp, r)
-	body, _ = ioutil.ReadAll(resp.Result().Body)
-	assert.Equal(t, http.StatusOK, resp.Code)
-	var result66139 shared.TestRun
-	json.Unmarshal(body, &result66139)
-	assert.Equal(t, "66.0.3359.139", result66139.BrowserVersion)
-
-	r, _ = i.NewRequest("GET", "/api/run?product=chrome-68", nil)
-	resp = httptest.NewRecorder()
-	apiTestRunGetHandler(resp, r)
-	body, _ = ioutil.ReadAll(resp.Result().Body)
-	assert.Equal(t, http.StatusOK, resp.Code)
-	var result68 shared.TestRun
-	json.Unmarshal(body, &result68)
-	assert.Equal(t, "68.0.3432.3", result68.BrowserVersion)
 }
 
 func TestTestRunPostHandler(t *testing.T) {

--- a/api/test_runs.go
+++ b/api/test_runs.go
@@ -34,7 +34,7 @@ func apiTestRunsHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := appengine.NewContext(r)
 	// When ?complete=true, make sure to show results for the same complete run (executed for all browsers).
 	var shas []string
-	if filters.Complete {
+	if filters.Complete != nil && *filters.Complete {
 		if shared.IsLatest(filters.SHA) {
 			shas, err = getCompleteRunSHAs(ctx, from, limit)
 			if err != nil {

--- a/api/test_runs_medium_test.go
+++ b/api/test_runs_medium_test.go
@@ -1,0 +1,152 @@
+// +build medium
+
+package api
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/web-platform-tests/wpt.fyi/shared"
+	"google.golang.org/appengine"
+	"google.golang.org/appengine/aetest"
+	"google.golang.org/appengine/datastore"
+)
+
+func TestGetTestRuns_VersionPrefix(t *testing.T) {
+	i, err := aetest.NewInstance(&aetest.Options{StronglyConsistentDatastore: true})
+	assert.Nil(t, err)
+	defer i.Close()
+	r, err := i.NewRequest("GET", "/api/run?product=chrome-66.0", nil)
+	assert.Nil(t, err)
+
+	// 'Yesterday', v66...139 earlier version.
+	ctx := appengine.NewContext(r)
+	now := time.Now()
+	chrome := shared.TestRun{
+		ProductAtRevision: shared.ProductAtRevision{
+			Product: shared.Product{
+				BrowserName:    "chrome",
+				BrowserVersion: "66.0.3359.139",
+			},
+			Revision: "abcdef0123",
+		},
+		CreatedAt: now.AddDate(0, 0, -1),
+	}
+	datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &chrome)
+
+	// 'Today', v66...181 (revision increased)
+	chrome.BrowserVersion = "66.0.3359.181"
+	chrome.CreatedAt = now
+	datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &chrome)
+
+	// Also 'today', a v68 run.
+	chrome.BrowserVersion = "68.0.3432.3"
+	datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &chrome)
+
+	r, _ = i.NewRequest("GET", "/api/run?product=chrome-6", nil)
+	resp := httptest.NewRecorder()
+	apiTestRunGetHandler(resp, r)
+	assert.Equal(t, http.StatusNotFound, resp.Code)
+
+	r, _ = i.NewRequest("GET", "/api/run?product=chrome-66.0", nil)
+	resp = httptest.NewRecorder()
+	apiTestRunGetHandler(resp, r)
+	body, _ := ioutil.ReadAll(resp.Result().Body)
+	assert.Equalf(t, http.StatusOK, resp.Code, string(body))
+	var result66 shared.TestRun
+	json.Unmarshal(body, &result66)
+	assert.Equal(t, "66.0.3359.181", result66.BrowserVersion)
+
+	r, _ = i.NewRequest("GET", "/api/run?product=chrome-66.0.3359.139", nil)
+	resp = httptest.NewRecorder()
+	apiTestRunGetHandler(resp, r)
+	body, _ = ioutil.ReadAll(resp.Result().Body)
+	assert.Equal(t, http.StatusOK, resp.Code)
+	var result66139 shared.TestRun
+	json.Unmarshal(body, &result66139)
+	assert.Equal(t, "66.0.3359.139", result66139.BrowserVersion)
+
+	r, _ = i.NewRequest("GET", "/api/run?product=chrome-68", nil)
+	resp = httptest.NewRecorder()
+	apiTestRunGetHandler(resp, r)
+	body, _ = ioutil.ReadAll(resp.Result().Body)
+	assert.Equal(t, http.StatusOK, resp.Code)
+	var result68 shared.TestRun
+	json.Unmarshal(body, &result68)
+	assert.Equal(t, "68.0.3432.3", result68.BrowserVersion)
+}
+
+func TestGetTestRuns_SHA(t *testing.T) {
+	i, err := aetest.NewInstance(&aetest.Options{StronglyConsistentDatastore: true})
+	assert.Nil(t, err)
+	defer i.Close()
+	r, err := i.NewRequest("GET", "/api/runs", nil)
+	assert.Nil(t, err)
+
+	ctx := appengine.NewContext(r)
+	now := time.Now()
+	run := shared.TestRun{}
+	run.BrowserVersion = "66.0.3359.139"
+	run.Revision = "abcdef0123"
+	run.CreatedAt = now.AddDate(0, 0, -1)
+
+	run.BrowserName = "chrome"
+	datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
+	run.BrowserName = "safari"
+	datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
+
+	run.Revision = "9876543210"
+	run.BrowserName = "firefox"
+	datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
+
+	run.Revision = "9999999999"
+	run.BrowserName = "edge"
+	datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
+
+	r, _ = i.NewRequest("GET", "/api/runs?sha=abcdef0123", nil)
+	resp := httptest.NewRecorder()
+	apiTestRunsHandler(resp, r)
+	body, _ := ioutil.ReadAll(resp.Result().Body)
+	assert.Equal(t, http.StatusOK, resp.Code)
+	var results shared.TestRuns
+	json.Unmarshal(body, &results)
+	assert.Equal(t, 2, len(results))
+	assert.Equal(t, "abcdef0123", results[0].Revision)
+
+	// ?complete ignored if SHA provided.
+	r, _ = i.NewRequest("GET", "/api/runs?sha=abcdef0123&complete", nil)
+	resp = httptest.NewRecorder()
+	apiTestRunsHandler(resp, r)
+	body, _ = ioutil.ReadAll(resp.Result().Body)
+	assert.Equal(t, http.StatusOK, resp.Code)
+	json.Unmarshal(body, &results)
+	assert.Equal(t, 2, len(results))
+	assert.Equal(t, "abcdef0123", results[0].Revision)
+
+	// ?complete - no complete runs.
+	r, _ = i.NewRequest("GET", "/api/runs?complete", nil)
+	resp = httptest.NewRecorder()
+	apiTestRunsHandler(resp, r)
+	body, _ = ioutil.ReadAll(resp.Result().Body)
+	assert.Equal(t, http.StatusNotFound, resp.Code)
+
+	run.Revision = "1111111111"
+	browserNames, _ := shared.GetBrowserNames()
+	for _, name := range browserNames {
+		run.BrowserName = name
+		datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
+	}
+	r, _ = i.NewRequest("GET", "/api/runs?complete", nil)
+	resp = httptest.NewRecorder()
+	apiTestRunsHandler(resp, r)
+	body, _ = ioutil.ReadAll(resp.Result().Body)
+	assert.Equal(t, http.StatusOK, resp.Code)
+	json.Unmarshal(body, &results)
+	assert.Equal(t, 4, len(results))
+	assert.Equal(t, "1111111111", results[0].Revision)
+}

--- a/shared/datastore.go
+++ b/shared/datastore.go
@@ -42,7 +42,8 @@ func LoadTestRuns(
 		for i := range labels.Iter() {
 			label := i.(string)
 			if IsStableBrowserName(label) {
-				// Browser name labels are already handled in GetProductsForRequest (which produces `products`).
+				// Browser name labels are already handled in TestRunFilter.GetProductsOrDefault
+				// (which produces `products`).
 				continue
 			}
 			baseQuery = baseQuery.Filter("Labels =", label)

--- a/shared/params.go
+++ b/shared/params.go
@@ -55,7 +55,7 @@ func (filter TestRunFilter) ToQuery(completeIfDefault bool) (q url.Values) {
 		q.Set("max-count", fmt.Sprintf("%v", *filter.MaxCount))
 	}
 	if filter.From != nil {
-		q.Set("from", fmt.Sprintf("%v", *filter.From))
+		q.Set("from", filter.From.Format(time.RFC3339))
 	}
 	return q
 }

--- a/shared/params_test.go
+++ b/shared/params_test.go
@@ -388,35 +388,37 @@ func TestParseProductAtRevision_OSVersion(t *testing.T) {
 }
 
 func TestParseComplete(t *testing.T) {
-	r := httptest.NewRequest("GET", "http://wpt.fyi/api/runs?complete", nil)
+	r := httptest.NewRequest("GET", "http://wpt.fyi/api/runs", nil)
 	complete, _ := ParseCompleteParam(r)
-	assert.True(t, complete)
+	assert.Nil(t, complete)
+
+	r = httptest.NewRequest("GET", "http://wpt.fyi/api/runs?complete", nil)
+	complete, _ = ParseCompleteParam(r)
+	assert.True(t, *complete)
 
 	r = httptest.NewRequest("GET", "http://wpt.fyi/api/runs?complete=true", nil)
 	complete, _ = ParseCompleteParam(r)
-	assert.True(t, complete)
+	assert.True(t, *complete)
 
 	r = httptest.NewRequest("GET", "http://wpt.fyi/api/runs?complete=false", nil)
 	complete, _ = ParseCompleteParam(r)
-	assert.False(t, complete)
+	assert.False(t, *complete)
 }
 
 func TestParseTestRunFilterParams(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/", nil)
 	filter, _ := ParseTestRunFilterParams(r)
-	assert.False(t, filter.Complete)
+	assert.Nil(t, filter.Complete)
 	assert.Equal(t, "complete=true", filter.ToQuery(true).Encode())
 	assert.Equal(t, "", filter.ToQuery(false).Encode())
 
 	r = httptest.NewRequest("GET", "http://wpt.fyi/?label=stable", nil)
 	filter, _ = ParseTestRunFilterParams(r)
-	assert.False(t, filter.Complete)
 	assert.Equal(t, "label=stable", filter.ToQuery(true).Encode())
 	assert.Equal(t, "label=stable", filter.ToQuery(false).Encode())
 
 	r = httptest.NewRequest("GET", "http://wpt.fyi/?from=2018-01-01T00%3A00%3A00Z", nil)
 	filter, _ = ParseTestRunFilterParams(r)
-	assert.False(t, filter.Complete)
 	assert.Equal(t, "complete=true&from=2018-01-01T00%3A00%3A00Z", filter.ToQuery(true).Encode())
 	assert.Equal(t, "from=2018-01-01T00%3A00%3A00Z", filter.ToQuery(false).Encode())
 }

--- a/shared/params_test.go
+++ b/shared/params_test.go
@@ -413,4 +413,10 @@ func TestParseTestRunFilterParams(t *testing.T) {
 	assert.False(t, filter.Complete)
 	assert.Equal(t, "label=stable", filter.ToQuery(true).Encode())
 	assert.Equal(t, "label=stable", filter.ToQuery(false).Encode())
+
+	r = httptest.NewRequest("GET", "http://wpt.fyi/?from=2018-01-01T00%3A00%3A00Z", nil)
+	filter, _ = ParseTestRunFilterParams(r)
+	assert.False(t, filter.Complete)
+	assert.Equal(t, "complete=true&from=2018-01-01T00%3A00%3A00Z", filter.ToQuery(true).Encode())
+	assert.Equal(t, "from=2018-01-01T00%3A00%3A00Z", filter.ToQuery(false).Encode())
 }

--- a/webapp/test_results_handler.go
+++ b/webapp/test_results_handler.go
@@ -156,6 +156,8 @@ func getTestRunsAndSources(r *http.Request, runSHA string) (testRunSources []str
 		if err != nil {
 			return nil, nil, err
 		}
+		// max-count doesn't make sense in the results UI.
+		f.MaxCount = nil
 		sourceURL.RawQuery = f.ToQuery(true).Encode()
 		testRunSources = []string{sourceURL.String()}
 	}

--- a/webapp/test_results_handler.go
+++ b/webapp/test_results_handler.go
@@ -51,7 +51,7 @@ func testResultsHandler(w http.ResponseWriter, r *http.Request) {
 
 	var testRunSources []string
 	var testRuns []shared.TestRun
-	if testRunSources, testRuns, err = getTestRunsAndSources(r, runSHA); err != nil {
+	if testRunSources, testRuns, err = getTestRunsAndSources(r); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -111,7 +111,7 @@ func testResultsHandler(w http.ResponseWriter, r *http.Request) {
 // for the current request.
 // When diffing, 'before' and 'after' parameters can be test-run specs (i.e. [product]@[sha]), or base64 encoded
 // TestRun JSON blobs for the results summaries.
-func getTestRunsAndSources(r *http.Request, runSHA string) (testRunSources []string, testRuns []shared.TestRun, err error) {
+func getTestRunsAndSources(r *http.Request) (testRunSources []string, testRuns []shared.TestRun, err error) {
 	before := r.URL.Query().Get("before")
 	after := r.URL.Query().Get("after")
 	if before != "" || after != "" {
@@ -156,8 +156,6 @@ func getTestRunsAndSources(r *http.Request, runSHA string) (testRunSources []str
 		if err != nil {
 			return nil, nil, err
 		}
-		// max-count doesn't make sense in the results UI.
-		f.MaxCount = nil
 		sourceURL.RawQuery = f.ToQuery(true).Encode()
 		testRunSources = []string{sourceURL.String()}
 	}

--- a/webapp/test_results_handler_test.go
+++ b/webapp/test_results_handler_test.go
@@ -1,0 +1,22 @@
+// +build small
+
+// Copyright 2017 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package webapp
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetTestRunsAndSources(t *testing.T) {
+	r := httptest.NewRequest("GET", "/results/?max-count=3", nil)
+	srcs, runs, err := getTestRunsAndSources(r, "latest")
+	assert.Nil(t, err)
+	assert.Nil(t, runs)
+	assert.Equal(t, []string{"/api/runs?complete=true"}, srcs)
+}

--- a/webapp/test_results_handler_test.go
+++ b/webapp/test_results_handler_test.go
@@ -15,8 +15,14 @@ import (
 
 func TestGetTestRunsAndSources(t *testing.T) {
 	r := httptest.NewRequest("GET", "/results/?max-count=3", nil)
-	srcs, runs, err := getTestRunsAndSources(r, "latest")
+	srcs, runs, err := getTestRunsAndSources(r)
 	assert.Nil(t, err)
 	assert.Nil(t, runs)
-	assert.Equal(t, []string{"/api/runs?complete=true"}, srcs)
+	assert.Equal(t, []string{"/api/runs?complete=true&max-count=3"}, srcs)
+
+	r = httptest.NewRequest("GET", "/results/?max-count=5&product=chrome-69&sha=abcdef0123", nil)
+	srcs, runs, err = getTestRunsAndSources(r)
+	assert.Nil(t, err)
+	assert.Nil(t, runs)
+	assert.Equal(t, []string{"/api/runs?max-count=5&product=chrome-69&sha=abcdef0123"}, srcs)
 }


### PR DESCRIPTION
Follow-up for #318, re-using the generalized `TestRunFilter` code in the `/api/runs` endpoint.