### PR TITLE
Propagate the `complete` param to client

### DIFF
--- a/webapp/components/test-runs.html
+++ b/webapp/components/test-runs.html
@@ -51,6 +51,7 @@ found in the LICENSE file.
           },
           maxCount: Number,
           sha: String,
+          complete: Boolean,
           isLatest: {
             type: Boolean,
             computed: 'computeIsLatest(sha)'
@@ -153,7 +154,7 @@ found in the LICENSE file.
 
         // Insist on complete runs iff there is no other parameter.
         // This is a temporary hack for https://github.com/web-platform-tests/wpt.fyi/issues/468
-        if (Object.keys(params).length === 0) {
+        if (this.complete || Object.keys(params).length === 0) {
           params.complete = true;
         }
 

--- a/webapp/templates/interoperability.html
+++ b/webapp/templates/interoperability.html
@@ -13,6 +13,7 @@
                    {{- if .Products}} products="{{ .Products }}"{{end}}
                    {{- if .SHA}} sha="{{ .SHA }}" {{end}}
                    {{- if .Labels}} labels="{{ .Labels }}"{{end}}
+                   {{- if .Complete}} complete{{end}}
                  {{- end}}></wpt-interop>
   </div>
 </div>

--- a/webapp/templates/results.html
+++ b/webapp/templates/results.html
@@ -13,6 +13,7 @@
           {{- if .Labels}} labels="{{ .Labels }}"{{end}}
           {{- if .MaxCount}} max-count="{{ .MaxCount }}"{{end}}
           {{- if .Diff}} diff{{end}}
+          {{- if .Complete}} complete{{end}}
         {{- end}}></wpt-results>
   </div>
 </div>

--- a/webapp/test_results_handler.go
+++ b/webapp/test_results_handler.go
@@ -20,6 +20,7 @@ type testRunUIFilter struct {
 	Products      string
 	Labels        string
 	SHA           string
+	Complete      bool
 	MaxCount      *int
 	BeforeSpec    *shared.ProductSpec
 	AfterSpec     *shared.ProductSpec
@@ -150,6 +151,7 @@ func parseTestRunUIFilter(r *http.Request) (filter testRunUIFilter, err error) {
 		filter.Products = string(data)
 	}
 	filter.MaxCount = testRunFilter.MaxCount
+	filter.Complete = testRunFilter.Complete != nil && *testRunFilter.Complete
 
 	diff, err := shared.ParseBooleanParam(r, "diff")
 	if err != nil {


### PR DESCRIPTION
## Description
Further work toward https://github.com/web-platform-tests/wpt.fyi/issues/468

Follow up from #488, making sure that `complete` appears in the outgoing query, even when other params are present, if it was originally present.

Existing issue demonstrated by https://staging.wpt.fyi/interop/?complete&label=stable

## Review Information
- Visit https://complete-client-dot-wptdashboard-staging.appspot.com/interop/?complete&label=stable
- Observe that the outgoing request contains `complete` (and the result is complete.)