### PR TITLE
update displayed tests if there is only 1

### DIFF
--- a/webapp/components/test-file-results.html
+++ b/webapp/components/test-file-results.html
@@ -214,10 +214,10 @@ found in the LICENSE file.
       }
 
       resultsURL(testRun, path) {
-        path = this.encodeTestPath(path);
         if (testRun.revision === 'diff') {
           return `${testRun.results_url}&path=${encodeURIComponent(path)}`;
         }
+        path = this.encodeTestPath(path);
         // This is relying on the assumption that result files end with '-summary.json.gz'.
         const resultsBase = testRun.results_url.slice(0, testRun.results_url.lastIndexOf('-summary.json.gz'));
         return `${resultsBase}${path}`;

--- a/webapp/components/test-file-results.html
+++ b/webapp/components/test-file-results.html
@@ -205,7 +205,7 @@ found in the LICENSE file.
       }
 
       async loadResultFile(testRun) {
-        const url = this.resultsURL(testRun);
+        const url = this.resultsURL(testRun, this.path);
         const response = await window.fetch(url);
         if (!response.ok) {
           return null;
@@ -213,13 +213,14 @@ found in the LICENSE file.
         return response.json();
       }
 
-      resultsURL(testRun) {
+      resultsURL(testRun, path) {
+        path = this.encodeTestPath(path);
         if (testRun.revision === 'diff') {
-          return `${testRun.results_url}&path=${encodeURIComponent(this.path)}`;
+          return `${testRun.results_url}&path=${encodeURIComponent(path)}`;
         }
         // This is relying on the assumption that result files end with '-summary.json.gz'.
         const resultsBase = testRun.results_url.slice(0, testRun.results_url.lastIndexOf('-summary.json.gz'));
-        return `${resultsBase}${this.encodedPath}`;
+        return `${resultsBase}${path}`;
       }
 
       subtestNameForDisplay(subtestName, isTestHarness) {

--- a/webapp/components/test-results-chart.html
+++ b/webapp/components/test-results-chart.html
@@ -131,7 +131,9 @@ found in the LICENSE file.
         const url = new URL('/api/runs', window.location);
         url.searchParams.append('complete', true);
         url.searchParams.append('max-count', chunkSize);
-        url.searchParams.append('labels', labels.join(','));
+        if (labels && labels.length) {
+          url.searchParams.append('labels', labels.join(','));
+        }
         const resp = await window.fetch(url.toString());
         const runs = await resp.json();
 
@@ -160,8 +162,7 @@ found in the LICENSE file.
         let num = 0;
         let denom = 0;
         await Promise.all(tests.map(async path => {
-          let resp;
-          let r;
+          let resp, r;
           // Not all runs contain all tests.
           try {
             resp = await window.fetch(this.resultsURL(run, path));

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -269,7 +269,7 @@ found in the LICENSE file.
           },
           displayedTests: {
             type: Array,
-            value: [],
+            value: 'computeDisplayedTests(displayedNodes)',
           },
           // Show a diff column (if there are 2 testRuns).
           diff: Boolean,
@@ -430,9 +430,7 @@ found in the LICENSE file.
         const partCountIfTestFile = this.path === '/' ? 1 : currentPathParts.length + 1;
         const nextSubdirIndex = this.path === '/' ? 0 : currentPathParts.length;
 
-        let displayedTests = [];
         const updateResults = (testFileName, dirPath, isDir) => {
-          displayedTests.push(testFileName);
           if (!displayedNodeMap.has(dirPath)) {
             displayedNodeMap.set(dirPath, {isDir: isDir, results: {}});
           }
@@ -470,7 +468,14 @@ found in the LICENSE file.
         }));
 
         this.displayedNodes.sort(this.nodeSort);
-        this.displayedTests = displayedTests;
+      }
+
+      computeDisplayedTests(nodes) {
+        let displayedTests = (nodes || []).map(n => n.path);
+        if (!displayedTests.length && this.computePathIsATestFile(this.path)) {
+          return [this.path];
+        }
+        return displayedTests;
       }
 
       platformID({browser_name, browser_version, os_name, os_version}) {

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -269,7 +269,8 @@ found in the LICENSE file.
           },
           displayedTests: {
             type: Array,
-            value: 'computeDisplayedTests(displayedNodes)',
+            value: [],
+            computed: 'computeDisplayedTests(displayedNodes)',
           },
           // Show a diff column (if there are 2 testRuns).
           diff: Boolean,

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -269,8 +269,7 @@ found in the LICENSE file.
           },
           displayedTests: {
             type: Array,
-            value: [],
-            computed: 'computeDisplayedTests(displayedNodes)',
+            value: []
           },
           // Show a diff column (if there are 2 testRuns).
           diff: Boolean,
@@ -410,6 +409,7 @@ found in the LICENSE file.
         if (!this.computePathIsATestFile(path)) {
           return;
         }
+        path = this.encodeTestPath(path);
         this.manifest = null; // Clear ASAP.
         this.manifest = await fetch(`/api/manifest?path=${path}`).then(r => r.json());
       }
@@ -427,11 +427,31 @@ found in the LICENSE file.
       refreshDisplayedNodes() {
         /* Recomputes the list of displayed directories and test files. */
         const displayedNodeMap = new Map();
+        const displayedTests = [];
         const currentPathParts = this.splitPathIntoLinkedParts(this.path);
         const partCountIfTestFile = this.path === '/' ? 1 : currentPathParts.length + 1;
         const nextSubdirIndex = this.path === '/' ? 0 : currentPathParts.length;
 
-        const updateResults = (testFileName, dirPath, isDir) => {
+        let files = this.searchResults || Array.from(Object.keys(this.testFiles));
+        if (this.path !== '/') {
+          files = files.filter(
+            testFileName => testFileName.startsWith(`${this.path}/`));
+        }
+
+        for (const testFileName of files) {
+          let parts = this.splitPathIntoLinkedParts(testFileName);
+          let isDir, dirPath;
+          if (parts.length === partCountIfTestFile) {
+            // Add test files in current directory
+            dirPath = testFileName;
+            isDir = false;
+          } else if (parts.length > partCountIfTestFile) {
+            // Add subdirectories in current directory
+            dirPath = parts[nextSubdirIndex].path;
+            isDir = true;
+          }
+
+          displayedTests.push(testFileName);
           if (!displayedNodeMap.has(dirPath)) {
             displayedNodeMap.set(dirPath, {isDir: isDir, results: {}});
           }
@@ -443,24 +463,7 @@ found in the LICENSE file.
             displayedNodeMap.get(dirPath).results[resultURL].passing += results[resultURL][0];
             displayedNodeMap.get(dirPath).results[resultURL].total += results[resultURL][1];
           });
-        };
-
-        const files = this.searchResults || Array.from(Object.keys(this.testFiles));
-        files.forEach(testFileName => {
-          if (this.path !== '/' && !testFileName.startsWith(`${this.path}/`)) {
-            return;
-          }
-
-          let parts = this.splitPathIntoLinkedParts(testFileName);
-          if (parts.length === partCountIfTestFile) {
-            // Add test files in current directory
-            updateResults(testFileName, testFileName, false);
-          } else if (parts.length > partCountIfTestFile) {
-            // Add subdirectories in current directory
-            let dirPath = parts[nextSubdirIndex].path;
-            updateResults(testFileName, dirPath, true);
-          }
-        });
+        }
 
         this.displayedNodes = Array.from(displayedNodeMap.keys()).map(key => ({
           path: key,
@@ -469,14 +472,12 @@ found in the LICENSE file.
         }));
 
         this.displayedNodes.sort(this.nodeSort);
-      }
 
-      computeDisplayedTests(nodes) {
-        let displayedTests = (nodes || []).map(n => n.path);
         if (!displayedTests.length && this.computePathIsATestFile(this.path)) {
-          return [this.path];
+          displayedTests.push(this.path);
         }
-        return displayedTests;
+        displayedTests.sort();
+        this.displayedTests = displayedTests;
       }
 
       platformID({browser_name, browser_version, os_name, os_version}) {


### PR DESCRIPTION
## Description
When viewing directories with only one test, the history chart will not show up.

## Review Information
see any individual test file in the auto-deploy environment, eg. FileAPI/FileReader/Progress_event_bubbles_cancelable.html

cc/ @lukebjerring 
