### PR TITLE
Add a retry to the travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,5 +65,5 @@ script:
     fi
   - | # Run tests
     if [ "${MAKE_TEST_TARGET}" != "" ]; then
-      docker exec -t -u $(id -u $USER):$(id -g $USER) "${DOCKER_INSTANCE}" make "${MAKE_TEST_TARGET}" ${MAKE_TEST_FLAGS}
+      travis_retry docker exec -t -u $(id -u $USER):$(id -g $USER) "${DOCKER_INSTANCE}" make "${MAKE_TEST_TARGET}" ${MAKE_TEST_FLAGS}
     fi


### PR DESCRIPTION
## Description
We're fairly consistently seeing flakiness due to network errors (usually, `go get`) which are transient and fixed with a job retry.

Worst-case, this triples our computation of tasks that have genuine failures.
Best-case, this stops transient issues blocking clean/happy PRs.

See https://docs.travis-ci.com/user/common-build-problems/#travis_retry