### PR TITLE
Copy immutable `legacy_status` data by value into mutable `results` entries

### DIFF
--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -528,7 +528,9 @@ found in the LICENSE file.
                 acc.push({
                   path: `${prefix}${name}`,
                   isDir,
-                  results: Array.from(r.legacy_status),
+                  // Copy legacy_status node contents.
+                  results: r.legacy_status
+                    .map(stats => Object.assign({}, stats)),
                 });
               } else {
                 const rs = r.legacy_status;


### PR DESCRIPTION
Fixes #510.

`wptResultsInstance.searchResults[i].legacy_status` contains the pass rate data for a single file. However, it was being copied by reference into `wptResultsInstance.searchResults.displayedNodes[j].results`, which models (sometimes) the pass rate data for an entire directory. Hence, when the `wptResultsInstance.searchResults.displayedNodes[j].results` was mutated to accumulate all data for its directory, "immutable-after-fetched" `searchResults` nodes were being mutated.

This fixes the problem by copying the values inside `legacy_status` properties into new `results` properties.