### PR TITLE
Revert "TEMPORARILY allow go_medium_tests to fail (#425)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ go_small_test: go_deps
 	cd $(WPTD_GO_PATH); go test -tags=small -v ./...
 
 go_medium_test: go_deps dev_appserver_deps
-	cd $(WPTD_GO_PATH); go test -tags=medium -v $(FLAGS) ./... || true
+	cd $(WPTD_GO_PATH); go test -tags=medium -v $(FLAGS) ./...
 
 go_large_test: go_all_browsers_test
 

--- a/shared/sharedtest/util.go
+++ b/shared/sharedtest/util.go
@@ -16,6 +16,7 @@ import (
 func NewAEInstance(stronglyConsistentDatastore bool) (aetest.Instance, error) {
 	return aetest.NewInstance(&aetest.Options{
 		StronglyConsistentDatastore: stronglyConsistentDatastore,
+		SuppressDevAppServerLog:     true,
 	})
 }
 


### PR DESCRIPTION
This reverts commit 0d6743e4b9dbb6a8e1cd26440e27784cd49c8de6.

So I don't know what happened. Gcloud SDK v212 seems to have fixed the mysterious flaky failure in our medium tests. The changelog doesn't say any bug fixes, either.

Fixes #413 ... Sigh

(Please do not merge the PR immediately. I'd like to watch the tree for a bit longer.)