### PR TITLE
File-level view data mirrors view structure

### DIFF
--- a/webapp/components/abstract-test-file-results-table.html
+++ b/webapp/components/abstract-test-file-results-table.html
@@ -10,39 +10,22 @@ found in the LICENSE file.
     const AbstractTestFileResultsTable = superClass => class extends superClass {
       static get properties() {
         return {
-          subtestNames: {
+          resultsTable: {
             type: Array,
             value: [],
-          },
-          hasSubtests: {
-            type: Boolean,
           },
         };
       }
 
-      subtestNameForDisplay(subtestName, hasSubtests) {
-        if (subtestName !== 'STATUS') {
-          return subtestName;
+      subtestMessage(result) {
+        if (result.status === 'OK' || result.status === 'PASS' ||
+          result.status === 'TIMEOUT') {
+          return result.status;
         }
-        return hasSubtests ? 'Harness status' : 'Test status';
-      }
-
-      subtestResultForTestRun(testRun, subtestName) {
-        if (!testRun) {
-          return null;
+        if (!result.status) {
+          return 'MISSING';
         }
-        if (!testRun.subtests) {
-          return null;
-        }
-        if (!testRun.subtests[subtestName]) {
-          return null;
-        }
-        return testRun.subtests[subtestName].status;
-      }
-
-      // eslint-disable-next-line no-unused-vars
-      subtestMessageForTestRun(testRun, subtestName) {
-        return 'NOT IMPLEMENTED';
+        return '';
       }
 
       computeSubtestThWidth(testRuns) {

--- a/webapp/components/abstract-test-file-results-table.html
+++ b/webapp/components/abstract-test-file-results-table.html
@@ -10,6 +10,10 @@ found in the LICENSE file.
     const AbstractTestFileResultsTable = superClass => class extends superClass {
       static get properties() {
         return {
+          statusesAsMessage: {
+            type: Array,
+            value: ['OK', 'PASS', 'TIMEOUT'],
+          },
           resultsTable: {
             type: Array,
             value: [],
@@ -18,8 +22,7 @@ found in the LICENSE file.
       }
 
       subtestMessage(result) {
-        if (result.status === 'OK' || result.status === 'PASS' ||
-          result.status === 'TIMEOUT') {
+        if (this.statusesAsMessage.includes(result.status)) {
           return result.status;
         }
         if (!result.status) {

--- a/webapp/components/test-file-results-table-terse.html
+++ b/webapp/components/test-file-results-table-terse.html
@@ -64,13 +64,13 @@ found in the LICENSE file.
         </tr>
       </thead>
       <tbody>
-        <template is="dom-repeat" items="[[subtestNames]]" as="subtestName">
+        <template is="dom-repeat" items="[[resultsTable]]" as="row">
           <tr>
-            <td class="sub-test-name"><code>[[ subtestNameForDisplay(subtestName, hasSubtests) ]]</code></td>
+            <td class="sub-test-name"><code>[[ row.name ]]</code></td>
 
-            <template is="dom-repeat" items="{{testRuns}}" as="testRun">
-              <td class$="result [[ subtestResultForTestRun(testRun, subtestName) ]]">
-                <code>[[ subtestMessageForTestRun(testRun, subtestName) ]]</code>
+            <template is="dom-repeat" items="{{row.results}}" as="result">
+              <td class$="result [[ result.status ]]">
+                <code>[[ subtestMessage(result) ]]</code>
               </td>
             </template>
           </tr>
@@ -137,26 +137,14 @@ found in the LICENSE file.
         };
       }
 
-      subtestMessageForTestRun(testRun, subtestName) {
-        if (!testRun) {
-          return null;
+      subtestMessage(result) {
+        if (result.status === 'OK' || result.status === 'PASS') {
+          return result.status;
         }
-        if (!testRun.subtests) {
-          return null;
+        if (!result.message) {
+          return '';
         }
-        if (!testRun.subtests[subtestName]) {
-          return null;
-        }
-        if (testRun.subtests[subtestName].status === 'OK') {
-          return 'OK';
-        }
-        if (testRun.subtests[subtestName].status === 'PASS') {
-          return 'PASS';
-        }
-        if (testRun.subtests[subtestName].message) {
-          return this.parseFailureMessage(testRun.subtests[subtestName].message);
-        }
-        return testRun.subtests[subtestName].status;
+        return this.parseFailureMessage(result.message);
       }
 
       parseFailureMessage(msg) {

--- a/webapp/components/test-file-results-table-terse.html
+++ b/webapp/components/test-file-results-table-terse.html
@@ -138,13 +138,8 @@ found in the LICENSE file.
       }
 
       subtestMessage(result) {
-        if (result.status === 'OK' || result.status === 'PASS') {
-          return result.status;
-        }
-        if (!result.message) {
-          return '';
-        }
-        return this.parseFailureMessage(result.message);
+        return super.subtestMessage(result) ||
+          this.parseFailureMessage(result.message);
       }
 
       parseFailureMessage(msg) {

--- a/webapp/components/test-file-results-table-verbose.html
+++ b/webapp/components/test-file-results-table-verbose.html
@@ -47,13 +47,13 @@ found in the LICENSE file.
         </tr>
       </thead>
       <tbody>
-        <template is="dom-repeat" items="[[subtestNames]]" as="subtestName">
+        <template is="dom-repeat" items="[[resultsTable]]" as="row">
           <tr>
-            <td class="sub-test-name"><code>[[ subtestNameForDisplay(subtestName, hasSubtests) ]]</code></td>
+            <td class="sub-test-name"><code>[[ row.name ]]</code></td>
 
-            <template is="dom-repeat" items="{{testRuns}}" as="testRun">
-              <td class$="result [[ subtestResultForTestRun(testRun, subtestName) ]]">
-                <code>[[ subtestMessageForTestRun(testRun, subtestName) ]]</code>
+            <template is="dom-repeat" items="{{row.results}}" as="result">
+              <td class$="result [[ result.status ]]">
+                <code>[[ subtestMessage(result) ]]</code>
               </td>
             </template>
           </tr>
@@ -69,26 +69,14 @@ found in the LICENSE file.
         return 'test-file-results-table-verbose';
       }
 
-      subtestMessageForTestRun(testRun, subtestName) {
-        if (!testRun) {
-          return null;
+      subtestMessage(result) {
+        if (result.status === 'OK' || result.status === 'PASS') {
+          return result.status;
         }
-        if (!testRun.subtests) {
-          return null;
+        if (!result.message) {
+          return '';
         }
-        if (!testRun.subtests[subtestName]) {
-          return null;
-        }
-        if (testRun.subtests[subtestName].status === 'OK') {
-          return 'OK';
-        }
-        if (testRun.subtests[subtestName].status === 'PASS') {
-          return 'PASS';
-        }
-        if (testRun.subtests[subtestName].message) {
-          return `Failure message: ${testRun.subtests[subtestName].message}`;
-        }
-        return testRun.subtests[subtestName].status;
+        return `Failure message: ${result.message}`;
       }
     }
 

--- a/webapp/components/test-file-results-table-verbose.html
+++ b/webapp/components/test-file-results-table-verbose.html
@@ -70,13 +70,8 @@ found in the LICENSE file.
       }
 
       subtestMessage(result) {
-        if (result.status === 'OK' || result.status === 'PASS') {
-          return result.status;
-        }
-        if (!result.message) {
-          return '';
-        }
-        return `Failure message: ${result.message}`;
+        return super.subtestMessage(result)  ||
+          `Failure message: ${result.message}`;
       }
     }
 

--- a/webapp/components/test-file-results.html
+++ b/webapp/components/test-file-results.html
@@ -87,54 +87,49 @@ found in the LICENSE file.
       }
 
       async fetchTestFile(path, testRuns) {
-        this.subtestNames = []; // Clear any existing rows.
+        this.resultsTable = []; // Clear any existing rows.
         if (!path || !testRuns) {
           return;
         }
         const resultsPerTestRun = await Promise.all(
           testRuns.map(tr => this.loadResultFile(tr)));
 
-        // resultsTable[0].name set after discovering subtests. Use "" to
-        // remain first in resultsTable.sort() later.
+        // resultsTable[0].name set after discovering subtests.
         let resultsTable = [{
-          name: '',
           results: resultsPerTestRun.map(data => {
             return {status: data && data.status};
           }),
         }];
 
-        let subtestNamesSet = new Set();
-        resultsPerTestRun
-          .forEach(data => data && data.subtests && data.subtests
-            .forEach(sub => subtestNamesSet.add(sub.name)));
-        for (const subtestName of subtestNamesSet.values()) {
-          resultsTable.push({
-            name: subtestName,
-            results: resultsPerTestRun
-              .map(data => {
-                if (!(data && data.subtests)) {
-                  return {status: null, message: null};
-                }
-                const datum = data.subtests
-                  .find(sub => sub.name === subtestName);
-                if (!datum) {
-                  return {status: null, message: null};
-                }
-                return {status: datum.status, message: datum.message};
-              }),
-          });
+        // Setup test name order according to when they appear in run results.
+        let names = [];
+        for (const runResults of resultsPerTestRun) {
+          if (!(runResults && runResults.subtests)) {
+            continue;
+          }
+
+          for (const subResult of runResults.subtests) {
+            if (!names.includes(subResult.name)) {
+              names.push(subResult.name);
+            }
+          }
         }
 
-        // Sort before setting resultsTable[0].name.
-        resultsTable.sort((a, b) => {
-          if (a.name < b.name) {
-            return -1;
+        // Copy results into resultsTable.
+        for (const name of names) {
+          let results = [];
+          for (const runResults of resultsPerTestRun) {
+            const result = runResults.subtests.find(sub => sub.name === name);
+            results.push(result ? {
+              status: result.status,
+              message: result.message,
+            } : {status: null, message: null});
           }
-          if (a.name > b.name) {
-            return 1;
-          }
-          return 0;
-        });
+          resultsTable.push({
+            name,
+            results,
+          });
+        }
 
         // Set name for test-level status entry after subtests discovered.
         resultsTable[0].name = resultsTable.length > 1 ? 'Harness status' :

--- a/webapp/components/test-file-results.html
+++ b/webapp/components/test-file-results.html
@@ -97,20 +97,20 @@ found in the LICENSE file.
         // resultsTable[0].name set after discovering subtests.
         let resultsTable = [{
           results: resultsPerTestRun.map(data => {
-            return {status: data.status};
+            return {status: data && data.status};
           }),
         }];
 
         let subtestNamesSet = new Set();
         resultsPerTestRun
-          .forEach(data => data.subtests && data.subtests
+          .forEach(data => data && data.subtests && data.subtests
             .forEach(sub => subtestNamesSet.add(sub.name)));
         for (const subtestName of subtestNamesSet.values()) {
           resultsTable.push({
             name: subtestName,
             results: resultsPerTestRun
               .map(data => {
-                if (!data.subtests) {
+                if (!(data && data.subtests)) {
                   return {status: null, message: null};
                 }
                 const datum = data.subtests

--- a/webapp/components/test-file-results.html
+++ b/webapp/components/test-file-results.html
@@ -94,8 +94,10 @@ found in the LICENSE file.
         const resultsPerTestRun = await Promise.all(
           testRuns.map(tr => this.loadResultFile(tr)));
 
-        // resultsTable[0].name set after discovering subtests.
+        // resultsTable[0].name set after discovering subtests. Use "" to
+        // remain first in resultsTable.sort() later.
         let resultsTable = [{
+          name: '',
           results: resultsPerTestRun.map(data => {
             return {status: data && data.status};
           }),
@@ -122,6 +124,17 @@ found in the LICENSE file.
               }),
           });
         }
+
+        // Sort before setting resultsTable[0].name.
+        resultsTable.sort((a, b) => {
+          if (a.name < b.name) {
+            return -1;
+          }
+          if (a.name > b.name) {
+            return 1;
+          }
+          return 0;
+        });
 
         // Set name for test-level status entry after subtests discovered.
         resultsTable[0].name = resultsTable.length > 1 ? 'Harness status' :

--- a/webapp/components/test-file-results.html
+++ b/webapp/components/test-file-results.html
@@ -44,16 +44,14 @@ found in the LICENSE file.
     <template is="dom-if" if="{{!isVerbose}}">
       <test-file-results-table-terse
           test-runs="[[testRuns]]"
-          has-subtests="[[hasSubtests]]"
-          subtest-names="[[subtestNames]]">
+          results-table="[[resultsTable]]">
       </test-file-results-table-terse>
     </template>
 
     <template is="dom-if" if="{{isVerbose}}">
       <test-file-results-table-verbose
           test-runs="[[testRuns]]"
-          has-subtests="[[hasSubtests]]"
-          subtest-names="[[subtestNames]]">
+          results-table="[[resultsTable]]">
       </test-file-results-table-verbose>
     </template>
   </template>
@@ -67,13 +65,9 @@ found in the LICENSE file.
 
       static get properties() {
         return {
-          subtestNames: {
+          resultsTable: {
             type: Array,
             value: [],
-          },
-          hasSubtests: {
-            type: Boolean,
-            value: false,
           },
           isVerbose: {
             type: Boolean,
@@ -97,33 +91,43 @@ found in the LICENSE file.
         if (!path || !testRuns) {
           return;
         }
-        const resultPerTestRun = await Promise.all(
+        const resultsPerTestRun = await Promise.all(
           testRuns.map(tr => this.loadResultFile(tr)));
 
-        const subtestNames = ['STATUS'];
-        let hasSubtests = false;
-        resultPerTestRun.forEach((resultData, i) => {
-          if (!resultData) {
-            testRuns[i].subtests = {};
-            testRuns[i].subtests['STATUS'] = { status: '(results not found)' };
-            return;
-          }
-          testRuns[i].subtests = {};
-          testRuns[i].subtests['STATUS'] = { status: resultData.status };
-          if (resultData.subtests && resultData.subtests.length > 0) {
-            // Since we spoof the file-level status also as a "subtest", we
-            // store whether the test originally has subtests here.
-            hasSubtests = true;
-            for (let subtestResult of resultData.subtests) {
-              testRuns[i].subtests[subtestResult.name] = subtestResult;
-              if (!subtestNames.includes(subtestResult.name)) {
-                subtestNames.push(subtestResult.name);
-              }
-            }
-          }
-        });
-        this.hasSubtests = hasSubtests;
-        this.subtestNames = subtestNames;
+        // resultsTable[0].name set after discovering subtests.
+        let resultsTable = [{
+          results: resultsPerTestRun.map(data => {
+            return {status: data.status};
+          }),
+        }];
+
+        let subtestNamesSet = new Set();
+        resultsPerTestRun
+          .forEach(data => data.subtests && data.subtests
+            .forEach(sub => subtestNamesSet.add(sub.name)));
+        for (const subtestName of subtestNamesSet.values()) {
+          resultsTable.push({
+            name: subtestName,
+            results: resultsPerTestRun
+              .map(data => {
+                if (!data.subtests) {
+                  return {status: null, message: null};
+                }
+                const datum = data.subtests
+                  .find(sub => sub.name === subtestName);
+                if (!datum) {
+                  return {status: null, message: null};
+                }
+                return {status: datum.status, message: datum.message};
+              }),
+          });
+        }
+
+        // Set name for test-level status entry after subtests discovered.
+        resultsTable[0].name = resultsTable.length > 1 ? 'Harness status' :
+          'Test status';
+
+        this.resultsTable = resultsTable;
       }
 
       async loadResultFile(testRun) {

--- a/webapp/components/test-file-results.html
+++ b/webapp/components/test-file-results.html
@@ -119,6 +119,10 @@ found in the LICENSE file.
         for (const name of names) {
           let results = [];
           for (const runResults of resultsPerTestRun) {
+            if (!(runResults && runResults.subtests)) {
+              continue;
+            }
+
             const result = runResults.subtests.find(sub => sub.name === name);
             results.push(result ? {
               status: result.status,

--- a/webapp/components/test-file-results.html
+++ b/webapp/components/test-file-results.html
@@ -119,11 +119,8 @@ found in the LICENSE file.
         for (const name of names) {
           let results = [];
           for (const runResults of resultsPerTestRun) {
-            if (!(runResults && runResults.subtests)) {
-              continue;
-            }
-
-            const result = runResults.subtests.find(sub => sub.name === name);
+            const result = runResults && runResults.subtests &&
+              runResults.subtests.find(sub => sub.name === name);
             results.push(result ? {
               status: result.status,
               message: result.message,


### PR DESCRIPTION
Fixes #494.

Polymer was only updating table rows when their name column happened to change. This was a consequence of depending on `testRuns` and `subtestName`. In the case of the "Harness status" row, the `subtestName` didn't change and Polymer doesn't know that `testRuns[i].subtests.STATUS.*` changed, so so we observed #494.

This change replaces most of the `test-file-results*.html` properties with a `resultsTable` that contains an array of`{name, results: [{status, message}]` where the inner array is parallel to the `testRuns` array. This mirrors the structure of the views themselves and simplifies the binding logic, while also fixing #494.