### PR TITLE
Allow custom products when computing `complete`

### DIFF
--- a/api/shas.go
+++ b/api/shas.go
@@ -24,13 +24,13 @@ func apiSHAsHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := appengine.NewContext(r)
 
 	var shas []string
+	products := filters.GetProductsOrDefault()
 	if filters.Complete != nil && *filters.Complete {
-		if shas, err = shared.GetCompleteRunSHAs(ctx, filters.From, filters.To, filters.MaxCount); err != nil {
+		if shas, err = shared.GetCompleteRunSHAs(ctx, products, filters.Labels, filters.From, filters.To, filters.MaxCount); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 	} else {
-		products := filters.GetProductsOrDefault()
 		testRuns, err := shared.LoadTestRuns(ctx, products, filters.Labels, nil, filters.From, filters.To, filters.MaxCount)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -56,6 +56,5 @@ func apiSHAsHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-
 	w.Write(shasBytes)
 }

--- a/api/test_runs.go
+++ b/api/test_runs.go
@@ -30,6 +30,7 @@ func apiTestRunsHandler(w http.ResponseWriter, r *http.Request) {
 		one := 1
 		limit = &one
 	}
+	products := filters.GetProductsOrDefault()
 
 	ctx := appengine.NewContext(r)
 	// When ?complete=true, make sure to show results for the same complete run (executed for all browsers).
@@ -38,7 +39,7 @@ func apiTestRunsHandler(w http.ResponseWriter, r *http.Request) {
 		shas = []string{filters.SHA}
 	} else if filters.Complete != nil && *filters.Complete {
 		if shared.IsLatest(filters.SHA) {
-			shas, err = shared.GetCompleteRunSHAs(ctx, from, filters.To, limit)
+			shas, err = shared.GetCompleteRunSHAs(ctx, products, filters.Labels, from, filters.To, limit)
 			if err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
@@ -51,7 +52,6 @@ func apiTestRunsHandler(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
-	products := filters.GetProductsOrDefault()
 	testRuns, err := shared.LoadTestRuns(ctx, products, filters.Labels, shas, from, filters.To, limit)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/shared/datastore.go
+++ b/shared/datastore.go
@@ -148,8 +148,7 @@ func VersionPrefix(query *datastore.Query, fieldName, versionPrefix string, desc
 }
 
 // GetCompleteRunSHAs returns an array of the SHA[0:10] for runs that
-// exists for all initially-loaded browser names (see GetDefaultBrowserNames),
-// ordered by most-recent.
+// exists for all the given products, ordered by most-recent.
 func GetCompleteRunSHAs(
 	ctx context.Context,
 	products ProductSpecs,

--- a/shared/datastore_medium_test.go
+++ b/shared/datastore_medium_test.go
@@ -357,7 +357,7 @@ func TestGetCompleteRunSHAs(t *testing.T) {
 	browserNames := GetDefaultBrowserNames()
 
 	// Nothing in datastore.
-	shas, _ := GetCompleteRunSHAs(ctx, nil, nil, nil)
+	shas, _ := GetCompleteRunSHAs(ctx, GetDefaultProducts(), nil, nil, nil, nil)
 	assert.Equal(t, 0, len(shas))
 
 	// Only 3 browsers.
@@ -365,14 +365,30 @@ func TestGetCompleteRunSHAs(t *testing.T) {
 		ProductAtRevision: ProductAtRevision{
 			Revision: "abcdef0000",
 		},
+		Labels:    []string{"foo"},
 		TimeStart: time.Now().AddDate(0, 0, -1),
 	}
 	for _, browser := range browserNames[:len(browserNames)-1] {
 		run.BrowserName = browser
 		datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
 	}
-	shas, _ = GetCompleteRunSHAs(ctx, nil, nil, nil)
-	assert.Equal(t, 0, len(shas))
+	shas, _ = GetCompleteRunSHAs(ctx, GetDefaultProducts(), nil, nil, nil, nil)
+	assert.Len(t, shas, 0)
+
+	// But, if request by any subset of those 3 browsers, we find the SHA.
+	var products ProductSpecs
+	for _, browser := range browserNames[:len(browserNames)-1] {
+		product := ProductSpec{}
+		product.BrowserName = browser
+		products = append(products, product)
+		shas, _ = GetCompleteRunSHAs(ctx, products, nil, nil, nil, nil)
+		assert.Len(t, shas, 1)
+	}
+	// And labels
+	shas, _ = GetCompleteRunSHAs(ctx, products, mapset.NewSetWith("foo"), nil, nil, nil)
+	assert.Len(t, shas, 1)
+	shas, _ = GetCompleteRunSHAs(ctx, products, mapset.NewSetWith("bar"), nil, nil, nil)
+	assert.Len(t, shas, 0)
 
 	// All 4 browsers, but experimental.
 	run.Revision = "abcdef0111"
@@ -381,7 +397,7 @@ func TestGetCompleteRunSHAs(t *testing.T) {
 		run.BrowserName = browser + "-" + ExperimentalLabel
 		datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
 	}
-	shas, _ = GetCompleteRunSHAs(ctx, nil, nil, nil)
+	shas, _ = GetCompleteRunSHAs(ctx, GetDefaultProducts(), nil, nil, nil, nil)
 	assert.Equal(t, 0, len(shas))
 
 	// 2 browsers, and other 2, but experimental.
@@ -394,7 +410,7 @@ func TestGetCompleteRunSHAs(t *testing.T) {
 		}
 		datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
 	}
-	shas, _ = GetCompleteRunSHAs(ctx, nil, nil, nil)
+	shas, _ = GetCompleteRunSHAs(ctx, GetDefaultProducts(), nil, nil, nil, nil)
 	assert.Equal(t, 0, len(shas))
 
 	// All 4 browsers.
@@ -404,7 +420,7 @@ func TestGetCompleteRunSHAs(t *testing.T) {
 		run.BrowserName = browser
 		datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
 	}
-	shas, _ = GetCompleteRunSHAs(ctx, nil, nil, nil)
+	shas, _ = GetCompleteRunSHAs(ctx, GetDefaultProducts(), nil, nil, nil, nil)
 	assert.Equal(t, []string{"abcdef0123"}, shas)
 
 	// Another (earlier) run, also all 4 browsers.
@@ -414,14 +430,14 @@ func TestGetCompleteRunSHAs(t *testing.T) {
 		run.BrowserName = browser
 		datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
 	}
-	shas, _ = GetCompleteRunSHAs(ctx, nil, nil, nil)
+	shas, _ = GetCompleteRunSHAs(ctx, GetDefaultProducts(), nil, nil, nil, nil)
 	assert.Equal(t, []string{"abcdef0123", "abcdef9999"}, shas)
 	// Limit 1
 	one := 1
-	shas, _ = GetCompleteRunSHAs(ctx, nil, nil, &one)
+	shas, _ = GetCompleteRunSHAs(ctx, GetDefaultProducts(), nil, nil, nil, &one)
 	assert.Equal(t, []string{"abcdef0123"}, shas)
 	// From 4 days ago @ midnight.
 	from := time.Now().AddDate(0, 0, -4).Truncate(24 * time.Hour)
-	shas, _ = GetCompleteRunSHAs(ctx, &from, nil, nil)
+	shas, _ = GetCompleteRunSHAs(ctx, GetDefaultProducts(), nil, &from, nil, nil)
 	assert.Equal(t, []string{"abcdef0123"}, shas)
 }


### PR DESCRIPTION
## Description
Builds on #489 to actually "fix" the behaviour of combining `labels` + `complete` when getting SHAs.

We're currently just ignoring labels when we get a list of complete SHAs, which may mean that if we limit the number to 1, we get a SHA that isn't complete for those labels.

e.g.
- https://staging.wpt.fyi/api/shas?label=stable&complete&max-count=1 (currently says `["6a9c5cbeae"]`)
- https://staging.wpt.fyi/test-runs?labels=stable (shows the most recent complete is `d2fa1bdc90`)

This fixes the issue, e.g. 
https://complete-from-products-dot-wptdashboard-staging.appspot.com/api/shas?label=stable&complete&max-count=1 now shows `d2fa1bdc90`

Also supports the corrected meaning of `complete` to be product combos, e.g.
https://complete-from-products-dot-wptdashboard-staging.appspot.com/api/shas?label=experimental&products=chrome,firefox&complete