### PR TITLE
Handle empty api/shas result as 404 empty array.

### DIFF
--- a/api/shas.go
+++ b/api/shas.go
@@ -48,6 +48,12 @@ func apiSHAsHandler(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
+	if len(shas) < 1 {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte("[]"))
+		return
+	}
+
 	shasBytes, err := json.Marshal(shas)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
## Description
Current issue, e.g. https://staging.wpt.fyi/api/shas?label=foo is not 404ing and has `null` as the output.