### PR TITLE
Refactor the way 'complete' is implemented

### DIFF
--- a/api/shas.go
+++ b/api/shas.go
@@ -5,15 +5,12 @@
 package api
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
-	"time"
 
 	mapset "github.com/deckarep/golang-set"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 	"google.golang.org/appengine"
-	"google.golang.org/appengine/datastore"
 )
 
 // apiSHAsHandler is responsible for emitting just the revision SHAs for test runs.
@@ -28,7 +25,7 @@ func apiSHAsHandler(w http.ResponseWriter, r *http.Request) {
 
 	var shas []string
 	if filters.Complete != nil && *filters.Complete {
-		if shas, err = getCompleteRunSHAs(ctx, filters.From, filters.To, filters.MaxCount); err != nil {
+		if shas, err = shared.GetCompleteRunSHAs(ctx, filters.From, filters.To, filters.MaxCount); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
@@ -55,52 +52,4 @@ func apiSHAsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Write(shasBytes)
-}
-
-// getCompleteRunSHAs returns an array of the SHA[0:10] for runs that
-// exists for all initially-loaded browser names (see GetDefaultBrowserNames),
-// ordered by most-recent.
-func getCompleteRunSHAs(ctx context.Context, from, to *time.Time, limit *int) (shas []string, err error) {
-	query := datastore.
-		NewQuery("TestRun").
-		Order("-TimeStart").
-		Project("Revision", "BrowserName")
-
-	browserNames := shared.GetDefaultBrowserNames()
-
-	if from != nil {
-		query = query.Filter("TimeStart >=", *from)
-	}
-	if to != nil {
-		query = query.Filter("TimeStart <", *to)
-	}
-
-	bySHA := make(map[string]mapset.Set)
-	done := mapset.NewSet()
-	it := query.Run(ctx)
-	for {
-		var testRun shared.TestRun
-		_, err := it.Next(&testRun)
-		if err == datastore.Done {
-			break
-		} else if err != nil {
-			return nil, err
-		} else if !shared.IsStableBrowserName(testRun.BrowserName) {
-			continue
-		}
-		set, ok := bySHA[testRun.Revision]
-		if !ok {
-			bySHA[testRun.Revision] = mapset.NewSetWith(testRun.BrowserName)
-		} else {
-			set.Add(testRun.BrowserName)
-			if set.Cardinality() == len(browserNames) && !done.Contains(testRun.Revision) {
-				done.Add(testRun.Revision)
-				shas = append(shas, testRun.Revision)
-				if limit != nil && len(shas) >= *limit {
-					return shas, nil
-				}
-			}
-		}
-	}
-	return shas, err
 }

--- a/api/shas_medium_test.go
+++ b/api/shas_medium_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/web-platform-tests/wpt.fyi/shared"
@@ -16,83 +15,6 @@ import (
 	"google.golang.org/appengine"
 	"google.golang.org/appengine/datastore"
 )
-
-func TestGetCompleteRunSHAs(t *testing.T) {
-	ctx, done, err := sharedtest.NewAEContext(true)
-	assert.Nil(t, err)
-	defer done()
-
-	browserNames := shared.GetDefaultBrowserNames()
-
-	// Nothing in datastore.
-	shas, _ := getCompleteRunSHAs(ctx, nil, nil, nil)
-	assert.Equal(t, 0, len(shas))
-
-	// Only 3 browsers.
-	run := shared.TestRun{
-		ProductAtRevision: shared.ProductAtRevision{
-			Revision: "abcdef0000",
-		},
-		TimeStart: time.Now().AddDate(0, 0, -1),
-	}
-	for _, browser := range browserNames[:len(browserNames)-1] {
-		run.BrowserName = browser
-		datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
-	}
-	shas, _ = getCompleteRunSHAs(ctx, nil, nil, nil)
-	assert.Equal(t, 0, len(shas))
-
-	// All 4 browsers, but experimental.
-	run.Revision = "abcdef0111"
-	run.TimeStart = time.Now().AddDate(0, 0, -2)
-	for _, browser := range browserNames {
-		run.BrowserName = browser + "-" + shared.ExperimentalLabel
-		datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
-	}
-	shas, _ = getCompleteRunSHAs(ctx, nil, nil, nil)
-	assert.Equal(t, 0, len(shas))
-
-	// 2 browsers, and other 2, but experimental.
-	run.Revision = "abcdef0222"
-	run.TimeStart = time.Now().AddDate(0, 0, -3)
-	for i, browser := range browserNames {
-		run.BrowserName = browser
-		if i > 1 {
-			run.BrowserName += "-" + shared.ExperimentalLabel
-		}
-		datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
-	}
-	shas, _ = getCompleteRunSHAs(ctx, nil, nil, nil)
-	assert.Equal(t, 0, len(shas))
-
-	// All 4 browsers.
-	run.Revision = "abcdef0123"
-	run.TimeStart = time.Now().AddDate(0, 0, -4)
-	for _, browser := range browserNames {
-		run.BrowserName = browser
-		datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
-	}
-	shas, _ = getCompleteRunSHAs(ctx, nil, nil, nil)
-	assert.Equal(t, []string{"abcdef0123"}, shas)
-
-	// Another (earlier) run, also all 4 browsers.
-	run.Revision = "abcdef9999"
-	run.TimeStart = time.Now().AddDate(0, 0, -5)
-	for _, browser := range browserNames {
-		run.BrowserName = browser
-		datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
-	}
-	shas, _ = getCompleteRunSHAs(ctx, nil, nil, nil)
-	assert.Equal(t, []string{"abcdef0123", "abcdef9999"}, shas)
-	// Limit 1
-	one := 1
-	shas, _ = getCompleteRunSHAs(ctx, nil, nil, &one)
-	assert.Equal(t, []string{"abcdef0123"}, shas)
-	// From 4 days ago @ midnight.
-	from := time.Now().AddDate(0, 0, -4).Truncate(24 * time.Hour)
-	shas, _ = getCompleteRunSHAs(ctx, &from, nil, nil)
-	assert.Equal(t, []string{"abcdef0123"}, shas)
-}
 
 func TestApiSHAsHandler(t *testing.T) {
 	i, err := sharedtest.NewAEInstance(true)

--- a/api/test_runs.go
+++ b/api/test_runs.go
@@ -38,7 +38,7 @@ func apiTestRunsHandler(w http.ResponseWriter, r *http.Request) {
 		shas = []string{filters.SHA}
 	} else if filters.Complete != nil && *filters.Complete {
 		if shared.IsLatest(filters.SHA) {
-			shas, err = getCompleteRunSHAs(ctx, from, filters.To, limit)
+			shas, err = shared.GetCompleteRunSHAs(ctx, from, filters.To, limit)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return

--- a/shared/datastore.go
+++ b/shared/datastore.go
@@ -146,3 +146,61 @@ func VersionPrefix(query *datastore.Query, fieldName, versionPrefix string, desc
 		Filter(fieldName+" >=", fmt.Sprintf("%s.", versionPrefix)).
 		Filter(fieldName+" <=", fmt.Sprintf("%s.%c", versionPrefix, '9'+1))
 }
+
+// GetCompleteRunSHAs returns an array of the SHA[0:10] for runs that
+// exists for all initially-loaded browser names (see GetDefaultBrowserNames),
+// ordered by most-recent.
+func GetCompleteRunSHAs(ctx context.Context, from, to *time.Time, limit *int) (shas []string, err error) {
+	query := datastore.
+		NewQuery("TestRun").
+		Order("-TimeStart").
+		Project("Revision", "BrowserName")
+
+	// TODO(lukebjerring): Pass in products.
+	products := GetDefaultProducts()
+
+	if from != nil {
+		query = query.Filter("TimeStart >=", *from)
+	}
+	if to != nil {
+		query = query.Filter("TimeStart <", *to)
+	}
+
+	bySHA := make(map[string]mapset.Set)
+	done := mapset.NewSet()
+	it := query.Run(ctx)
+	for {
+		var testRun TestRun
+		var matchingProduct *ProductSpec
+		_, err := it.Next(&testRun)
+		if err == datastore.Done {
+			break
+		} else if err != nil {
+			return nil, err
+		} else {
+			for _, product := range products {
+				if product.Matches(testRun) {
+					matchingProduct = &product
+					break
+				}
+			}
+		}
+		if matchingProduct == nil {
+			continue
+		}
+		set, ok := bySHA[testRun.Revision]
+		if !ok {
+			bySHA[testRun.Revision] = mapset.NewSetWith(testRun.BrowserName)
+		} else {
+			set.Add(testRun.BrowserName)
+			if set.Cardinality() == len(products) && !done.Contains(testRun.Revision) {
+				done.Add(testRun.Revision)
+				shas = append(shas, testRun.Revision)
+				if limit != nil && len(shas) >= *limit {
+					return shas, nil
+				}
+			}
+		}
+	}
+	return shas, err
+}

--- a/shared/datastore.go
+++ b/shared/datastore.go
@@ -189,9 +189,9 @@ func GetCompleteRunSHAs(ctx context.Context, from, to *time.Time, limit *int) (s
 		}
 		set, ok := bySHA[testRun.Revision]
 		if !ok {
-			bySHA[testRun.Revision] = mapset.NewSetWith(*matchingProduct)
+			bySHA[testRun.Revision] = mapset.NewSetWith(matchingProduct)
 		} else {
-			set.Add(*matchingProduct)
+			set.Add(matchingProduct)
 			if set.Cardinality() == len(products) && !done.Contains(testRun.Revision) {
 				done.Add(testRun.Revision)
 				shas = append(shas, testRun.Revision)

--- a/shared/datastore.go
+++ b/shared/datastore.go
@@ -153,8 +153,7 @@ func VersionPrefix(query *datastore.Query, fieldName, versionPrefix string, desc
 func GetCompleteRunSHAs(ctx context.Context, from, to *time.Time, limit *int) (shas []string, err error) {
 	query := datastore.
 		NewQuery("TestRun").
-		Order("-TimeStart").
-		Project("Revision", "BrowserName")
+		Order("-TimeStart")
 
 	// TODO(lukebjerring): Pass in products.
 	products := GetDefaultProducts()
@@ -190,9 +189,9 @@ func GetCompleteRunSHAs(ctx context.Context, from, to *time.Time, limit *int) (s
 		}
 		set, ok := bySHA[testRun.Revision]
 		if !ok {
-			bySHA[testRun.Revision] = mapset.NewSetWith(testRun.BrowserName)
+			bySHA[testRun.Revision] = mapset.NewSetWith(*matchingProduct)
 		} else {
-			set.Add(testRun.BrowserName)
+			set.Add(*matchingProduct)
 			if set.Cardinality() == len(products) && !done.Contains(testRun.Revision) {
 				done.Add(testRun.Revision)
 				shas = append(shas, testRun.Revision)

--- a/shared/models.go
+++ b/shared/models.go
@@ -99,7 +99,7 @@ type TestRun struct {
 // LabelsSet creates a set from the run's labels.
 func (run TestRun) LabelsSet() mapset.Set {
 	runLabels := mapset.NewSet()
-	for label := range run.Labels {
+	for _, label := range run.Labels {
 		runLabels.Add(label)
 	}
 	return runLabels

--- a/shared/models.go
+++ b/shared/models.go
@@ -96,6 +96,15 @@ type TestRun struct {
 	Labels []string `json:"labels"`
 }
 
+// LabelsSet creates a set from the run's labels.
+func (run TestRun) LabelsSet() mapset.Set {
+	runLabels := mapset.NewSet()
+	for label := range run.Labels {
+		runLabels.Add(label)
+	}
+	return runLabels
+}
+
 // TestRuns is a helper type for an array of TestRun entities.
 type TestRuns []TestRun
 

--- a/shared/params.go
+++ b/shared/params.go
@@ -83,7 +83,7 @@ func (p ProductSpec) Matches(run TestRun) bool {
 	}
 	if p.Labels != nil && p.Labels.Cardinality() > 0 {
 		runLabels := run.LabelsSet()
-		if runLabels.Intersect(p.Labels).Cardinality() < p.Labels.Cardinality() {
+		if !p.Labels.IsSubset(runLabels) {
 			return false
 		}
 	}

--- a/shared/params.go
+++ b/shared/params.go
@@ -89,7 +89,7 @@ func (p ProductSpec) Matches(run TestRun) bool {
 	}
 	if p.BrowserVersion != "" {
 		// Make "6" not match "60.123" by adding trailing dots to both.
-		if strings.Index(run.BrowserVersion+".", p.BrowserVersion+".") != 0 {
+		if !strings.HasPrefix(run.BrowserVersion+".", p.BrowserVersion+".") {
 			return false
 		}
 	}

--- a/shared/params.go
+++ b/shared/params.go
@@ -74,22 +74,22 @@ type ProductSpec struct {
 }
 
 // Matches returns whether the spec matches the given run.
-func (productSpec ProductSpec) Matches(run TestRun) bool {
-	if run.BrowserName != productSpec.BrowserName {
+func (p ProductSpec) Matches(run TestRun) bool {
+	if run.BrowserName != p.BrowserName {
 		return false
 	}
-	if !IsLatest(productSpec.Revision) && productSpec.Revision != run.Revision {
+	if !IsLatest(p.Revision) && p.Revision != run.Revision {
 		return false
 	}
-	if productSpec.Labels != nil && productSpec.Labels.Cardinality() > 0 {
+	if p.Labels != nil && p.Labels.Cardinality() > 0 {
 		runLabels := run.LabelsSet()
-		if runLabels.Intersect(productSpec.Labels).Cardinality() < productSpec.Labels.Cardinality() {
+		if runLabels.Intersect(p.Labels).Cardinality() < p.Labels.Cardinality() {
 			return false
 		}
 	}
-	if productSpec.BrowserVersion != "" {
+	if p.BrowserVersion != "" {
 		// Make "6" not match "60.123" by adding trailing dots to both.
-		if strings.Index(run.BrowserVersion+".", productSpec.BrowserVersion+".") != 0 {
+		if strings.Index(run.BrowserVersion+".", p.BrowserVersion+".") != 0 {
 			return false
 		}
 	}

--- a/shared/params.go
+++ b/shared/params.go
@@ -73,6 +73,29 @@ type ProductSpec struct {
 	Labels mapset.Set
 }
 
+// Matches returns whether the spec matches the given run.
+func (productSpec ProductSpec) Matches(run TestRun) bool {
+	if run.BrowserName != productSpec.BrowserName {
+		return false
+	}
+	if !IsLatest(productSpec.Revision) && productSpec.Revision != run.Revision {
+		return false
+	}
+	if productSpec.Labels != nil && productSpec.Labels.Cardinality() > 0 {
+		runLabels := run.LabelsSet()
+		if runLabels.Intersect(productSpec.Labels).Cardinality() < productSpec.Labels.Cardinality() {
+			return false
+		}
+	}
+	if productSpec.BrowserVersion != "" {
+		// Make "6" not match "60.123" by adding trailing dots to both.
+		if strings.Index(run.BrowserVersion+".", productSpec.BrowserVersion+".") != 0 {
+			return false
+		}
+	}
+	return true
+}
+
 // ProductSpecs is a helper type for a slice of ProductSpec structs.
 type ProductSpecs []ProductSpec
 

--- a/shared/params_test.go
+++ b/shared/params_test.go
@@ -490,3 +490,22 @@ func TestParseTestRunFilterParams(t *testing.T) {
 	assert.Equal(t, "complete=true&from=2018-01-01T00%3A00%3A00Z", filter.ToQuery(true).Encode())
 	assert.Equal(t, "from=2018-01-01T00%3A00%3A00Z", filter.ToQuery(false).Encode())
 }
+
+func TestProductSpecMatches(t *testing.T) {
+	chrome, err := ParseProductSpec("chrome")
+	assert.Nil(t, err)
+
+	chromeRun := TestRun{}
+	chromeRun.BrowserName = "chrome"
+	chromeRun.BrowserVersion = "63.123"
+	assert.True(t, chrome.Matches(chromeRun))
+
+	chrome6, err := ParseProductSpec("chrome-6")
+	assert.False(t, chrome6.Matches(chromeRun))
+	chrome63, err := ParseProductSpec("chrome-63")
+	assert.True(t, chrome63.Matches(chromeRun))
+
+	safariRun := TestRun{}
+	safariRun.BrowserName = "safari"
+	assert.False(t, chrome.Matches(safariRun))
+}

--- a/shared/params_test.go
+++ b/shared/params_test.go
@@ -7,6 +7,7 @@
 package shared
 
 import (
+	"fmt"
 	"net/http/httptest"
 	"testing"
 
@@ -516,7 +517,24 @@ func TestProductSpecMatches_Labels(t *testing.T) {
 
 	chromeRun := TestRun{}
 	chromeRun.BrowserName = "chrome"
-	// assert.False(t, chrome.Matches(chromeRun))
+	assert.False(t, chrome.Matches(chromeRun))
 	chromeRun.Labels = []string{"bar", "foo"}
+	assert.True(t, chrome.Matches(chromeRun))
+}
+
+func TestProductSpecMatches_Revision(t *testing.T) {
+	revision := "abcdef0123"
+	version := "69.1.1.1"
+	chrome, err := ParseProductSpec(fmt.Sprintf("chrome-%s@%s", version, revision))
+	assert.Nil(t, err)
+
+	chromeRun := TestRun{}
+	chromeRun.BrowserName = "chrome"
+	chromeRun.BrowserVersion = "69.1.1.0"
+	chromeRun.Revision = "1234567890"
+	assert.False(t, chrome.Matches(chromeRun))
+	chromeRun.Revision = revision
+	assert.False(t, chrome.Matches(chromeRun)) // Still wrong version
+	chromeRun.BrowserVersion = version
 	assert.True(t, chrome.Matches(chromeRun))
 }

--- a/shared/params_test.go
+++ b/shared/params_test.go
@@ -509,3 +509,14 @@ func TestProductSpecMatches(t *testing.T) {
 	safariRun.BrowserName = "safari"
 	assert.False(t, chrome.Matches(safariRun))
 }
+
+func TestProductSpecMatches_Labels(t *testing.T) {
+	chrome, err := ParseProductSpec("chrome[foo]")
+	assert.Nil(t, err)
+
+	chromeRun := TestRun{}
+	chromeRun.BrowserName = "chrome"
+	// assert.False(t, chrome.Matches(chromeRun))
+	chromeRun.Labels = []string{"bar", "foo"}
+	assert.True(t, chrome.Matches(chromeRun))
+}


### PR DESCRIPTION
## Description
Migrates the `getCompleteSHAs` code to the shared codebase, and re-jigs it a bit, such that we grab the default products set, and find (any) product that matches the run. Since the default product specs are versionless, this is a no-op, intended to be followed up with actual changes in another PR.

## Review Information
In particular, review the code for `ProductSpec.Matches(TestRun)`