### PR TITLE
Improve error handling in test-file-results

### DIFF
--- a/webapp/components/test-file-results.html
+++ b/webapp/components/test-file-results.html
@@ -178,6 +178,7 @@ found in the LICENSE file.
         const resultPerTestRun = await Promise.all(
           testRuns.map(tr => this.loadResultFile(tr)));
 
+        let isTestHarness = false;
         const subtestNames = ['STATUS'];
         resultPerTestRun.forEach((resultData, i) => {
           if (!resultData) {
@@ -187,6 +188,9 @@ found in the LICENSE file.
           }
           testRuns[i].subtests = {};
           testRuns[i].subtests['STATUS'] = { status: resultData.status };
+          if (['OK', 'ERROR'].includes(resultData.status)) {
+            isTestHarness = true;
+          }
 
           for (let subtestResult of resultData.subtests) {
             testRuns[i].subtests[subtestResult.name] = subtestResult;
@@ -196,8 +200,7 @@ found in the LICENSE file.
           }
         });
 
-        this.isTestHarness =
-          resultPerTestRun.some(r => ['OK', 'ERROR'].includes(r.status));
+        this.isTestHarness = isTestHarness;
         this.subtestNames = subtestNames;
       }
 
@@ -205,7 +208,6 @@ found in the LICENSE file.
         const url = this.resultsURL(testRun);
         const response = await window.fetch(url);
         if (!response.ok) {
-          console.error(`Got non-OK status ${response.status} for url: ${url}`);
           return null;
         }
         return response.json();


### PR DESCRIPTION
This commit:

1. Removes a redundant `console.error` for non-OK `fetch`; `fetch`
   already prints errors to console.
2. Fixes a null access error in isTestHarness: `resultPerTestRun` may
   contain null (e.g. when 404), so we can't unconditionally check the
   `status` field.

## Review Information

Code health improvements. No visible changes (apart from fewer console errors).