### PR TITLE
Distinguish runs in history tab

### DIFF
--- a/webapp/components/test-run.html
+++ b/webapp/components/test-run.html
@@ -110,7 +110,7 @@ See models.go for more details.
       }
 
       containerClass(small) {
-        return small && 'small';
+        return small ? 'small' : '';
       }
 
       dateFormat(isoDate) {

--- a/webapp/components/test-run.html
+++ b/webapp/components/test-run.html
@@ -46,21 +46,27 @@ See models.go for more details.
         width: 32px;
         height: 32px;
       }
+      .small img {
+        width: 24px;
+        height: 24px;
+      }
     </style>
 
-    <div>
-      <div><img src="{{displayLogo(testRun)}}" /></div>
-      <div>{{displayName(testRun.browser_name)}} {{shortVersion(testRun.browser_name, testRun.browser_version)}}</div>
-      <template is="dom-if" if="{{ !isDiff(testRun.browser_name) }}">
-        <div>{{displayName(testRun.os_name)}} {{testRun.os_version}}</div>
-        <div class="revision">@<a href="?sha={{testRun.revision}}">{{testRun.revision}}</a></div>
-        <div>{{dateFormat(testRun.created_at)}}</div>
-        <paper-tooltip offset=0>
-          {{displayName(testRun.browser_name)}} {{testRun.browser_version}}<br>
-          Labels: {{displayLabels(testRun.labels)}}<br>
-          {{moreTooltip(testRun)}}
-        </paper-tooltip>
+    <div class$='[[containerClass(small)]]'>
+      <div><img small="[[small]]" src="{{displayLogo(testRun)}}" /></div>
+      <template is="dom-if" if="[[!small]]">
+        <div>{{displayName(testRun.browser_name)}} {{shortVersion(testRun.browser_name, testRun.browser_version)}}</div>
+        <template is="dom-if" if="{{ !isDiff(testRun.browser_name) }}">
+          <div>{{displayName(testRun.os_name)}} {{testRun.os_version}}</div>
+          <div class="revision">@<a href="?sha={{testRun.revision}}">{{testRun.revision}}</a></div>
+          <div>{{dateFormat(testRun.created_at)}}</div>
+        </template>
       </template>
+      <paper-tooltip offset=0>
+        {{displayName(testRun.browser_name)}} {{testRun.browser_version}}<br>
+        Labels: {{displayLabels(testRun.labels)}}<br>
+        {{moreTooltip(testRun)}}
+      </paper-tooltip>
     </div>
   </template>
 
@@ -90,10 +96,18 @@ See models.go for more details.
 
       static get properties() {
         return {
+          small: {
+            type: Boolean,
+            value: false,
+          },
           testRun: {
-            type: Object
-          }
+            type: Object,
+          },
         };
+      }
+
+      containerClass(small) {
+        return small && 'small';
       }
 
       dateFormat(isoDate) {

--- a/webapp/components/test-run.html
+++ b/webapp/components/test-run.html
@@ -62,11 +62,14 @@ See models.go for more details.
           <div>{{dateFormat(testRun.created_at)}}</div>
         </template>
       </template>
-      <paper-tooltip offset=0>
-        {{displayName(testRun.browser_name)}} {{testRun.browser_version}}<br>
-        Labels: {{displayLabels(testRun.labels)}}<br>
-        {{moreTooltip(testRun)}}
-      </paper-tooltip>
+
+      <template is="dom-if" if="{{ !isDiff(testRun.browser_name) }}">
+        <paper-tooltip offset=0>
+          {{displayName(testRun.browser_name)}} {{testRun.browser_version}}<br>
+          Labels: {{displayLabels(testRun.labels)}}<br>
+          {{moreTooltip(testRun)}}
+        </paper-tooltip>
+      </template>
     </div>
   </template>
 

--- a/webapp/components/test-run.html
+++ b/webapp/components/test-run.html
@@ -52,7 +52,7 @@ See models.go for more details.
       }
     </style>
 
