### PR TITLE
Use lowercase "wpt" to represent the root path in UI

### DIFF
--- a/webapp/components/interop.html
+++ b/webapp/components/interop.html
@@ -114,7 +114,7 @@ found in the LICENSE file.
 
   <section class="search">
     <div class="path">
-      <a href="/interop/" on-click="navigate">WPT</a>
+      <a href="/interop/" on-click="navigate">wpt</a>
       <template is="dom-repeat" items="{{ splitPathIntoLinkedParts(path) }}" as="part">
         <span class="path-separator">/</span>
         <a href="/interop{{ part.path }}" on-click="navigate">{{ part.name }}</a>

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -125,7 +125,7 @@ found in the LICENSE file.
 
     <section class="search">
       <div class="path">
-        <a href="/results/" on-click="navigate">WPT</a>
+        <a href="/results/" on-click="navigate">wpt</a>
         <template is="dom-repeat" items="{{ splitPathIntoLinkedParts(path) }}" as="part">
           <span class="path-separator">/</span>
           <a href="/results{{ part.path }}" on-click="navigate">{{ part.name }}</a>


### PR DESCRIPTION
This is now the repo name, and with a checkout the paths on the
filesytem will looks something like "wpt/FileAPI/unicode.html".

## Review Information

This is bikeshedding.