### PR TITLE
Stop pinning the version of Go protobuf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,6 @@ go_small_test: go_deps
 	cd $(WPTD_GO_PATH); go test -tags=small -v ./...
 
 go_medium_test: go_deps dev_appserver_deps
-	# Hack to work around https://github.com/golang/appengine/issues/136
-	cd $(GOPATH)/src/github.com/golang/protobuf; git checkout ac606b1
 	cd $(WPTD_GO_PATH); go test -tags=medium -v $(FLAGS) ./...
 
 go_large_test: go_all_browsers_test


### PR DESCRIPTION
https://github.com/golang/appengine/issues/136 has been fixed so we
don't need the hack.

This change only stops to pin protobuf in new Go workspace. If your
protobuf pkg has already been pinned, you'd need to manually:

cd $GOPATH/src/github.com/golang/protobuf && git checkout master && git pull

Or if you use Docker, simply remove the Docker instance.
