### PR TITLE
Implement the "@SHA" part of ProductSpec

### DIFF
--- a/shared/datastore.go
+++ b/shared/datastore.go
@@ -52,8 +52,8 @@ func LoadTestRuns(
 				query = query.Filter("Labels =", i.(string))
 			}
 		}
-		if product.Revision != "" {
-			query.Filter("Revision = ", product.Revision)
+		if !IsLatest(product.Revision) {
+			query = query.Filter("Revision = ", product.Revision)
 		}
 		if product.BrowserVersion != "" {
 			if prefiltered, err = loadKeysForBrowserVersion(ctx, query, product.BrowserVersion); err != nil {

--- a/shared/datastore.go
+++ b/shared/datastore.go
@@ -52,6 +52,9 @@ func LoadTestRuns(
 				query = query.Filter("Labels =", i.(string))
 			}
 		}
+		if product.Revision != "" {
+			query.Filter("Revision = ", product.Revision)
+		}
 		if product.BrowserVersion != "" {
 			if prefiltered, err = loadKeysForBrowserVersion(ctx, query, product.BrowserVersion); err != nil {
 				return nil, err

--- a/shared/params.go
+++ b/shared/params.go
@@ -91,12 +91,14 @@ func (p ProductSpecs) Strings() []string {
 func (p ProductSpec) String() string {
 	s := p.Product.String()
 	if p.Labels != nil && p.Labels.Cardinality() > 0 {
-		s += "["
-		for label := range p.Labels.Iter() {
-			s += label.(string) + ","
+		labels := make([]string, 0, p.Labels.Cardinality())
+		for l := range p.Labels.Iter() {
+			labels = append(labels, l.(string))
 		}
-		s = s[:len(s)-1]
-		s += "]"
+		s += "[" + strings.Join(labels, ",") + "]"
+	}
+	if p.Revision != "" {
+		s += "@" + p.Revision
 	}
 	return s
 }

--- a/shared/params.go
+++ b/shared/params.go
@@ -32,27 +32,27 @@ type TestRunFilter struct {
 
 // IsDefaultQuery returns whether the params are just an empty query (or,
 // the equivalent defaults of an empty query).
-func (f TestRunFilter) IsDefaultQuery() bool {
-	return IsLatest(f.SHA) &&
-		(f.Labels == nil || f.Labels.Cardinality() < 1) &&
-		(f.Complete == nil || *f.Complete) &&
-		(f.From == nil) &&
-		(f.MaxCount == nil || *f.MaxCount == 1) &&
-		(len(f.Products) < 1)
+func (filter TestRunFilter) IsDefaultQuery() bool {
+	return IsLatest(filter.SHA) &&
+		(filter.Labels == nil || filter.Labels.Cardinality() < 1) &&
+		(filter.Complete == nil || *filter.Complete) &&
+		(filter.From == nil) &&
+		(filter.MaxCount == nil || *filter.MaxCount == 1) &&
+		(len(filter.Products) < 1)
 }
 
 // IsDefaultProducts returns whether the params products are empty, or the
 // equivalent of the default product set.
-func (f TestRunFilter) IsDefaultProducts() bool {
-	if len(f.Products) == 0 {
+func (filter TestRunFilter) IsDefaultProducts() bool {
+	if len(filter.Products) == 0 {
 		return true
 	}
 	def := GetDefaultProducts()
-	if len(f.Products) != len(def) {
+	if len(filter.Products) != len(def) {
 		return false
 	}
 	for i := range def {
-		if def[i] != f.Products[i] {
+		if def[i] != filter.Products[i] {
 			return false
 		}
 	}

--- a/shared/params.go
+++ b/shared/params.go
@@ -97,7 +97,7 @@ func (p ProductSpec) String() string {
 		}
 		s += "[" + strings.Join(labels, ",") + "]"
 	}
-	if p.Revision != "" {
+	if !IsLatest(p.Revision) {
 		s += "@" + p.Revision
 	}
 	return s

--- a/shared/params_test.go
+++ b/shared/params_test.go
@@ -387,6 +387,12 @@ func TestParseProductSpec_Labels(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+func TestParseProductSpec_String(t *testing.T) {
+	productSpec, err := ParseProductSpec("chrome-64[foo,bar]@1234512345")
+	assert.Nil(t, err)
+	assert.Equal(t, "chrome-64[foo,bar]@1234512345", productSpec.String())
+}
+
 func TestParseComplete(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/api/runs", nil)
 	complete, _ := ParseCompleteParam(r)

--- a/webapp/test_results_handler_test.go
+++ b/webapp/test_results_handler_test.go
@@ -22,6 +22,6 @@ func TestParseTestRunUIFilter(t *testing.T) {
 	r = httptest.NewRequest("GET", "/results/?products=chrome,safari&diff", nil)
 	f, err = parseTestRunUIFilter(r)
 	assert.Nil(t, err)
-	assert.Equal(t, f.Products, "[\"chrome\",\"safari\"]")
-	assert.Equal(t, f.Diff, true)
+	assert.Equal(t, "[\"chrome\",\"safari\"]", f.Products)
+	assert.Equal(t, true, f.Diff)
 }


### PR DESCRIPTION
## Description

This PR should make the "@SHA" part of ProductSpec fully working.

## Review Information

When the staging instance is up, try `/results/?product=edge@b7f4f1d1ea`.

## Changes

Two pieces were missing previously:
1. `ProductSpec.String()` didn't add SHA back when serializing `ProductSpec`, which caused SHA to be missing in the UI (the arguments for components).
2. `LoadTestRuns()` didn't filter by `ProductSpec.Revision`.

They are added in this PR along with tests.

Besides, the receiver name of some functions in `shared/params.go` are renamed to fix a warning from my local golint ("receiver name should be consistent"). I'm not sure why Travis didn't complain. Perhaps my local golint is newer.