### PR TITLE
Include URL params in href (especially path-part)

### DIFF
--- a/webapp/components/interop.html
+++ b/webapp/components/interop.html
@@ -121,9 +121,9 @@ found in the LICENSE file.
   <section class="search">
     <div class="path">
       <a href="/interop/" on-click="navigate">wpt</a>
-      <template is="dom-repeat" items="{{ splitPathIntoLinkedParts(path) }}" as="part">
+      <template is="dom-repeat" items="[[ splitPathIntoLinkedParts(path) ]]" as="part">
         <span class="path-separator">/</span>
-        <a href="/interop{{ part.path }}" on-click="navigate">{{ part.name }}</a>
+        <a href="/interop[[ part.path ]][[ query ]]" on-click="navigate">[[ part.name ]]</a>
       </template>
     </div>
 
@@ -180,7 +180,7 @@ found in the LICENSE file.
       <template is="dom-repeat" items="{{ displayedNodes }}" as="node">
         <tr>
           <td>
-            <path-part path="{{ node.path }}" is-dir="{{ !computePathIsATestFile(node.path) }}" prefix="/interop" navigate="{{ bindNavigate() }}"></path-part>
+            <path-part prefix="/interop" path="{{ node.path }}" query="{{ query }}" is-dir="{{ !computePathIsATestFile(node.path) }}" navigate="{{ bindNavigate() }}"></path-part>
           </td>
 
           <template is="dom-repeat" items="{{node.pass_rates}}" as="passRate" index-as="i">

--- a/webapp/components/interop.html
+++ b/webapp/components/interop.html
@@ -120,7 +120,7 @@ found in the LICENSE file.
 
   <section class="search">
     <div class="path">
-      <a href="/interop/" on-click="navigate">wpt</a>
+      <a href="/interop/[[ query ]]" on-click="navigate">wpt</a>
       <template is="dom-repeat" items="[[ splitPathIntoLinkedParts(path) ]]" as="part">
         <span class="path-separator">/</span>
         <a href="/interop[[ part.path ]][[ query ]]" on-click="navigate">[[ part.name ]]</a>

--- a/webapp/components/path-part.html
+++ b/webapp/components/path-part.html
@@ -43,6 +43,9 @@ found in the LICENSE file.
           path: {
             type: String
           },
+          query: {
+            type: String
+          },
           // Domain path-prefix, e.g. '/interop/'
           prefix: {
             type: String,
@@ -60,7 +63,7 @@ found in the LICENSE file.
           },
           href: {
             type: String,
-            computed: 'computeHref(prefix, path)'
+            computed: 'computeHref(prefix, path, query)'
           },
           styleClass: {
             type: String,
@@ -69,10 +72,10 @@ found in the LICENSE file.
         };
       }
 
-      computeHref(prefix, path) {
+      computeHref(prefix, path, query) {
         let parts = path.split('/');
         parts.push(encodeURIComponent(parts.pop()));
-        return `${prefix || ''}${parts.join('/')}`;
+        return `${prefix || ''}${parts.join('/')}${query || ''}`;
       }
 
       computedDisplayableRelativePath(path) {

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -137,9 +137,9 @@ found in the LICENSE file.
     <section class="search">
       <div class="path">
         <a href="/results/" on-click="navigate">wpt</a>
-        <template is="dom-repeat" items="{{ splitPathIntoLinkedParts(path) }}" as="part">
+        <template is="dom-repeat" items="[[ splitPathIntoLinkedParts(path) ]]" as="part">
           <span class="path-separator">/</span>
-          <a href="/results{{ part.path }}" on-click="navigate">{{ part.name }}</a>
+          <a href="/results[[ part.path ]][[ query ]]" on-click="navigate">[[ part.name ]]</a>
         </template>
       </div>
 
@@ -201,7 +201,7 @@ found in the LICENSE file.
           <template is="dom-repeat" items="{{displayedNodes}}" as="node">
             <tr>
               <td>
-                <path-part prefix="/results" path="{{ node.path }}" is-dir="{{ node.isDir }}" navigate="{{ bindNavigate() }}"></path-part>
+                <path-part prefix="/results" path="{{ node.path }}" query="{{ query }}" is-dir="{{ node.isDir }}" navigate="{{ bindNavigate() }}"></path-part>
               </td>
 
               <template is="dom-repeat" items="{{testRuns}}" as="testRun">

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -136,7 +136,7 @@ found in the LICENSE file.
 
     <section class="search">
       <div class="path">
-        <a href="/results/" on-click="navigate">wpt</a>
+        <a href="/results/[[ query ]]" on-click="navigate">wpt</a>
         <template is="dom-repeat" items="[[ splitPathIntoLinkedParts(path) ]]" as="part">
           <span class="path-separator">/</span>
           <a href="/results[[ part.path ]][[ query ]]" on-click="navigate">[[ part.name ]]</a>


### PR DESCRIPTION
So that "open in new tab" (or equivalant) can preserve URL parameters
correctly. Towards #193 resolution.

## Review Information

Go to `/results/?complete=true&label=stable` on the staging instance. Hovering on various links (especially the top path just below the tab switcher, and the list of subdirectories/files), and you should see the URL parameters included in the linked paths.