### PR TITLE
Fix "File/Harness status"

### DIFF
--- a/webapp/components/abstract-test-file-results-table.html
+++ b/webapp/components/abstract-test-file-results-table.html
@@ -24,7 +24,7 @@ found in the LICENSE file.
         if (subtestName !== 'STATUS') {
           return subtestName;
         }
-        return hasSubtests ? 'Harness status' : 'File status';
+        return hasSubtests ? 'Harness status' : 'Test status';
       }
 
       subtestResultForTestRun(testRun, subtestName) {

--- a/webapp/components/abstract-test-file-results-table.html
+++ b/webapp/components/abstract-test-file-results-table.html
@@ -14,29 +14,17 @@ found in the LICENSE file.
             type: Array,
             value: [],
           },
-          isTestHarness: {
+          hasSubtests: {
             type: Boolean,
-            computed: 'computeIsTestHarness(subtestNames)',
           },
         };
       }
 
-      computeIsTestHarness(subtestNames) {
-        // subtestNames is always updated after testRuns[].subtests are updated,
-        // so as long as 'STATUS' exists in subtestNames, we can safely access
-        // testRuns[].subtests['STATUS'].
-        if (subtestNames.includes('STATUS')) {
-          return false;
-        }
-        const statuses = this.testRuns.map(tr => tr.subtests['STATUS'].status);
-        return statuses.includes('OK') || statuses.includes('ERROR');
-      }
-
-      subtestNameForDisplay(subtestName, isTestHarness) {
+      subtestNameForDisplay(subtestName, hasSubtests) {
         if (subtestName !== 'STATUS') {
           return subtestName;
         }
-        return isTestHarness ? 'Harness status' : 'File status';
+        return hasSubtests ? 'Harness status' : 'File status';
       }
 
       subtestResultForTestRun(testRun, subtestName) {

--- a/webapp/components/abstract-test-file-results-table.html
+++ b/webapp/components/abstract-test-file-results-table.html
@@ -8,17 +8,72 @@ found in the LICENSE file.
   <script>
     // eslint-disable-next-line no-unused-vars
     const AbstractTestFileResultsTable = superClass => class extends superClass {
-      static get is() {
-        return 'abstract-test-file-results-table';
-      }
-
       static get properties() {
         return {
           subtestNames: {
             type: Array,
             value: [],
           },
+          isTestHarness: {
+            type: Boolean,
+            value: false,
+          },
         };
+      }
+
+      static get observers() {
+        return ['fetchTestFile(path, testRuns)'];
+      }
+
+      async fetchTestFile(path, testRuns) {
+        if (!path || !testRuns) {
+          this.subtestNames = [];
+          return;
+        }
+
+        const resultPerTestRun = await Promise.all(
+          testRuns.map(tr => this.loadResultFile(tr)));
+
+        let isTestHarness = false;
+        const subtestNames = ['STATUS'];
+        resultPerTestRun.forEach((resultData, i) => {
+          if (!resultData) {
+            testRuns[i].subtests = {};
+            testRuns[i].subtests['STATUS'] = { status: '(results not found)' };
+            return;
+          }
+          testRuns[i].subtests = {};
+          testRuns[i].subtests['STATUS'] = { status: resultData.status };
+          if (['OK', 'ERROR'].includes(resultData.status)) {
+            isTestHarness = true;
+          }
+
+          for (let subtestResult of resultData.subtests) {
+            testRuns[i].subtests[subtestResult.name] = subtestResult;
+            if (!subtestNames.includes(subtestResult.name)) {
+              subtestNames.push(subtestResult.name);
+            }
+          }
+        });
+
+        this.isTestHarness = isTestHarness;
+        this.subtestNames = subtestNames;
+      }
+
+      async loadResultFile(testRun) {
+        const url = this.resultsURL(testRun, this.path);
+        const response = await window.fetch(url);
+        if (!response.ok) {
+          return null;
+        }
+        return response.json();
+      }
+
+      resultsURL(testRun, path) {
+        path = this.encodeTestPath(path);
+        // This is relying on the assumption that result files end with '-summary.json.gz'.
+        const resultsBase = testRun.results_url.slice(0, testRun.results_url.lastIndexOf('-summary.json.gz'));
+        return `${resultsBase}${path}`;
       }
 
       subtestNameForDisplay(subtestName, isTestHarness) {

--- a/webapp/components/abstract-test-file-results-table.html
+++ b/webapp/components/abstract-test-file-results-table.html
@@ -8,72 +8,17 @@ found in the LICENSE file.
   <script>
     // eslint-disable-next-line no-unused-vars
     const AbstractTestFileResultsTable = superClass => class extends superClass {
+      static get is() {
+        return 'abstract-test-file-results-table';
+      }
+
       static get properties() {
         return {
           subtestNames: {
             type: Array,
             value: [],
           },
-          isTestHarness: {
-            type: Boolean,
-            value: false,
-          },
         };
-      }
-
-      static get observers() {
-        return ['fetchTestFile(path, testRuns)'];
-      }
-
-      async fetchTestFile(path, testRuns) {
-        if (!path || !testRuns) {
-          this.subtestNames = [];
-          return;
-        }
-
-        const resultPerTestRun = await Promise.all(
-          testRuns.map(tr => this.loadResultFile(tr)));
-
-        let isTestHarness = false;
-        const subtestNames = ['STATUS'];
-        resultPerTestRun.forEach((resultData, i) => {
-          if (!resultData) {
-            testRuns[i].subtests = {};
-            testRuns[i].subtests['STATUS'] = { status: '(results not found)' };
-            return;
-          }
-          testRuns[i].subtests = {};
-          testRuns[i].subtests['STATUS'] = { status: resultData.status };
-          if (['OK', 'ERROR'].includes(resultData.status)) {
-            isTestHarness = true;
-          }
-
-          for (let subtestResult of resultData.subtests) {
-            testRuns[i].subtests[subtestResult.name] = subtestResult;
-            if (!subtestNames.includes(subtestResult.name)) {
-              subtestNames.push(subtestResult.name);
-            }
-          }
-        });
-
-        this.isTestHarness = isTestHarness;
-        this.subtestNames = subtestNames;
-      }
-
-      async loadResultFile(testRun) {
-        const url = this.resultsURL(testRun, this.path);
-        const response = await window.fetch(url);
-        if (!response.ok) {
-          return null;
-        }
-        return response.json();
-      }
-
-      resultsURL(testRun, path) {
-        path = this.encodeTestPath(path);
-        // This is relying on the assumption that result files end with '-summary.json.gz'.
-        const resultsBase = testRun.results_url.slice(0, testRun.results_url.lastIndexOf('-summary.json.gz'));
-        return `${resultsBase}${path}`;
       }
 
       subtestNameForDisplay(subtestName, isTestHarness) {

--- a/webapp/components/abstract-test-file-results-table.html
+++ b/webapp/components/abstract-test-file-results-table.html
@@ -25,7 +25,7 @@ found in the LICENSE file.
         // subtestNames is always updated after testRuns[].subtests are updated,
         // so as long as 'STATUS' exists in subtestNames, we can safely access
         // testRuns[].subtests['STATUS'].
-        if (subtestNames.indexOf('STATUS') === -1) {
+        if (subtestNames.includes('STATUS')) {
           return false;
         }
         const statuses = this.testRuns.map(tr => tr.subtests['STATUS'].status);

--- a/webapp/components/abstract-test-file-results-table.html
+++ b/webapp/components/abstract-test-file-results-table.html
@@ -14,7 +14,22 @@ found in the LICENSE file.
             type: Array,
             value: [],
           },
+          isTestHarness: {
+            type: Boolean,
+            computed: 'computeIsTestHarness(subtestNames)',
+          },
         };
+      }
+
+      computeIsTestHarness(subtestNames) {
+        // subtestNames is always updated after testRuns[].subtests are updated,
+        // so as long as 'STATUS' exists in subtestNames, we can safely access
+        // testRuns[].subtests['STATUS'].
+        if (subtestNames.indexOf('STATUS') === -1) {
+          return false;
+        }
+        const statuses = this.testRuns.map(tr => tr.subtests['STATUS'].status);
+        return statuses.includes('OK') || statuses.includes('ERROR');
       }
 
       subtestNameForDisplay(subtestName, isTestHarness) {

--- a/webapp/components/abstract-test-file-results-table.html
+++ b/webapp/components/abstract-test-file-results-table.html
@@ -8,10 +8,6 @@ found in the LICENSE file.
   <script>
     // eslint-disable-next-line no-unused-vars
     const AbstractTestFileResultsTable = superClass => class extends superClass {
-      static get is() {
-        return 'abstract-test-file-results-table';
-      }
-
       static get properties() {
         return {
           subtestNames: {

--- a/webapp/components/test-file-results-table-terse.html
+++ b/webapp/components/test-file-results-table-terse.html
@@ -66,7 +66,7 @@ found in the LICENSE file.
       <tbody>
         <template is="dom-repeat" items="[[subtestNames]]" as="subtestName">
           <tr>
-            <td class="sub-test-name"><code>[[ subtestNameForDisplay(subtestName, isTestHarness) ]]</code></td>
+            <td class="sub-test-name"><code>[[ subtestNameForDisplay(subtestName, hasSubtests) ]]</code></td>
 
             <template is="dom-repeat" items="{{testRuns}}" as="testRun">
               <td class$="result [[ subtestResultForTestRun(testRun, subtestName) ]]">

--- a/webapp/components/test-file-results-table-verbose.html
+++ b/webapp/components/test-file-results-table-verbose.html
@@ -49,7 +49,7 @@ found in the LICENSE file.
       <tbody>
         <template is="dom-repeat" items="[[subtestNames]]" as="subtestName">
           <tr>
-            <td class="sub-test-name"><code>[[ subtestNameForDisplay(subtestName, isTestHarness) ]]</code></td>
+            <td class="sub-test-name"><code>[[ subtestNameForDisplay(subtestName, hasSubtests) ]]</code></td>
 
             <template is="dom-repeat" items="{{testRuns}}" as="testRun">
               <td class$="result [[ subtestResultForTestRun(testRun, subtestName) ]]">

--- a/webapp/components/test-file-results.html
+++ b/webapp/components/test-file-results.html
@@ -44,16 +44,18 @@ found in the LICENSE file.
     <template is="dom-if" if="{{!isVerbose}}">
       <test-file-results-table-terse
           test-runs="[[testRuns]]"
+          has-subtests="[[hasSubtests]]"
           subtest-names="[[subtestNames]]">
       </test-file-results-table-terse>
     </template>
 
     <template is="dom-if" if="{{isVerbose}}">
-        <test-file-results-table-verbose
-            test-runs="[[testRuns]]"
-            subtest-names="[[subtestNames]]">
-        </test-file-results-table-verbose>
-      </template>
+      <test-file-results-table-verbose
+          test-runs="[[testRuns]]"
+          has-subtests="[[hasSubtests]]"
+          subtest-names="[[subtestNames]]">
+      </test-file-results-table-verbose>
+    </template>
   </template>
 
   <script>
@@ -68,6 +70,10 @@ found in the LICENSE file.
           subtestNames: {
             type: Array,
             value: [],
+          },
+          hasSubtests: {
+            type: Boolean,
+            value: false,
           },
           isVerbose: {
             type: Boolean,
@@ -95,6 +101,7 @@ found in the LICENSE file.
           testRuns.map(tr => this.loadResultFile(tr)));
 
         const subtestNames = ['STATUS'];
+        let hasSubtests = false;
         resultPerTestRun.forEach((resultData, i) => {
           if (!resultData) {
             testRuns[i].subtests = {};
@@ -103,13 +110,19 @@ found in the LICENSE file.
           }
           testRuns[i].subtests = {};
           testRuns[i].subtests['STATUS'] = { status: resultData.status };
-          for (let subtestResult of resultData.subtests) {
-            testRuns[i].subtests[subtestResult.name] = subtestResult;
-            if (!subtestNames.includes(subtestResult.name)) {
-              subtestNames.push(subtestResult.name);
+          if (resultData.subtests && resultData.subtests.length > 0) {
+            // Since we spoof the file-level status also as a "subtest", we
+            // store whether the test originally has subtests here.
+            hasSubtests = true;
+            for (let subtestResult of resultData.subtests) {
+              testRuns[i].subtests[subtestResult.name] = subtestResult;
+              if (!subtestNames.includes(subtestResult.name)) {
+                subtestNames.push(subtestResult.name);
+              }
             }
           }
         });
+        this.hasSubtests = true;
         this.subtestNames = subtestNames;
       }
 

--- a/webapp/components/test-file-results.html
+++ b/webapp/components/test-file-results.html
@@ -43,6 +43,7 @@ found in the LICENSE file.
 
     <template is="dom-if" if="{{!isVerbose}}">
       <test-file-results-table-terse
+          path="[[path]]"
           test-runs="[[testRuns]]"
           subtest-names="[[subtestNames]]">
       </test-file-results-table-terse>
@@ -50,6 +51,7 @@ found in the LICENSE file.
 
     <template is="dom-if" if="{{isVerbose}}">
         <test-file-results-table-verbose
+            path="[[path]]"
             test-runs="[[testRuns]]"
             subtest-names="[[subtestNames]]">
         </test-file-results-table-verbose>

--- a/webapp/components/test-file-results.html
+++ b/webapp/components/test-file-results.html
@@ -65,14 +65,6 @@ found in the LICENSE file.
 
       static get properties() {
         return {
-          subtestNames: {
-            type: Array,
-            value: [],
-          },
-          isTestHarness: {
-            type: Boolean,
-            value: false,
-          },
           isVerbose: {
             type: Boolean,
             value: false,
@@ -84,60 +76,6 @@ found in the LICENSE file.
         await super.connectedCallback();
         console.assert(this.path);
         console.assert(this.path[0] === '/');
-      }
-
-      static get observers() {
-        return ['fetchTestFile(path, testRuns)'];
-      }
-
-      async fetchTestFile(path, testRuns) {
-        this.subtestNames = []; // Clear any existing rows.
-        if (!path || !testRuns) {
-          return;
-        }
-        const resultPerTestRun = await Promise.all(
-          testRuns.map(tr => this.loadResultFile(tr)));
-
-        let isTestHarness = false;
-        const subtestNames = ['STATUS'];
-        resultPerTestRun.forEach((resultData, i) => {
-          if (!resultData) {
-            testRuns[i].subtests = {};
-            testRuns[i].subtests['STATUS'] = { status: '(results not found)' };
-            return;
-          }
-          testRuns[i].subtests = {};
-          testRuns[i].subtests['STATUS'] = { status: resultData.status };
-          if (['OK', 'ERROR'].includes(resultData.status)) {
-            isTestHarness = true;
-          }
-
-          for (let subtestResult of resultData.subtests) {
-            testRuns[i].subtests[subtestResult.name] = subtestResult;
-            if (!subtestNames.includes(subtestResult.name)) {
-              subtestNames.push(subtestResult.name);
-            }
-          }
-        });
-
-        this.isTestHarness = isTestHarness;
-        this.subtestNames = subtestNames;
-      }
-
-      async loadResultFile(testRun) {
-        const url = this.resultsURL(testRun, this.path);
-        const response = await window.fetch(url);
-        if (!response.ok) {
-          return null;
-        }
-        return response.json();
-      }
-
-      resultsURL(testRun, path) {
-        path = this.encodeTestPath(path);
-        // This is relying on the assumption that result files end with '-summary.json.gz'.
-        const resultsBase = testRun.results_url.slice(0, testRun.results_url.lastIndexOf('-summary.json.gz'));
-        return `${resultsBase}${path}`;
       }
     }
 

--- a/webapp/components/test-file-results.html
+++ b/webapp/components/test-file-results.html
@@ -43,7 +43,6 @@ found in the LICENSE file.
 
     <template is="dom-if" if="{{!isVerbose}}">
       <test-file-results-table-terse
-          path="[[path]]"
           test-runs="[[testRuns]]"
           subtest-names="[[subtestNames]]">
       </test-file-results-table-terse>
@@ -51,7 +50,6 @@ found in the LICENSE file.
 
     <template is="dom-if" if="{{isVerbose}}">
         <test-file-results-table-verbose
-            path="[[path]]"
             test-runs="[[testRuns]]"
             subtest-names="[[subtestNames]]">
         </test-file-results-table-verbose>
@@ -70,10 +68,6 @@ found in the LICENSE file.
           subtestNames: {
             type: Array,
             value: [],
-          },
-          isTestHarness: {
-            type: Boolean,
-            value: false,
           },
           isVerbose: {
             type: Boolean,
@@ -100,7 +94,6 @@ found in the LICENSE file.
         const resultPerTestRun = await Promise.all(
           testRuns.map(tr => this.loadResultFile(tr)));
 
-        let isTestHarness = false;
         const subtestNames = ['STATUS'];
         resultPerTestRun.forEach((resultData, i) => {
           if (!resultData) {
@@ -110,10 +103,6 @@ found in the LICENSE file.
           }
           testRuns[i].subtests = {};
           testRuns[i].subtests['STATUS'] = { status: resultData.status };
-          if (['OK', 'ERROR'].includes(resultData.status)) {
-            isTestHarness = true;
-          }
-
           for (let subtestResult of resultData.subtests) {
             testRuns[i].subtests[subtestResult.name] = subtestResult;
             if (!subtestNames.includes(subtestResult.name)) {
@@ -121,8 +110,6 @@ found in the LICENSE file.
             }
           }
         });
-
-        this.isTestHarness = isTestHarness;
         this.subtestNames = subtestNames;
       }
 

--- a/webapp/components/test-file-results.html
+++ b/webapp/components/test-file-results.html
@@ -67,6 +67,14 @@ found in the LICENSE file.
 
       static get properties() {
         return {
+          subtestNames: {
+            type: Array,
+            value: [],
+          },
+          isTestHarness: {
+            type: Boolean,
+            value: false,
+          },
           isVerbose: {
             type: Boolean,
             value: false,
@@ -78,6 +86,60 @@ found in the LICENSE file.
         await super.connectedCallback();
         console.assert(this.path);
         console.assert(this.path[0] === '/');
+      }
+
+      static get observers() {
+        return ['fetchTestFile(path, testRuns)'];
+      }
+
+      async fetchTestFile(path, testRuns) {
+        this.subtestNames = []; // Clear any existing rows.
+        if (!path || !testRuns) {
+          return;
+        }
+        const resultPerTestRun = await Promise.all(
+          testRuns.map(tr => this.loadResultFile(tr)));
+
+        let isTestHarness = false;
+        const subtestNames = ['STATUS'];
+        resultPerTestRun.forEach((resultData, i) => {
+          if (!resultData) {
+            testRuns[i].subtests = {};
+            testRuns[i].subtests['STATUS'] = { status: '(results not found)' };
+            return;
+          }
+          testRuns[i].subtests = {};
+          testRuns[i].subtests['STATUS'] = { status: resultData.status };
+          if (['OK', 'ERROR'].includes(resultData.status)) {
+            isTestHarness = true;
+          }
+
+          for (let subtestResult of resultData.subtests) {
+            testRuns[i].subtests[subtestResult.name] = subtestResult;
+            if (!subtestNames.includes(subtestResult.name)) {
+              subtestNames.push(subtestResult.name);
+            }
+          }
+        });
+
+        this.isTestHarness = isTestHarness;
+        this.subtestNames = subtestNames;
+      }
+
+      async loadResultFile(testRun) {
+        const url = this.resultsURL(testRun, this.path);
+        const response = await window.fetch(url);
+        if (!response.ok) {
+          return null;
+        }
+        return response.json();
+      }
+
+      resultsURL(testRun, path) {
+        path = this.encodeTestPath(path);
+        // This is relying on the assumption that result files end with '-summary.json.gz'.
+        const resultsBase = testRun.results_url.slice(0, testRun.results_url.lastIndexOf('-summary.json.gz'));
+        return `${resultsBase}${path}`;
       }
     }
 

--- a/webapp/components/test-file-results.html
+++ b/webapp/components/test-file-results.html
@@ -122,7 +122,7 @@ found in the LICENSE file.
             }
           }
         });
-        this.hasSubtests = true;
+        this.hasSubtests = hasSubtests;
         this.subtestNames = subtestNames;
       }
 


### PR DESCRIPTION
In #405, we turned `test-file-results` into a thin layer was only responsible for fetching data and delegated the UI logic to new embedded components `test-file-results-table-{terse,verbose}` (which were subclasses of `AbstractTestFileResultsTable(TestRunsBase)`).

Therefore, information needs to be explicitly passed into the new components. Yet we forgot to pass `isTestHarness`, which caused the regression. This PR turns `isTestHarness` into `hasSubtests` (which is really a more accurate name as we don't know the type of a test for sure without consulting the manifest), and passes the property down to the embedded components.

This PR also removes the `is` getter from `abstract-test-file-results-table`; the abstract class is not a DOM template and doesn't need the `is` getter.

Fixes #419 .

## Review Information

Check out a testharness test and a reftest in the staging instance. They should show "Harness status" and "File status" respectively.