### PR TITLE
Remove special case of browser name label

### DIFF
--- a/shared/datastore.go
+++ b/shared/datastore.go
@@ -41,11 +41,6 @@ func LoadTestRuns(
 	if labels != nil {
 		for i := range labels.Iter() {
 			label := i.(string)
-			if IsStableBrowserName(label) {
-				// Browser name labels are already handled in TestRunFilter.GetProductsOrDefault
-				// (which produces `products`).
-				continue
-			}
 			baseQuery = baseQuery.Filter("Labels =", label)
 		}
 	}

--- a/shared/params.go
+++ b/shared/params.go
@@ -273,35 +273,6 @@ func (filter TestRunFilter) GetProductsOrDefault() (products []Product) {
 	if products == nil {
 		products = GetDefaultProducts()
 	}
-	browserNames := GetDefaultBrowserNames()
-
-	if filter.Labels != nil {
-		browserLabel := ""
-		for _, name := range browserNames {
-			if !filter.Labels.Contains(name) {
-				continue
-			}
-			// If we already encountered a browser name, nothing is two browsers (return empty set).
-			if browserLabel != "" {
-				products = nil
-				break
-			}
-			browserLabel = name
-			products = []Product{
-				Product{
-					BrowserName: name,
-				},
-			}
-			// For a browser label (e.g. "chrome"), we also include its -experimental variant because
-			// we used to spoof the experimental label by adding it as a suffix to browser names.
-			// The experimental label filtering will happen later in datastore.go.
-			// TODO(Hexcles): remove this once we convert all history -experimental runs.
-			products = append(products, Product{
-				BrowserName: name + "-" + ExperimentalLabel,
-			})
-		}
-	}
-
 	sort.Sort(ByBrowserName(products))
 	return products
 }

--- a/shared/params_test.go
+++ b/shared/params_test.go
@@ -148,27 +148,6 @@ func TestGetProductsOrDefault_BrowserParam_MultiBrowserParam_SafariInvalid(t *te
 	assert.NotNil(t, err)
 }
 
-func TestGetProductsOrDefault_BrowserParam_ChromeLabel(t *testing.T) {
-	r := httptest.NewRequest("GET", "http://wpt.fyi/?label=chrome", nil)
-	filters, err := ParseTestRunFilterParams(r)
-	products := filters.GetProductsOrDefault()
-	assert.Nil(t, err)
-	assert.Equal(t, 2, len(products))
-	assert.Equal(t, "chrome", products[0].BrowserName)
-	assert.Equal(t, "chrome-experimental", products[1].BrowserName)
-}
-
-func TestGetProductsOrDefault_BrowserParam_ChromeAndExperimentalLabel(t *testing.T) {
-	// The experimental label is no longer handled in params.go.
-	r := httptest.NewRequest("GET", "http://wpt.fyi/?labels=chrome,experimental", nil)
-	filters, err := ParseTestRunFilterParams(r)
-	products := filters.GetProductsOrDefault()
-	assert.Nil(t, err)
-	assert.Equal(t, 2, len(products))
-	assert.Equal(t, "chrome", products[0].BrowserName)
-	assert.Equal(t, "chrome-experimental", products[1].BrowserName)
-}
-
 func TestGetProductsOrDefault_BrowserAndProductParam(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?product=edge-16&browser=chrome", nil)
 	filters, err := ParseTestRunFilterParams(r)


### PR DESCRIPTION
This no longer works as intended - you end up comparing `chrome-experimental` with (the latest) `chrome`, which is also experimental.

Related to #311 