-    <div class$='[[containerClass(small)]]'>
+    <div class$="[[containerClass(small)]]">
       <div><img small="[[small]]" src="{{displayLogo(testRun)}}" /></div>
       <template is="dom-if" if="[[!small]]">
         <div>{{displayName(testRun.browser_name)}} {{shortVersion(testRun.browser_name, testRun.browser_version)}}</div>

--- a/webapp/components/wpt-runs.html
+++ b/webapp/components/wpt-runs.html
@@ -7,7 +7,9 @@ found in the LICENSE file.
 <link rel="import" href="../bower_components/polymer/polymer-element.html">
 <link rel="import" href="../bower_components/polymer/lib/elements/dom-if.html">
 <link rel="import" href="../bower_components/polymer/lib/elements/dom-repeat.html">
+<link rel="import" href="../bower_components/paper-styles/color.html">
 <link rel="import" href="test-runs.html">
+<link rel="import" href="test-run.html">
 
 <dom-module id="wpt-runs">
   <template>
@@ -26,7 +28,7 @@ found in the LICENSE file.
         margin: 2px;
       }
       td.month {
-        border-top: 1px solid #e3edfd;
+        border-top: 1px solid var(--paper-blue-100);
       }
 
       .info {
@@ -37,10 +39,14 @@ found in the LICENSE file.
         border-left: solid 4px #7477f4;
       }
       .missing {
-        background-color: #e3edfd;
+        background-color: var(--paper-grey-100);
       }
-      .present {
-        background-color: #337af3;
+      .runs div {
+        display: flex;
+        justify-content: center;
+      }
+      .runs.present {
+        background-color: var(--paper-blue-100);
       }
 
       @media (max-width: 800px) {
@@ -74,7 +80,15 @@ found in the LICENSE file.
             <a href="/?sha={{ results.sha }}" title="{{ computeDateTooltip(results.date) }}">{{ results.sha }}</a>
           </td>
           <template is="dom-repeat" items="{{ browsers }}" as="browser">
-            <td class$="{{ runClass(results.runs, browser) }}"></td>
+            <td class$="runs [[ runClass(results.runs, browser) ]]">
+              <div>
+                <template is="dom-repeat" items="[[runList(results.runs, browser)]]" as="run">
+                  <a href='[[runLink(run)]]'>
+                    <test-run small test-run="[[run]]"></test-run>
+                  </a>
+                </template>
+              </div>
+            </td>
           </template>
           <template is="dom-if" if="{{ results.month_boundary }}">
             <td class="month">{{ computeMonthName(results.date) }}</td>
@@ -143,17 +157,17 @@ found in the LICENSE file.
             accum[results.revision] = {};
           }
           if (!accum[results.revision][results.browser_name]) {
-            accum[results.revision][results.browser_name] = results;
+            accum[results.revision][results.browser_name] = [];
           }
+          accum[results.revision][results.browser_name].push(results);
           return accum;
         }, {});
 
         // We flatten into an array of objects so Polymer can deal with them.
-        const firstRunTime = x => Object.values(x.runs)[0].created_at;
+        const firstRunTime = x => Object.values(x.runs)[0][0].created_at;
         const flattened = Object.entries(testRunsBySha)
           .map(({0: sha, 1: runs}) => ({ sha, runs }))
           .sort((a, b) => firstRunTime(a) < firstRunTime(b) ? 1 : -1);
-
 
         // Append time (month) metadata.
         if (flattened.length > 1) {
@@ -177,6 +191,20 @@ found in the LICENSE file.
           return 'missing';
         }
         return 'present';
+      }
+
+      runList(testRuns, browser) {
+        return testRuns[browser] || [];
+      }
+
+      runLink(run) {
+        let link = `/results?sha=${run.revision}`;
+        for (const label of ['experimental', 'stable']) {
+          if (run.labels && run.labels.includes(label)) {
+            link += `&label=${label}`;
+          }
+        }
+        return link;
       }
     }
 

