### PR TITLE
Clean up webapp/test_runs_handler.go

### DIFF
--- a/api/test_run.go
+++ b/api/test_run.go
@@ -21,6 +21,7 @@ import (
 func apiTestRunHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != "GET" {
 		http.Error(w, "Only GET is supported.", http.StatusMethodNotAllowed)
+		return
 	}
 
 	vars := mux.Vars(r)


### PR DESCRIPTION
To use shared param parsing routines.

Also fix a bug in api/test_run.go where the handler didn't return early
after an error occurred.