### PR TITLE
Revert "Use ?complete=true as default query for /api/runs"

### DIFF
--- a/webapp/components/test-runs.html
+++ b/webapp/components/test-runs.html
@@ -150,12 +150,6 @@ found in the LICENSE file.
         if (maxCount) {
           params['max-count'] = maxCount;
         }
-
-        // Insist on complete runs iff neither sha nor products are specified.
-        if (!sha && (!products || products.length === 0)) {
-          params.complete = true;
-        }
-
         return params;
       }
 


### PR DESCRIPTION
Reverts web-platform-tests/wpt.fyi#450

https://github.com/web-platform-tests/wpt.fyi/pull/450#issuecomment-415329150 hasn't been addressed. And it in fact breaks our integration test: https://staging.wpt.fyi/results/?label=experimental now only has three runs.