### PR TITLE
Fix diff view in wpt-results

### DIFF
--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -200,9 +200,9 @@ found in the LICENSE file.
               </template>
               <template is="dom-if" if="[[diffShown]]">
                 <td class$="numbers [[ testResultClass(node, index, diffRun, 'passes') ]]">
-                  <span class$="passing [[ testResultClass(node, index, diffRun, 'passes') ]]">{{ getNodeResultDataByPropertyName(node, diffRun, 'passing') }}</span>
+                  <span class$="passes [[ testResultClass(node, index, diffRun, 'passes') ]]">{{ getNodeResultDataByPropertyName(node, -1, diffRun, 'passes') }}</span>
                   /
-                  <span class$="total [[ testResultClass(node, index, diffRun, 'total') ]]">{{ getNodeResultDataByPropertyName(node, diffRun, 'total') }}</span>
+                  <span class$="total [[ testResultClass(node, index, diffRun, 'total') ]]">{{ getNodeResultDataByPropertyName(node, -1, diffRun, 'total') }}</span>
                 </td>
               </template>
             </tr>
@@ -304,14 +304,9 @@ found in the LICENSE file.
           searchURL: {
             type: String,
             computed: 'computeSearchURL(testRuns, search)',
+            observer: 'observeSearchURL',
           },
         };
-      }
-
-      static get observers() {
-        return [
-          'fetchResults(searchURL, diffRun)',
-        ];
       }
 
       isDiffShown(diff, diffRun) {
@@ -380,7 +375,10 @@ found in the LICENSE file.
         this.loadRuns().then(async runs => {
           // Load a diff data into this.diffRun, if needed.
           if (this.diff && runs && runs.length === 2) {
-            this.fetchDiff(runs);
+            this.diffRun = {
+              revision: 'diff',
+              browser_name: 'diff',
+            };
           }
         });
 
@@ -393,11 +391,8 @@ found in the LICENSE file.
         };
       }
 
-      // fetchResults should be triggered by changes in searchURL or diffRun,
-      // but diffRun is only used in subroutine: refreshDisplayedNodes.
-      /* eslint-disable no-unused-vars */
-      async fetchResults(searchURL, diffRun) {
-        const response = await window.fetch(searchURL);
+      async observeSearchURL(newValue, oldValue) {
+        const response = await window.fetch(newValue);
         if (response.status !== 200) {
           throw response;
         }
@@ -405,18 +400,6 @@ found in the LICENSE file.
 
         this.searchResults = json.results;
         this.refreshDisplayedNodes();
-      }
-
-      async fetchDiff(testRuns) {
-        const [before, after] = testRuns;
-        const b = `${before.browser_name}@${before.revision}`;
-        const a = `${after.browser_name}@${after.revision}`;
-        const diffRunURL = `/api/diff?before=${b}&after=${a}&filter=${this.filter}`;
-        this.diffRun = {
-          revision: 'diff',
-          browser_name: 'diff',
-          results_url: diffRunURL,
-        };
       }
 
       pathUpdated(path) {
@@ -507,11 +490,10 @@ found in the LICENSE file.
         }
 
         const result = node.results[index];
-        if (typeof result === 'undefined') {
+        const isDiff = this.isDiff(testRun);
+        if (!isDiff && typeof result === 'undefined') {
           return 'none';
         }
-
-        const isDiff = this.isDiff(testRun);
         if (this.path === '/' && !isDiff) {
           // Do not add color to top-level directories
           return 'top';
@@ -520,7 +502,7 @@ found in the LICENSE file.
         if (isDiff) {
           const delta = this.getDiffDelta(node, prop);
           if (!delta) {
-            return 'delta none';
+            return 'delta';
           }
           return `delta ${delta > 0 ? 'positive' : 'negative'}`;
         } else {
@@ -537,7 +519,7 @@ found in the LICENSE file.
       getDiffDeltaStr(node, prop) {
         const delta = this.getDiffDelta(node, prop);
         if (delta === 0) {
-          return 0;
+          return '0';
         }
         const posOrNeg = delta > 0 ? '+' : '';
         return `${posOrNeg}${delta}`;

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -489,27 +489,32 @@ found in the LICENSE file.
       }
 
       testResultClass(node, index, testRun, prop) {
+        // Guard against incomplete data.
         if (!node || !testRun) {
           return 'none';
         }
 
         const result = node.results[index];
         const isDiff = this.isDiff(testRun);
-        if (!isDiff && typeof result === 'undefined') {
-          return 'none';
-        }
-        if (this.path === '/' && !isDiff) {
-          // Do not add color to top-level directories
-          return 'top';
-        }
-
         if (isDiff) {
+          // Diff case: 'delta [positive|negative|<nothing>]' based on delta
+          // value;
           const delta = this.getDiffDelta(node, prop);
-          if (!delta) {
+          if (delta === 0) {
             return 'delta';
           }
+
           return `delta ${delta > 0 ? 'positive' : 'negative'}`;
         } else {
+          // Non-diff case: total=0 -> 'none'; path='/' -> 'top';
+          // otherwise -> 'passes-[colouring-by-percent]'.
+          if (typeof result === 'undefined' && prop === 'total') {
+            return 'none';
+          }
+          if (this.path === '/') {
+            return 'top';
+          }
+
           const passes = result.passes / result.total;
           return `passes-${passes * 100 - (passes * 100 % 20)}`;
         }

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -392,6 +392,10 @@ found in the LICENSE file.
       }
 
       async observeSearchURL(newValue, oldValue) {
+        if (oldValue === newValue || !newValue) {
+          return;
+        }
+
         const response = await window.fetch(newValue);
         if (response.status !== 200) {
           throw response;


### PR DESCRIPTION
Fixes #477

- Misspelled CSS class names
- Incorrect parameters to helper functions
- Broken/needless fetch of diff
- Fix application logic for 'none' CSS class:
  - Early return needed `!isDiff &&`
  - Do not use 'delta none'; other num (passes or total) may be non-zero
- nit: `getDiffDeltaStr` always returns string