### PR TITLE
Add a helper script to clean up staging versions

### DIFF
--- a/util/cleanup-versions.sh
+++ b/util/cleanup-versions.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Helper script to remove stale versions (without upstream branches) from the
+# staging project semi-automatically (users need to confirm before deleting).
+
+set -e
+
+UTIL_DIR="$(dirname "${BASH_SOURCE[0]}")"
+source "${UTIL_DIR}/logging.sh"
+
+# A safety cutoff. Only versions last deployed more than 4 weeks ago may be
+# deleted.
+CUTOFF="-P4W"
+
+# This is a constant instead of an argument because production versions should
+# be deleted carefully and manually.
+PROJECT_ARG="--project=wptdashboard-staging"
+
+function cleanup() {
+  info "Cleaning stale versions of $1..."
+
+  local SERVICE_ARG="-s $1"
+  local versions_to_delete=()
+
+  for version in $( gcloud app versions list $PROJECT_ARG $SERVICE_ARG --filter="last_deployed_time.datetime<$CUTOFF" --format="value(id)" ); do
+    if ! git show-ref --quiet --verify refs/remotes/origin/$version; then
+      debug "'$version' is not a branch in upstream and will be deleted."
+      versions_to_delete+=($version)
+    fi
+  done
+
+  if [[ ${#versions_to_delete[*]} == 0 ]]; then
+    debug "Nothing to do"
+    return 0
+  fi
+
+  gcloud app versions delete $PROJECT_ARG $SERVICE_ARG ${versions_to_delete[*]}
+}
+
+
+# Sanity check (script will exit if origin does not exist because of set -e.)
+REMOTE_URL=$(git remote get-url origin)
+if [[ $REMOTE_URL != *web-platform-tests/wpt.fyi* ]]; then
+  fatal "origin isn't web-platform-tests/wpt.fyi" 1
+fi
+
+cleanup "default"
+cleanup "processor"
+cleanup "announcer"

--- a/util/docker-dev/dev_data.sh
+++ b/util/docker-dev/dev_data.sh
@@ -2,7 +2,6 @@
 
 DOCKER_DIR=$(dirname $0)
 source "${DOCKER_DIR}/../commands.sh"
-source "${DOCKER_DIR}/../path.sh"
 
 # Run util/populate_dev_data.go (via make) in the docker environment.
 wptd_exec make dev_data FLAGS=\"$@\"


### PR DESCRIPTION
Fixes #123 .

Also make a drive-by change in dev_data.sh to remove an unused import.

I already used the script locally to delete a bunch of stale versions.