### PR TITLE
Install go1.11 gofmt as part of go_deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ FROM gcr.io/gcp-runtimes/go1-builder:1.10
 # See Dockerfiles in sub-directories for individual service deployments.
 #
 # Caveats:
-# - AppEngine Standard uses golang 1.8, whereas AppEngine Flex defaults to 
-#   golang 1.10. This development environment uses the base image recommended 
+# - AppEngine Standard uses golang 1.8, whereas AppEngine Flex defaults to
+#   golang 1.10. This development environment uses the base image recommended
 #   for AppEngine Flex custom golang runtime, hence golang 1.10 is the default
 #   golang toolchain. However, when using the gcloud dev_appserver toolchain,
 #   it will internally use a custom golang 1.8 environment.
@@ -24,12 +24,12 @@ ENV WPTD_OUT_PATH="${USER_HOME}/wptdout"
 
 # Setup go environment
 ENV GOPATH="${USER_HOME}/go"
-RUN mkdir -p "${GOPATH}"
+RUN mkdir -p "${GOPATH}/bin"
 ENV GCLOUD_PATH="${USER_HOME}/google-cloud-sdk"
 ENV WPTD_GO_PATH="${GOPATH}/src/github.com/web-platform-tests/wpt.fyi"
 
 # Setup go + python binaries path
-ENV PATH=$PATH:/usr/local/go/bin:$GOPATH/bin:${USER_HOME}/.local/bin:${GCLOUD_PATH}/bin
+ENV PATH=$PATH:$GOPATH/bin:/usr/local/go/bin:${USER_HOME}/.local/bin:${GCLOUD_PATH}/bin
 
 # Install sudo so that unpriv'd dev user can "sudo apt-get install ..." in from
 # Makefile.

--- a/Makefile
+++ b/Makefile
@@ -212,17 +212,14 @@ node: curl gpg
 gofmt:
 	if [[ "$$(which gofmt)" != "$(GOPATH)/bin/gofmt" ]]; then \
 		TMP_DIR=$$(mktemp -d); \
-		pushd $$TMP_DIR > /dev/null 2>&1; \
-		git clone "https://github.com/golang/go.git"; \
+		cd $$TMP_DIR; \
+		git clone --depth 1 "https://github.com/golang/go.git" -b "release-branch.go1.11"; \
 		cd go; \
-		git checkout "origin/release-branch.go1.11"; \
 		mv "src/cmd" "$(GOPATH)/src/cmd"; \
-		popd > /dev/null 2>&1; \
 		rm -rf "$$TMP_DIR"; \
-		pushd "$(GOPATH)/src" > /dev/null 2>&1; \
+		cd "$(GOPATH)/src"; \
 		go build -o "$(GOPATH)/bin/gofmt" cmd/gofmt; \
 		rm -rf "$(GOPATH)/src/cmd"; \
-		popd > /dev/null 2>&1; \
 	fi
 
 gcloud: python curl gpg

--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ firefox_install: firefox_deps bzip2 wget java
 firefox_deps:
 	sudo apt-get install -qqy --no-install-suggests $$(apt-cache depends firefox-esr | grep Depends | sed "s/.*ends:\ //" | tr '\n' ' ')
 
-go_deps: gcloud go_packages $(GO_FILES)
+go_deps: gcloud gofmt go_packages $(GO_FILES)
 
 go_packages: git
 	cd $(WPTD_GO_PATH); go get -t -tags="small medium large" ./...
@@ -207,6 +207,22 @@ node: curl gpg
 	if [[ "$$(which node)" == "" ]]; then \
 		curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -; \
 		sudo apt-get install -qqy nodejs; \
+	fi
+
+gofmt:
+	if [[ "$$(which gofmt)" != "$(GOPATH)/bin/gofmt" ]]; then \
+		TMP_DIR=$$(mktemp -d); \
+		pushd $$TMP_DIR > /dev/null 2>&1; \
+		git clone "https://github.com/golang/go.git"; \
+		cd go; \
+		git checkout "origin/release-branch.go1.11"; \
+		mv "src/cmd" "$(GOPATH)/src/cmd"; \
+		popd > /dev/null 2>&1; \
+		rm -rf "$$TMP_DIR"; \
+		pushd "$(GOPATH)/src" > /dev/null 2>&1; \
+		go build -o "$(GOPATH)/bin/gofmt" cmd/gofmt; \
+		go install cmd/gofmt; \
+		popd > /dev/null 2>&1; \
 	fi
 
 gcloud: python curl gpg

--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,7 @@ gofmt:
 		rm -rf "$$TMP_DIR"; \
 		pushd "$(GOPATH)/src" > /dev/null 2>&1; \
 		go build -o "$(GOPATH)/bin/gofmt" cmd/gofmt; \
-		go install cmd/gofmt; \
+		rm -rf "$(GOPATH)/src/cmd"; \
 		popd > /dev/null 2>&1; \
 	fi
 


### PR DESCRIPTION
Unfortunately, there is no go1.11 image under the `gcr.io/gcp-runtimes/go1-builder` docker dossier. All we really need for tooling consistency is go1.11 `gofmt`. This manually installs it from source to a location earlier in `PATH` than the default go toolchain.