### PR TITLE
Set all-permissive CORS for all read-only APIs

### DIFF
--- a/api/routes.go
+++ b/api/routes.go
@@ -9,28 +9,28 @@ import "github.com/web-platform-tests/wpt.fyi/shared"
 // RegisterRoutes adds all the api route handlers.
 func RegisterRoutes() {
 	// API endpoint for diff of two test run summary JSON blobs.
-	shared.AddRoute("/api/diff", "api-diff", apiDiffHandler)
+	shared.AddRoute("/api/diff", "api-diff", shared.WrapPermissiveCORS(apiDiffHandler))
 
 	// API endpoint for fetching interoperability metadata.
-	shared.AddRoute("/api/interop", "api-interop", apiInteropHandler)
+	shared.AddRoute("/api/interop", "api-interop", shared.WrapPermissiveCORS(apiInteropHandler))
 
 	// API endpoint for fetching a manifest for a commit SHA.
-	shared.AddRoute("/api/manifest", "api-manifest", apiManifestHandler)
+	shared.AddRoute("/api/manifest", "api-manifest", shared.WrapPermissiveCORS(apiManifestHandler))
 
 	// API endpoint for listing all test runs for a given SHA.
-	shared.AddRoute("/api/runs", "api-test-runs", apiTestRunsHandler)
+	shared.AddRoute("/api/runs", "api-test-runs", shared.WrapPermissiveCORS(apiTestRunsHandler))
 
 	// API endpoint for listing SHAs for the test runs.
-	shared.AddRoute("/api/shas", "api-shas", apiSHAsHandler)
+	shared.AddRoute("/api/shas", "api-shas", shared.WrapPermissiveCORS(apiSHAsHandler))
 
 	// API endpoints for a single test run, by
 	// ID:
-	shared.AddRoute("/api/runs/{id}", "api-test-run", apiTestRunHandler)
+	shared.AddRoute("/api/runs/{id}", "api-test-run", shared.WrapPermissiveCORS(apiTestRunHandler))
 	// 'product' param & 'sha' param:
-	shared.AddRoute("/api/run", "api-test-run", apiTestRunHandler)
+	shared.AddRoute("/api/run", "api-test-run", shared.WrapPermissiveCORS(apiTestRunHandler))
 
 	// API endpoint for redirecting to a run's summary JSON blob.
-	shared.AddRoute("/api/results", "api-results", apiResultsRedirectHandler)
+	shared.AddRoute("/api/results", "api-results", shared.WrapPermissiveCORS(apiResultsRedirectHandler))
 
 	// PROTECTED API endpoint for receiving test results (wptreport) from runners.
 	// This API is authenticated. Runners have credentials.

--- a/shared/routing.go
+++ b/shared/routing.go
@@ -37,3 +37,12 @@ func WrapHSTS(h http.HandlerFunc) http.HandlerFunc {
 		h(w, r)
 	})
 }
+
+// WrapPermissiveCORS wraps the given handler func in one that sets an
+// all-permissive CORS header on the response.
+func WrapPermissiveCORS(h http.HandlerFunc) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Access-Control-Allow-Origin", "*")
+		h(w, r)
+	})
+}

