### PR TITLE
No longer require sudo and Chrome on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,9 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-sudo: required
-
 branches:
   only:
     - master
-
-# Ensure latest stable chrome for WCT
-addons:
-  chrome: stable
 
 services:
   - docker


### PR DESCRIPTION
Everything now runs inside the Docker container so we no longer need sudo or Chrome outside of Docker. This hopefully speeds up the build a bit.