### PR TITLE
Handle ?complete=true in /api/interop

### DIFF
--- a/api/interop.go
+++ b/api/interop.go
@@ -31,8 +31,7 @@ func apiInteropHandler(w http.ResponseWriter, r *http.Request) {
 	if !filters.IsDefaultQuery() {
 		// Load default browser runs for SHA.
 		// Ignore any max-count; makes no sense for a interop run.
-		one := 1
-		filters.MaxCount = &one
+		filters.MaxCount = nil
 		runs, err := LoadTestRunsForFilters(ctx, filters)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/api/interop.go
+++ b/api/interop.go
@@ -36,6 +36,9 @@ func apiInteropHandler(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
+		} else if len(runs) < 1 {
+			http.Error(w, "No metrics runs found", http.StatusNotFound)
+			return
 		}
 		for _, run := range runs {
 			query = query.Filter("TestRunIDs =", run.ID)

--- a/api/interop.go
+++ b/api/interop.go
@@ -32,8 +32,8 @@ func apiInteropHandler(w http.ResponseWriter, r *http.Request) {
 		// Load default browser runs for SHA.
 		// Ignore any max-count; makes no sense for a interop run.
 		one := 1
-		runs, err := shared.LoadTestRuns(
-			ctx, filters.GetProductsOrDefault(), filters.Labels, []string{filters.SHA}, filters.From, filters.To, &one)
+		filters.MaxCount = &one
+		runs, err := LoadTestRunsForFilters(ctx, filters)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/api/interop.go
+++ b/api/interop.go
@@ -30,8 +30,9 @@ func apiInteropHandler(w http.ResponseWriter, r *http.Request) {
 	// We 'load by SHA' by fetching any interop result with all TestRunIDs for that SHA.
 	if !filters.IsDefaultQuery() {
 		// Load default browser runs for SHA.
-		// Ignore any max-count; makes no sense for a interop run.
-		filters.MaxCount = nil
+		// Force any max-count to one; more than one of each product makes no sense for a interop run.
+		one := 1
+		filters.MaxCount = &one
 		runs, err := LoadTestRunsForFilters(ctx, filters)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/shared/params.go
+++ b/shared/params.go
@@ -42,7 +42,7 @@ type TestRunFilter struct {
 func (filter TestRunFilter) IsDefaultQuery() bool {
 	return IsLatest(filter.SHA) &&
 		(filter.Labels == nil || filter.Labels.Cardinality() < 1) &&
-		(filter.Complete == nil || *filter.Complete) &&
+		(filter.Complete == nil) &&
 		(filter.From == nil) &&
 		(filter.MaxCount == nil || *filter.MaxCount == 1) &&
 		(len(filter.Products) < 1)

--- a/webdriver/search_test.go
+++ b/webdriver/search_test.go
@@ -52,8 +52,8 @@ func testSearch(t *testing.T, wd selenium.WebDriver, app AppServer, path string,
 	if err != nil {
 		panic(err)
 	}
-	const query = "2dcontext" + selenium.EnterKey
-	if err := searchBox.SendKeys(query); err != nil {
+	const query = "2dcontext"
+	if err := searchBox.SendKeys(query + selenium.EnterKey); err != nil {
 		panic(err)
 	}
 	filteredPathPartsCondition := func(wd selenium.WebDriver) (bool, error) {


### PR DESCRIPTION
## Description
Handles ?complete=true (in the `/api/interop` endpoint), by consolidating the handling of params when querying for any non-default `interop` request.

## Review Information
- See [auto-deployed enviroment](https://complete-interop-dot-wptdashboard-staging.appspot.com/)
- Visit various param combos, e.g.
  - https://complete-interop-dot-wptdashboard-staging.appspot.com/api/interop/?complete=true
  - https://complete-interop-dot-wptdashboard-staging.appspot.com/api/interop/?complete=true&label=experimental
  - https://complete-interop-dot-wptdashboard-staging.appspot.com/api/interop/?complete=false&label=stable
