### PR TITLE
Fix `complete` implementation

### DIFF
--- a/shared/datastore.go
+++ b/shared/datastore.go
@@ -177,9 +177,9 @@ func GetCompleteRunSHAs(ctx context.Context, from, to *time.Time, limit *int) (s
 		} else if err != nil {
 			return nil, err
 		} else {
-			for _, product := range products {
-				if product.Matches(testRun) {
-					matchingProduct = &product
+			for i := range products {
+				if products[i].Matches(testRun) {
+					matchingProduct = &products[i]
 					break
 				}
 			}

--- a/shared/datastore_medium_test.go
+++ b/shared/datastore_medium_test.go
@@ -397,6 +397,17 @@ func TestGetCompleteRunSHAs(t *testing.T) {
 	shas, _ = GetCompleteRunSHAs(ctx, nil, nil, nil)
 	assert.Equal(t, 0, len(shas))
 
+	// 2 browsers which are twice.
+	run.Revision = "abcdef0333"
+	run.TimeStart = time.Now().AddDate(0, 0, -3)
+	for _, browser := range browserNames[:2] {
+		run.BrowserName = browser
+		datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
+		datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
+	}
+	shas, _ = GetCompleteRunSHAs(ctx, nil, nil, nil)
+	assert.Equal(t, 0, len(shas))
+
 	// All 4 browsers.
 	run.Revision = "abcdef0123"
 	run.TimeStart = time.Now().AddDate(0, 0, -4)


### PR DESCRIPTION
## Description
Fixes the `complete` check for the case that we have 2 browsers twice.
This was a subtle bug from the use of a pointer for a local loop variable, instead of the pointer of the item in the array.