### PR TITLE
Hide the diff column in single-file results

### DIFF
--- a/webapp/components/test-file-results.html
+++ b/webapp/components/test-file-results.html
@@ -134,9 +134,6 @@ found in the LICENSE file.
       }
 
       resultsURL(testRun, path) {
-        if (testRun.revision === 'diff') {
-          return `${testRun.results_url}&path=${encodeURIComponent(path)}`;
-        }
         path = this.encodeTestPath(path);
         // This is relying on the assumption that result files end with '-summary.json.gz'.
         const resultsBase = testRun.results_url.slice(0, testRun.results_url.lastIndexOf('-summary.json.gz'));

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -89,6 +89,9 @@ found in the LICENSE file.
       td.none {
         visibility: hidden;
       }
+      td.numbers {
+        white-space: nowrap;
+      }
       .yellow-button {
         color: var(--paper-yellow-500);
         margin-left: 32px;
@@ -172,8 +175,10 @@ found in the LICENSE file.
           <tr>
             <th>Path</th>
             <template is="dom-repeat" items="{{testRuns}}" as="testRun">
-              <!-- Repeats for as many different browser test runs are available -->
               <th><test-run test-run="[[testRun]]"></test-run></th>
+            </template>
+            <template is="dom-if" if="[[diffShown]]">
+              <th><test-run test-run="[[diffRun]]"></test-run></th>
             </template>
           </tr>
         </thead>
@@ -186,10 +191,17 @@ found in the LICENSE file.
               </td>
 
               <template is="dom-repeat" items="{{testRuns}}" as="testRun">
-                <td class$="[[ testResultClass(node, testRun, 'passing') ]]">
+                <td class$="numbers [[ testResultClass(node, testRun, 'passing') ]]">
                   <span class$="passing [[ testResultClass(node, testRun, 'passing') ]]">{{ getNodeResultDataByPropertyName(node, testRun, 'passing') }}</span>
                   /
                   <span class$="total [[ testResultClass(node, testRun, 'total') ]]">{{ getNodeResultDataByPropertyName(node, testRun, 'total') }}</span>
+                </td>
+              </template>
+              <template is="dom-if" if="[[diffShown]]">
+                <td class$="numbers [[ testResultClass(node, diffRun, 'passing') ]]">
+                  <span class$="passing [[ testResultClass(node, diffRun, 'passing') ]]">{{ getNodeResultDataByPropertyName(node, diffRun, 'passing') }}</span>
+                  /
+                  <span class$="total [[ testResultClass(node, diffRun, 'total') ]]">{{ getNodeResultDataByPropertyName(node, diffRun, 'total') }}</span>
                 </td>
               </template>
             </tr>
@@ -271,8 +283,17 @@ found in the LICENSE file.
             type: Array,
             value: []
           },
-          // Show a diff column (if there are 2 testRuns).
+          // Users request to show a diff column.
           diff: Boolean,
+          diffRun: {
+            type: Object,
+            value: null,
+          },
+          // A diff column is shown if requested by users and there are 2 testRuns.
+          diffShown: {
+            type: Boolean,
+            computed: 'isDiffShown(diff, diffRun)',
+          },
           // Override TestRunsBase to add diff.
           queryParams: {
             type: Object,
@@ -289,10 +310,12 @@ found in the LICENSE file.
         };
       }
 
+      isDiffShown(diff, diffRun) {
+        return diff && diffRun !== null;
+      }
+
       isInvalidDiffUse(diff, testRuns) {
-        return diff
-            && testRuns
-            && testRuns.filter(r => r.revision !== 'diff').length !== 2;
+        return diff && testRuns && testRuns.length !== 2;
       }
 
       hideDiffInvalidToast() {
@@ -334,7 +357,6 @@ found in the LICENSE file.
       ready() {
         super.ready();
         this.loadRuns().then(async runs => {
-          // Add a diff testRun spoof, if needed.
           if (this.diff && runs && runs.length === 2) {
             this.fetchDiff(runs);
           }
@@ -389,13 +411,12 @@ found in the LICENSE file.
         const b = `${before.browser_name}@${before.revision}`;
         const a = `${after.browser_name}@${after.revision}`;
         const diffRunURL = `/api/diff?before=${b}&after=${a}&filter=${this.filter}`;
-        const diffRun = {
+        this.diffRun = {
           revision: 'diff',
           browser_name: 'diff',
           results_url: diffRunURL,
         };
-        await this.fetchResults([diffRun]);
-        this.push('testRuns', diffRun);
+        await this.fetchResults([this.diffRun]);
         this.refreshDisplayedNodes();
       }
 


### PR DESCRIPTION
We don't have meaningful diff data to show in the single-file result
view (the API simply returns a pair of delta pass/total for the test
file without any subtest details). Besides, the diff column is currently
broken in the web component anyway (empty on prod and uncaught
exceptions on staging). Hence, we hide the diff column in the
single-file view but keep the parameter in URL so that when users go
back to the directory view the diff column will appear again.

In terms of implementation, this PR stops spoofing a diff run into the
`testRuns` array, which is awkward and forces all subclasses of
TestRunsBase to deal with the special case. Instead, the PR creates a
dedicated `diffRun` property that's only used in wpt-results.html (i.e.
the directory view).

Lastly, the PR also fixes a UI glitch where the passing/total numbers
might be wrapped into two lines by setting nowrap in the number cells.

Fixes #410 and #112 (yeah just realized they were duplicate).

## Review Information

Compare the following two cases between `staging.wpt.fyi` and the staging instance of this PR:

1. Go to `/results/FileAPI?product=chrome&product=edge&diff=true`; then click on "idlharness.html".
    * On `staging.wpt.fyi`, an uncaught exception is raised and the page is empty.
    * With this PR, the page renders correctly (but note that there'll be no "diff" column).
2. Go to `/results/accelerometer?product=chrome&product=edge&diff=true`.
    * On `staging.wpt.fyi`, the delta passing/total numbers in the diff column are split into two lines.
    * With this PR, number pairs are always in a single line.