### PR TITLE
Add 'msedge' source svg

### DIFF
--- a/webapp/components/test-run.html
+++ b/webapp/components/test-run.html
@@ -180,7 +180,8 @@ See models.go for more details.
         if (!showSource || !testRun.labels) {
           return '';
         }
-        return testRun.labels.find(l => ['taskcluster', 'buildbot'].includes(l));
+        const sources = ['taskcluster', 'buildbot', 'msedge'];
+        return testRun.labels.find(l => sources.includes(l));
       }
 
       minorIsSignificant(browserName) {

--- a/webapp/static/msedge.svg
+++ b/webapp/static/msedge.svg
@@ -1,0 +1,8 @@
+<svg version="1.1" id="Calque_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="439px" height="439px" viewBox="0 0 439 439" style="enable-background:new 0 0 439 439;" xml:space="preserve">
+<rect fill="#F3F3F3" width="439" height="439"/>
+<rect x="17" y="17" fill="#F35325" width="194" height="194"/>
+<rect x="228" y="17" fill="#81BC06" width="194" height="194"/>
+<rect x="17" y="228" fill="#05A6F0" width="194" height="194"/>
+<rect x="228" y="228" fill="#FFBA08" width="194" height="194"/>
+</svg>


### PR DESCRIPTION
## Description
Following up from #541, with a little Microsoft logo when `msedge` label is present.

You'll need to load /test-runs?product=edge[experimental] to see it.