### PR TITLE
Document impact of static_runs flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ execute the script which leverages `util/populate_dev_data.go` by running:
 ./util/docker-dev/dev_data.sh
 ```
 
+*NOTE*: Some web UI views, such as `/interop`, only work in the presence of so-called "static runs". If some views
+do not work while debugging locally, try clearing your local datastore and memcache, then run:
+
+```sh
+source ./util/commands.sh
+wptd_exec go run ./util/populate_dev_data.go -static_runs=true
+```
+
 See [CONTRIBUTING.md](/CONTRIBUTING.md) for more information on local development.
 
 # Filesystem and network output

--- a/util/populate_dev_data.go
+++ b/util/populate_dev_data.go
@@ -23,7 +23,7 @@ import (
 var (
 	host          = flag.String("host", "wpt.fyi", "wpt.fyi host to fetch prod runs from")
 	numRemoteRuns = flag.Int("num_remote_runs", 10, "number of remote runs to copy from host to local environment")
-	staticRuns    = flag.Bool("static_runs", false, "Include runs in the /static dir")
+	staticRuns    = flag.Bool("static_runs", false, "include runs in the /static dir; some views such as /interop only work locally when this value is true")
 )
 
 // populate_dev_data.go populates a local running webapp instance with some


### PR DESCRIPTION
Documents impact of `-static_runs=true` for `populate_dev_data.go`.

Fixes #478.