### PR TITLE
Change FetchRun signature to take filter struct

### DIFF
--- a/shared/fetch_runs.go
+++ b/shared/fetch_runs.go
@@ -11,27 +11,19 @@ import (
 	"log"
 	"net/http"
 	"strconv"
-
-	"github.com/deckarep/golang-set"
 )
 
 // FetchLatestRuns fetches the TestRun metadata for the latest runs, using the
 // API on the given host.
 func FetchLatestRuns(wptdHost string) TestRuns {
-	return FetchRuns(wptdHost, "latest", nil, nil)
+	return FetchRuns(wptdHost, TestRunFilter{})
 }
 
 // FetchRuns fetches the TestRun metadata for the given sha / labels, using the
 // API on the given host.
-func FetchRuns(wptdHost, sha string, maxCount *int, labels mapset.Set) TestRuns {
+func FetchRuns(wptdHost string, filter TestRunFilter) TestRuns {
 	url := "https://" + wptdHost + "/api/runs"
-
-	filters := TestRunFilter{
-		Labels:   labels,
-		SHA:      sha,
-		MaxCount: maxCount,
-	}
-	url += "?" + filters.ToQuery(true).Encode()
+	url += "?" + filter.ToQuery(true).Encode()
 	log.Printf("Fetching %s...", url)
 
 	resp, err := http.Get(url)

--- a/util/populate_dev_data.go
+++ b/util/populate_dev_data.go
@@ -191,7 +191,11 @@ func main() {
 
 	log.Print("Adding latest production TestRun data...")
 	maxCount := *numRemoteRuns
-	prodTestRuns := shared.FetchRuns(*host, "latest", &maxCount, mapset.NewSetWith("stable"))
+	filters := shared.TestRunFilter{
+		MaxCount: &maxCount,
+		Labels:   mapset.NewSetWith("stable"),
+	}
+	prodTestRuns := shared.FetchRuns(*host, filters)
 	labelRuns(prodTestRuns, "prod")
 	latestProductionTestRunMetadata := make([]interface{}, len(prodTestRuns))
 	for i := range prodTestRuns {
@@ -200,7 +204,8 @@ func main() {
 	addData(ctx, testRunKindName, latestProductionTestRunMetadata)
 
 	log.Print("Adding latest experimental TestRun data...")
-	prodTestRuns = shared.FetchRuns(*host, "latest", &maxCount, mapset.NewSetWith("experimental"))
+	filters.Labels = mapset.NewSetWith("experimental")
+	prodTestRuns = shared.FetchRuns(*host, filters)
 	labelRuns(prodTestRuns, "prod")
 
 	latestProductionTestRunMetadata = make([]interface{}, len(prodTestRuns))


### PR DESCRIPTION
## Description
Simplify the `FetchRun` signature to re-use the `TestRunFilter` struct.