### PR TITLE
Handle test-run elements where run has no labels

### DIFF
--- a/webapp/components/test-run.html
+++ b/webapp/components/test-run.html
@@ -104,7 +104,8 @@ See models.go for more details.
 
       displayLogo(testRun) {
         let name = testRun.browser_name;
-        if (testRun.labels.includes('experimental') && !name.endsWith('-experimental')) {
+        const exp = testRun.labels && testRun.labels.includes('experimental');
+        if (exp && !name.endsWith('-experimental')) {
           name += '-experimental';
         }
         return `/static/${name}_64x64.png`;


### PR DESCRIPTION
Fixes console output, e.g. https://staging.wpt.fyi/results/?product=chrome&product=safari&diff

> async.html:33 Uncaught TypeError: Cannot read property 'includes' of undefined
    at HTMLElement.displayLogo (test-run.html:107)
    at runMethodEffect (property-effects.html:818)
    at Function._evaluateBinding (property-effects.html:2721)
    at Object.runBindingEffect [as fn] (property-effects.html:581)
    at runEffectsForProperty (property-effects.html:162)
    at runEffects (property-effects.html:128)
    at HTMLElement._propagatePropertyChanges (property-effects.html:1741)
    at HTMLElement._propertiesChanged (property-effects.html:1705)
    at HTMLElement._flushProperties (properties-changed.html:341)
    at HTMLElement._flushProperties (property-effects.html:1559)