### PR TITLE
Simplify the caveat

### DIFF
--- a/webapp/templates/caveat.html
+++ b/webapp/templates/caveat.html
@@ -1,3 +1,3 @@
 <section class="caveat">
-  The web-platform-tests dashboard is a work-in-progress. The reported results do not necessarily reflect the true capabilities of each web browser, so they should not be used evaluate or compare feature support. Each browser listed here is currently tested at its latest stable release.
+  wpt.fyi is a work in progress. The reported results do not necessarily reflect the true capabilities of each web browser, so they should not be used evaluate or compare feature support.
 </section>


### PR DESCRIPTION
Hyphenated "work-in-progress" acts like an adjective and not correct here:
https://www.grammarly.com/blog/hyphen-with-compound-modifiers/

And we now have both stable and experimental browsers.

Related: https://github.com/web-platform-tests/wpt.fyi/issues/24