### PR TITLE
Add toggle for two file results layouts

### DIFF
--- a/webapp/bower.json
+++ b/webapp/bower.json
@@ -12,7 +12,8 @@
     "webcomponentsjs": "webcomponents/webcomponentsjs#^2.0.0",
     "paper-tabs": "@Polymer/paper-tabs#^2.1.1",
     "paper-tooltip": "@Polymer/paper-tooltip#^2.1.1",
-    "google-chart": "^2.0.0"
+    "google-chart": "^2.0.0",
+    "paper-toggle-button": "PolymerElements/paper-toggle-button#^2.1.1"
   },
   "devDependencies": {
     "web-component-tester": "^6.4.3"

--- a/webapp/components/abstract-test-file-results-table.html
+++ b/webapp/components/abstract-test-file-results-table.html
@@ -6,7 +6,8 @@ found in the LICENSE file.
 
 <dom-module id="abstract-test-file-results-table">
   <script>
-    const AbstractTestFileResultsTable = (superclass) => class extends superclass {
+    // eslint-disable-next-line no-unused-vars
+    const AbstractTestFileResultsTable = superClass => class extends superClass {
       static get is() {
         return 'abstract-test-file-results-table';
       }
@@ -40,6 +41,7 @@ found in the LICENSE file.
         return testRun.subtests[subtestName].status;
       }
 
+      // eslint-disable-next-line no-unused-vars
       subtestMessageForTestRun(testRun, subtestName) {
         return 'NOT IMPLEMENTED';
       }
@@ -51,6 +53,6 @@ found in the LICENSE file.
       computeRunThWidth(testRuns) {
         return `${100 / (testRuns.length + 2)}%`;
       }
-    }
+    };
   </script>
 </dom-module>

--- a/webapp/components/abstract-test-file-results-table.html
+++ b/webapp/components/abstract-test-file-results-table.html
@@ -1,0 +1,56 @@
+<!--
+Copyright 2018 The WPT Dashboard Project. All rights reserved.
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file.
+-->
+
+<dom-module id="abstract-test-file-results-table">
+  <script>
+    const AbstractTestFileResultsTable = (superclass) => class extends superclass {
+      static get is() {
+        return 'abstract-test-file-results-table';
+      }
+
+      static get properties() {
+        return {
+          subtestNames: {
+            type: Array,
+            value: [],
+          },
+        };
+      }
+
+      subtestNameForDisplay(subtestName, isTestHarness) {
+        if (subtestName !== 'STATUS') {
+          return subtestName;
+        }
+        return isTestHarness ? 'Harness status' : 'File status';
+      }
+
+      subtestResultForTestRun(testRun, subtestName) {
+        if (!testRun) {
+          return null;
+        }
+        if (!testRun.subtests) {
+          return null;
+        }
+        if (!testRun.subtests[subtestName]) {
+          return null;
+        }
+        return testRun.subtests[subtestName].status;
+      }
+
+      subtestMessageForTestRun(testRun, subtestName) {
+        return 'NOT IMPLEMENTED';
+      }
+
+      computeSubtestThWidth(testRuns) {
+        return `${200 / (testRuns.length + 2)}%`;
+      }
+
+      computeRunThWidth(testRuns) {
+        return `${100 / (testRuns.length + 2)}%`;
+      }
+    }
+  </script>
+</dom-module>

--- a/webapp/components/test-file-results-table-terse.html
+++ b/webapp/components/test-file-results-table-terse.html
@@ -79,7 +79,7 @@ found in the LICENSE file.
   </template>
 
   <script>
-    /* global AbstractTestFileResultsTable */
+    /* global AbstractTestFileResultsTable, TestRunsBase */
     class TestFileResultsTableTerse extends AbstractTestFileResultsTable(TestRunsBase) {
       static get is() {
         return 'test-file-results-table-terse';
@@ -171,6 +171,6 @@ found in the LICENSE file.
     }
 
     window.customElements.define(
-        TestFileResultsTableTerse.is, TestFileResultsTableTerse);
+      TestFileResultsTableTerse.is, TestFileResultsTableTerse);
   </script>
 </dom-module>

