### PR TITLE
Use proper filters for the run fetch

### DIFF
--- a/shared/fetch_runs.go
+++ b/shared/fetch_runs.go
@@ -7,7 +7,6 @@ package shared
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -25,12 +24,13 @@ func FetchLatestRuns(wptdHost string) TestRuns {
 // FetchRuns fetches the TestRun metadata for the given sha / labels, using the
 // API on the given host.
 func FetchRuns(wptdHost, sha string, labels mapset.Set) TestRuns {
-	url := "https://" + wptdHost + "/api/runs?complete=true"
-	if labels != nil && labels.Cardinality() > 0 {
-		for label := range labels.Iter() {
-			url += fmt.Sprintf("&label=%s", label.(string))
-		}
+	url := "https://" + wptdHost + "/api/runs"
+
+	filters := TestRunFilter{
+		Labels: labels,
+		SHA:    sha,
 	}
+	url += "?" + filters.ToQuery(true).Encode()
 	log.Printf("Fetching %s...", url)
 
 	resp, err := http.Get(url)


### PR DESCRIPTION
## Description
Another case where non-consolidated query param handling causes problems. This causes `complete` to only be used when nothing that clashes with it is used (e.g. `?label=experimental`, used by results-analysis).

## Review Information
The current interop view @ https://staging.wpt.fyi/interop/?label=experimental was computed using this change locally.
The previous one, https://staging.wpt.fyi/interop/?label=experimental&sha=27406c9d23 was computed without the fix.