--- a/webapp/components/wpt-runs.html
+++ b/webapp/components/wpt-runs.html
@@ -86,7 +86,7 @@ found in the LICENSE file.
             <td class$="runs [[ runClass(results.runs, browser) ]]">
               <div>
                 <template is="dom-repeat" items="[[runList(results.runs, browser)]]" as="run">
-                  <a href='[[runLink(run)]]'>
+                  <a href="[[runLink(run)]]">
                     <test-run small test-run="[[run]]"></test-run>
                   </a>
                 </template>

--- a/webapp/components/wpt-runs.html
+++ b/webapp/components/wpt-runs.html
@@ -198,13 +198,14 @@ found in the LICENSE file.
       }
 
       runLink(run) {
-        let link = `/results?sha=${run.revision}`;
+        let link = new URL('/results', window.location);
+        link.searchParams.set('sha', run.revision);
         for (const label of ['experimental', 'stable']) {
           if (run.labels && run.labels.includes(label)) {
-            link += `&label=${label}`;
+            link.searchParams.append('label', label);
           }
         }
-        return link;
+        return link.toString();
       }
 
       computeThWidth(browsers) {

--- a/webapp/components/wpt-runs.html
+++ b/webapp/components/wpt-runs.html
@@ -41,12 +41,11 @@ found in the LICENSE file.
       .missing {
         background-color: var(--paper-grey-100);
       }
-      .runs div {
-        display: flex;
-        flex-wrap: wrap;
-        justify-content: center;
-        max-width: 120px;
-        margin: auto;
+      .runs {
+        text-align: center;
+      }
+      .runs a {
+        display: inline-block;
       }
       .runs.present {
         background-color: var(--paper-blue-100);
@@ -84,13 +83,11 @@ found in the LICENSE file.
           </td>
           <template is="dom-repeat" items="{{ browsers }}" as="browser">
             <td class$="runs [[ runClass(results.runs, browser) ]]">
-              <div>
-                <template is="dom-repeat" items="[[runList(results.runs, browser)]]" as="run">
-                  <a href="[[runLink(run)]]">
-                    <test-run small test-run="[[run]]"></test-run>
-                  </a>
-                </template>
-              </div>
+              <template is="dom-repeat" items="[[runList(results.runs, browser)]]" as="run">
+                <a href="[[runLink(run)]]">
+                  <test-run small test-run="[[run]]"></test-run>
+                </a>
+              </template>
             </td>
           </template>
           <template is="dom-if" if="{{ results.month_boundary }}">

--- a/webapp/components/wpt-runs.html
+++ b/webapp/components/wpt-runs.html
@@ -43,7 +43,10 @@ found in the LICENSE file.
       }
       .runs div {
         display: flex;
+        flex-wrap: wrap;
         justify-content: center;
+        max-width: 120px;
+        margin: auto;
       }
       .runs.present {
         background-color: var(--paper-blue-100);
@@ -66,9 +69,9 @@ found in the LICENSE file.
     <table>
       <thead>
         <tr>
-          <th>SHA</th>
+          <th width="[[computeThWidth(browsers)]]">SHA</th>
           <template is="dom-repeat" items="{{ browsers }}" as="browser">
-            <th>[[browser]]</th>
+            <th width="[[computeThWidth(browsers)]]">[[browser]]</th>
           </template>
         </tr>
       </thead>
@@ -205,6 +208,10 @@ found in the LICENSE file.
           }
         }
         return link;
+      }
+
+      computeThWidth(browsers) {
+        return `${100 / (browsers.length + 2)}%`;
       }
     }
 


### PR DESCRIPTION
## Description
Fixes #495 

Re-use the `test-run` component to enumerate all the runs that occurred for each browser at a given revision, rather than just dichotomizing "had runs" and "didn't have runs" per browser.

## Review Information
Review the code like any PR, but also give opinionated feedback on the aesthetics and behaviour!

See https://distinct-run-history-dot-wptdashboard-staging.appspot.com/test-runs