--- a/webapp/components/test-file-results-table-terse.html
+++ b/webapp/components/test-file-results-table-terse.html
@@ -1,0 +1,176 @@
+<!--
+Copyright 2018 The WPT Dashboard Project. All rights reserved.
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file.
+-->
+
+<link rel="import" href="../bower_components/polymer/lib/elements/dom-repeat.html">
+<link rel="import" href="abstract-test-file-results-table.html">
+
+<dom-module id="test-file-results-table-terse">
+  <template>
+    <style>
+      table {
+        width: 100%;
+        border-collapse: collapse;
+      }
+      td {
+        height: 1.5em;
+        position: relative;
+      }
+      td.sub-test-name {
+        background-color: white;
+      }
+      td code {
+        box-sizing: border-box;
+        height: 100%;
+        left: 0;
+        overflow: hidden;
+        padding: 4px;
+        position: absolute;
+        text-overflow: ellipsis;
+        top: 0;
+        white-space: nowrap;
+        width: 100%;
+      }
+      td code:hover {
+        z-index: 1;
+        text-overflow: initial;
+        background-color: inherit;
+        width: max-content;
+      }
+      td.result {
+        background-color: #eee;
+      }
+      td.result.OK, td.result.PASS {
+        background-color: rgb(90, 242, 113);
+      }
+      td.result.FAIL {
+        background-color: rgb(242, 90, 90);
+      }
+    </style>
+
+    <table>
+      <thead>
+        <tr>
+          <th width="[[computeSubtestThWidth(testRuns)]]">Subtest</th>
+          <template is="dom-repeat" items="[[testRuns]]" as="testRun">
+            <th width="[[computeRunThWidth(testRuns)]]">
+              <test-run test-run="[[testRun]]"></test-run>
+            </th>
+          </template>
+        </tr>
+      </thead>
+      <tbody>
+        <template is="dom-repeat" items="[[subtestNames]]" as="subtestName">
+          <tr>
+            <td class="sub-test-name"><code>[[ subtestNameForDisplay(subtestName, isTestHarness) ]]</code></td>
+
+            <template is="dom-repeat" items="{{testRuns}}" as="testRun">
+              <td class$="result [[ subtestResultForTestRun(testRun, subtestName) ]]">
+                <code>[[ subtestMessageForTestRun(testRun, subtestName) ]]</code>
+              </td>
+            </template>
+          </tr>
+        </template>
+      </tbody>
+    </table>
+
+  </template>
+
+  <script>
+    /* global AbstractTestFileResultsTable */
+    class TestFileResultsTableTerse extends AbstractTestFileResultsTable(TestRunsBase) {
+      static get is() {
+        return 'test-file-results-table-terse';
+      }
+
+      static get properties() {
+        return {
+          matchers: {
+            type: Array,
+            value: [
+              {
+                re: /^assert_equals:.* expected ("(\\"|[^"])*"|[^ ]*) but got ("(\\"|[^"])*"|[^ ]*)$/,
+                getMessage: match => `!EQ(${match[1]}, ${match[3]})`,
+              },
+              {
+                re: /^assert_approx_equals:.* expected ("(\\"|[^"])*"| [+][/][-] |[^:]*) but got ("(\\"|[^"])*"| [+][/][-] |[^:]*):.*$/,
+                getMessage: match => `!~EQ(${match[1]}, ${match[3]})`,
+              },
+              {
+                re: /^assert ("(\\"|[^"])*"|[^ ]*) == ("(\\"|[^"])*"|[^ ]*)$/,
+                getMessage: match => `!EQ(${match[1]}, ${match[3]})`,
+              },
+              {
+                re: /^assert_array_equals:.*$/,
+                getMessage: () => '!ARRAY_EQ(a, b)',
+              },
+              {
+                re: /^Uncaught [^ ]*Error:.*$/,
+                getMessage: () => 'UNCAUGHT_ERROR',
+              },
+              {
+                re: /^([^ ]*) is not ([a-zA-Z0-9 ]*)$/,
+                getMessage: match => `NOT_${match[2].toUpperCase().replace(/\s/g, '_')}(${match[1]})`,
+              },
+              {
+                re: /^promise_test: Unhandled rejection with value: (.*)$/,
+                getMessage: match => `PROMISE_REJECT(${match[1]})`,
+              },
+              {
+                re: /^assert_true: .*$/,
+                getMessage: () => '!TRUE',
+              },
+              {
+                re: /^assert_own_property: [^"]*"([^"]*)".*$/,
+                getMessage: match => `!OWN_PROPERTY(${match[1]})`,
+              },
+              {
+                re: /^assert_inherits: [^"]*"([^"]*)".*$/,
+                getMessage: match => `!INHERITS(${match[1]})`,
+              },
+            ],
+          },
+        };
+      }
+
+      subtestMessageForTestRun(testRun, subtestName) {
+        if (!testRun) {
+          return null;
+        }
+        if (!testRun.subtests) {
+          return null;
+        }
+        if (!testRun.subtests[subtestName]) {
+          return null;
+        }
+        if (testRun.subtests[subtestName].status === 'OK') {
+          return 'OK';
+        }
+        if (testRun.subtests[subtestName].status === 'PASS') {
+          return 'PASS';
+        }
+        if (testRun.subtests[subtestName].message) {
+          return this.parseFailureMessage(testRun.subtests[subtestName].message);
+        }
+        return testRun.subtests[subtestName].status;
+      }
+
+      parseFailureMessage(msg) {
+        let matchedMsg = '';
+        for (const matcher of this.matchers) {
+          const match = msg.match(matcher.re);
+          if (match !== null) {
+            matchedMsg = matcher.getMessage(match);
+            break;
+          }
+        }
+        return matchedMsg ? matchedMsg : 'FAIL';
+      }
+    }
+
+    window.customElements.define(
+        TestFileResultsTableTerse.is, TestFileResultsTableTerse);
+  </script>
+</dom-module>

--- a/webapp/components/test-file-results-table-verbose.html
+++ b/webapp/components/test-file-results-table-verbose.html
@@ -1,0 +1,92 @@
+<!--
+Copyright 2018 The WPT Dashboard Project. All rights reserved.
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file.
+-->
+
+<link rel="import" href="../bower_components/polymer/lib/elements/dom-repeat.html">
+<link rel="import" href="abstract-test-file-results-table.html">
+
+<dom-module id="test-file-results-table-verbose">
+  <template>
+    <style>
+      table {
+        width: 100%;
+        border-collapse: collapse;
+      }
+      td.sub-test-name {
+        font-family: monospace;
+        font-size: 0.9em;
+      }
+      td.result {
+        background-color: #eee;
+      }
+      td.result.OK, td.result.PASS {
+        background-color: rgb(90, 242, 113);
+      }
+      td.result.FAIL {
+        background-color: rgb(242, 90, 90);
+      }
+    </style>
+
+    <table>
+      <thead>
+        <tr>
+          <th width="[[computeSubtestThWidth(testRuns)]]">Subtest</th>
+          <template is="dom-repeat" items="[[testRuns]]" as="testRun">
+            <th width="[[computeRunThWidth(testRuns)]]">
+              <test-run test-run="[[testRun]]"></test-run>
+            </th>
+          </template>
+        </tr>
+      </thead>
+      <tbody>
+        <template is="dom-repeat" items="[[subtestNames]]" as="subtestName">
+          <tr>
+            <td class="sub-test-name"><code>[[ subtestNameForDisplay(subtestName, isTestHarness) ]]</code></td>
+
+            <template is="dom-repeat" items="{{testRuns}}" as="testRun">
+              <td class$="result [[ subtestResultForTestRun(testRun, subtestName) ]]">
+                <code>[[ subtestMessageForTestRun(testRun, subtestName) ]]</code>
+              </td>
+            </template>
+          </tr>
+        </template>
+      </tbody>
+    </table>
+  </template>
+
+  <script>
+    /* global AbstractTestFileResultsTable */
+    class TestFileResultsTableVerbose extends AbstractTestFileResultsTable(TestRunsBase) {
+      static get is() {
+        return 'test-file-results-table-verbose';
+      }
+
+      subtestMessageForTestRun(testRun, subtestName) {
+        if (!testRun) {
+          return null;
+        }
+        if (!testRun.subtests) {
+          return null;
+        }
+        if (!testRun.subtests[subtestName]) {
+          return null;
+        }
+        if (testRun.subtests[subtestName].status === 'OK') {
+          return 'OK';
+        }
+        if (testRun.subtests[subtestName].status === 'PASS') {
+          return 'PASS';
+        }
+        if (testRun.subtests[subtestName].message) {
+          return `Failure message: ${testRun.subtests[subtestName].message}`;
+        }
+        return testRun.subtests[subtestName].status;
+      }
+    }
+
+    window.customElements.define(
+        TestFileResultsTableVerbose.is, TestFileResultsTableVerbose);
+  </script>
+</dom-module>

--- a/webapp/components/test-file-results-table-verbose.html
+++ b/webapp/components/test-file-results-table-verbose.html
@@ -57,7 +57,7 @@ found in the LICENSE file.
   </template>
 
   <script>
-    /* global AbstractTestFileResultsTable */
+    /* global AbstractTestFileResultsTable, TestRunsBase */
     class TestFileResultsTableVerbose extends AbstractTestFileResultsTable(TestRunsBase) {
       static get is() {
         return 'test-file-results-table-verbose';
@@ -87,6 +87,6 @@ found in the LICENSE file.
     }
 
     window.customElements.define(
-        TestFileResultsTableVerbose.is, TestFileResultsTableVerbose);
+      TestFileResultsTableVerbose.is, TestFileResultsTableVerbose);
   </script>
 </dom-module>

--- a/webapp/components/test-file-results.html
+++ b/webapp/components/test-file-results.html
@@ -125,7 +125,7 @@ found in the LICENSE file.
       }
 
       async loadResultFile(testRun) {
-        const url = this.resultsURL(testRun);
+        const url = this.resultsURL(testRun, this.path);
         const response = await window.fetch(url);
         if (!response.ok) {
           return null;
@@ -133,13 +133,14 @@ found in the LICENSE file.
         return response.json();
       }
 
-      resultsURL(testRun) {
+      resultsURL(testRun, path) {
         if (testRun.revision === 'diff') {
-          return `${testRun.results_url}&path=${encodeURIComponent(this.path)}`;
+          return `${testRun.results_url}&path=${encodeURIComponent(path)}`;
         }
+        path = this.encodeTestPath(path);
         // This is relying on the assumption that result files end with '-summary.json.gz'.
         const resultsBase = testRun.results_url.slice(0, testRun.results_url.lastIndexOf('-summary.json.gz'));
-        return `${resultsBase}${this.encodedPath}`;
+        return `${resultsBase}${path}`;
       }
     }
 

--- a/webapp/components/test-file-results.html
+++ b/webapp/components/test-file-results.html
@@ -5,9 +5,11 @@ found in the LICENSE file.
 -->
 
 <link rel="import" href="../bower_components/polymer/lib/elements/dom-if.html">
-<link rel="import" href="../bower_components/polymer/lib/elements/dom-repeat.html">
+<link rel="import" href="../bower_components/paper-toggle-button/paper-toggle-button.html">
 <link rel="import" href="test-runs.html">
 <link rel="import" href="test-run.html">
+<link rel="import" href="test-file-results-table-terse.html">
+<link rel="import" href="test-file-results-table-verbose.html">
 
 <dom-module id="test-file-results">
   <template>
@@ -19,73 +21,39 @@ found in the LICENSE file.
       h1 {
         font-size: 1.5em;
       }
-
-      table {
-        width: 100%;
-        border-collapse: collapse;
+      .right {
+        display: flex;
+        justify-content: flex-end;
       }
-      td {
-        height: 1.5em;
-        position: relative;
+      .right .pad {
+        padding: 8px;
       }
-      td.sub-test-name {
-        background-color: white;
-      }
-      td code {
-        box-sizing: border-box;
-        height: 100%;
-        left: 0;
-        overflow: hidden;
-        padding: 4px;
-        position: absolute;
-        text-overflow: ellipsis;
-        top: 0;
-        white-space: nowrap;
-        width: 100%;
-      }
-      td code:hover {
-        z-index: 1;
-        text-overflow: initial;
-        background-color: inherit;
-        width: max-content;
-      }
-      td.result {
-        background-color: #eee;
-      }
-      td.result.OK, td.result.PASS {
-        background-color: rgb(90, 242, 113);
-      }
-      td.result.FAIL {
-        background-color: rgb(242, 90, 90);
+      paper-toggle-button {
+        --paper-toggle-button-checked-bar-color:  var(--paper-blue-500);
+        --paper-toggle-button-checked-button-color:  var(--paper-blue-700);
+        --paper-toggle-button-checked-ink-color: var(--paper-blue-300);
       }
     </style>
 
-    <table>
-      <thead>
-        <tr>
-          <th width="[[computeSubtestThWidth(testRuns)]]">Subtest</th>
-          <template is="dom-repeat" items="[[testRuns]]" as="testRun">
-            <th width="[[computeRunThWidth(testRuns)]]">
-              <test-run test-run="[[testRun]]"></test-run>
-            </th>
-          </template>
-        </tr>
-      </thead>
-      <tbody>
-        <template is="dom-repeat" items="[[subtestNames]]" as="subtestName">
-          <tr>
-            <td class="sub-test-name"><code>[[ subtestNameForDisplay(subtestName, isTestHarness) ]]</code></td>
+    <div class="right">
+      <label class="pad">Verbose</label>
+      <paper-toggle-button class="pad" checked="{{isVerbose}}">
+      </paper-toggle-button>
+    </div>
 
-            <template is="dom-repeat" items="{{testRuns}}" as="testRun">
-              <td class$="result [[ subtestResultForTestRun(testRun, subtestName) ]]">
-                <code>[[ subtestMessageForTestRun(testRun, subtestName) ]]</code>
-              </td>
-            </template>
-          </tr>
-        </template>
+    <template is="dom-if" if="{{!isVerbose}}">
+      <test-file-results-table-terse
+          test-runs="[[testRuns]]"
+          subtest-names="[[subtestNames]]">
+      </test-file-results-table-terse>
+    </template>
 
-      </tbody>
-    </table>
+    <template is="dom-if" if="{{isVerbose}}">
+        <test-file-results-table-verbose
+            test-runs="[[testRuns]]"
+            subtest-names="[[subtestNames]]">
+        </test-file-results-table-verbose>
+      </template>
   </template>
 
   <script>
@@ -105,58 +73,10 @@ found in the LICENSE file.
             type: Boolean,
             value: false,
           },
-          matchers: {
-            type: Array,
-            value: [
-              {
-                re: /^assert_equals:.* expected ("(\\"|[^"])*"|[^ ]*) but got ("(\\"|[^"])*"|[^ ]*)$/,
-                getMessage: match => `!EQ(${match[1]}, ${match[3]})`,
-              },
-              {
-                re: /^assert_approx_equals:.* expected ("(\\"|[^"])*"| [+][/][-] |[^:]*) but got ("(\\"|[^"])*"| [+][/][-] |[^:]*):.*$/,
-                getMessage: match => `!~EQ(${match[1]}, ${match[3]})`,
-              },
-              {
-                re: /^assert ("(\\"|[^"])*"|[^ ]*) == ("(\\"|[^"])*"|[^ ]*)$/,
-                getMessage: match => `!EQ(${match[1]}, ${match[3]})`,
-              },
-              {
-                re: /^assert_array_equals:.*$/,
-                getMessage: () => '!ARRAY_EQ(a, b)',
-              },
-              {
-                re: /^Uncaught [^ ]*Error:.*$/,
-                getMessage: () => 'UNCAUGHT_ERROR',
-              },
-              {
-                re: /^([^ ]*) is not ([a-zA-Z0-9 ]*)$/,
-                getMessage: match => `NOT_${match[2].toUpperCase().replace(/\s/g, '_')}(${match[1]})`,
-              },
-              {
-                re: /^promise_test: Unhandled rejection with value: (.*)$/,
-                getMessage: match => `PROMISE_REJECT(${match[1]})`,
-              },
-              {
-                re: /^assert_true: .*$/,
-                getMessage: () => '!TRUE',
-              },
-              {
-                re: /^assert_own_property: [^"]*"([^"]*)".*$/,
-                getMessage: match => `!OWN_PROPERTY(${match[1]})`,
-              },
-              {
-                re: /^assert_inherits: [^"]*"([^"]*)".*$/,
-                getMessage: match => `!INHERITS(${match[1]})`,
-              },
-            ],
+          isVerbose: {
+            type: Boolean,
+            value: false,
           },
-        };
-      }
-
-      static get matchers() {
-        return {
-          re: /^/,
-          getMsg: () => '',
         };
       }
 
@@ -205,7 +125,7 @@ found in the LICENSE file.
       }
 
       async loadResultFile(testRun) {
-        const url = this.resultsURL(testRun, this.path);
+        const url = this.resultsURL(testRun);
         const response = await window.fetch(url);
         if (!response.ok) {
           return null;
@@ -213,76 +133,13 @@ found in the LICENSE file.
         return response.json();
       }
 
-      resultsURL(testRun, path) {
+      resultsURL(testRun) {
         if (testRun.revision === 'diff') {
-          return `${testRun.results_url}&path=${encodeURIComponent(path)}`;
+          return `${testRun.results_url}&path=${encodeURIComponent(this.path)}`;
         }
-        path = this.encodeTestPath(path);
         // This is relying on the assumption that result files end with '-summary.json.gz'.
         const resultsBase = testRun.results_url.slice(0, testRun.results_url.lastIndexOf('-summary.json.gz'));
-        return `${resultsBase}${path}`;
-      }
-
-      subtestNameForDisplay(subtestName, isTestHarness) {
-        if (subtestName !== 'STATUS') {
-          return subtestName;
-        }
-        return isTestHarness ? 'Harness status' : 'File status';
-      }
-
-      subtestResultForTestRun(testRun, subtestName) {
-        if (!testRun) {
-          return null;
-        }
-        if (!testRun.subtests) {
-          return null;
-        }
-        if (!testRun.subtests[subtestName]) {
-          return null;
-        }
-        return testRun.subtests[subtestName].status;
-      }
-
-      subtestMessageForTestRun(testRun, subtestName) {
-        if (!testRun) {
-          return null;
-        }
-        if (!testRun.subtests) {
-          return null;
-        }
-        if (!testRun.subtests[subtestName]) {
-          return null;
-        }
-        if (testRun.subtests[subtestName].status === 'OK') {
-          return 'OK';
-        }
-        if (testRun.subtests[subtestName].status === 'PASS') {
-          return 'PASS';
-        }
-        if (testRun.subtests[subtestName].message) {
-          return this.parseFailureMessage(testRun.subtests[subtestName].message);
-        }
-        return testRun.subtests[subtestName].status;
-      }
-
-      parseFailureMessage(msg) {
-        let matchedMsg = '';
-        for (const matcher of this.matchers) {
-          const match = msg.match(matcher.re);
-          if (match !== null) {
-            matchedMsg = matcher.getMessage(match);
-            break;
-          }
-        }
-        return matchedMsg ? matchedMsg : `Failure message: ${msg}`;
-      }
-
-      computeSubtestThWidth(testRuns) {
-        return `${200 / (testRuns.length + 2)}%`;
-      }
-
-      computeRunThWidth(testRuns) {
-        return `${100 / (testRuns.length + 2)}%`;
+        return `${resultsBase}${this.encodedPath}`;
       }
     }
 

--- a/webapp/components/test-results-history-grid.html
+++ b/webapp/components/test-results-history-grid.html
@@ -62,7 +62,7 @@ found in the LICENSE file.
     <pre id="status">&nbsp;</pre>
   </template>
   <script>
-    /* global AbstractTestFileResultsTable */
+    /* global AbstractTestFileResultsTable, TestFileResults */
     class TestFileResultsTimeSeries extends AbstractTestFileResultsTable(TestFileResults) {
       static get is() {
         return 'test-results-history-grid';

--- a/webapp/components/test-results-history-grid.html
+++ b/webapp/components/test-results-history-grid.html
@@ -6,6 +6,7 @@ found in the LICENSE file.
 
 <link rel="import" href="../bower_components/polymer/lib/elements/dom-repeat.html">
 <link rel="import" href="test-file-results.html">
+<link rel="import" href="abstract-test-file-results-table.html">
 
 <dom-module id="test-results-history-grid">
   <template>
@@ -61,8 +62,8 @@ found in the LICENSE file.
     <pre id="status">&nbsp;</pre>
   </template>
   <script>
-    /* global TestFileResults */
-    class TestFileResultsTimeSeries extends TestFileResults {
+    /* global AbstractTestFileResultsTable */
+    class TestFileResultsTimeSeries extends AbstractTestFileResultsTable(TestFileResults) {
       static get is() {
         return 'test-results-history-grid';
       }
@@ -94,6 +95,13 @@ found in the LICENSE file.
           params.complete = true;
         }
         return params;
+      }
+
+      subtestNameForDisplay(subtestName, isTestHarness) {
+        if (subtestName !== 'STATUS') {
+          return subtestName;
+        }
+        return isTestHarness ? 'Harness status' : 'File status';
       }
 
       bindResultHover(run, subTestName) {

--- a/webapp/components/test-results-history-grid.html
+++ b/webapp/components/test-results-history-grid.html
@@ -97,13 +97,6 @@ found in the LICENSE file.
         return params;
       }
 
-      subtestNameForDisplay(subtestName, isTestHarness) {
-        if (subtestName !== 'STATUS') {
-          return subtestName;
-        }
-        return isTestHarness ? 'Harness status' : 'File status';
-      }
-
       bindResultHover(run, subTestName) {
         return () => {
           let statusElement = this.shadowRoot.querySelector('#status');


### PR DESCRIPTION
- Default layout: terse (mostly as-is without this change)
- Alternate layout: verbose (previous layout before message-matching and ellipsis were added)
- Common table layout patterns in abstract mixin
- Mixin applied over different base classes for history grid view and two concrete table classes
- Toggle between layouts with styled paper-toggle-button