--- a/webapp/routes_test.go
+++ b/webapp/routes_test.go
@@ -79,11 +79,13 @@ func TestApiResultsBoundCORS(t *testing.T) {
 func TestApiResultsUploadBoundHSTS(t *testing.T) {
 	assertHandlerIs(t, "/api/results/upload", "api-results-upload")
 	assertHSTS(t, "/api/results/upload")
+	assertNoCORS(t, "/api/results/upload")
 }
 
 func TestApiResultsCreateBoundHSTS(t *testing.T) {
 	assertHandlerIs(t, "/api/results/create", "api-results-create")
 	assertHSTS(t, "/api/results/create")
+	assertNoCORS(t, "/api/results/create")
 }
 
 func TestResultsBound(t *testing.T) {
@@ -118,10 +120,11 @@ func assertHSTS(t *testing.T, path string) {
 	rr := httptest.NewRecorder()
 	handler, _ := http.DefaultServeMux.Handler(req)
 	handler.ServeHTTP(rr, req)
+	res := rr.Result()
 	assert.Equal(
 		t,
 		"[max-age=31536000; preload]",
-		fmt.Sprintf("%s", rr.HeaderMap["Strict-Transport-Security"]))
+		fmt.Sprintf("%s", res.Header["Strict-Transport-Security"]))
 }
 
 func assertCORS(t *testing.T, path string) {
@@ -129,8 +132,18 @@ func assertCORS(t *testing.T, path string) {
 	rr := httptest.NewRecorder()
 	handler, _ := http.DefaultServeMux.Handler(req)
 	handler.ServeHTTP(rr, req)
+	res := rr.Result()
 	assert.Equal(
 		t,
 		"[*]",
-		fmt.Sprintf("%s", rr.HeaderMap["Access-Control-Allow-Origin"]))
+		fmt.Sprintf("%s", res.Header["Access-Control-Allow-Origin"]))
+}
+
+func assertNoCORS(t *testing.T, path string) {
+	req := httptest.NewRequest("GET", path, nil)
+	rr := httptest.NewRecorder()
+	handler, _ := http.DefaultServeMux.Handler(req)
+	handler.ServeHTTP(rr, req)
+	res := rr.Result()
+	assert.Equal(t, "", res.Header.Get("Access-Control-Allow-Origin"))
 }

--- a/webapp/routes_test.go
+++ b/webapp/routes_test.go
@@ -40,33 +40,53 @@ func TestInteropAnomaliesBound(t *testing.T) {
 	assertHandlerIs(t, "/anomalies", "anomaly")
 }
 
-func TestRunsBound(t *testing.T) {
-	assertBound(t, "/test-runs")
-}
-
 func TestRunsBoundHSTS(t *testing.T) {
+	assertHandlerIs(t, "/test-runs", "test-runs")
 	assertHSTS(t, "/test-runs")
 }
 
-func TestApiDiffBound(t *testing.T) {
-	assertBound(t, "/api/diff")
+func TestApiDiffBoundCORS(t *testing.T) {
+	assertHandlerIs(t, "/api/diff", "api-diff")
+	assertCORS(t, "/api/diff")
+}
+
+func TestApiInteropBound(t *testing.T) {
+	assertHandlerIs(t, "/api/interop", "api-interop")
+}
+
+func TestApiManifestBound(t *testing.T) {
+	assertHandlerIs(t, "/api/manifest", "api-manifest")
 }
 
 func TestApiRunsBound(t *testing.T) {
-	assertBound(t, "/api/runs")
+	assertHandlerIs(t, "/api/runs", "api-test-runs")
+}
+
+func TestApiShasBound(t *testing.T) {
+	assertHandlerIs(t, "/api/shas", "api-shas")
 }
 
 func TestApiRunBound(t *testing.T) {
-	assertBound(t, "/api/run")
+	assertHandlerIs(t, "/api/run", "api-test-run")
 	assertHandlerIs(t, "/api/runs/123", "api-test-run")
 }
 
-func TestApiResultsUploadBound(t *testing.T) {
+func TestApiResultsBoundCORS(t *testing.T) {
+	assertHandlerIs(t, "/api/results", "api-results")
+	assertCORS(t, "/api/results")
+}
+
+func TestApiResultsUploadBoundHSTS(t *testing.T) {
+	assertHandlerIs(t, "/api/results/upload", "api-results-upload")
 	assertHSTS(t, "/api/results/upload")
 }
 
+func TestApiResultsCreateBoundHSTS(t *testing.T) {
+	assertHandlerIs(t, "/api/results/create", "api-results-create")
+	assertHSTS(t, "/api/results/create")
+}
+
 func TestResultsBound(t *testing.T) {
-	assertBound(t, "/results")
 	assertHandlerIs(t, "/results", "results")
 	assertHandlerIs(t, "/results/", "results")
 	assertHandlerIs(t, "/results/2dcontext", "results")
@@ -102,4 +122,15 @@ func assertHSTS(t *testing.T, path string) {
 		t,
 		"[max-age=31536000; preload]",
 		fmt.Sprintf("%s", rr.HeaderMap["Strict-Transport-Security"]))
+}
+
+func assertCORS(t *testing.T, path string) {
+	req := httptest.NewRequest("GET", path, nil)
+	rr := httptest.NewRecorder()
+	handler, _ := http.DefaultServeMux.Handler(req)
+	handler.ServeHTTP(rr, req)
+	assert.Equal(
+		t,
+		"[*]",
+		fmt.Sprintf("%s", rr.HeaderMap["Access-Control-Allow-Origin"]))
 }


### PR DESCRIPTION
This commit adds Access-Control-Allow-Origin: * to the headers of all
read-only APIs. Fixes #433.
