### PR TITLE
Sort test runs by start time

### DIFF
--- a/api/shas.go
+++ b/api/shas.go
@@ -63,13 +63,13 @@ func apiSHAsHandler(w http.ResponseWriter, r *http.Request) {
 func getCompleteRunSHAs(ctx context.Context, from *time.Time, limit *int) (shas []string, err error) {
 	query := datastore.
 		NewQuery("TestRun").
-		Order("-CreatedAt").
+		Order("-TimeStart").
 		Project("Revision", "BrowserName")
 
 	browserNames := shared.GetDefaultBrowserNames()
 
 	if from != nil {
-		query = query.Filter("CreatedAt >=", *from)
+		query = query.Filter("TimeStart >=", *from)
 	}
 
 	bySHA := make(map[string]mapset.Set)

--- a/api/shas_medium_test.go
+++ b/api/shas_medium_test.go
@@ -17,7 +17,7 @@ import (
 	"google.golang.org/appengine/datastore"
 )
 
-func TestCompleteSHAs(t *testing.T) {
+func TestGetCompleteRunSHAs(t *testing.T) {
 	i, err := aetest.NewInstance(&aetest.Options{StronglyConsistentDatastore: true})
 	assert.Nil(t, err)
 	defer i.Close()
@@ -36,7 +36,7 @@ func TestCompleteSHAs(t *testing.T) {
 		ProductAtRevision: shared.ProductAtRevision{
 			Revision: "abcdef0000",
 		},
-		CreatedAt: time.Now().AddDate(0, 0, -1),
+		TimeStart: time.Now().AddDate(0, 0, -1),
 	}
 	for _, browser := range browserNames[:len(browserNames)-1] {
 		run.BrowserName = browser
@@ -47,7 +47,7 @@ func TestCompleteSHAs(t *testing.T) {
 
 	// All 4 browsers, but experimental.
 	run.Revision = "abcdef0111"
-	run.CreatedAt = time.Now().AddDate(0, 0, -2)
+	run.TimeStart = time.Now().AddDate(0, 0, -2)
 	for _, browser := range browserNames {
 		run.BrowserName = browser + "-" + shared.ExperimentalLabel
 		datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
@@ -57,7 +57,7 @@ func TestCompleteSHAs(t *testing.T) {
 
 	// 2 browsers, and other 2, but experimental.
 	run.Revision = "abcdef0222"
-	run.CreatedAt = time.Now().AddDate(0, 0, -3)
+	run.TimeStart = time.Now().AddDate(0, 0, -3)
 	for i, browser := range browserNames {
 		run.BrowserName = browser
 		if i > 1 {
@@ -70,7 +70,7 @@ func TestCompleteSHAs(t *testing.T) {
 
 	// All 4 browsers.
 	run.Revision = "abcdef0123"
-	run.CreatedAt = time.Now().AddDate(0, 0, -4)
+	run.TimeStart = time.Now().AddDate(0, 0, -4)
 	for _, browser := range browserNames {
 		run.BrowserName = browser
 		datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
@@ -80,7 +80,7 @@ func TestCompleteSHAs(t *testing.T) {
 
 	// Another (earlier) run, also all 4 browsers.
 	run.Revision = "abcdef9999"
-	run.CreatedAt = time.Now().AddDate(0, 0, -5)
+	run.TimeStart = time.Now().AddDate(0, 0, -5)
 	for _, browser := range browserNames {
 		run.BrowserName = browser
 		datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
@@ -95,6 +95,28 @@ func TestCompleteSHAs(t *testing.T) {
 	from := time.Now().AddDate(0, 0, -4).Truncate(24 * time.Hour)
 	shas, _ = getCompleteRunSHAs(ctx, &from, nil)
 	assert.Equal(t, []string{"abcdef0123"}, shas)
+}
+
+func TestApiSHAsHandler(t *testing.T) {
+	i, err := aetest.NewInstance(&aetest.Options{StronglyConsistentDatastore: true})
+	assert.Nil(t, err)
+	defer i.Close()
+	r, err := i.NewRequest("GET", "/api/shas", nil)
+	assert.Nil(t, err)
+	ctx := appengine.NewContext(r)
+	browserNames := shared.GetDefaultBrowserNames()
+	run := shared.TestRun{
+		ProductAtRevision: shared.ProductAtRevision{
+			Revision: "abcdef0123",
+		},
+	}
+	for _, browser := range browserNames {
+		run.BrowserName = browser
+		datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
+	}
+	run.Revision = "abcdef0000"
+	datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
+	var shas []string
 
 	// Complete
 	shas = nil
@@ -104,7 +126,7 @@ func TestCompleteSHAs(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	bytes, _ := ioutil.ReadAll(w.Result().Body)
 	json.Unmarshal(bytes, &shas)
-	assert.Equal(t, []string{"abcdef0123", "abcdef9999"}, shas)
+	assert.Equal(t, []string{"abcdef0123"}, shas)
 
 	// Not complete
 	shas = nil
@@ -114,7 +136,7 @@ func TestCompleteSHAs(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	bytes, _ = ioutil.ReadAll(w.Result().Body)
 	json.Unmarshal(bytes, &shas)
-	assert.Equal(t, []string{"abcdef0000", "abcdef0222", "abcdef0123", "abcdef9999"}, shas)
+	assert.Equal(t, []string{"abcdef0123", "abcdef0000"}, shas)
 
 	// Bad param
 	r, err = i.NewRequest("GET", "/api/shas?complete=bad-value", nil)

--- a/shared/datastore.go
+++ b/shared/datastore.go
@@ -57,10 +57,10 @@ func LoadTestRuns(
 			}
 		}
 		// TODO(lukebjerring): Indexes + filtering for OS + version.
-		query = query.Order("-CreatedAt")
+		query = query.Order("-TimeStart")
 
 		if from != nil {
-			query = query.Filter("CreatedAt >", *from)
+			query = query.Filter("TimeStart >", *from)
 		}
 
 		fetched, err := query.KeysOnly().GetAll(ctx, nil)

--- a/shared/datastore.go
+++ b/shared/datastore.go
@@ -60,7 +60,7 @@ func LoadTestRuns(
 		query = query.Order("-TimeStart")
 
 		if from != nil {
-			query = query.Filter("TimeStart >", *from)
+			query = query.Filter("TimeStart >=", *from)
 		}
 
 		fetched, err := query.KeysOnly().GetAll(ctx, nil)

--- a/shared/datastore_medium_test.go
+++ b/shared/datastore_medium_test.go
@@ -166,3 +166,49 @@ func TestLoadTestRuns_MultipleSHAs(t *testing.T) {
 	assert.Equal(t, shas[0], loaded[0].Revision)
 	assert.Equal(t, shas[1], loaded[1].Revision)
 }
+
+func TestLoadTestRuns_Ordering(t *testing.T) {
+	testRuns := []TestRun{
+		TestRun{
+			ProductAtRevision: ProductAtRevision{
+				Product: Product{
+					BrowserName: "chrome",
+				},
+				Revision: "1234567890",
+			},
+			CreatedAt: time.Now(),
+			TimeStart: time.Now().AddDate(0, 0, -1),
+		},
+		TestRun{
+			ProductAtRevision: ProductAtRevision{
+				Product: Product{
+					BrowserName: "chrome",
+				},
+				Revision: "0987654321",
+			},
+			CreatedAt: time.Now().AddDate(0, 0, -1),
+			TimeStart: time.Now(),
+		},
+	}
+
+	i, err := aetest.NewInstance(&aetest.Options{StronglyConsistentDatastore: true})
+	assert.Nil(t, err)
+	defer i.Close()
+	// URL is a placeholder and is not used in this test.
+	r, err := i.NewRequest("GET", "/api/run", nil)
+	assert.Nil(t, err)
+
+	ctx := appengine.NewContext(r)
+	for _, testRun := range testRuns {
+		key := datastore.NewIncompleteKey(ctx, "TestRun", nil)
+		datastore.Put(ctx, key, &testRun)
+	}
+
+	chrome, _ := ParseProductSpec("chrome")
+	loaded, err := LoadTestRuns(ctx, []ProductSpec{chrome}, nil, nil, nil, nil)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(loaded))
+	// Runs should be ordered descendingly by TimeStart.
+	assert.Equal(t, "0987654321", loaded[0].Revision)
+	assert.Equal(t, "1234567890", loaded[1].Revision)
+}

--- a/webapp/index.yaml
+++ b/webapp/index.yaml
@@ -16,37 +16,37 @@ indexes:
 - kind: TestRun
   properties:
   - name: BrowserName
-  - name: CreatedAt
+  - name: TimeStart
     direction: desc
 - kind: TestRun
   properties:
   - name: Revision
-  - name: CreatedAt
+  - name: TimeStart
     direction: desc
 - kind: TestRun
   properties:
   - name: Browser
   - name: Revision
-  - name: CreatedAt
+  - name: TimeStart
     direction: desc
 - kind: TestRun
   properties:
   - name: BrowserName
   - name: Revision
-  - name: CreatedAt
+  - name: TimeStart
     direction: desc
 - kind: TestRun
   properties:
   - name: BrowserName
   - name: BrowserVersion
-  - name: CreatedAt
+  - name: TimeStart
     direction: desc
 - kind: TestRun
   properties:
   - name: BrowserName
   - name: BrowserVersion
   - name: OSName
-  - name: CreatedAt
+  - name: TimeStart
     direction: desc
 - kind: TestRun
   properties:
@@ -54,29 +54,23 @@ indexes:
   - name: BrowserVersion
   - name: OSName
   - name: OSVersion
-  - name: CreatedAt
+  - name: TimeStart
     direction: desc
 - kind: TestRun
   properties:
-  - name: BrowserName
-  - name: CreatedAt
+  - name: Labels
+  - name: TimeStart
     direction: desc
+- kind: TestRun
+  properties:
+  - name: TimeStart
+    direction: desc
+  - name: BrowserName
   - name: Revision
 - kind: TestRun
   properties:
   - name: BrowserName
   - name: BrowserVersion
-    direction: desc
-- kind: TestRun
-  properties:
-  - name: CreatedAt
-    direction: desc
-  - name: BrowserName
-  - name: Revision
-- kind: TestRun
-  properties:
-  - name: Labels
-  - name: CreatedAt
     direction: desc
 - kind: TestRun
   properties:


### PR DESCRIPTION
## Description

Fixes #310 by changing the sorting property from `CreatedAt` (when the test run is uploaded to wpt.fyi) to `TimeStart` (which the test run starts). Ideally we should order by the commit date of the revision, but `TimeStart` is a good approximation which already exists in the wptreport (as `time_start`) and saves us the trouble of consulting git.

For historical runs, `CreatedAt` is used to backfill `TimeStart` using [this script](https://github.com/web-platform-tests/data-migration/blob/master/add_time_start/add_time_start.go). I've already run the migration script against the staging project.

## Review Information

Because of the backfilling, there should be no observable change at the moment, but moving forward we should expect Edge & Safari runs to space more evenly in "recent runs".

## Changes

In addition to changing the argument of `query.Order` in a few places, this PR also refactors `api/results_redirect_handler.go` by the way to reuse `shared.ParseProductParam` & `shared.LoadTestRuns`. A monolithic test (`api/shas_medium_test.go`) is split into two.

`index.yaml` is updated accordingly. Besides, an unneeded index (AFAIK) is removed:
```yaml
- kind: TestRun
  properties:
  - name: BrowserName
  - name: CreatedAt
    direction: desc
  - name: Revision
```