### PR TITLE
Don't handle ctrl+click in self-navigator

### DIFF
--- a/webapp/components/self-navigator.html
+++ b/webapp/components/self-navigator.html
@@ -90,6 +90,10 @@
       }
 
       navigate(event) {
+        // Don't intercept ctrl+click.
+        if (event.ctrlKey) {
+          return;
+        }
         event.preventDefault();
         this.navigateToLocation(event.target);
       }


### PR DESCRIPTION
## Description
Fixes #400.

## Review Information
Visit /results
Hold Command or Ctrl. Click a link. Should open in new tab (not navigate in the same tab).