### PR TITLE
Add a loading spinner + failure message for interop

### DIFF
--- a/webapp/components/interop.html
+++ b/webapp/components/interop.html
@@ -7,7 +7,10 @@ found in the LICENSE file.
 <link rel="import" href="../bower_components/polymer/polymer-element.html">
 <link rel="import" href="../bower_components/polymer/lib/elements/dom-if.html">
 <link rel="import" href="../bower_components/polymer/lib/elements/dom-repeat.html">
+<link rel="import" href="../bower_components/paper-spinner/paper-spinner-lite.html">
 <link rel="import" href="../bower_components/paper-styles/color.html">
+<link rel="import" href="info-banner.html">
+<link rel="import" href="loading-state.html">
 <link rel="import" href="path-part.html">
 <link rel="import" href="test-runs.html">
 <link rel="import" href="test-file-results.html">
@@ -33,10 +36,15 @@ found in the LICENSE file.
       border-bottom: solid 1px #ccc;
       padding-bottom: 1em;
       margin-bottom: 1em;
+      position: relative;
     }
-
     section.search .path {
       margin-top: 1em;
+    }
+    section.search paper-spinner-lite {
+      position: absolute;
+      top: 0;
+      right: 0;
     }
 
     /* Direct access to test-search from local shadowRoot prevents using
@@ -115,6 +123,8 @@ found in the LICENSE file.
       </template>
     </div>
 
+    <paper-spinner-lite active="[[isLoading]]" class="blue"></paper-spinner-lite>
+
     <test-search class$="search-[[pathIsATestFile]]" query="[[search]]">
     </test-search>
 
@@ -130,6 +140,12 @@ found in the LICENSE file.
       </div>
     </template>
   </section>
+
+  <template is="dom-if" if="[[interopLoadFailed]]">
+    <info-banner type="error">
+      Failed to fetch interop data.
+    </info-banner>
+  </template>
 
   <template is="dom-if" if="[[!pathIsATestFile]]">
     <section class="runs">
@@ -198,8 +214,8 @@ found in the LICENSE file.
     [118, 255,   3], // --paper-light-green-a200
   ];
 
-  /* global TestRunsBase, SelfNavigation */
-  class WPTInterop extends SelfNavigation(TestRunsBase) {
+  /* global TestRunsBase, SelfNavigation, LoadingState */
+  class WPTInterop extends SelfNavigation(LoadingState(TestRunsBase)) {
     static get is() {
       return 'wpt-interop';
     }
@@ -235,12 +251,16 @@ found in the LICENSE file.
         },
         searchResults: Array,
         onSearchCommit: Function,
+        interopLoadFailed: Boolean,
       };
     }
 
     constructor() {
       super();
       this.onSearchCommit = this.handleSearchCommit.bind(this);
+      this.onLoadingComplete = () => {
+        this.interopLoadFailed = !(this.passRateMetadata && this.allMetrics);
+      }
     }
 
     connectedCallback() {
@@ -257,19 +277,19 @@ found in the LICENSE file.
 
     async ready() {
       await super.ready();
-      this.passRateMetadata = await fetch(`/api/interop${this.query}`).then(
-        function(r) {
-          if (!r.ok) {
-            return Promise.reject('Failed to fetch interop data');
-          }
-          return r.json();
-        });
-      this.allMetrics = await this.fetchMetrics(this.passRateMetadata.url);
-    }
-
-    async fetchMetrics(url) {
-      const response = await window.fetch(url);
-      return await response.json();
+      this.loadingCount++;
+      try {
+        this.passRateMetadata = await fetch(`/api/interop${this.query}`)
+          .then(async r => {
+            if (!r.ok || r.status !== 200) {
+              Promise.reject('Failed to fetch interop data');
+            }
+            return r.json();
+          });
+        this.allMetrics = await fetch(this.passRateMetadata.url).then(r => r.json());
+      } finally {
+        this.loadingCount--;
+      }
     }
 
     navigationPathPrefix() {

--- a/webapp/components/interop.html
+++ b/webapp/components/interop.html
@@ -259,6 +259,8 @@ found in the LICENSE file.
       super();
       this.onSearchCommit = this.handleSearchCommit.bind(this);
       this.onLoadingComplete = () => {
+        // passRateMetadata contains the url for the JSON blob of allMetrics;
+        // both fetches need to succeed + parse.
         this.interopLoadFailed = !(this.passRateMetadata && this.allMetrics);
       }
     }
@@ -290,11 +292,6 @@ found in the LICENSE file.
       } finally {
         this.loadingCount--;
       }
