### PR TITLE
Propagate the query params to the interop component

### DIFF
--- a/webapp/interop_handler.go
+++ b/webapp/interop_handler.go
@@ -59,6 +59,12 @@ func interopHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	uiFilters, err := parseTestRunUIFilter(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
 	metadataBytes, err := json.Marshal(*metadata)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -66,12 +72,10 @@ func interopHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	data := struct {
 		Metadata string
-		SHA      string
+		Filter   testRunUIFilter
 	}{
 		Metadata: string(metadataBytes),
-	}
-	if !shared.IsLatest(filters.SHA) {
-		data.SHA = filters.SHA
+		Filter:   uiFilters,
 	}
 
 	if err := templates.ExecuteTemplate(w, "interoperability.html", data); err != nil {

--- a/webapp/templates/interoperability.html
+++ b/webapp/templates/interoperability.html
@@ -8,7 +8,12 @@
 <div id="content">
   {{ template "_header.html" }}
   <div>
-    <wpt-interop pass-rate-metadata="{{ .Metadata }}" sha="{{ .SHA }}"></wpt-interop>
+    <wpt-interop pass-rate-metadata="{{ .Metadata }}"
+                 {{- with .Filter}}
+                   {{- if .Products}} products="{{ .Products }}"{{end}}
+                   {{- if .SHA}} sha="{{ .SHA }}" {{end}}
+                   {{- if .Labels}} labels="{{ .Labels }}"{{end}}
+                 {{- end}}></wpt-interop>
   </div>
 </div>
 {{ template "_ga.html" }}


### PR DESCRIPTION
## Description
Adds an integration test that the label param is piped between `interop` / `results` (which failed).
Then, propagates the (relevant) params to the component.

## Review Information
See auto-deployed environment.

Note: Probably clashes with #383 , so we should land that first.