### PR TITLE
Fix test-file-results.html

### DIFF
--- a/webapp/components/test-file-results.html
+++ b/webapp/components/test-file-results.html
@@ -217,7 +217,7 @@ found in the LICENSE file.
         }
         // This is relying on the assumption that result files end with '-summary.json.gz'.
         const resultsBase = testRun.results_url.slice(0, testRun.results_url.lastIndexOf('-summary.json.gz'));
-        return `${resultsBase}${this.encodedTestFile}`;
+        return `${resultsBase}${this.encodedPath}`;
       }
 
       subtestNameForDisplay(subtestName, isTestHarness) {


### PR DESCRIPTION
## Description

Commit 26b7470752c6ecb4343dafdae5cf369ed6ce987c removed the redundant
`testFile` and `encodedTestFile` properties from test-file-results.html
and switched to `path` & `encodedPath` from the base class instead. Yet
there was one `encodedTestFile` that was left unrenamed, which broke
test-file-results.

## Review Information

Go to any individual test file and results should render properly. (staging.wpt.fyi is showing empty results right now.)