### PR TITLE
Change test-runs to default to 1 month

### DIFF
--- a/webapp/components/wpt-runs.html
+++ b/webapp/components/wpt-runs.html
@@ -62,7 +62,7 @@ found in the LICENSE file.
     </style>
 
     <section class="info">
-      Showing the last 3 months of test runs.
+      Showing the last month of test runs.
     </section>
 
     <table>

--- a/webapp/test_runs_handler.go
+++ b/webapp/test_runs_handler.go
@@ -25,9 +25,9 @@ func testRunsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get runs from 3 months ago onward by default.
+	// Get runs from a month ago, onward, by default.
 	if filter.From == nil {
-		threeMonthsAgo := time.Now().Truncate(time.Hour*24).AddDate(0, -3, 0)
+		threeMonthsAgo := time.Now().Truncate(time.Hour*24).AddDate(0, -1, 0)
 		filter.From = &threeMonthsAgo
 	}
 


### PR DESCRIPTION
## Description
3 months loads 
- A) way too many runs
- B) more than 1000 runs (see #539, still a bug on /test-runs)