### PR TITLE
Extend test-results-chart from test-file-results

### DIFF
--- a/webapp/components/test-results-chart.html
+++ b/webapp/components/test-results-chart.html
@@ -6,6 +6,7 @@ found in the LICENSE file.
 
 <link rel="import" href="../bower_components/polymer/polymer-element.html">
 <link rel="import" href="../bower_components/google-chart/google-chart.html">
+<link rel="import" href="test-file-results.html">
 
 <dom-module id="test-results-chart">
   <template>
@@ -24,7 +25,8 @@ found in the LICENSE file.
                   options="[[chartOptions]]"></google-chart>
   </template>
   <script>
-    class TestResultsChart extends window.Polymer.Element {
+    /* global TestFileResults */
+    class TestResultsChart extends TestFileResults {
       static get is() {
         return 'test-results-chart';
       }
@@ -290,12 +292,6 @@ found in the LICENSE file.
         }
 
         return values[vIdx];
-      }
-
-      resultsURL(run, path) {
-        // This is relying on the assumption that result files end with '-summary.json.gz'.
-        const resultsBase = run.results_url.slice(0, run.results_url.lastIndexOf('-summary.json.gz'));
-        return `${resultsBase}${path}`;
       }
 
       reset() {

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -210,7 +210,7 @@ found in the LICENSE file.
             History <span>(Experimental)</span>
           </h3>
           <test-results-chart
-              path="[[encodedPath]]"
+              path="[[path]]"
               labels="[[labels]]"
               tests="[[displayedTests]]">
           </test-results-chart>


### PR DESCRIPTION
## Description

While reviewing #397 , I noticed that the chart couldn't handle test names with query strings properly.

This change gets rid of the duplicate and out-of-date `resultsURL` method (that does not contain bug fixes for test names with query strings), and hence fixes the chart for test names with query strings.

## Review Information

Unfortunately, this change is almost a no-op right now as the chart doesn't show up in single-file views without #397. I'll rebase this PR once that lands, and then we can see the change easily on the staging instance.