### PR TITLE
Fetch the latest interop run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,6 +221,7 @@ gcloud: python curl gpg
 eslint: node-babel-eslint node-eslint node-eslint-plugin-html
 	cd $(WPTD_PATH)webapp; npm run lint
 
+dev_data: FLAGS := -host=staging.wpt.fyi
 dev_data:
 	cd $(WPTD_GO_PATH)/util; go get -t ./...
 	go run $(WPTD_GO_PATH)/util/populate_dev_data.go $(FLAGS)

--- a/shared/fetch_runs.go
+++ b/shared/fetch_runs.go
@@ -24,6 +24,15 @@ func FetchLatestRuns(wptdHost string) TestRuns {
 func FetchRuns(wptdHost string, filter TestRunFilter) TestRuns {
 	url := "https://" + wptdHost + "/api/runs"
 	url += "?" + filter.ToQuery(true).Encode()
+
+	var runs TestRuns
+	FetchAPIJSON(url, &runs)
+	return runs
+}
+
+// FetchAPIJSON fetches the given URL and unmarshals it into the given
+// value pointer, fatally logging any errors.
+func FetchAPIJSON(url string, value interface{}) {
 	log.Printf("Fetching %s...", url)
 
 	resp, err := http.Get(url)
@@ -39,9 +48,7 @@ func FetchRuns(wptdHost string, filter TestRunFilter) TestRuns {
 	if err != nil {
 		log.Fatal(err)
 	}
-	var runs TestRuns
-	if err := json.Unmarshal(body, &runs); err != nil {
+	if err := json.Unmarshal(body, value); err != nil {
 		log.Fatal(err)
 	}
-	return runs
 }

--- a/shared/fetch_runs.go
+++ b/shared/fetch_runs.go
@@ -26,13 +26,13 @@ func FetchRuns(wptdHost string, filter TestRunFilter) TestRuns {
 	url += "?" + filter.ToQuery(true).Encode()
 
 	var runs TestRuns
-	FetchAPIJSON(url, &runs)
+	FetchJSON(url, &runs)
 	return runs
 }
 
-// FetchAPIJSON fetches the given URL and unmarshals it into the given
-// value pointer, fatally logging any errors.
-func FetchAPIJSON(url string, value interface{}) {
+// FetchJSON fetches the given URL, which is expected to be JSON, and unmarshals
+// it into the given value pointer, fatally logging any errors.
+func FetchJSON(url string, value interface{}) {
 	log.Printf("Fetching %s...", url)
 
 	resp, err := http.Get(url)

--- a/util/populate_dev_data.go
+++ b/util/populate_dev_data.go
@@ -176,8 +176,7 @@ func main() {
 
 	if *staticRuns {
 		log.Print("Adding local mock data (static/)...")
-		testRunKeys := addData(ctx, testRunKindName, staticTestRunMetadata)
-		for i, key := range testRunKeys {
+		for i, key := range addData(ctx, testRunKindName, staticTestRunMetadata) {
 			staticTestRuns[i].ID = key.IntID()
 		}
 		for i := range staticPassRateMetadata {
@@ -193,10 +192,9 @@ func main() {
 	}
 
 	log.Print("Adding latest production TestRun data...")
-	maxCount := *numRemoteRuns
 	filters := shared.TestRunFilter{
-		MaxCount: &maxCount,
 		Labels:   mapset.NewSetWith("stable"),
+		MaxCount: numRemoteRuns,
 	}
 	prodTestRuns := shared.FetchRuns(*host, filters)
 	labelRuns(prodTestRuns, "prod")
@@ -204,7 +202,21 @@ func main() {
 	for i := range prodTestRuns {
 		latestProductionTestRunMetadata[i] = &prodTestRuns[i]
 	}
-	addData(ctx, testRunKindName, latestProductionTestRunMetadata)
+	for i, key := range addData(ctx, testRunKindName, latestProductionTestRunMetadata) {
+		prodTestRuns[i].ID = key.IntID()
+	}
+
+	log.Print("Adding latest production Interop data...")
+	filters.MaxCount = nil
+	prodPassRateMetadata := FetchInterop(*host, filters)
+	// Update the interop IDs to match the newly-copied local test-run IDs.
+	prodPassRateMetadata.TestRunIDs = make([]int64, len(prodPassRateMetadata.TestRuns))
+	one := 1
+	localRunCopies, err := shared.LoadTestRuns(ctx, shared.GetDefaultProducts(), mapset.NewSetWith("stable"), nil, nil, nil, &one)
+	for i := range prodPassRateMetadata.TestRunIDs {
+		prodPassRateMetadata.TestRunIDs[i] = localRunCopies[i].ID
+	}
+	addData(ctx, passRateMetadataKindName, []interface{}{&prodPassRateMetadata})
 
 	log.Print("Adding latest experimental TestRun data...")
 	filters.Labels = mapset.NewSetWith("experimental")
@@ -251,4 +263,16 @@ func getRemoteAPIContext() (context.Context, error) {
 	const localhost = "localhost:9999"
 	remoteContext, err := remote_api.NewRemoteContext(localhost, http.DefaultClient)
 	return remoteContext, err
+}
+
+// FetchInterop fetches the PassRateMetadata for the given sha / labels, using
+// the API on the given host.
+// TODO(lukebjerring): Migrate to results-analysis
+func FetchInterop(wptdHost string, filter shared.TestRunFilter) metrics.PassRateMetadata {
+	url := "https://" + wptdHost + "/api/interop"
+	url += "?" + filter.ToQuery(true).Encode()
+
+	var interop metrics.PassRateMetadata
+	shared.FetchAPIJSON(url, &interop)
+	return interop
 }

--- a/util/populate_dev_data.go
+++ b/util/populate_dev_data.go
@@ -202,9 +202,7 @@ func main() {
 	for i := range prodTestRuns {
 		latestProductionTestRunMetadata[i] = &prodTestRuns[i]
 	}
-	for i, key := range addData(ctx, testRunKindName, latestProductionTestRunMetadata) {
-		prodTestRuns[i].ID = key.IntID()
-	}
+	addData(ctx, testRunKindName, latestProductionTestRunMetadata)
 
 	log.Print("Adding latest production Interop data...")
 	filters.MaxCount = nil
@@ -212,7 +210,7 @@ func main() {
 	// Update the interop IDs to match the newly-copied local test-run IDs.
 	prodPassRateMetadata.TestRunIDs = make([]int64, len(prodPassRateMetadata.TestRuns))
 	one := 1
-	localRunCopies, err := shared.LoadTestRuns(ctx, shared.GetDefaultProducts(), mapset.NewSetWith("stable"), nil, nil, nil, &one)
+	localRunCopies, err := shared.LoadTestRuns(ctx, shared.GetDefaultProducts(), filters.Labels, nil, nil, nil, &one)
 	for i := range prodPassRateMetadata.TestRunIDs {
 		prodPassRateMetadata.TestRunIDs[i] = localRunCopies[i].ID
 	}
@@ -273,6 +271,6 @@ func FetchInterop(wptdHost string, filter shared.TestRunFilter) metrics.PassRate
 	url += "?" + filter.ToQuery(true).Encode()
 
 	var interop metrics.PassRateMetadata
-	shared.FetchAPIJSON(url, &interop)
+	shared.FetchJSON(url, &interop)
 	return interop
 }


### PR DESCRIPTION
## Description
Fix for https://github.com/web-platform-tests/wpt.fyi/issues/478

After adding a bunch of fetched/remote test-runs, also fetches the latest interop data, and copies it locally by switching out the `TestRunIDs` to match the locally created test-run copies.

## Review Information
Run:
`make dev_data`