### PR TITLE
Introduce GitHub issue template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,5 @@
+This project's primary focus is visualizing test results. It is not responsible
+for collecting web-platform-tests. The data is uploaded by external services,
+primarily https://github.com/web-platform-tests/results-collection . Issues
+regarding the collection methodology and/or accuracy of the data should be
+filed against those external services.

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,5 +1,7 @@
+<!--
 This project's primary focus is visualizing test results. It is not responsible
 for collecting web-platform-tests. The data is uploaded by external services,
 primarily https://github.com/web-platform-tests/results-collection . Issues
 regarding the collection methodology and/or accuracy of the data should be
 filed against those external services.
+-->


### PR DESCRIPTION
The contents of the `ISSUE_TEMPLATE.md` file will be displayed in the
GitHub.com UI when contributors attempt to report an issue. The goal of
the text introduced here is to help reporters orient themselves and file
issues in the appropriate project.