### PR TITLE
Persist params when switching tabs

### DIFF
--- a/shared/params.go
+++ b/shared/params.go
@@ -29,6 +29,17 @@ type TestRunFilter struct {
 	Products ProductSpecs
 }
 
+// IsDefaultQuery returns whether the params are just an empty query (or,
+// the equivalent defaults of an empty query).
+func (f TestRunFilter) IsDefaultQuery() bool {
+	return IsLatest(f.SHA) &&
+		(f.Labels == nil || f.Labels.Cardinality() < 1) &&
+		(f.Complete == nil || *f.Complete) &&
+		(f.From == nil) &&
+		(f.MaxCount == nil || *f.MaxCount == 1) &&
+		(len(f.Products) < 1)
+}
+
 // ProductSpec is a struct representing a parsed product spec string.
 type ProductSpec struct {
 	ProductAtRevision

--- a/webapp/components/interop.html
+++ b/webapp/components/interop.html
@@ -149,8 +149,8 @@ found in the LICENSE file.
     <thead>
       <tr>
         <th>Path</th>
-        <template is="dom-if" if="{{ thLabels.length }}">
-          <th colspan="100">Tests Passing in <var>X</var> / 4 Browsers</th>
+        <template is="dom-if" if="{{ testRuns }}">
+          <th colspan="100">Tests Passing in <var>X</var> / [[testRuns.length]] Browsers</th>
         </template>
       </tr>
       <tr>
@@ -209,6 +209,10 @@ found in the LICENSE file.
       return {
         sha: String,
         passRateMetadata: Object,
+        testRuns: {
+          type: Array,
+          computed: 'computeTestRuns(passRateMetadata)',
+        },
         allMetrics: Object,
         displayedNodes: {
           type: Object,
@@ -237,7 +241,7 @@ found in the LICENSE file.
         },
         thLabels: {
           type: Array,
-          computed: 'computeThLabels(passRateMetadata)'
+          computed: 'computeThLabels(testRuns)'
         },
         queryPlaceholder: {
           type: String,
@@ -316,16 +320,20 @@ found in the LICENSE file.
       return /(\.(html|htm|py|svg|xhtml|xht|xml)$)/.test(path);
     }
 
-    computeThLabels(metadata) {
-      if (!metadata || !metadata.test_runs) {
+    computeThLabels(testRuns) {
+      if (!testRuns) {
         return;
       }
-      const numLabels = metadata.test_runs.length + 1;
+      const numLabels = testRuns.length + 1;
       let labels = [];
       for (let i = 0; i < numLabels; i++) {
         labels[i] = `${i} / ${numLabels - 1}`;
       }
       return labels;
+    }
+
+    computeTestRuns(metadata) {
+      return metadata && metadata.test_runs;
     }
 
     computeDisplayedNodes(path, searchResults, allMetrics) {

--- a/webapp/components/interop.html
+++ b/webapp/components/interop.html
@@ -252,7 +252,6 @@ found in the LICENSE file.
         query: {
           type: String,
           value: urlToQuery(window.location),
-          observer: 'queryChanged'
         },
         pathIsATestFile: {
           type: Boolean,
@@ -276,6 +275,14 @@ found in the LICENSE file.
       if (this.allMetrics && this.allMetrics.data) {
         this.testFileNames = Array.from(Object.keys(this.allMetrics.data));
       }
+    }
+
+    ready() {
+      super.ready();
+      const tabs = this.shadowRoot.querySelector('results-navigation');
+      this.onpathupdated = path => {
+        tabs.path = path;
+      };
     }
 
     async fetchMetrics(url) {

--- a/webapp/components/results-navigation.html
+++ b/webapp/components/results-navigation.html
@@ -26,12 +26,12 @@
     </style>
     <paper-tabs selected='[[selected]]'>
       <paper-tab>
-        <a href="/results/[[query]]">
+        <a href="/results[[path]][[query]]">
           <h2>Test Results</h2>
         </a>
       </paper-tab>
       <paper-tab>
-        <a href="/interop/[[query]]">
+        <a href="/interop[[path]][[query]]">
           <h2>Interoperability</h2>
         </a>
       </paper-tab>
@@ -51,6 +51,10 @@
             type: Number,
             computed: 'computeSelectedTab(tab)',
             value: 0,
+          },
+          path: {
+            type: String,
+            value: window.location.pathname.replace(/^\/(interop|results)/, ''),
           },
           query: {
             type: String,

--- a/webapp/components/results-navigation.html
+++ b/webapp/components/results-navigation.html
@@ -26,12 +26,12 @@
     </style>
     <paper-tabs selected='[[selected]]'>
       <paper-tab>
-        <a href="/results/">
+        <a href="/results/[[query]]">
           <h2>Test Results</h2>
         </a>
       </paper-tab>
       <paper-tab>
-        <a href="/interop/">
+        <a href="/interop/[[query]]">
           <h2>Interoperability</h2>
         </a>
       </paper-tab>
@@ -51,6 +51,10 @@
             type: Number,
             computed: 'computeSelectedTab(tab)',
             value: 0,
+          },
+          query: {
+            type: String,
+            value: window.location.search,
           }
         };
       }
@@ -63,7 +67,7 @@
             e.preventDefault();
             const a = t.querySelector('a');
             window.setTimeout(() => {
-              window.location = a.href + window.location.search;
+              window.location = a.href;
             }, 300);
           };
         }

--- a/webapp/components/results-navigation.html
+++ b/webapp/components/results-navigation.html
@@ -63,7 +63,7 @@
             e.preventDefault();
             const a = t.querySelector('a');
             window.setTimeout(() => {
-              window.location = a.href;
+              window.location = a.href + window.location.search;
             }, 300);
           };
         }

