### PR TITLE
Fetch at most 1000 test run keys.

### DIFF
--- a/shared/datastore.go
+++ b/shared/datastore.go
@@ -33,7 +33,7 @@ func LoadTestRuns(
 	to *time.Time,
 	limit *int) (result []TestRun, err error) {
 	var testRuns []TestRun
-	baseQuery := datastore.NewQuery("TestRun")
+	baseQuery := datastore.NewQuery("TestRun").Limit(1000)
 	// NOTE(lukebjerring): While we can't filter on multiple SHAs, it's still much more efficient
 	// to (pre-)filter for a single SHA during the query.
 	if len(shas) == 1 && !IsLatest(shas[0]) {


### PR DESCRIPTION
## Description
Prevents the current error seen in staging `/test-runs`:

> API error 1 (datastore_v3: BAD_REQUEST): cannot get more than 1000 keys in a single call