### PR TITLE
Change the interop component to fetch from the client (via the api)

### DIFF
--- a/webapp/components/interop.html
+++ b/webapp/components/interop.html
@@ -247,10 +247,12 @@ found in the LICENSE file.
 
       if (this.passRateMetadataSrc) {
         this.passRateMetadata = await fetch(this.passRateMetadataSrc).then(
-            r => {
-              if (!r.ok) return Promise.reject('Failed to fetch interop data');
-              return r.json();
-            });
+          function(r) {
+            if (!r.ok) {
+              return Promise.reject('Failed to fetch interop data');
+            }
+            return r.json();
+          });
       }
       this.allMetrics = await this.fetchMetrics(this.passRateMetadata.url);
       if (this.allMetrics && this.allMetrics.data) {

--- a/webapp/components/interop.html
+++ b/webapp/components/interop.html
@@ -212,6 +212,7 @@ found in the LICENSE file.
     static get properties() {
       return {
         passRateMetadata: Object,
+        passRateMetadataSrc: String,
         testRuns: {
           type: Array,
           computed: 'computeTestRuns(passRateMetadata)',
@@ -244,6 +245,13 @@ found in the LICENSE file.
     async ready() {
       super.ready();
 
+      if (this.passRateMetadataSrc) {
+        this.passRateMetadata = await fetch(this.passRateMetadataSrc).then(
+            r => {
+              if (!r.ok) return Promise.reject('Failed to fetch interop data');
+              return r.json();
+            });
+      }
       this.allMetrics = await this.fetchMetrics(this.passRateMetadata.url);
       if (this.allMetrics && this.allMetrics.data) {
         this.testFileNames = Array.from(Object.keys(this.allMetrics.data));

--- a/webapp/interop_handler.go
+++ b/webapp/interop_handler.go
@@ -5,73 +5,30 @@
 package webapp
 
 import (
-	"encoding/json"
 	"net/http"
+	"net/url"
 
-	"github.com/web-platform-tests/results-analysis/metrics"
 	"github.com/web-platform-tests/wpt.fyi/shared"
-	"google.golang.org/appengine"
-	"google.golang.org/appengine/datastore"
 )
 
 // interopHandler handles the view of test results broken down by the
 // number of browsers for which the test passes.
 func interopHandler(w http.ResponseWriter, r *http.Request) {
-	ctx := appengine.NewContext(r)
-	passRateType := metrics.GetDatastoreKindName(metrics.PassRateMetadata{})
-	query := datastore.NewQuery(passRateType).Order("-StartTime").Limit(1)
-
-	filters, err := shared.ParseTestRunFilterParams(r)
+	sourceURL, _ := url.Parse("/api/interop")
+	f, err := shared.ParseTestRunFilterParams(r)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+	sourceURL.RawQuery = f.ToQuery(true).Encode()
 
-	// We 'load by SHA' by fetching any interop result with all TestRunIDs for that SHA.
-	if !filters.IsDefaultQuery() {
-		// Load default browser runs for SHA.
-		// Ignore any max-count; makes no sense for a interop run.
-		one := 1
-		runs, err := shared.LoadTestRuns(
-			ctx, filters.GetProductsOrDefault(), filters.Labels, []string{filters.SHA}, filters.From, filters.To, &one)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		for _, run := range runs {
-			query = query.Filter("TestRunIDs =", run.ID)
-		}
-	}
-
-	var metadataSlice []metrics.PassRateMetadataLegacy
-	if _, err := query.GetAll(ctx, &metadataSlice); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	if len(metadataSlice) != 1 {
-		http.Error(w, "No metrics runs found", http.StatusNotFound)
-		return
-	}
-
-	metadata := &metadataSlice[0]
-	if err := metadata.LoadTestRuns(ctx); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	metadataBytes, err := json.Marshal(*metadata)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
 	data := struct {
-		Metadata string
-		SHA      string
+		Metadata        string
+		MetadataSources string
+		SHA             string
 	}{
-		Metadata: string(metadataBytes),
-	}
-	if !shared.IsLatest(filters.SHA) {
-		data.SHA = filters.SHA
+		MetadataSources: sourceURL.String(),
+		SHA:             f.SHA,
 	}
 
 	if err := templates.ExecuteTemplate(w, "interoperability.html", data); err != nil {

--- a/webapp/templates/interoperability.html
+++ b/webapp/templates/interoperability.html
@@ -8,7 +8,7 @@
 <div id="content">
   {{ template "_header.html" }}
   <div>
-    <wpt-interop pass-rate-metadata="{{ .Metadata }}" sha="{{ .SHA }}"></wpt-interop>
+    <wpt-interop pass-rate-metadata-src="{{ .MetadataSources }}" sha="{{ .SHA }}"></wpt-interop>
   </div>
 </div>
 {{ template "_ga.html" }}


### PR DESCRIPTION
## Description
Currently we 404, server-side, resulting in a useless text-only view.

This defers the 404 to the component, meaning that the content of the page except that component will still all load.
<!-- A detailed description explaining what your code accomplishes, and why this work is taking place. If this affects an open issue, please make sure to properly reference it. -->

## Review Information
See auto-deployed environment.