--- a/webapp/components/self-navigator.html
+++ b/webapp/components/self-navigator.html
@@ -10,7 +10,8 @@
             type: String,
             value: '/',
             observer: 'pathUpdated',
-          }
+          },
+          onpathupdated: Function,
         };
       }
 
@@ -30,8 +31,10 @@
         return location.pathname;
       }
 
-      pathUpdated() {
-        // Default: Do nothing.
+      pathUpdated(path) {
+        if (this.onpathupdated) {
+          this.onpathupdated(path);
+        }
       }
 
       /**

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -320,6 +320,13 @@ found in the LICENSE file.
         this.refreshDisplayedNodes();
       }
 
+      ready() {
+        super.ready();
+        const tabs = this.shadowRoot.querySelector('results-navigation');
+        this.onpathupdated = path => {
+          tabs.path = path;
+        };
+      }
 
       async fetchResults(testRuns) {
         const testFileResults = await Promise.all(
@@ -366,6 +373,7 @@ found in the LICENSE file.
       }
 
       pathUpdated(path) {
+        super.pathUpdated(path);
         this.refreshDisplayedNodes();
         this.fetchManifest(path);
       }

--- a/webapp/interop_handler.go
+++ b/webapp/interop_handler.go
@@ -30,8 +30,10 @@ func interopHandler(w http.ResponseWriter, r *http.Request) {
 	// We 'load by SHA' by fetching any interop result with all TestRunIDs for that SHA.
 	if !filters.IsDefaultQuery() {
 		// Load default browser runs for SHA.
+		// Ignore any max-count; makes no sense for a interop run.
+		one := 1
 		runs, err := shared.LoadTestRuns(
-			ctx, filters.GetProductsOrDefault(), filters.Labels, []string{filters.SHA}, filters.From, filters.MaxCount)
+			ctx, filters.GetProductsOrDefault(), filters.Labels, []string{filters.SHA}, filters.From, &one)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return


### PR DESCRIPTION
## Description
Ensures params are kept when switching between `interop` and `results`.

## Review Information
e.g. https://interop-tab-dot-wptdashboard-staging.appspot.com/interop/?label=experimental