### PR TITLE
Reland "Use ?complete=true as default query for /api/runs"

### DIFF
--- a/webapp/components/test-runs.html
+++ b/webapp/components/test-runs.html
@@ -151,8 +151,9 @@ found in the LICENSE file.
           params['max-count'] = maxCount;
         }
 
-        // Insist on complete runs iff neither sha nor products are specified.
-        if (!sha && (!products || products.length === 0)) {
+        // Insist on complete runs iff there is no other parameter.
+        // This is a temporary hack for https://github.com/web-platform-tests/wpt.fyi/issues/468
+        if (Object.keys(params).length === 0) {
           params.complete = true;
         }
 

--- a/webapp/components/test-runs.html
+++ b/webapp/components/test-runs.html
@@ -150,6 +150,12 @@ found in the LICENSE file.
         if (maxCount) {
           params['max-count'] = maxCount;
         }
+
+        // Insist on complete runs iff neither sha nor products are specified.
+        if (!sha && (!products || products.length === 0)) {
+          params.complete = true;
+        }
+
         return params;
       }
 


### PR DESCRIPTION
Reverts web-platform-tests/wpt.fyi#475, i.e. relands https://github.com/web-platform-tests/wpt.fyi/pull/450

Fixes #441 . Also see #468 .