### PR TITLE
Don't intercept meta+click

### DIFF
--- a/webapp/components/self-navigator.html
+++ b/webapp/components/self-navigator.html
@@ -90,8 +90,8 @@
       }
 
       navigate(event) {
-        // Don't intercept ctrl+click.
-        if (event.ctrlKey) {
+        // Don't intercept Ctrl+click or Meta(Win/Command)+click (open new tabs).
+        if (event.ctrlKey || event.metaKey) {
           return;
         }
         event.preventDefault();


### PR DESCRIPTION
#401 missed the Meta key, which is the default modifier to open new tabs on macOS (Command).

Fixes #400 again.