### PR TITLE
Rename complete to aligned

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -37,6 +37,8 @@ __`sha`__ : SHA[0:10] of the runs to get, or the keyword `latest`. Defaults to `
 
 __`product`__ : Product(s) to include (repeated param), e.g. `chrome` or `firefox-60`.
 
+__`aligned`__ : boolean for whether to get only SHAs which were executed across all of the requested `product`s.
+
 __`labels`__: A comma-separated list of labels, e.g. `firefox,stable`; only runs with all
 the given labels will be returned. There are currently two kinds of labels supported,
 browser names (`chrome`, `edge`, `firefox`, `safari`) and release channels (`experimental`
@@ -132,7 +134,7 @@ This method behaves similarly to [/api/runs](#apiruns) above, but projects the `
 
 __Parameters__
 
-__`complete`__ : boolean for whether to get only SHAs which were executed across all four of the default (stable) browsers. Not compatible with `product`.
+__`aligned`__ : boolean for whether to get only SHAs which were executed across all of the requested `product`s.
 
 __`product`__ : Product(s) to include (repeated param), e.g. `chrome` or `firefox-60`
 

--- a/api/shas.go
+++ b/api/shas.go
@@ -24,8 +24,8 @@ func apiSHAsHandler(w http.ResponseWriter, r *http.Request) {
 
 	var shas []string
 	products := filters.GetProductsOrDefault()
-	if filters.Complete != nil && *filters.Complete {
-		if shas, err = shared.GetCompleteRunSHAs(ctx, products, filters.Labels, filters.From, filters.To, filters.MaxCount); err != nil {
+	if filters.Aligned != nil && *filters.Aligned {
+		if shas, err = shared.GetAlignedRunSHAs(ctx, products, filters.Labels, filters.From, filters.To, filters.MaxCount); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}

--- a/api/shas_medium_test.go
+++ b/api/shas_medium_test.go
@@ -47,9 +47,9 @@ func TestApiSHAsHandler(t *testing.T) {
 	run.Revision = "abcdef0000"
 	datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
 
-	// Complete
+	// Aligned
 	shas = nil
-	r, err = i.NewRequest("GET", "/api/shas?complete", nil)
+	r, err = i.NewRequest("GET", "/api/shas?aligned", nil)
 	w = httptest.NewRecorder()
 	apiSHAsHandler(w, r)
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -57,7 +57,7 @@ func TestApiSHAsHandler(t *testing.T) {
 	json.Unmarshal(bytes, &shas)
 	assert.Equal(t, []string{"abcdef0123"}, shas)
 
-	// Not complete
+	// Not aligned
 	shas = nil
 	r, err = i.NewRequest("GET", "/api/shas", nil)
 	w = httptest.NewRecorder()
@@ -68,7 +68,7 @@ func TestApiSHAsHandler(t *testing.T) {
 	assert.Equal(t, []string{"abcdef0123", "abcdef0000"}, shas)
 
 	// Bad param
-	r, err = i.NewRequest("GET", "/api/shas?complete=bad-value", nil)
+	r, err = i.NewRequest("GET", "/api/shas?aligned=bad-value", nil)
 	w = httptest.NewRecorder()
 	apiSHAsHandler(w, r)
 	assert.Equal(t, http.StatusBadRequest, w.Code)

--- a/api/test_runs.go
+++ b/api/test_runs.go
@@ -55,18 +55,18 @@ func LoadTestRunsForFilters(ctx context.Context, filters shared.TestRunFilter) (
 	}
 	products := filters.GetProductsOrDefault()
 
-	// When ?complete=true, make sure to show results for the same complete run (executed for all browsers).
+	// When ?aligned=true, make sure to show results for the same aligned run (executed for all browsers).
 	var shas []string
 	if !shared.IsLatest(filters.SHA) {
 		shas = []string{filters.SHA}
-	} else if filters.Complete != nil && *filters.Complete {
+	} else if filters.Aligned != nil && *filters.Aligned {
 		if shared.IsLatest(filters.SHA) {
-			shas, err = shared.GetCompleteRunSHAs(ctx, products, filters.Labels, from, filters.To, limit)
+			shas, err = shared.GetAlignedRunSHAs(ctx, products, filters.Labels, from, filters.To, limit)
 			if err != nil {
 				return result, err
 			}
 			if len(shas) < 1 {
-				// Bail out early - can't find any complete runs.
+				// Bail out early - can't find any aligned runs.
 				return result, nil
 			}
 		}

--- a/api/test_runs_medium_test.go
+++ b/api/test_runs_medium_test.go
@@ -117,8 +117,8 @@ func TestGetTestRuns_SHA(t *testing.T) {
 	assert.Equal(t, 2, len(results))
 	assert.Equal(t, "abcdef0123", results[0].Revision)
 
-	// ?complete ignored if SHA provided.
-	r, _ = i.NewRequest("GET", "/api/runs?sha=abcdef0123&complete", nil)
+	// ?aligned ignored if SHA provided.
+	r, _ = i.NewRequest("GET", "/api/runs?sha=abcdef0123&aligned", nil)
 	resp = httptest.NewRecorder()
 	apiTestRunsHandler(resp, r)
 	body, _ = ioutil.ReadAll(resp.Result().Body)
@@ -127,8 +127,8 @@ func TestGetTestRuns_SHA(t *testing.T) {
 	assert.Equal(t, 2, len(results))
 	assert.Equal(t, "abcdef0123", results[0].Revision)
 
-	// ?complete - no complete runs.
-	r, _ = i.NewRequest("GET", "/api/runs?complete", nil)
+	// ?aligned - no aligned runs.
+	r, _ = i.NewRequest("GET", "/api/runs?aligned", nil)
 	resp = httptest.NewRecorder()
 	apiTestRunsHandler(resp, r)
 	body, _ = ioutil.ReadAll(resp.Result().Body)
@@ -139,7 +139,7 @@ func TestGetTestRuns_SHA(t *testing.T) {
 		run.BrowserName = name
 		datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
 	}
-	r, _ = i.NewRequest("GET", "/api/runs?complete", nil)
+	r, _ = i.NewRequest("GET", "/api/runs?aligned", nil)
 	resp = httptest.NewRecorder()
 	apiTestRunsHandler(resp, r)
 	body, _ = ioutil.ReadAll(resp.Result().Body)

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -4,7 +4,7 @@ The UI consists of base HTML templates served by the Go App Engine app in `webap
 
 ## UI Principles
 
-- The dashboard should not surface any overall metrics that compare complete runs of different browsers against each other.
+- The dashboard should not surface any overall metrics that compare aligned runs of different browsers against each other.
 - Clean, uncluttered design.
 
 ### More specifically

--- a/shared/datastore.go
+++ b/shared/datastore.go
@@ -147,9 +147,9 @@ func VersionPrefix(query *datastore.Query, fieldName, versionPrefix string, desc
 		Filter(fieldName+" <=", fmt.Sprintf("%s.%c", versionPrefix, '9'+1))
 }
 
-// GetCompleteRunSHAs returns an array of the SHA[0:10] for runs that
+// GetAlignedRunSHAs returns an array of the SHA[0:10] for runs that
 // exists for all the given products, ordered by most-recent.
-func GetCompleteRunSHAs(
+func GetAlignedRunSHAs(
 	ctx context.Context,
 	products ProductSpecs,
 	labels mapset.Set,

--- a/shared/datastore_medium_test.go
+++ b/shared/datastore_medium_test.go
@@ -350,7 +350,7 @@ func TestLoadTestRuns_To(t *testing.T) {
 	assert.Equal(t, "0987654321", loaded[0].Revision)
 }
 
-func TestGetCompleteRunSHAs(t *testing.T) {
+func TestGetAlignedRunSHAs(t *testing.T) {
 	ctx, done, err := sharedtest.NewAEContext(true)
 	assert.Nil(t, err)
 	defer done()
@@ -358,7 +358,7 @@ func TestGetCompleteRunSHAs(t *testing.T) {
 	browserNames := shared.GetDefaultBrowserNames()
 
 	// Nothing in datastore.
-	shas, _ := shared.GetCompleteRunSHAs(ctx, shared.GetDefaultProducts(), nil, nil, nil, nil)
+	shas, _ := shared.GetAlignedRunSHAs(ctx, shared.GetDefaultProducts(), nil, nil, nil, nil)
 	assert.Equal(t, 0, len(shas))
 
 	// Only 3 browsers.
@@ -373,7 +373,7 @@ func TestGetCompleteRunSHAs(t *testing.T) {
 		run.BrowserName = browser
 		datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
 	}
-	shas, _ = shared.GetCompleteRunSHAs(ctx, shared.GetDefaultProducts(), nil, nil, nil, nil)
+	shas, _ = shared.GetAlignedRunSHAs(ctx, shared.GetDefaultProducts(), nil, nil, nil, nil)
 	assert.Len(t, shas, 0)
 
 	// But, if request by any subset of those 3 browsers, we find the SHA.
@@ -382,13 +382,13 @@ func TestGetCompleteRunSHAs(t *testing.T) {
 		product := shared.ProductSpec{}
 		product.BrowserName = browser
 		products = append(products, product)
-		shas, _ = shared.GetCompleteRunSHAs(ctx, products, nil, nil, nil, nil)
+		shas, _ = shared.GetAlignedRunSHAs(ctx, products, nil, nil, nil, nil)
 		assert.Len(t, shas, 1)
 	}
 	// And labels
-	shas, _ = shared.GetCompleteRunSHAs(ctx, products, mapset.NewSetWith("foo"), nil, nil, nil)
+	shas, _ = shared.GetAlignedRunSHAs(ctx, products, mapset.NewSetWith("foo"), nil, nil, nil)
 	assert.Len(t, shas, 1)
-	shas, _ = shared.GetCompleteRunSHAs(ctx, products, mapset.NewSetWith("bar"), nil, nil, nil)
+	shas, _ = shared.GetAlignedRunSHAs(ctx, products, mapset.NewSetWith("bar"), nil, nil, nil)
 	assert.Len(t, shas, 0)
 
 	// All 4 browsers, but experimental.
@@ -398,7 +398,7 @@ func TestGetCompleteRunSHAs(t *testing.T) {
 		run.BrowserName = browser + "-" + shared.ExperimentalLabel
 		datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
 	}
-	shas, _ = shared.GetCompleteRunSHAs(ctx, shared.GetDefaultProducts(), nil, nil, nil, nil)
+	shas, _ = shared.GetAlignedRunSHAs(ctx, shared.GetDefaultProducts(), nil, nil, nil, nil)
 	assert.Equal(t, 0, len(shas))
 
 	// 2 browsers, and other 2, but experimental.
@@ -411,7 +411,7 @@ func TestGetCompleteRunSHAs(t *testing.T) {
 		}
 		datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
 	}
-	shas, _ = shared.GetCompleteRunSHAs(ctx, shared.GetDefaultProducts(), nil, nil, nil, nil)
+	shas, _ = shared.GetAlignedRunSHAs(ctx, shared.GetDefaultProducts(), nil, nil, nil, nil)
 	assert.Equal(t, 0, len(shas))
 
 	// 2 browsers which are twice.
@@ -422,7 +422,7 @@ func TestGetCompleteRunSHAs(t *testing.T) {
 		datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
 		datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
 	}
-	shas, _ = shared.GetCompleteRunSHAs(ctx, shared.GetDefaultProducts(), nil, nil, nil, nil)
+	shas, _ = shared.GetAlignedRunSHAs(ctx, shared.GetDefaultProducts(), nil, nil, nil, nil)
 	assert.Equal(t, 0, len(shas))
 
 	// All 4 browsers.
@@ -432,7 +432,7 @@ func TestGetCompleteRunSHAs(t *testing.T) {
 		run.BrowserName = browser
 		datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
 	}
-	shas, _ = shared.GetCompleteRunSHAs(ctx, shared.GetDefaultProducts(), nil, nil, nil, nil)
+	shas, _ = shared.GetAlignedRunSHAs(ctx, shared.GetDefaultProducts(), nil, nil, nil, nil)
 	assert.Equal(t, []string{"abcdef0123"}, shas)
 
 	// Another (earlier) run, also all 4 browsers.
@@ -442,14 +442,14 @@ func TestGetCompleteRunSHAs(t *testing.T) {
 		run.BrowserName = browser
 		datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
 	}
-	shas, _ = shared.GetCompleteRunSHAs(ctx, shared.GetDefaultProducts(), nil, nil, nil, nil)
+	shas, _ = shared.GetAlignedRunSHAs(ctx, shared.GetDefaultProducts(), nil, nil, nil, nil)
 	assert.Equal(t, []string{"abcdef0123", "abcdef9999"}, shas)
 	// Limit 1
 	one := 1
-	shas, _ = shared.GetCompleteRunSHAs(ctx, shared.GetDefaultProducts(), nil, nil, nil, &one)
+	shas, _ = shared.GetAlignedRunSHAs(ctx, shared.GetDefaultProducts(), nil, nil, nil, &one)
 	assert.Equal(t, []string{"abcdef0123"}, shas)
 	// From 4 days ago @ midnight.
 	from := time.Now().AddDate(0, 0, -4).Truncate(24 * time.Hour)
-	shas, _ = shared.GetCompleteRunSHAs(ctx, shared.GetDefaultProducts(), nil, &from, nil, nil)
+	shas, _ = shared.GetAlignedRunSHAs(ctx, shared.GetDefaultProducts(), nil, &from, nil, nil)
 	assert.Equal(t, []string{"abcdef0123"}, shas)
 }

--- a/shared/params_test.go
+++ b/shared/params_test.go
@@ -394,22 +394,22 @@ func TestParseProductSpec_String(t *testing.T) {
 	assert.Equal(t, "chrome-64[bar,foo]@1234512345", productSpec.String())
 }
 
-func TestParseComplete(t *testing.T) {
+func TestParseAligned(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/api/runs", nil)
-	complete, _ := ParseCompleteParam(r)
-	assert.Nil(t, complete)
+	aligned, _ := ParseAlignedParam(r)
+	assert.Nil(t, aligned)
 
-	r = httptest.NewRequest("GET", "http://wpt.fyi/api/runs?complete", nil)
-	complete, _ = ParseCompleteParam(r)
-	assert.True(t, *complete)
+	r = httptest.NewRequest("GET", "http://wpt.fyi/api/runs?aligned", nil)
+	aligned, _ = ParseAlignedParam(r)
+	assert.True(t, *aligned)
 
-	r = httptest.NewRequest("GET", "http://wpt.fyi/api/runs?complete=true", nil)
-	complete, _ = ParseCompleteParam(r)
-	assert.True(t, *complete)
+	r = httptest.NewRequest("GET", "http://wpt.fyi/api/runs?aligned=true", nil)
+	aligned, _ = ParseAlignedParam(r)
+	assert.True(t, *aligned)
 
-	r = httptest.NewRequest("GET", "http://wpt.fyi/api/runs?complete=false", nil)
-	complete, _ = ParseCompleteParam(r)
-	assert.False(t, *complete)
+	r = httptest.NewRequest("GET", "http://wpt.fyi/api/runs?aligned=false", nil)
+	aligned, _ = ParseAlignedParam(r)
+	assert.False(t, *aligned)
 }
 
 func TestParseRunIDsParam_nil(t *testing.T) {
@@ -458,7 +458,7 @@ func TestParseQueryFilterParams_q(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func TestParseQueryFilterParams_complete(t *testing.T) {
+func TestParseQueryFilterParams_aligned(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/api/search?run_ids=1,2,3&q=abcd", nil)
 	filter, err := ParseQueryFilterParams(r)
 	assert.Equal(t, QueryFilter{
@@ -477,8 +477,8 @@ func TestParseQueryFilterParams_err(t *testing.T) {
 func TestParseTestRunFilterParams(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/", nil)
 	filter, _ := ParseTestRunFilterParams(r)
-	assert.Nil(t, filter.Complete)
-	assert.Equal(t, "complete=true", filter.ToQuery(true).Encode())
+	assert.Nil(t, filter.Aligned)
+	assert.Equal(t, "aligned=true", filter.ToQuery(true).Encode())
 	assert.Equal(t, "", filter.ToQuery(false).Encode())
 
 	r = httptest.NewRequest("GET", "http://wpt.fyi/?label=stable", nil)
@@ -488,7 +488,7 @@ func TestParseTestRunFilterParams(t *testing.T) {
 
 	r = httptest.NewRequest("GET", "http://wpt.fyi/?from=2018-01-01T00%3A00%3A00Z", nil)
 	filter, _ = ParseTestRunFilterParams(r)
-	assert.Equal(t, "complete=true&from=2018-01-01T00%3A00%3A00Z", filter.ToQuery(true).Encode())
+	assert.Equal(t, "aligned=true&from=2018-01-01T00%3A00%3A00Z", filter.ToQuery(true).Encode())
 	assert.Equal(t, "from=2018-01-01T00%3A00%3A00Z", filter.ToQuery(false).Encode())
 }
 

--- a/util/populate_dev_data.go
+++ b/util/populate_dev_data.go
@@ -204,9 +204,9 @@ func main() {
 }
 
 func copyProdRuns(ctx context.Context, filters shared.TestRunFilter) {
-	for _, complete := range []bool{false, true} {
-		if complete {
-			filters.Complete = &complete
+	for _, aligned := range []bool{false, true} {
+		if aligned {
+			filters.Aligned = &aligned
 		}
 		prodTestRuns, err := shared.FetchRuns(*host, filters)
 		if err != nil {
@@ -225,15 +225,15 @@ func copyProdRuns(ctx context.Context, filters shared.TestRunFilter) {
 		filters.MaxCount = nil
 		prodPassRateMetadata, err := FetchInterop(*host, filters)
 		if err != nil {
-			log.Printf("Failed to fetch interop (?complete=%v).", complete)
+			log.Printf("Failed to fetch interop (?aligned=%v).", aligned)
 			continue
 		}
 		// Update the interop IDs to match the newly-copied local test-run IDs.
 		prodPassRateMetadata.TestRunIDs = make([]int64, len(prodPassRateMetadata.TestRuns))
 		one := 1
 		var shas []string
-		if complete {
-			shas, _ = shared.GetCompleteRunSHAs(ctx, shared.GetDefaultProducts(), filters.Labels, nil, nil, &one)
+		if aligned {
+			shas, _ = shared.GetAlignedRunSHAs(ctx, shared.GetDefaultProducts(), filters.Labels, nil, nil, &one)
 		}
 		var localRunCopies []shared.TestRun
 		localRunCopies, err = shared.LoadTestRuns(ctx, shared.GetDefaultProducts(), filters.Labels, shas, nil, nil, &one)

--- a/webapp/components/test-results-chart.html
+++ b/webapp/components/test-results-chart.html
@@ -170,7 +170,7 @@ found in the LICENSE file.
         labels = labels || [];
 
         const url = new URL('/api/runs', window.location);
-        url.searchParams.append('complete', true);
+        url.searchParams.append('aligned', true);
         url.searchParams.append('max-count', chunkSize);
         if (labels && labels.length) {
           url.searchParams.append('labels', labels.join(','));

--- a/webapp/components/test-results-history-grid.html
+++ b/webapp/components/test-results-history-grid.html
@@ -92,7 +92,7 @@ found in the LICENSE file.
         sha = null;
         const params = super.testRunQueryParams(sha, labels, products, maxCount);
         if (!labels || !labels.length) {
-          params.complete = true;
+          params.aligned = true;
         }
         return params;
       }

--- a/webapp/components/test-runs.html
+++ b/webapp/components/test-runs.html
@@ -51,7 +51,7 @@ found in the LICENSE file.
           },
           maxCount: Number,
           sha: String,
-          complete: Boolean,
+          aligned: Boolean,
           isLatest: {
             type: Boolean,
             computed: 'computeIsLatest(sha)'
@@ -152,10 +152,10 @@ found in the LICENSE file.
           params['max-count'] = maxCount;
         }
 
-        // Insist on complete runs iff there is no other parameter.
+        // Insist on aligned runs iff there is no other parameter.
         // This is a temporary hack for https://github.com/web-platform-tests/wpt.fyi/issues/468
-        if (this.complete || Object.keys(params).length === 0) {
-          params.complete = true;
+        if (this.aligned || Object.keys(params).length === 0) {
+          params.aligned = true;
         }
 
         return params;

--- a/webapp/templates/interoperability.html
+++ b/webapp/templates/interoperability.html
@@ -13,7 +13,7 @@
                    {{- if .Products}} products="{{ .Products }}"{{end}}
                    {{- if .SHA}} sha="{{ .SHA }}" {{end}}
                    {{- if .Labels}} labels="{{ .Labels }}"{{end}}
-                   {{- if .Complete}} complete{{end}}
+                   {{- if .Aligned}} aligned{{end}}
                  {{- end}}></wpt-interop>
   </div>
 </div>

--- a/webapp/templates/results.html
+++ b/webapp/templates/results.html
@@ -13,7 +13,7 @@
           {{- if .Labels}} labels="{{ .Labels }}"{{end}}
           {{- if .MaxCount}} max-count="{{ .MaxCount }}"{{end}}
           {{- if .Diff}} diff{{end}}
-          {{- if .Complete}} complete{{end}}
+          {{- if .Aligned}} aligned{{end}}
         {{- end}}></wpt-results>
   </div>
 </div>

--- a/webapp/test_results_handler.go
+++ b/webapp/test_results_handler.go
@@ -20,7 +20,7 @@ type testRunUIFilter struct {
 	Products      string
 	Labels        string
 	SHA           string
-	Complete      bool
+	Aligned       bool
 	MaxCount      *int
 	BeforeSpec    *shared.ProductSpec
 	AfterSpec     *shared.ProductSpec
@@ -151,7 +151,7 @@ func parseTestRunUIFilter(r *http.Request) (filter testRunUIFilter, err error) {
 		filter.Products = string(data)
 	}
 	filter.MaxCount = testRunFilter.MaxCount
-	filter.Complete = testRunFilter.Complete != nil && *testRunFilter.Complete
+	filter.Aligned = testRunFilter.Aligned != nil && *testRunFilter.Aligned
 
 	diff, err := shared.ParseBooleanParam(r, "diff")
 	if err != nil {


### PR DESCRIPTION
## Description
Treats `complete` as a legacy fallback, and uses `aligned` instead.

`aligned` is much more descriptive of the effect of the param; for the requested products, return (the first / most recent) runs which share the same SHA.

`complete` was chosen under the assumption that all four browsers had run for the SHA, and does not take into account a custom set of products (added in #491)