### PR TITLE
test-file-results-table: Return status string for messageless status or "status-as-message"

### DIFF
--- a/webapp/components/abstract-test-file-results-table.html
+++ b/webapp/components/abstract-test-file-results-table.html
@@ -22,7 +22,9 @@ found in the LICENSE file.
       }
 
       subtestMessage(result) {
-        if (this.statusesAsMessage.includes(result.status)) {
+        // Return status string for messageless status or "status-as-message".
+        if ((result.status && !result.message) ||
+          this.statusesAsMessage.includes(result.status)) {
           return result.status;
         }
         if (!result.status) {


### PR DESCRIPTION
Fixes #501.