### PR TITLE
Run 2 instances of results processor

### DIFF
--- a/results-processor/app.yaml
+++ b/results-processor/app.yaml
@@ -3,7 +3,7 @@ runtime: custom
 env: flex
 
 manual_scaling:
-  instances: 1
+  instances: 2
 resources:
   cpu: 1
   memory_gb: 4

--- a/webapp/queue.yaml
+++ b/webapp/queue.yaml
@@ -1,5 +1,5 @@
 queue:
 - name: results-arrival
   target: processor
-  max_concurrent_requests: 1
+  max_concurrent_requests: 2
   rate: 1/m


### PR DESCRIPTION
## Description

Now that we have results coming from Taskcluster for every single PR merge, 1 instance of results processor isn't quite enough (it's still able to keep up, but the average latency for processing results is now much higher). So let's have 2 processors :)

## Review Information

Note that `queue.yaml` needs to be manually deployed for the change to take effect.