### PR TITLE
Fix history grid broken by missing helper function

### DIFF
--- a/webapp/components/test-file-results.html
+++ b/webapp/components/test-file-results.html
@@ -133,8 +133,8 @@ found in the LICENSE file.
         }
 
         // Set name for test-level status entry after subtests discovered.
-        resultsTable[0].name = resultsTable.length > 1 ? 'Harness status' :
-          'Test status';
+        // Parameter is number of subtests.
+        resultsTable[0].name = this.statusName(resultsTable.length - 1);
 
         this.resultsTable = resultsTable;
       }
@@ -153,6 +153,10 @@ found in the LICENSE file.
         // This is relying on the assumption that result files end with '-summary.json.gz'.
         const resultsBase = testRun.results_url.slice(0, testRun.results_url.lastIndexOf('-summary.json.gz'));
         return `${resultsBase}${path}`;
+      }
+
+      statusName(numSubtests) {
+        return numSubtests > 0 ? 'Harness status' : 'Test status';
       }
     }
 

--- a/webapp/components/test-results-history-grid.html
+++ b/webapp/components/test-results-history-grid.html
@@ -147,8 +147,10 @@ found in the LICENSE file.
         const resultsJSON = await resp.json();
         let newResults = [];
         newResults.push({
-          name: this.subtestNameForDisplay('STATUS', [resultsJSON]),
-          status: resultsJSON.status
+          // Status name determined by number of subtests.
+          name: this.statusName(resultsJSON && resultsJSON.subtests ?
+            resultsJSON.subtests.length : 0),
+          status: resultsJSON.status,
         });
         if (resultsJSON.subtests && resultsJSON.subtests.length > 0) {
           for (const sub of resultsJSON.subtests) {


### PR DESCRIPTION
Recent changes to `abstract-test-file-results-table.html` deleted a helper used in `test-results-history-grid.html`. This brings back a simplified version of the helper to ensure a single source of truth on how to name top-level test status.

Fixes #504.