### PR TITLE
Fix integration tests in staging environment

### DIFF
--- a/webdriver/label_test.go
+++ b/webdriver/label_test.go
@@ -22,7 +22,13 @@ func TestLabelParam(t *testing.T) {
 	defer service.Stop()
 	defer wd.Quit()
 
-	testLabel(t, wd, app, "/", "experimental", "wpt-results", 2)
+	if *staging {
+		// We have all 4 experimental browsers on staging.wpt.fyi.
+		testLabel(t, wd, app, "/", "experimental", "wpt-results", 4)
+	} else {
+		// Local static data only have 2 experimental browsers.
+		testLabel(t, wd, app, "/", "experimental", "wpt-results", 2)
+	}
 	testLabel(t, wd, app, "/interop", "stable", "wpt-interop", 4)
 }
 


### PR DESCRIPTION
Our staging environment now has all four experimental browsers, so the
assertion for testing "?label=experimental" needs to be adjusted
accordingly. The test has been broken for a while on master and wasn't
noticed because of #435.

## Review Information

Tested locally using `make go_chrome_test STAGING=true`.