-    }
-
-    async fetchMetrics(url) {
-      const response = await window.fetch(url);
-      return await response.json();
     }
 
     navigationPathPrefix() {

--- a/webapp/components/loading-state.html
+++ b/webapp/components/loading-state.html
@@ -1,0 +1,41 @@
+<!--
+Copyright 2018 The WPT Dashboard Project. All rights reserved.
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file.
+-->
+
+<!--
+`<loading-state>` is a behaviour component for indicating when information is
+still being loaded (generally, fetched).
+-->
+<dom-module id="loading-state">
+  <script>
+    // eslint-disable-next-line no-unused-vars
+    const LoadingState = (superClass) => class extends superClass {
+      static get properties() {
+        return {
+          loadingCount: {
+            type: Number,
+            value: 0,
+            observer: 'loadingCountChanged',
+          },
+          isLoading: {
+            type: Boolean,
+            computed: 'computeIsLoading(loadingCount)',
+          },
+          onLoadingComplete: Function,
+        };
+      }
+
+      computeIsLoading(loadingCount) {
+        return !!loadingCount;
+      }
+
+      loadingCountChanged(now, then) {
+        if (now === 0 && then > 0 && this.onLoadingComplete) {
+          this.onLoadingComplete();
+        }
+      }
+    };
+  </script>
+</dom-module>

--- a/webapp/components/test/interop.html
+++ b/webapp/components/test/interop.html
@@ -51,7 +51,6 @@
       suite('WPTInterop.prototype.*', () => {
         setup((done) => {
           sandbox.spy(window.Polymer.Element.prototype, 'ready');
-          sandbox.spy(WPTInterop.prototype, 'fetchMetrics');
 
           fixture('wpt-interop-fixture');
 
@@ -65,12 +64,6 @@
 
           test('fetches interop', () => {
             return waitingOn(() => window.fetch.calledWith('/api/interop'));
-          });
-        });
-
-        suite('async fetchMetrics()', () => {
-          test('Calls window.fetch(...)', () => {
-            return waitingOn(() => window.fetch.calledWith(fetches['/api/interop'].url));
           });
         });
       });

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -11,6 +11,8 @@ found in the LICENSE file.
 <link rel="import" href="../bower_components/polymer/lib/elements/dom-if.html">
 <link rel="import" href="../bower_components/polymer/lib/elements/dom-repeat.html">
 <link rel="import" href="../bower_components/polymer/polymer-element.html">
+<link rel="import" href="info-banner.html">
+<link rel="import" href="loading-state.html">
 <link rel="import" href="path-part.html">
 <link rel="import" href="results-navigation.html">
 <link rel="import" href="self-navigator.html">
@@ -20,7 +22,6 @@ found in the LICENSE file.
 <link rel="import" href="test-results-history-grid.html">
 <link rel="import" href="test-results-chart.html">
 <link rel="import" href="test-search.html">
-<link rel="import" href="info-banner.html">
 
 <dom-module id="wpt-results">
   <template>
@@ -164,7 +165,7 @@ found in the LICENSE file.
       </paper-toast>
     </template>
 
-    <template is="dom-if" if="[[runsNotFound]]">
+    <template is="dom-if" if="[[resultsLoadFailed]]">
       <info-banner type="error">
         Failed to fetch test runs.
       </info-banner>
@@ -251,14 +252,13 @@ found in the LICENSE file.
         </template>
       </div>
     </template>
-
   </template>
 
   <script>
     const TEST_TYPES = ['manual', 'reftest', 'testharness', 'visual', 'wdspec'];
 
-    /* global TestRunsBase, SelfNavigation */
-    class WPTResults extends SelfNavigation(TestRunsBase) {
+    /* global TestRunsBase, SelfNavigation, LoadingState */
+    class WPTResults extends SelfNavigation(LoadingState(TestRunsBase)) {
       static get is() {
         return 'wpt-results';
       }
@@ -321,17 +321,8 @@ found in the LICENSE file.
             type: String,
             computed: 'computeAutocompleteURL(testRuns, search)',
           },
-          loadingCount: {
-            type: Number,
-            value: 0,
-          },
-          isLoading: {
-            type: Boolean,
-            computed: 'computeIsLoading(loadingCount)',
-          },
-          runsNotFound: {
-            type: Boolean,
-            computed: 'computeRunsNotFound(isLoading, testRuns)',
+          resultsLoadFailed: {
+            type:Boolean, value: false,
           },
           onSearchCommit: Function,
         };
@@ -412,17 +403,14 @@ found in the LICENSE file.
         return url;
       }
 
-      computeIsLoading(loadingCount) {
-        return !!loadingCount;
-      }
-
-      computeRunsNotFound(isLoading, testRuns) {
-        return !isLoading && !(testRuns && testRuns.length);
-      }
-
       constructor() {
         super();
         this.onSearchCommit = this.handleSearchCommit.bind(this);
+        this.onLoadingComplete = () => {
+          this.resultsLoadFailed =
+            !(this.testRuns && this.testRuns.length
+              && this.searchResults && this.searchResults.length);
+        }
       }
 
       connectedCallback() {
@@ -437,37 +425,45 @@ found in the LICENSE file.
         super.disconnectedCallback();
       }
 
-      ready() {
-        super.ready();
-        this.loadRuns().then(async runs => {
-          this.fetchResults();
-
-          // Load a diff data into this.diffRun, if needed.
-          if (this.diff && runs && runs.length === 2) {
-            this.diffRun = {
-              revision: 'diff',
-              browser_name: 'diff',
-            };
-          }
-        });
+      async ready() {
+        await super.ready();
 
         // NOTE(lukebjerring): Overriding the pathUpdated method doesn't get
-        // called, so we wrap any given onpathupdated methd here.
+        // called, so we wrap any given onpathupdated method here.
         const onpathupdated = this.onpathupdated;
         this.onpathupdated = path => {
           onpathupdated && onpathupdated(path);
           this.showHistory = false;
         };
+
+        this.loadingCount++;
+        try {
+          await this.loadRuns().then(async runs => {
+            this.fetchResults();
+
+            // Load a diff data into this.diffRun, if needed.
+            if (this.diff && runs && runs.length === 2) {
+              this.diffRun = {
+                revision: 'diff',
+                browser_name: 'diff',
+              };
+            }
+          });
+        } finally {
+          this.loadingCount--;
+        }
       }
 
       async fetchResults() {
         this.loadingCount++;
         try {
-          const response = await window.fetch(this.searchURL);
-          if (response.status !== 200) {
-            throw response;
-          }
-          const json = await response.json();
+          const json = await window.fetch(this.searchURL)
+            .then(async r => {
+              if (!r.ok || r.status != 200) {
+                return Promise.reject('Failed to fetch results data.');
+              }
+              return r.json();
+            });
           this.searchResults = json.results;
           this.refreshDisplayedNodes();
         } finally {

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -322,7 +322,7 @@ found in the LICENSE file.
             computed: 'computeAutocompleteURL(testRuns, search)',
           },
           resultsLoadFailed: {
-            type:Boolean,
+            type: Boolean,
             value: false,
           },
           onSearchCommit: Function,

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -322,7 +322,8 @@ found in the LICENSE file.
             computed: 'computeAutocompleteURL(testRuns, search)',
           },
           resultsLoadFailed: {
-            type:Boolean, value: false,
+            type:Boolean,
+            value: false,
           },
           onSearchCommit: Function,
         };
@@ -458,7 +459,7 @@ found in the LICENSE file.
         this.loadingCount++;
         try {
           const json = await window.fetch(this.searchURL)
-            .then(async r => {
+            .then(r => {
               if (!r.ok || r.status != 200) {
                 return Promise.reject('Failed to fetch results data.');
               }


### PR DESCRIPTION
## Description
Re-uses the `loadingCount` and `isLoading` properties in a `loading-state` behaviour component.

## Review Information
- Visit the auto-deployed env's interop tab. See a spinner.
- add `?label=foo`. See a failure message.