### PR TITLE
Extract creation of AppEngine testing server

### DIFF
--- a/api/manifest_medium_test.go
+++ b/api/manifest_medium_test.go
@@ -7,15 +7,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"google.golang.org/appengine/aetest"
+	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
 	"google.golang.org/appengine/memcache"
 )
 
 func TestGetGitHubReleaseAsset_Caches(t *testing.T) {
-	ctx, done, err := aetest.NewContext()
-	if err != nil {
-		t.Fatal(err)
-	}
+	ctx, done, err := sharedtest.NewAEContext(true)
+	assert.Nil(t, err)
 	defer done()
 
 	downloadURL := "http://gith1ub.com/magic_url"

--- a/api/shas_medium_test.go
+++ b/api/shas_medium_test.go
@@ -12,19 +12,16 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/web-platform-tests/wpt.fyi/shared"
+	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
 	"google.golang.org/appengine"
-	"google.golang.org/appengine/aetest"
 	"google.golang.org/appengine/datastore"
 )
 
 func TestGetCompleteRunSHAs(t *testing.T) {
-	i, err := aetest.NewInstance(&aetest.Options{StronglyConsistentDatastore: true})
+	ctx, done, err := sharedtest.NewAEContext(true)
 	assert.Nil(t, err)
-	defer i.Close()
-	r, err := i.NewRequest("GET", "/api/shas?complete", nil)
-	assert.Nil(t, err)
+	defer done()
 
-	ctx := appengine.NewContext(r)
 	browserNames := shared.GetDefaultBrowserNames()
 
 	// Nothing in datastore.
@@ -98,7 +95,7 @@ func TestGetCompleteRunSHAs(t *testing.T) {
 }
 
 func TestApiSHAsHandler(t *testing.T) {
-	i, err := aetest.NewInstance(&aetest.Options{StronglyConsistentDatastore: true})
+	i, err := sharedtest.NewAEInstance(true)
 	assert.Nil(t, err)
 	defer i.Close()
 	r, err := i.NewRequest("GET", "/api/shas", nil)

--- a/api/test_run_medium_test.go
+++ b/api/test_run_medium_test.go
@@ -12,13 +12,13 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 	"github.com/web-platform-tests/wpt.fyi/shared"
+	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
 	"google.golang.org/appengine"
-	"google.golang.org/appengine/aetest"
 	"google.golang.org/appengine/datastore"
 )
 
 func TestGetTestRunByID(t *testing.T) {
-	i, err := aetest.NewInstance(&aetest.Options{StronglyConsistentDatastore: true})
+	i, err := sharedtest.NewAEInstance(true)
 	assert.Nil(t, err)
 	defer i.Close()
 	r, err := i.NewRequest("GET", "/api/runs/123", nil)

--- a/api/test_runs_medium_test.go
+++ b/api/test_runs_medium_test.go
@@ -12,13 +12,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/web-platform-tests/wpt.fyi/shared"
+	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
 	"google.golang.org/appengine"
-	"google.golang.org/appengine/aetest"
 	"google.golang.org/appengine/datastore"
 )
 
 func TestGetTestRuns_VersionPrefix(t *testing.T) {
-	i, err := aetest.NewInstance(&aetest.Options{StronglyConsistentDatastore: true})
+	i, err := sharedtest.NewAEInstance(true)
 	assert.Nil(t, err)
 	defer i.Close()
 	r, err := i.NewRequest("GET", "/api/run?product=chrome-66.0", nil)
@@ -82,7 +82,7 @@ func TestGetTestRuns_VersionPrefix(t *testing.T) {
 }
 
 func TestGetTestRuns_SHA(t *testing.T) {
-	i, err := aetest.NewInstance(&aetest.Options{StronglyConsistentDatastore: true})
+	i, err := sharedtest.NewAEInstance(true)
 	assert.Nil(t, err)
 	defer i.Close()
 	r, err := i.NewRequest("GET", "/api/runs", nil)

--- a/shared/datastore_medium_test.go
+++ b/shared/datastore_medium_test.go
@@ -9,10 +9,9 @@ import (
 	"time"
 
 	mapset "github.com/deckarep/golang-set"
+	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
 
 	"github.com/stretchr/testify/assert"
-	"google.golang.org/appengine"
-	"google.golang.org/appengine/aetest"
 	"google.golang.org/appengine/datastore"
 )
 
@@ -30,14 +29,10 @@ func TestLoadTestRuns(t *testing.T) {
 		CreatedAt:  time.Now(),
 	}
 
-	i, err := aetest.NewInstance(&aetest.Options{StronglyConsistentDatastore: true})
+	ctx, done, err := sharedtest.NewAEContext(true)
 	assert.Nil(t, err)
-	defer i.Close()
-	// URL is a placeholder and is not used in this test.
-	r, err := i.NewRequest("GET", "/api/run", nil)
-	assert.Nil(t, err)
+	defer done()
 
-	ctx := appengine.NewContext(r)
 	key := datastore.NewIncompleteKey(ctx, "TestRun", nil)
 	key, _ = datastore.Put(ctx, key, &testRun)
 
@@ -104,14 +99,10 @@ func TestLoadTestRuns_Experimental_Only(t *testing.T) {
 		},
 	}
 
-	i, err := aetest.NewInstance(&aetest.Options{StronglyConsistentDatastore: true})
+	ctx, done, err := sharedtest.NewAEContext(true)
 	assert.Nil(t, err)
-	defer i.Close()
-	// URL is a placeholder and is not used in this test.
-	r, err := i.NewRequest("GET", "/api/run", nil)
-	assert.Nil(t, err)
+	defer done()
 
-	ctx := appengine.NewContext(r)
 	keys := make([]*datastore.Key, len(testRuns))
 	for i := range testRuns {
 		keys[i] = datastore.NewIncompleteKey(ctx, "TestRun", nil)
@@ -142,14 +133,10 @@ func TestLoadTestRuns_MultipleSHAs(t *testing.T) {
 		testRuns = append(testRuns, testRun)
 	}
 
-	i, err := aetest.NewInstance(&aetest.Options{StronglyConsistentDatastore: true})
+	ctx, done, err := sharedtest.NewAEContext(true)
 	assert.Nil(t, err)
-	defer i.Close()
-	// URL is a placeholder and is not used in this test.
-	r, err := i.NewRequest("GET", "/api/runs", nil)
-	assert.Nil(t, err)
+	defer done()
 
-	ctx := appengine.NewContext(r)
 	keys := make([]*datastore.Key, len(testRuns))
 	for i := range testRuns {
 		keys[i] = datastore.NewIncompleteKey(ctx, "TestRun", nil)
@@ -191,14 +178,10 @@ func TestLoadTestRuns_Ordering(t *testing.T) {
 		},
 	}
 
-	i, err := aetest.NewInstance(&aetest.Options{StronglyConsistentDatastore: true})
+	ctx, done, err := sharedtest.NewAEContext(true)
 	assert.Nil(t, err)
-	defer i.Close()
-	// URL is a placeholder and is not used in this test.
-	r, err := i.NewRequest("GET", "/api/run", nil)
-	assert.Nil(t, err)
+	defer done()
 
-	ctx := appengine.NewContext(r)
 	for _, testRun := range testRuns {
 		key := datastore.NewIncompleteKey(ctx, "TestRun", nil)
 		datastore.Put(ctx, key, &testRun)
@@ -238,14 +221,10 @@ func TestLoadTestRuns_From(t *testing.T) {
 		},
 	}
 
-	i, err := aetest.NewInstance(&aetest.Options{StronglyConsistentDatastore: true})
+	ctx, done, err := sharedtest.NewAEContext(true)
 	assert.Nil(t, err)
-	defer i.Close()
-	// URL is a placeholder and is not used in this test.
-	r, err := i.NewRequest("GET", "/api/run?from", nil)
-	assert.Nil(t, err)
+	defer done()
 
-	ctx := appengine.NewContext(r)
 	for _, testRun := range testRuns {
 		key := datastore.NewIncompleteKey(ctx, "TestRun", nil)
 		datastore.Put(ctx, key, &testRun)
@@ -282,14 +261,10 @@ func TestLoadTestRuns_To(t *testing.T) {
 		},
 	}
 
-	i, err := aetest.NewInstance(&aetest.Options{StronglyConsistentDatastore: true})
+	ctx, done, err := sharedtest.NewAEContext(true)
 	assert.Nil(t, err)
-	defer i.Close()
-	// URL is a placeholder and is not used in this test.
-	r, err := i.NewRequest("GET", "/api/run?from", nil)
-	assert.Nil(t, err)
+	defer done()
 
-	ctx := appengine.NewContext(r)
 	for _, testRun := range testRuns {
 		key := datastore.NewIncompleteKey(ctx, "TestRun", nil)
 		datastore.Put(ctx, key, &testRun)

--- a/shared/sharedtest/util.go
+++ b/shared/sharedtest/util.go
@@ -1,0 +1,40 @@
+// Copyright 2018 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package sharedtest
+
+import (
+	"golang.org/x/net/context"
+	"google.golang.org/appengine"
+	"google.golang.org/appengine/aetest"
+)
+
+// NewAEInstance creates a new aetest instance backed by dev_appserver whose
+// logs are suppressed. It takes a boolean argument for whether the Datastore
+// emulation should be strongly consistent.
+func NewAEInstance(stronglyConsistentDatastore bool) (aetest.Instance, error) {
+	return aetest.NewInstance(&aetest.Options{
+		StronglyConsistentDatastore: stronglyConsistentDatastore,
+		SuppressDevAppServerLog:     true,
+	})
+}
+
+// NewAEContext creates a new aetest context backed by dev_appserver whose
+// logs are suppressed. It takes a boolean argument for whether the Datastore
+// emulation should be strongly consistent.
+func NewAEContext(stronglyConsistentDatastore bool) (context.Context, func(), error) {
+	inst, err := NewAEInstance(stronglyConsistentDatastore)
+	if err != nil {
+		return nil, nil, err
+	}
+	req, err := inst.NewRequest("GET", "/", nil)
+	if err != nil {
+		inst.Close()
+		return nil, nil, err
+	}
+	ctx := appengine.NewContext(req)
+	return ctx, func() {
+		inst.Close()
+	}, nil
+}


### PR DESCRIPTION
There are multiple benefits for doing this:

1. The same code that creates a new aetest instance and then a new
   context with a dummy request and two error checks is repeated many
   times throughout the codebase only to get a strongly consistent
   Datastore emulation. This is error-prone and sometimes confusing
   (because of the fake URL).
2. With a central reusable routine, we can easily control all the aetest
   instances. For example, in this PR SuppressDevAppServerLog is added
   to suppress the lengthy and unhelpful messages from dev_appserver to
   make the output of go_test much cleaner.

The utiltiy function is placed inside shared/sharedtest package,
following the Go convention as seen in http/httptest.