### PR TITLE
Change default dev data to 10 prod runs, no static runs

### DIFF
--- a/util/populate_dev_data.go
+++ b/util/populate_dev_data.go
@@ -22,7 +22,7 @@ import (
 
 var (
 	host          = flag.String("host", "wpt.fyi", "wpt.fyi host to fetch prod runs from")
-	numRemoteRuns = flag.Int("num_remote_runs", 1, "number of remote runs to copy from host to local environment")
+	numRemoteRuns = flag.Int("num_remote_runs", 10, "number of remote runs to copy from host to local environment")
 	staticRuns    = flag.Bool("static_runs", false, "Include runs in the /static dir")
 )
 


### PR DESCRIPTION
## Description
Changes the default result of running `make dev_data` to be more useful. There's no downsides to a bunch of runs being available, and the static runs are only useful in very rare cases (no internet..? Changes relative to prod..?)