### PR TITLE
Fix logos for experimental browsers

### DIFF
--- a/webapp/components/test-run.html
+++ b/webapp/components/test-run.html
@@ -48,7 +48,7 @@ See models.go for more details.
     </style>
 
     <div>
-      <div><img src="{{displayLogo(testRun.browser_name, testRun.labels)}}" /></div>
+      <div><img src="{{displayLogo(testRun)}}" /></div>
       <div>{{displayName(testRun.browser_name)}} {{shortVersion(testRun.browser_name, testRun.browser_version)}}</div>
       <template is="dom-if" if="{{ !isDiff(testRun.browser_name) }}">
         <div>{{displayName(testRun.os_name)}} {{testRun.os_version}}</div>
@@ -102,8 +102,9 @@ See models.go for more details.
         return DISPLAY_NAMES.get(name) || name;
       }
 
-      displayLogo(name, labels) {
-        if (labels.includes('experimental') && !name.endsWith('-experimental')) {
+      displayLogo(testRun) {
+        let name = testRun.browser_name;
+        if (testRun.labels.includes('experimental') && !name.endsWith('-experimental')) {
           name += '-experimental';
         }
         return `/static/${name}_64x64.png`

--- a/webapp/components/test-run.html
+++ b/webapp/components/test-run.html
@@ -48,7 +48,7 @@ See models.go for more details.
     </style>
 
     <div>
-      <div><img src="/static/{{testRun.browser_name}}_64x64.png" /></div>
+      <div><img src="{{displayLogo(testRun.browser_name, testRun.labels)}}" /></div>
       <div>{{displayName(testRun.browser_name)}} {{shortVersion(testRun.browser_name, testRun.browser_version)}}</div>
       <template is="dom-if" if="{{ !isDiff(testRun.browser_name) }}">
         <div>{{displayName(testRun.os_name)}} {{testRun.os_version}}</div>
@@ -100,6 +100,13 @@ See models.go for more details.
 
       displayName(name) {
         return DISPLAY_NAMES.get(name) || name;
+      }
+
+      displayLogo(name, labels) {
+        if (labels.includes('experimental') && !name.endsWith('-experimental')) {
+          name += '-experimental';
+        }
+        return `/static/${name}_64x64.png`
       }
 
       minorIsSignificant(browserName) {

--- a/webapp/components/test-run.html
+++ b/webapp/components/test-run.html
@@ -107,7 +107,7 @@ See models.go for more details.
         if (testRun.labels.includes('experimental') && !name.endsWith('-experimental')) {
           name += '-experimental';
         }
-        return `/static/${name}_64x64.png`
+        return `/static/${name}_64x64.png`;
       }
 
       minorIsSignificant(browserName) {


### PR DESCRIPTION
Fixes #331 

## Description

This PR takes both the browser names and the labels into account when deciding the logos, because browser names in the recent runs (since the introduction of results receiver) no longer have the "-experimental" suffix.

## Review Information

See the homepage of the staging deployment. Chrome Dev logo should be used.