### PR TITLE
Add tooltips to browsers

### DIFF
--- a/webapp/bower.json
+++ b/webapp/bower.json
@@ -10,7 +10,8 @@
     "paper-button": "PolymerElements/paper-button#^2.1.1",
     "paper-card": "PolymerElements/paper-card#^2.1.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^2.0.0",
-    "paper-tabs": "@Polymer/paper-tabs#^2.1.1"
+    "paper-tabs": "@Polymer/paper-tabs#^2.1.1",
+    "paper-tooltip": "@Polymer/paper-tooltip#^2.1.1"
   },
   "devDependencies": {
     "web-component-tester": "^6.4.3"

--- a/webapp/components/test-run.html
+++ b/webapp/components/test-run.html
@@ -4,6 +4,7 @@ Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file.
 -->
 
+<link rel="import" href="../bower_components/paper-tooltip/paper-tooltip.html">
 <link rel="import" href="../bower_components/polymer/polymer-element.html">
 <link rel="import" href="../bower_components/polymer/lib/elements/dom-if.html">
 
@@ -54,6 +55,11 @@ See models.go for more details.
         <div>{{displayName(testRun.os_name)}} {{testRun.os_version}}</div>
         <div class="revision">@<a href="?sha={{testRun.revision}}">{{testRun.revision}}</a></div>
         <div>{{dateFormat(testRun.created_at)}}</div>
+        <paper-tooltip offset=0>
+          {{displayName(testRun.browser_name)}} {{testRun.browser_version}}<br>
+          Labels: {{displayLabels(testRun.labels)}}<br>
+          {{moreTooltip(testRun)}}
+        </paper-tooltip>
       </template>
     </div>
   </template>
@@ -102,6 +108,13 @@ See models.go for more details.
         return DISPLAY_NAMES.get(name) || name;
       }
 
+      displayLabels(labels) {
+        if (labels && labels instanceof Array) {
+          return labels.join(', ');
+        }
+        return '';
+      }
+
       displayLogo(testRun) {
         let name = testRun.browser_name;
         const exp = testRun.labels && testRun.labels.includes('experimental');
@@ -129,6 +142,16 @@ See models.go for more details.
         }
 
         return match[1];
+      }
+
+      moreTooltip(testRun) {
+        if (testRun.browser_name.startsWith('chrome') && testRun.labels.includes('experimental')) {
+          return 'With --enable-experimental-web-platform-features';
+        }
+        if (testRun.browser_name.startsWith('firefox')) {
+          return 'Using prefs in /testing/profiles/; some experimental features enabled';
+        }
+        return '';
       }
     }
 


### PR DESCRIPTION
## Description

This PR exposes more information about browsers using `<paper-tooltip>, namely:

* The full, untruncated version
* All labels
* Optional explanation text (currently it only has a reminder for whether experimental features are enabled, related to #333 .)

## Review Information

Hover your mouse on any browser (both the logo and the text) in the staging deployment. Specifically, try the following browsers: Chrome stable, Chrome experimental and Firefox (any channel).