### PR TITLE
Make search and autocomplete case-insensitive

### DIFF
--- a/api/query/autocomplete.go
+++ b/api/query/autocomplete.go
@@ -46,12 +46,15 @@ type byQueryIndex struct {
 func (r byQueryIndex) Len() int      { return len(r.rs) }
 func (r byQueryIndex) Swap(i, j int) { r.rs[i], r.rs[j] = r.rs[j], r.rs[i] }
 func (r byQueryIndex) Less(i, j int) bool {
-	a := strings.Index(r.rs[i].QueryString, r.q)
-	b := strings.Index(r.rs[j].QueryString, r.q)
+	iqs := canonicalizeStr(r.rs[i].QueryString)
+	jqs := canonicalizeStr(r.rs[j].QueryString)
+	q := canonicalizeStr(r.q)
+	a := strings.Index(iqs, q)
+	b := strings.Index(jqs, q)
 	if a == b {
 		return r.rs[i].QueryString < r.rs[j].QueryString
 	}
-	return strings.Index(r.rs[i].QueryString, r.q) < strings.Index(r.rs[j].QueryString, r.q)
+	return a < b
 }
 
 type autocompleteHandler struct {
@@ -123,10 +126,11 @@ func prepareAutocompleteResponse(limit int, filters *shared.QueryFilter, testRun
 		}
 	}
 
+	q := canonicalizeStr(filters.Q)
 	files := make([]AutocompleteResult, 0, fileSet.Cardinality()/len(testRuns))
 	for fileInterface := range fileSet.Iter() {
 		file := fileInterface.(string)
-		if strings.Contains(file, filters.Q) {
+		if strings.Contains(canonicalizeStr(file), q) {
 			files = append(files, AutocompleteResult{file})
 		}
 	}

--- a/api/query/autocomplete_test.go
+++ b/api/query/autocomplete_test.go
@@ -183,7 +183,7 @@ func TestPrepareAutocompleteResponse_limited(t *testing.T) {
 	}
 	filters := shared.QueryFilter{
 		RunIDs: runIDs,
-		Q:      "/b/",
+		Q:      "/B/",
 	}
 	summaries := []summary{
 		map[string][]int{

--- a/api/query/search.go
+++ b/api/query/search.go
@@ -92,12 +92,13 @@ func prepareSearchResponse(filters *shared.QueryFilter, testRuns []shared.TestRu
 	resp := SearchResponse{
 		Runs: testRuns,
 	}
+	q := canonicalizeStr(filters.Q)
 	// Dedup visited file names via a map of results.
 	resMap := make(map[string]SearchResult)
 	for i, s := range summaries {
 		for filename, passAndTotal := range s {
 			// Exclude filenames that do not match query.
-			if !strings.Contains(filename, filters.Q) {
+			if !strings.Contains(canonicalizeStr(filename), q) {
 				continue
 			}
 

--- a/api/query/search_test.go
+++ b/api/query/search_test.go
@@ -27,7 +27,7 @@ func TestPrepareSearchResponse(t *testing.T) {
 	}
 	filters := shared.QueryFilter{
 		RunIDs: runIDs,
-		Q:      "/b/",
+		Q:      "/B/",
 	}
 	summaries := []summary{
 		map[string][]int{

--- a/api/query/util.go
+++ b/api/query/util.go
@@ -1,0 +1,7 @@
+package query
+
+import "strings"
+
+func canonicalizeStr(str string) string {
+	return strings.ToLower(str)
+}


### PR DESCRIPTION
This creates a helper for "canonicalizing" strings in the context of the `api/query` package. This is used sparingly in the search and autocomplete implementations to perform case-insensitive comparisons.

Fixes #508.