### PR TITLE
[processor] Save the merged report and infer labels from browser_channel

### DIFF
--- a/results-processor/wptreport.py
+++ b/results-processor/wptreport.py
@@ -414,6 +414,14 @@ class WPTReport(object):
         self.sha_product_path
         self.test_run_metadata
 
+    def serialize_gzip(self, filepath):
+        """Serializes and gzips the in-memory report to a file.
+
+        Args:
+            filepath: A file path to write to.
+        """
+        self.write_gzip_json(filepath, self._report)
+
 
 def prepare_labels(report, labels_str, uploader):
     """Prepares the list of labels for a test run.
@@ -438,7 +446,6 @@ def prepare_labels(report, labels_str, uploader):
     # Empty labels may be generated here, but they will be removed later.
     for label in labels_str.split(','):
         labels.add(label.strip())
-    # Set the default channel to stable.
     if ('stable' not in labels) and ('experimental' not in labels):
         labels.add('stable')
     # Remove any empty labels.

--- a/results-processor/wptreport.py
+++ b/results-processor/wptreport.py
@@ -23,6 +23,15 @@ import gsutil
 
 DEFAULT_PROJECT = 'wptdashboard'
 GCS_PUBLIC_DOMAIN = 'https://storage.googleapis.com'
+CHANNEL_TO_LABEL = {
+    'release': 'stable',
+    'stable': 'stable',
+    'beta': 'beta',
+    'dev': 'experimental',
+    'experimental': 'experimental',
+    'nightly': 'experimental',
+    'preview': 'experimental',
+}
 
 _log = logging.getLogger(__name__)
 
@@ -429,8 +438,7 @@ def prepare_labels(report, labels_str, uploader):
     The following labels will be automatically added:
     * The name of the uploader
     * The name of the browser
-    * "stable" (as in release channels), if neither "stable" or "experimental"
-      is provided by the uploader.
+    * The release channel of the browser (if the uploader doesn't provide one)
 
     Args:
         report: A WPTReport.
@@ -446,8 +454,15 @@ def prepare_labels(report, labels_str, uploader):
     # Empty labels may be generated here, but they will be removed later.
     for label in labels_str.split(','):
         labels.add(label.strip())
-    if ('stable' not in labels) and ('experimental' not in labels):
-        labels.add('stable')
+
+    # Add the release channel label.
+    if not any([i in labels for i in set(CHANNEL_TO_LABEL.values())]):
+        if report.run_info.get('browser_channel') in CHANNEL_TO_LABEL:
+            labels.add(CHANNEL_TO_LABEL[report.run_info['browser_channel']])
+        else:
+            # Default to "stable".
+            labels.add('stable')
+
     # Remove any empty labels.
     if '' in labels:
         labels.remove('')

--- a/results-processor/wptreport_test.py
+++ b/results-processor/wptreport_test.py
@@ -505,3 +505,8 @@ class HelpersTest(unittest.TestCase):
             prepare_labels(r, '', 'blade-runner'),
             ['blade-runner', 'experimental', 'firefox']
         )
+        r._report['run_info']['browser_channel'] = 'beta'
+        self.assertListEqual(
+            prepare_labels(r, '', 'blade-runner'),
+            ['beta', 'blade-runner', 'firefox']
+        )

--- a/results-processor/wptreport_test.py
+++ b/results-processor/wptreport_test.py
@@ -479,3 +479,29 @@ class HelpersTest(unittest.TestCase):
             prepare_labels(r, 'experimental', 'blade-runner'),
             ['blade-runner', 'experimental', 'firefox']
         )
+
+    def test_prepare_labels_from_stable_label(self):
+        r = WPTReport()
+        r.update_metadata(browser_name='firefox')
+        self.assertListEqual(
+            prepare_labels(r, 'stable', 'blade-runner'),
+            ['blade-runner', 'firefox', 'stable']
+        )
+
+    def test_prepare_labels_from_browser_channel(self):
+        r = WPTReport()
+        r._report = {
+            'run_info': {
+                'product': 'firefox',
+                'browser_channel': 'dev',
+            }
+        }
+        self.assertListEqual(
+            prepare_labels(r, '', 'blade-runner'),
+            ['blade-runner', 'experimental', 'firefox']
+        )
+        r._report['run_info']['browser_channel'] = 'nightly'
+        self.assertListEqual(
+            prepare_labels(r, '', 'blade-runner'),
+            ['blade-runner', 'experimental', 'firefox']
+        )


### PR DESCRIPTION
This change makes the results processor to save the merged report
instead of just the last chunk of the report if the original report is
chunked when uploaded.

Besides, it also sets the channel label (stable/experimental) based on a
new property in the report, `run_info.browser_channel`, introduced in
https://github.com/web-platform-tests/wpt/pull/12679 .

## Review

The integration, including the modified upload process for full raw reports, is tested by deploying to staging.wpt.fyi. The heuristics for adding labels are tested in unit tests.