### PR TITLE
Disable external Datastore emulator

### DIFF
--- a/webdriver/webapp_server.go
+++ b/webdriver/webapp_server.go
@@ -147,6 +147,10 @@ func NewDevAppServer() (s DevAppServerInstance, err error) {
 		// admin port directly so we don't need to use pickUnusedPort.
 		fmt.Sprintf("--admin_port=%d", 0),
 		"--automatic_restart=false",
+		// TODO(Hexcles): Force the legacy internal Datastore emulation
+		// in dev_appserver instead of the external one until
+		// https://issuetracker.google.com/issues/112817362 is solved.
+		"--support_datastore_emulator=false",
 		"--skip_sdk_update_check=true",
 		"--clear_datastore=true",
 		"--datastore_consistency_policy=consistent",


### PR DESCRIPTION
dev_appserver is migrating from a builtin Datastore emulation to
[Cloud Datastore Emulator](https://cloud.google.com/appengine/docs/standard/python/tools/migrate-cloud-datastore-emulator).

Currently, dev_appserver will randomly select some machines (based on
analytics ID) to enable the external emulator. However, the integration
depends on a Python package grpcio which has a native module that
doesn't work on some platforms, including our Docker.

Therefore, explicitly disable the external emulator until the bug is
fixed (or until the internal emulation is deprecated).

A related public issue: https://issuetracker.google.com/issues/112817362

## Review Information

The bug can be reproduced locally inside Docker by specifying `--support_datastore_emulator=true`.

With this PR, Travis should pass consistently.

However, this is a really nasty bug because of the A/B testing of dev_appserver. When the flag is absent, the bug only demonstrates itself on some particular Travis VMs (presumably the experiment selection depends on some machine information like MAC).