### PR TITLE
Add param to populate_dev_data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ eslint: node-babel-eslint node-eslint node-eslint-plugin-html
 
 dev_data:
 	cd $(WPTD_GO_PATH)/util; go get -t ./...
-	go run $(WPTD_GO_PATH)/util/populate_dev_data.go $(FLAGS) "-static_dir=$(WPTD_GO_PATH)/webapp/static"
+	go run $(WPTD_GO_PATH)/util/populate_dev_data.go $(FLAGS) " -static_dir=$(WPTD_GO_PATH)/webapp/static"
 
 deploy_staging: gcloud webapp_deps package_announcer var-BRANCH_NAME var-APP_PATH var-PROJECT $(WPTD_PATH)client-secret.json
 	gcloud config set project $(PROJECT)

--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ eslint: node-babel-eslint node-eslint node-eslint-plugin-html
 
 dev_data:
 	cd $(WPTD_GO_PATH)/util; go get -t ./...
-	go run $(WPTD_GO_PATH)/util/populate_dev_data.go $(FLAGS)
+	go run $(WPTD_GO_PATH)/util/populate_dev_data.go $(FLAGS) "-static_dir=$(WPTD_GO_PATH)/webapp/static"
 
 deploy_staging: gcloud webapp_deps package_announcer var-BRANCH_NAME var-APP_PATH var-PROJECT $(WPTD_PATH)client-secret.json
 	gcloud config set project $(PROJECT)

--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ eslint: node-babel-eslint node-eslint node-eslint-plugin-html
 
 dev_data:
 	cd $(WPTD_GO_PATH)/util; go get -t ./...
-	go run $(WPTD_GO_PATH)/util/populate_dev_data.go $(FLAGS) " -static_dir=$(WPTD_GO_PATH)/webapp/static"
+	go run $(WPTD_GO_PATH)/util/populate_dev_data.go $(FLAGS) -static_dir="$(WPTD_GO_PATH)/webapp/static"
 
 deploy_staging: gcloud webapp_deps package_announcer var-BRANCH_NAME var-APP_PATH var-PROJECT $(WPTD_PATH)client-secret.json
 	gcloud config set project $(PROJECT)

