### PR TITLE
Abstract GAE-compatible logging interface

### DIFF
--- a/api/diff.go
+++ b/api/diff.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 
 	"github.com/web-platform-tests/wpt.fyi/shared"
-	"google.golang.org/appengine"
 )
 
 // apiDiffHandler takes 2 test-run results JSON blobs and produces JSON in the same format, with only the differences
@@ -28,7 +27,7 @@ func apiDiffHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func handleAPIDiffGet(w http.ResponseWriter, r *http.Request) {
-	ctx := appengine.NewContext(r)
+	ctx := shared.NewAppEngineContext(r)
 
 	var err error
 	params, err := url.ParseQuery(r.URL.RawQuery)
@@ -83,7 +82,7 @@ func handleAPIDiffGet(w http.ResponseWriter, r *http.Request) {
 // handleAPIDiffPost handles POST requests to /api/diff, which allows the caller to produce the diff of an arbitrary
 // run result JSON blob against a historical production run.
 func handleAPIDiffPost(w http.ResponseWriter, r *http.Request) {
-	ctx := appengine.NewContext(r)
+	ctx := shared.NewAppEngineContext(r)
 
 	var err error
 	params, err := url.ParseQuery(r.URL.RawQuery)

--- a/api/interop.go
+++ b/api/interop.go
@@ -10,14 +10,13 @@ import (
 
 	"github.com/web-platform-tests/results-analysis/metrics"
 	"github.com/web-platform-tests/wpt.fyi/shared"
-	"google.golang.org/appengine"
 	"google.golang.org/appengine/datastore"
 )
 
 // interopHandler handles the view of test results broken down by the
 // number of browsers for which the test passes.
 func apiInteropHandler(w http.ResponseWriter, r *http.Request) {
-	ctx := appengine.NewContext(r)
+	ctx := shared.NewAppEngineContext(r)
 	passRateType := metrics.GetDatastoreKindName(metrics.PassRateMetadata{})
 	query := datastore.NewQuery(passRateType).Order("-StartTime").Limit(1)
 

--- a/api/manifest.go
+++ b/api/manifest.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/deckarep/golang-set"
 	"github.com/web-platform-tests/wpt.fyi/shared"
-	"google.golang.org/appengine"
 	"google.golang.org/appengine/datastore"
 	"google.golang.org/appengine/memcache"
 )
@@ -29,7 +28,7 @@ func apiManifestHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	paths := shared.ParsePathsParam(r)
-	ctx := appengine.NewContext(r)
+	ctx := shared.NewAppEngineContext(r)
 	sha, manifestBytes, err := getManifestForSHA(ctx, sha)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusNotFound)

--- a/api/query/autocomplete.go
+++ b/api/query/autocomplete.go
@@ -12,7 +12,6 @@ import (
 
 	mapset "github.com/deckarep/golang-set"
 	"github.com/web-platform-tests/wpt.fyi/shared"
-	"google.golang.org/appengine"
 )
 
 var (
@@ -59,10 +58,11 @@ type autocompleteHandler struct {
 }
 
 func apiAutocompleteHandler(w http.ResponseWriter, r *http.Request) {
-	ctx := appengine.NewContext(r)
+	ctx := shared.NewAppEngineContext(r)
 	sh := autocompleteHandler{queryHandler{
 		sharedImpl: defaultShared{ctx},
 		dataSource: cachedStore{
+			ctx:   ctx,
 			cache: gzipReadWritable{memcacheReadWritable{ctx}},
 			store: httpReadable{ctx},
 		},

--- a/api/query/autocomplete_medium_test.go
+++ b/api/query/autocomplete_medium_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/web-platform-tests/wpt.fyi/api/query/test"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
-	"google.golang.org/appengine"
 	"google.golang.org/appengine/datastore"
 )
 
@@ -50,7 +49,7 @@ func TestAutocompleteHandler(t *testing.T) {
 	{
 		req, err := i.NewRequest("GET", "/", nil)
 		assert.Nil(t, err)
-		ctx := appengine.NewContext(req)
+		ctx := shared.NewAppEngineContext(req)
 
 		for idx, testRun := range testRuns {
 			key, err := datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &testRun)
@@ -83,12 +82,13 @@ func TestAutocompleteHandler(t *testing.T) {
 		url.QueryEscape("2"))
 	r, err := i.NewRequest("GET", url, nil)
 	assert.Nil(t, err)
-	ctx := appengine.NewContext(r)
+	ctx := shared.NewAppEngineContext(r)
 	w := httptest.NewRecorder()
 
 	sh := autocompleteHandler{queryHandler{
 		sharedImpl: defaultShared{ctx},
 		dataSource: cachedStore{
+			ctx:   ctx,
 			cache: memcacheReadWritable{ctx},
 			store: store,
 		},

--- a/api/query/query_test.go
+++ b/api/query/query_test.go
@@ -38,6 +38,7 @@ func TestLoadSummary_cacheMiss(t *testing.T) {
 	store := NewMockreadable(mockCtrl)
 	sh := searchHandler{queryHandler{
 		dataSource: cachedStore{
+			ctx:   shared.NewTestContext(),
 			cache: cache,
 			store: store,
 		},
@@ -77,7 +78,10 @@ func TestLoadSummary_cacheHit(t *testing.T) {
 
 	cache := NewMockreadWritable(mockCtrl)
 	sh := searchHandler{queryHandler{
-		dataSource: cachedStore{cache: cache},
+		dataSource: cachedStore{
+			ctx:   shared.NewTestContext(),
+			cache: cache,
+		},
 	}}
 	smry := []byte("{}")
 	r := test.NewMockReadCloser(t, smry)
@@ -108,6 +112,7 @@ func TestLoadSummary_missing(t *testing.T) {
 	store := NewMockreadable(mockCtrl)
 	sh := searchHandler{queryHandler{
 		dataSource: cachedStore{
+			ctx:   shared.NewTestContext(),
 			cache: cache,
 			store: store,
 		},
@@ -150,7 +155,10 @@ func TestLoadSummaries_success(t *testing.T) {
 
 	cache := NewMockreadWritable(mockCtrl)
 	sh := searchHandler{queryHandler{
-		dataSource: cachedStore{cache: cache},
+		dataSource: cachedStore{
+			ctx:   shared.NewTestContext(),
+			cache: cache,
+		},
 	}}
 	summaryBytes := [][]byte{
 		[]byte(`{"/a/b/c":[1,2]}`),
@@ -203,6 +211,7 @@ func TestLoadSummaries_fail(t *testing.T) {
 	store := NewMockreadable(mockCtrl)
 	sh := searchHandler{queryHandler{
 		dataSource: cachedStore{
+			ctx:   shared.NewTestContext(),
 			cache: cache,
 			store: store,
 		},

--- a/api/query/search.go
+++ b/api/query/search.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/web-platform-tests/wpt.fyi/shared"
-	"google.golang.org/appengine"
 )
 
 // LegacySearchRunResult is the results data from legacy test summarys.  These
@@ -61,10 +60,11 @@ type searchHandler struct {
 
 func apiSearchHandler(w http.ResponseWriter, r *http.Request) {
 	// Parse query params.
-	ctx := appengine.NewContext(r)
+	ctx := shared.NewAppEngineContext(r)
 	sh := searchHandler{queryHandler{
 		sharedImpl: defaultShared{ctx},
 		dataSource: cachedStore{
+			ctx:   ctx,
 			cache: gzipReadWritable{memcacheReadWritable{ctx}},
 			store: httpReadable{ctx},
 		},

--- a/api/query/search_medium_test.go
+++ b/api/query/search_medium_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/web-platform-tests/wpt.fyi/api/query/test"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
-	"google.golang.org/appengine"
 	"google.golang.org/appengine/datastore"
 )
 
@@ -50,7 +49,7 @@ func TestSearchHandler(t *testing.T) {
 	{
 		req, err := i.NewRequest("GET", "/", nil)
 		assert.Nil(t, err)
-		ctx := appengine.NewContext(req)
+		ctx := shared.NewAppEngineContext(req)
 
 		for idx, testRun := range testRuns {
 			key, err := datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &testRun)
@@ -83,12 +82,13 @@ func TestSearchHandler(t *testing.T) {
 		url.QueryEscape(q))
 	r, err := i.NewRequest("GET", url, nil)
 	assert.Nil(t, err)
-	ctx := appengine.NewContext(r)
+	ctx := shared.NewAppEngineContext(r)
 	w := httptest.NewRecorder()
 
 	sh := searchHandler{queryHandler{
 		sharedImpl: defaultShared{ctx},
 		dataSource: cachedStore{
+			ctx:   ctx,
 			cache: memcacheReadWritable{ctx},
 			store: store,
 		},

--- a/api/results_receive_handler.go
+++ b/api/results_receive_handler.go
@@ -7,9 +7,8 @@ package api
 import (
 	"net/http"
 
-	"google.golang.org/appengine"
-
 	"github.com/web-platform-tests/wpt.fyi/api/receiver"
+	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
 func apiResultsUploadHandler(w http.ResponseWriter, r *http.Request) {
@@ -18,7 +17,7 @@ func apiResultsUploadHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx := appengine.NewContext(r)
+	ctx := shared.NewAppEngineContext(r)
 	a := receiver.NewAppEngineAPI(ctx)
 	receiver.HandleResultsUpload(a, w, r)
 }
@@ -29,7 +28,7 @@ func apiResultsCreateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx := appengine.NewContext(r)
+	ctx := shared.NewAppEngineContext(r)
 	a := receiver.NewAppEngineAPI(ctx)
 	receiver.HandleResultsCreate(a, w, r)
 }

--- a/api/results_redirect_handler.go
+++ b/api/results_redirect_handler.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/web-platform-tests/wpt.fyi/shared"
-	"google.golang.org/appengine"
 )
 
 // apiResultsRedirectHandler is responsible for redirecting to the Google Cloud Storage API
@@ -31,7 +30,7 @@ func apiResultsRedirectHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx := appengine.NewContext(r)
+	ctx := shared.NewAppEngineContext(r)
 	one := 1
 	testRuns, err := shared.LoadTestRuns(ctx, filters.Products, filters.Labels, []string{filters.SHA}, nil, nil, &one)
 	if err != nil {

--- a/api/shas.go
+++ b/api/shas.go
@@ -10,7 +10,6 @@ import (
 
 	mapset "github.com/deckarep/golang-set"
 	"github.com/web-platform-tests/wpt.fyi/shared"
-	"google.golang.org/appengine"
 )
 
 // apiSHAsHandler is responsible for emitting just the revision SHAs for test runs.
@@ -21,7 +20,7 @@ func apiSHAsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx := appengine.NewContext(r)
+	ctx := shared.NewAppEngineContext(r)
 
 	var shas []string
 	products := filters.GetProductsOrDefault()

--- a/api/shas_medium_test.go
+++ b/api/shas_medium_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
-	"google.golang.org/appengine"
 	"google.golang.org/appengine/datastore"
 )
 
@@ -22,7 +21,7 @@ func TestApiSHAsHandler(t *testing.T) {
 	defer i.Close()
 	r, err := i.NewRequest("GET", "/api/shas", nil)
 	assert.Nil(t, err)
-	ctx := appengine.NewContext(r)
+	ctx := shared.NewAppEngineContext(r)
 
 	// No results - empty JSON array, 404
 	var shas []string

--- a/api/test_run.go
+++ b/api/test_run.go
@@ -13,7 +13,6 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/web-platform-tests/wpt.fyi/shared"
-	"google.golang.org/appengine"
 	"google.golang.org/appengine/datastore"
 )
 
@@ -26,7 +25,7 @@ func apiTestRunHandler(w http.ResponseWriter, r *http.Request) {
 
 	vars := mux.Vars(r)
 	idParam := vars["id"]
-	ctx := appengine.NewContext(r)
+	ctx := shared.NewAppEngineContext(r)
 	var testRun shared.TestRun
 	if idParam != "" {
 		id, err := strconv.ParseInt(idParam, 10, 0)

--- a/api/test_run_medium_test.go
+++ b/api/test_run_medium_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
-	"google.golang.org/appengine"
 	"google.golang.org/appengine/datastore"
 )
 
@@ -25,7 +24,7 @@ func TestGetTestRunByID(t *testing.T) {
 	r = mux.SetURLVars(r, map[string]string{"id": "123"})
 	assert.Nil(t, err)
 
-	ctx := appengine.NewContext(r)
+	ctx := shared.NewAppEngineContext(r)
 	resp := httptest.NewRecorder()
 	apiTestRunHandler(resp, r)
 	assert.Equal(t, http.StatusNotFound, resp.Code)

--- a/api/test_runs.go
+++ b/api/test_runs.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 
 	"github.com/web-platform-tests/wpt.fyi/shared"
-	"google.golang.org/appengine"
 )
 
 // apiTestRunsHandler is responsible for emitting test-run JSON for all the runs at a given SHA.
@@ -24,7 +23,7 @@ func apiTestRunsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx := appengine.NewContext(r)
+	ctx := shared.NewAppEngineContext(r)
 	testRuns, err := LoadTestRunsForFilters(ctx, filters)
 
 	if err != nil {

--- a/api/test_runs_medium_test.go
+++ b/api/test_runs_medium_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
-	"google.golang.org/appengine"
 	"google.golang.org/appengine/datastore"
 )
 
@@ -25,7 +24,7 @@ func TestGetTestRuns_VersionPrefix(t *testing.T) {
 	assert.Nil(t, err)
 
 	// 'Yesterday', v66...139 earlier version.
-	ctx := appengine.NewContext(r)
+	ctx := shared.NewAppEngineContext(r)
 	now := time.Now()
 	chrome := shared.TestRun{
 		ProductAtRevision: shared.ProductAtRevision{
@@ -88,7 +87,7 @@ func TestGetTestRuns_SHA(t *testing.T) {
 	r, err := i.NewRequest("GET", "/api/runs", nil)
 	assert.Nil(t, err)
 
-	ctx := appengine.NewContext(r)
+	ctx := shared.NewAppEngineContext(r)
 	now := time.Now()
 	run := shared.TestRun{}
 	run.BrowserVersion = "66.0.3359.139"

--- a/shared/sharedtest/util.go
+++ b/shared/sharedtest/util.go
@@ -5,9 +5,11 @@
 package sharedtest
 
 import (
-	"github.com/web-platform-tests/wpt.fyi/shared"
-	"golang.org/x/net/context"
+	"context"
+
 	"google.golang.org/appengine/aetest"
+
+	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
 // NewAEInstance creates a new aetest instance backed by dev_appserver whose

--- a/shared/sharedtest/util.go
+++ b/shared/sharedtest/util.go
@@ -5,8 +5,8 @@
 package sharedtest
 
 import (
+	"github.com/web-platform-tests/wpt.fyi/shared"
 	"golang.org/x/net/context"
-	"google.golang.org/appengine"
 	"google.golang.org/appengine/aetest"
 )
 
@@ -33,7 +33,7 @@ func NewAEContext(stronglyConsistentDatastore bool) (context.Context, func(), er
 		inst.Close()
 		return nil, nil, err
 	}
-	ctx := appengine.NewContext(req)
+	ctx := shared.NewAppEngineContext(req)
 	return ctx, func() {
 		inst.Close()
 	}, nil

--- a/shared/util.go
+++ b/shared/util.go
@@ -5,8 +5,6 @@
 package shared
 
 import (
-	"fmt"
-	"log"
 	"net/http"
 
 	mapset "github.com/deckarep/golang-set"
@@ -48,8 +46,9 @@ func IsLatest(sha string) bool {
 	return sha == "" || sha == "latest"
 }
 
+// Logger is an abstract logging interface that contains an intersection of
+// logrus and GAE logging functionality.
 type Logger interface {
-	Criticalf(format string, args ...interface{})
 	Debugf(format string, args ...interface{})
 	Errorf(format string, args ...interface{})
 	Infof(format string, args ...interface{})
@@ -60,13 +59,7 @@ type gaeLogger struct {
 	ctx context.Context
 }
 
-type stdLogger struct{}
-
 type nilLogger struct{}
-
-func (l gaeLogger) Criticalf(format string, args ...interface{}) {
-	gaelog.Criticalf(l.ctx, format, args...)
-}
 
 func (l gaeLogger) Debugf(format string, args ...interface{}) {
 	gaelog.Criticalf(l.ctx, format, args...)
@@ -84,28 +77,6 @@ func (l gaeLogger) Warningf(format string, args ...interface{}) {
 	gaelog.Warningf(l.ctx, format, args...)
 }
 
-func (l stdLogger) Criticalf(format string, args ...interface{}) {
-	log.Printf("CRIT: %s", fmt.Sprintf(format, args...))
-}
-
-func (l stdLogger) Debugf(format string, args ...interface{}) {
-	log.Printf("DEBG: %s", fmt.Sprintf(format, args...))
-}
-
-func (l stdLogger) Errorf(format string, args ...interface{}) {
-	log.Printf("ERRO: %s", fmt.Sprintf(format, args...))
-}
-
-func (l stdLogger) Infof(format string, args ...interface{}) {
-	log.Printf("INFO: %s", fmt.Sprintf(format, args...))
-}
-
-func (l stdLogger) Warningf(format string, args ...interface{}) {
-	log.Printf("WARN: %s", fmt.Sprintf(format, args...))
-}
-
-func (l nilLogger) Criticalf(format string, args ...interface{}) {}
-
 func (l nilLogger) Debugf(format string, args ...interface{}) {}
 
 func (l nilLogger) Errorf(format string, args ...interface{}) {}
@@ -119,7 +90,6 @@ type LoggerCtxKey struct{}
 
 var (
 	gl  = gaeLogger{}
-	sl  = stdLogger{}
 	nl  = nilLogger{}
 	lck = LoggerCtxKey{}
 )
@@ -128,11 +98,6 @@ var (
 // the given context.
 func NewGAELogger(ctx context.Context) Logger {
 	return gaeLogger{ctx}
-}
-
-// NewSTDLogger returns a new standard logger.
-func NewSTDLogger() Logger {
-	return sl
 }
 
 // NewNilLogger returns a new logger that silently ignores all Logger calls.

--- a/shared/util.go
+++ b/shared/util.go
@@ -5,7 +5,14 @@
 package shared
 
 import (
+	"fmt"
+	"log"
+	"net/http"
+
 	mapset "github.com/deckarep/golang-set"
+	"golang.org/x/net/context"
+	"google.golang.org/appengine"
+	gaelog "google.golang.org/appengine/log"
 )
 
 // ExperimentalLabel is the implicit label present for runs marked 'experimental'.
@@ -39,4 +46,117 @@ func ToStringSlice(set mapset.Set) []string {
 // of which are treated as looking up the latest run for each browser.
 func IsLatest(sha string) bool {
 	return sha == "" || sha == "latest"
+}
+
+type Logger interface {
+	Criticalf(format string, args ...interface{})
+	Debugf(format string, args ...interface{})
+	Errorf(format string, args ...interface{})
+	Infof(format string, args ...interface{})
+	Warningf(format string, args ...interface{})
+}
+
+type gaeLogger struct {
+	ctx context.Context
+}
+
+type stdLogger struct{}
+
+type nilLogger struct{}
+
+func (l gaeLogger) Criticalf(format string, args ...interface{}) {
+	gaelog.Criticalf(l.ctx, format, args...)
+}
+
+func (l gaeLogger) Debugf(format string, args ...interface{}) {
+	gaelog.Criticalf(l.ctx, format, args...)
+}
+
+func (l gaeLogger) Errorf(format string, args ...interface{}) {
+	gaelog.Errorf(l.ctx, format, args...)
+}
+
+func (l gaeLogger) Infof(format string, args ...interface{}) {
+	gaelog.Infof(l.ctx, format, args...)
+}
+
+func (l gaeLogger) Warningf(format string, args ...interface{}) {
+	gaelog.Warningf(l.ctx, format, args...)
+}
+
+func (l stdLogger) Criticalf(format string, args ...interface{}) {
+	log.Printf("CRIT: %s", fmt.Sprintf(format, args...))
+}
+
+func (l stdLogger) Debugf(format string, args ...interface{}) {
+	log.Printf("DEBG: %s", fmt.Sprintf(format, args...))
+}
+
+func (l stdLogger) Errorf(format string, args ...interface{}) {
+	log.Printf("ERRO: %s", fmt.Sprintf(format, args...))
+}
+
+func (l stdLogger) Infof(format string, args ...interface{}) {
+	log.Printf("INFO: %s", fmt.Sprintf(format, args...))
+}
+
+func (l stdLogger) Warningf(format string, args ...interface{}) {
+	log.Printf("WARN: %s", fmt.Sprintf(format, args...))
+}
+
+func (l nilLogger) Criticalf(format string, args ...interface{}) {}
+
+func (l nilLogger) Debugf(format string, args ...interface{}) {}
+
+func (l nilLogger) Errorf(format string, args ...interface{}) {}
+
+func (l nilLogger) Infof(format string, args ...interface{}) {}
+
+func (l nilLogger) Warningf(format string, args ...interface{}) {}
+
+// LoggerCtxKey is a key for attaching a Logger to a context.Context.
+type LoggerCtxKey struct{}
+
+var (
+	gl  = gaeLogger{}
+	sl  = stdLogger{}
+	nl  = nilLogger{}
+	lck = LoggerCtxKey{}
+)
+
+// NewGAELogger returns a Google App Engine Standard Environment logger bound to
+// the given context.
+func NewGAELogger(ctx context.Context) Logger {
+	return gaeLogger{ctx}
+}
+
+// NewSTDLogger returns a new standard logger.
+func NewSTDLogger() Logger {
+	return sl
+}
+
+// NewNilLogger returns a new logger that silently ignores all Logger calls.
+func NewNilLogger() Logger {
+	return nl
+}
+
+// DefaultLoggerCtxKey returns the default key where a logger instance should be
+// stored in a context.Context object.
+func DefaultLoggerCtxKey() LoggerCtxKey {
+	return lck
+}
+
+// NewAppEngineContext creates a new Google App Engine-based context bound to
+// an http.Request.
+func NewAppEngineContext(r *http.Request) context.Context {
+	ctx := appengine.NewContext(r)
+	ctx = context.WithValue(ctx, DefaultLoggerCtxKey(), NewGAELogger(ctx))
+	return ctx
+}
+
+// NewTestContext creates a new context.Context for small tests.
+func NewTestContext() context.Context {
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, DefaultLoggerCtxKey(), NewNilLogger())
+	return ctx
 }

--- a/webapp/admin_handler.go
+++ b/webapp/admin_handler.go
@@ -7,13 +7,12 @@ package webapp
 import (
 	"net/http"
 
-	"google.golang.org/appengine"
-
 	"github.com/web-platform-tests/wpt.fyi/api/receiver"
+	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
 func adminUploadHandler(w http.ResponseWriter, r *http.Request) {
-	ctx := appengine.NewContext(r)
+	ctx := shared.NewAppEngineContext(r)
 	a := receiver.NewAppEngineAPI(ctx)
 	showAdminUploadForm(a, w, r)
 }

--- a/webapp/anomaly_handler.go
+++ b/webapp/anomaly_handler.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/web-platform-tests/results-analysis/metrics"
 	"github.com/web-platform-tests/wpt.fyi/shared"
-	"google.golang.org/appengine"
 	"google.golang.org/appengine/datastore"
 )
 
@@ -32,7 +31,7 @@ func anomalyHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx := appengine.NewContext(r)
+	ctx := shared.NewAppEngineContext(r)
 	passRateType := metrics.GetDatastoreKindName(metrics.PassRateMetadata{})
 	query := datastore.NewQuery(passRateType).Order("-StartTime").Limit(1)
 
@@ -67,7 +66,7 @@ func anomalyHandler(w http.ResponseWriter, r *http.Request) {
 // browserAnomalyHandler handles the view of test results showing which tests
 // fail in a specific browser, but pass in at least one other browser.
 func browserAnomalyHandler(w http.ResponseWriter, r *http.Request, browser string) {
-	ctx := appengine.NewContext(r)
+	ctx := shared.NewAppEngineContext(r)
 	query := datastore.
 		NewQuery(metrics.GetDatastoreKindName(
 			metrics.FailuresMetadata{})).


### PR DESCRIPTION
Logging in GAE Standard Environment goes nowhere when the golang `"log"` package is used. This change introduces an abstract `Logger` interface that is `".../appengine/log"`-compatible. Other implementations are available for GAE Flex (`stdLogger`) and test (`nilLogger`) environments.

Might be easier to review commit-by-commit.