### PR TITLE
Add dispatch.yaml for the announcer

### DIFF
--- a/docs/app-engine.md
+++ b/docs/app-engine.md
@@ -25,10 +25,11 @@ make deploy_production PROJECT=wptdashboard APP_PATH=results-processor
 make deploy_production PROJECT=wptdashboard APP_PATH=revisions/service
 ```
 
-If you've updated [`index.yaml`](../webapp/index.yaml) or
-[`queue.yaml`](../webapp/queue.yaml) you must also deploy them manually.
+If you've updated [`index.yaml`](../webapp/index.yaml),
+[`queue.yaml`](../webapp/queue.yaml), or
+[`dispatch.yaml`](../webapp/dispatch.yaml) you must also deploy them manually.
 
 ```sh
 cd webapp
-gcloud app deploy --project=wptdashboard index.yaml queue.yaml
+gcloud app deploy --project=wptdashboard index.yaml queue.yaml dispatch.yaml
 ```

--- a/webapp/dispatch.yaml
+++ b/webapp/dispatch.yaml
@@ -1,0 +1,3 @@
+dispatch:
+  - url: "*/api/revisions/*"
+    service: announcer

--- a/webapp/dispatch.yaml
+++ b/webapp/dispatch.yaml
@@ -1,3 +1,5 @@
 dispatch:
-  - url: "*/api/revisions/*"
+  - url: "*wpt.fyi/api/revisions/*"
+    service: announcer
+  - url: "*.appspot.com/api/revisions/*"
     service: announcer


### PR DESCRIPTION
Fixes #326

I **think** URLs that don't match any of the rules will go to the default service, but I can't find the doc to prove it. https://cloud.google.com/appengine/docs/standard/python/reference/dispatch-yaml