--- a/shared/fetch_runs.go
+++ b/shared/fetch_runs.go
@@ -18,17 +18,18 @@ import (
 // FetchLatestRuns fetches the TestRun metadata for the latest runs, using the
 // API on the given host.
 func FetchLatestRuns(wptdHost string) TestRuns {
-	return FetchRuns(wptdHost, "latest", nil)
+	return FetchRuns(wptdHost, "latest", nil, nil)
 }
 
 // FetchRuns fetches the TestRun metadata for the given sha / labels, using the
 // API on the given host.
-func FetchRuns(wptdHost, sha string, labels mapset.Set) TestRuns {
+func FetchRuns(wptdHost, sha string, maxCount *int, labels mapset.Set) TestRuns {
 	url := "https://" + wptdHost + "/api/runs"
 
 	filters := TestRunFilter{
-		Labels: labels,
-		SHA:    sha,
+		Labels:   labels,
+		SHA:      sha,
+		MaxCount: maxCount,
 	}
 	url += "?" + filters.ToQuery(true).Encode()
 	log.Printf("Fetching %s...", url)

--- a/util/commands.sh
+++ b/util/commands.sh
@@ -12,10 +12,10 @@ function wptd_useradd() {
   docker exec -u 0:0 "${DOCKER_INSTANCE}" sh -c 'echo "%user ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers'
 }
 function wptd_exec() {
-  docker exec -u $(id -u $USER):$(id -g $USER) "${DOCKER_INSTANCE}" "$@"
+  docker exec -u $(id -u $USER):$(id -g $USER) "${DOCKER_INSTANCE}" sh -c "$*"
 }
 function wptd_exec_it() {
-  docker exec -it -u $(id -u $USER):$(id -g $USER) "${DOCKER_INSTANCE}" "$@"
+  docker exec -it -u $(id -u $USER):$(id -g $USER) "${DOCKER_INSTANCE}" sh -c "$*"
 }
 # function wptd_run() {}
 function wptd_stop() {

--- a/util/docker-dev/dev_data.sh
+++ b/util/docker-dev/dev_data.sh
@@ -27,4 +27,4 @@ else
     ${COPY_COMMAND}
 fi
 
-wptd_exec make dev_data FLAGS="$@"
+wptd_exec make dev_data FLAGS=\"$@\"

--- a/util/populate_dev_data.go
+++ b/util/populate_dev_data.go
@@ -5,10 +5,14 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
+	"strings"
 	"time"
 
 	mapset "github.com/deckarep/golang-set"
@@ -21,7 +25,10 @@ import (
 )
 
 var (
-	host = flag.String("host", "wpt.fyi", "wpt.fyi host to fetch prod runs from")
+	host            = flag.String("host", "wpt.fyi", "wpt.fyi host to fetch prod runs from")
+	numRemoteRuns   = flag.Int("num_remote_runs", 1, "number of remote runs to copy from host to local environment")
+	storageToStatic = flag.Bool("storage_to_static", false, "whether or not to copy data from GCS to the local static directory")
+	staticDir       = flag.String("static_dir", "..", "static assets directory for local wpt.fyi mirror; only applies when -storage_to_static=true")
 )
 
 // populate_dev_data.go populates a local running webapp instance with some
@@ -189,17 +196,24 @@ func main() {
 	addData(ctx, failuresMetadataKindName, staticFailuresMetadata)
 
 	log.Print("Adding latest production TestRun data...")
-	prodTestRuns := shared.FetchRuns(*host, "latest", mapset.NewSetWith("stable"))
+	maxCount := *numRemoteRuns
+	prodTestRuns := shared.FetchRuns(*host, "latest", &maxCount, mapset.NewSetWith("stable"))
 	labelRuns(prodTestRuns, "prod")
 	latestProductionTestRunMetadata := make([]interface{}, len(prodTestRuns))
 	for i := range prodTestRuns {
 		latestProductionTestRunMetadata[i] = &prodTestRuns[i]
 	}
 	addData(ctx, testRunKindName, latestProductionTestRunMetadata)
+	if *storageToStatic {
+		copyFromStorage(ctx, prodTestRuns)
+	}
 
 	log.Print("Adding latest experimental TestRun data...")
-	prodTestRuns = shared.FetchRuns(*host, "latest", mapset.NewSetWith("experimental"))
+	prodTestRuns = shared.FetchRuns(*host, "latest", &maxCount, mapset.NewSetWith("experimental"))
 	labelRuns(prodTestRuns, "prod")
+	if *storageToStatic {
+		copyFromStorage(ctx, prodTestRuns)
+	}
 
 	latestProductionTestRunMetadata = make([]interface{}, len(prodTestRuns))
 	for i := range prodTestRuns {
@@ -241,4 +255,84 @@ func getRemoteAPIContext() (context.Context, error) {
 	const localhost = "localhost:9999"
 	remoteContext, err := remote_api.NewRemoteContext(localhost, http.DefaultClient)
 	return remoteContext, err
+}
+
+func copyFromStorage(ctx context.Context, runs shared.TestRuns) {
+	for _, run := range runs {
+		summaryURLParts := strings.Split(run.ResultsURL, "/")
+
+		if len(summaryURLParts) != 6 {
+			log.Printf("WARN: Unexpected ResultsURL format: %s", run.ResultsURL)
+			return
+		}
+		sha := summaryURLParts[4]
+		name := summaryURLParts[5][0 : len(summaryURLParts[5])-len("-summary.json.gz")]
+		parentDir := *staticDir + "/" + sha
+		dir := parentDir + "/" + name
+		if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+			log.Printf("WARN: Failed to create directory: %s", dir)
+			return
+		}
+
+		resp, err := http.Get(run.ResultsURL)
+		if err != nil {
+			log.Printf("WARN: Failed to load run results summary from %s", run.ResultsURL)
+			return
+		}
+		if resp.StatusCode != 200 {
+			log.Printf("WARN: Bad status code from %s: %d", run.ResultsURL, resp.StatusCode)
+			return
+		}
+		defer resp.Body.Close()
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			log.Printf("WARN: Error reading body from %s", run.ResultsURL)
+			return
+		}
+		if err := ioutil.WriteFile(parentDir+"/"+summaryURLParts[5], body, 0644); err != nil {
+			log.Printf("WARN: Failed to copy %s to %s", run.ResultsURL, parentDir+"/"+summaryURLParts[5])
+			return
+		}
+
+		resp, err = http.Get(run.RawResultsURL)
+		if err != nil {
+			log.Printf("WARN: Failed to load run results from %s", run.RawResultsURL)
+			return
+		}
+		if resp.StatusCode != 200 {
+			log.Printf("WARN: Bad status code from %s: %d", run.RawResultsURL, resp.StatusCode)
+			return
+		}
+		defer resp.Body.Close()
+		body, err = ioutil.ReadAll(resp.Body)
+		if err != nil {
+			log.Printf("WARN: Error reading body from %s", run.RawResultsURL)
+			return
+		}
+		var report metrics.TestResultsReport
+		if err := json.Unmarshal(body, &report); err != nil {
+			log.Printf("WARN: Failed to unmarshal data from %s", run.RawResultsURL)
+			return
+		}
+
+		for _, res := range report.Results {
+			data, err := json.Marshal(res)
+			if err != nil {
+				log.Printf("WARN: Failed to unmarshal data from %v", res)
+				continue
+			}
+			pathSuffixParts := strings.Split(res.Test, "/")
+			pathSuffix := strings.Join(pathSuffixParts[1:len(pathSuffixParts)-1], "/")
+			subdir := dir + "/" + pathSuffix
+			file := subdir + "/" + pathSuffixParts[len(pathSuffixParts)-1]
+			if err := os.MkdirAll(subdir, os.ModePerm); err != nil {
+				log.Printf("WARN: Failed to create directory: %s", subdir)
+				continue
+			}
+			if err := ioutil.WriteFile(file, data, 0644); err != nil {
+				log.Printf("WARN: Failed to copy %v to %s", res, file)
+				continue
+			}
+		}
+	}
 }

--- a/util/populate_dev_data.go
+++ b/util/populate_dev_data.go
@@ -5,14 +5,10 @@
 package main
 
 import (
-	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
-	"os"
-	"strings"
 	"time"
 
 	mapset "github.com/deckarep/golang-set"
@@ -25,10 +21,8 @@ import (
 )
 
 var (
-	host            = flag.String("host", "wpt.fyi", "wpt.fyi host to fetch prod runs from")
-	numRemoteRuns   = flag.Int("num_remote_runs", 1, "number of remote runs to copy from host to local environment")
-	storageToStatic = flag.Bool("storage_to_static", false, "whether or not to copy data from GCS to the local static directory")
-	staticDir       = flag.String("static_dir", "..", "static assets directory for local wpt.fyi mirror; only applies when -storage_to_static=true")
+	host          = flag.String("host", "wpt.fyi", "wpt.fyi host to fetch prod runs from")
+	numRemoteRuns = flag.Int("num_remote_runs", 1, "number of remote runs to copy from host to local environment")
 )
 
 // populate_dev_data.go populates a local running webapp instance with some
@@ -204,16 +198,10 @@ func main() {
 		latestProductionTestRunMetadata[i] = &prodTestRuns[i]
 	}
 	addData(ctx, testRunKindName, latestProductionTestRunMetadata)
-	if *storageToStatic {
-		copyFromStorage(ctx, prodTestRuns)
-	}
 
 	log.Print("Adding latest experimental TestRun data...")
 	prodTestRuns = shared.FetchRuns(*host, "latest", &maxCount, mapset.NewSetWith("experimental"))
 	labelRuns(prodTestRuns, "prod")
-	if *storageToStatic {
-		copyFromStorage(ctx, prodTestRuns)
-	}
 
 	latestProductionTestRunMetadata = make([]interface{}, len(prodTestRuns))
 	for i := range prodTestRuns {
@@ -255,84 +243,4 @@ func getRemoteAPIContext() (context.Context, error) {
 	const localhost = "localhost:9999"
 	remoteContext, err := remote_api.NewRemoteContext(localhost, http.DefaultClient)
 	return remoteContext, err
-}
-
-func copyFromStorage(ctx context.Context, runs shared.TestRuns) {
-	for _, run := range runs {
-		summaryURLParts := strings.Split(run.ResultsURL, "/")
-
-		if len(summaryURLParts) != 6 {
-			log.Printf("WARN: Unexpected ResultsURL format: %s", run.ResultsURL)
-			return
-		}
-		sha := summaryURLParts[4]
-		name := summaryURLParts[5][0 : len(summaryURLParts[5])-len("-summary.json.gz")]
-		parentDir := *staticDir + "/" + sha
-		dir := parentDir + "/" + name
-		if err := os.MkdirAll(dir, os.ModePerm); err != nil {
-			log.Printf("WARN: Failed to create directory: %s", dir)
-			return
-		}
-
-		resp, err := http.Get(run.ResultsURL)
-		if err != nil {
-			log.Printf("WARN: Failed to load run results summary from %s", run.ResultsURL)
-			return
-		}
-		if resp.StatusCode != 200 {
-			log.Printf("WARN: Bad status code from %s: %d", run.ResultsURL, resp.StatusCode)
-			return
-		}
-		defer resp.Body.Close()
-		body, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			log.Printf("WARN: Error reading body from %s", run.ResultsURL)
-			return
-		}
-		if err := ioutil.WriteFile(parentDir+"/"+summaryURLParts[5], body, 0644); err != nil {
-			log.Printf("WARN: Failed to copy %s to %s", run.ResultsURL, parentDir+"/"+summaryURLParts[5])
-			return
-		}
-
-		resp, err = http.Get(run.RawResultsURL)
-		if err != nil {
-			log.Printf("WARN: Failed to load run results from %s", run.RawResultsURL)
-			return
-		}
-		if resp.StatusCode != 200 {
-			log.Printf("WARN: Bad status code from %s: %d", run.RawResultsURL, resp.StatusCode)
-			return
-		}
-		defer resp.Body.Close()
-		body, err = ioutil.ReadAll(resp.Body)
-		if err != nil {
-			log.Printf("WARN: Error reading body from %s", run.RawResultsURL)
-			return
-		}
-		var report metrics.TestResultsReport
-		if err := json.Unmarshal(body, &report); err != nil {
-			log.Printf("WARN: Failed to unmarshal data from %s", run.RawResultsURL)
-			return
-		}
-
-		for _, res := range report.Results {
-			data, err := json.Marshal(res)
-			if err != nil {
-				log.Printf("WARN: Failed to unmarshal data from %v", res)
-				continue
-			}
-			pathSuffixParts := strings.Split(res.Test, "/")
-			pathSuffix := strings.Join(pathSuffixParts[1:len(pathSuffixParts)-1], "/")
-			subdir := dir + "/" + pathSuffix
-			file := subdir + "/" + pathSuffixParts[len(pathSuffixParts)-1]
-			if err := os.MkdirAll(subdir, os.ModePerm); err != nil {
-				log.Printf("WARN: Failed to create directory: %s", subdir)
-				continue
-			}
-			if err := ioutil.WriteFile(file, data, 0644); err != nil {
-				log.Printf("WARN: Failed to copy %v to %s", res, file)
-				continue
-			}
-		}
-	}
 }


### PR DESCRIPTION
This allows for use cases like `./util/docker-dev/dev_data.sh -num_remote_runs=10`for 10 runs from each label configuration to be copied from remote (prod/staging) to local datastore.