### PR TITLE
Correct description of results format

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -342,8 +342,8 @@ The JSON file roughly looks like this:
 ```json
 {
   "results": [...],
-  "time_start": MICROSECONDS_SINCE_EPOCH,
-  "time_end": MICROSECONDS_SINCE_EPOCH,
+  "time_start": MILLISECONDS_SINCE_EPOCH,
+  "time_end": MILLISECONDS_SINCE_EPOCH,
   "run_info": {
     "revision": "WPT revision of the test run",
     "product": "your browser",
@@ -357,7 +357,7 @@ The JSON file roughly looks like this:
 
 __Notes__
 
-The `time_start` and `time_end` fields are numerical timestamps (in microseconds since the UNIX epoch)
+The `time_start` and `time_end` fields are numerical timestamps (in milliseconds since the UNIX epoch)
 when the whole test run starts and finishes. They are optional, but encouraged. `wpt run` produces
 them in the report by default.
 


### PR DESCRIPTION
The `time_start` and `time_end` properties are cited as being inserted
by the WPT CLI. That tool does indeed define those properties [1], but
the values are in units of milliseconds, not microseconds. This is
documented by the MozLog project [2] which the WPT CLI uses to provide
structured logging:

> time - The timestamp of the message in ms since the epoch (int).

[1] https://github.com/web-platform-tests/wpt/blob/632a3f59238036b6e24b28d47218ba9986ff4c62/tools/wptrunner/wptrunner/formatters.py#L13-L25
[2] https://firefox-source-docs.mozilla.org/mozbase/mozlog.html#data-format