### PR TITLE
Check aligned in TestLabelParam webdriver test

### DIFF
--- a/webdriver/install.sh
+++ b/webdriver/install.sh
@@ -44,21 +44,21 @@ then
 fi
 cd ${INSTALL_DIR}
 
-# Firefox 60
+# Firefox 62
 FIREFOX="firefox"
 case "${UNAME_OUT}" in
     Darwin*)
         FIREFOX_OS="mac"
-        FIREFOX_DMG="Firefox 60.0.dmg"
+        FIREFOX_DMG="Firefox 62.0.dmg"
         FIREFOX_SRC="${FIREFOX_DMG}"
         ;;
     Linux*|*)
         FIREFOX_OS="linux-x86_64"
-        FIREFOX_TBZ="${FIREFOX}-60.0.tar.bz2"
+        FIREFOX_TBZ="${FIREFOX}-62.0.tar.bz2"
         FIREFOX_SRC="${FIREFOX_TBZ}"
         ;;
 esac
-FIREFOX_URL="https://releases.mozilla.org/pub/firefox/releases/60.0/${FIREFOX_OS}/en-US/${FIREFOX_SRC}"
+FIREFOX_URL="https://releases.mozilla.org/pub/firefox/releases/62.0/${FIREFOX_OS}/en-US/${FIREFOX_SRC}"
 
 info "Getting ${FIREFOX} binary..."
 if [[ ! -e ${FIREFOX} || "${REINSTALL}" == "true" ]]

--- a/webdriver/label_test.go
+++ b/webdriver/label_test.go
@@ -7,8 +7,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/deckarep/golang-set"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/tebeka/selenium"
+	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
 func TestLabelParam(t *testing.T) {
@@ -25,14 +28,17 @@ func TestLabelParam(t *testing.T) {
 	defer service.Stop()
 	defer wd.Quit()
 
+	// Local static data only have 2 experimental browsers, and neither has aligned
+	// experimental runs.
 	if *staging {
-		// We have all 4 experimental browsers on staging.wpt.fyi.
-		testLabel(t, wd, app, "/", "experimental", "wpt-results", 4)
+		testLabel(t, wd, app, "/", "experimental", "wpt-results", 4, false)
 	} else {
-		// Local static data only have 2 experimental browsers.
-		testLabel(t, wd, app, "/", "experimental", "wpt-results", 2)
+		testLabel(t, wd, app, "/", "experimental", "wpt-results", 2, false)
 	}
-	testLabel(t, wd, app, "/interop", "stable", "wpt-interop", 4)
+
+	for _, aligned := range []bool{true, false} {
+		testLabel(t, wd, app, "/interop", "stable", "wpt-interop", 4, aligned)
+	}
 }
 
 func testLabel(
@@ -40,9 +46,14 @@ func testLabel(
 	wd selenium.WebDriver,
 	app AppServer,
 	path, label, elementName string,
-	runs int) {
+	runs int,
+	aligned bool) {
 	// Navigate to the wpt.fyi homepage.
-	url := fmt.Sprintf("%s?label=%s", path, label)
+	filters := shared.TestRunFilter{
+		Labels:  mapset.NewSetWith(label),
+		Aligned: &aligned,
+	}
+	url := fmt.Sprintf("%s?%s", path, filters.ToQuery().Encode())
 	if err := wd.Get(app.GetWebappURL(url)); err != nil {
 		panic(err)
 	}
@@ -63,6 +74,9 @@ func testLabel(
 		panic(err)
 	}
 	assert.Lenf(t, testRuns, runs, "Expected exactly %v TestRuns search result.", runs)
+	if aligned {
+		assertAligned(t, wd, testRuns)
+	}
 
 	// Check tab URLs propagate label
 	tabs, err := getTabElements(wd, elementName)
@@ -100,5 +114,20 @@ func getTabElements(wd selenium.WebDriver, element string) ([]selenium.WebElemen
 			return nil, err
 		}
 		return FindShadowElements(wd, e, "results-navigation", "paper-tab")
+	}
+}
+
+func assertAligned(t *testing.T, wd selenium.WebDriver, testRuns []selenium.WebElement) {
+	if len(testRuns) < 2 {
+		return
+	}
+	args := []interface{}{testRuns[0]}
+	shaProp := "return arguments[0].testRun.revision"
+	sha, _ := wd.ExecuteScriptRaw(shaProp, args)
+	assert.NotEqual(t, sha, "")
+	for i := 1; i < len(testRuns); i++ {
+		args = []interface{}{testRuns[0]}
+		otherSHA, _ := wd.ExecuteScriptRaw(shaProp, args)
+		assert.Equal(t, sha, otherSHA)
 	}
 }

--- a/webdriver/label_test.go
+++ b/webdriver/label_test.go
@@ -55,7 +55,7 @@ func testLabel(
 	}
 	url := fmt.Sprintf("%s?%s", path, filters.ToQuery().Encode())
 	if err := wd.Get(app.GetWebappURL(url)); err != nil {
-		panic(err)
+		panic(fmt.Sprintf("Failed to load %s: %s", url, err.Error()))
 	}
 
 	// Wait for the results view to load.
@@ -66,12 +66,14 @@ func testLabel(
 		}
 		return len(testRuns) > 0, nil
 	}
-	wd.WaitWithTimeout(runsLoadedCondition, time.Second*10)
+	if err := wd.WaitWithTimeout(runsLoadedCondition, time.Second*10); err != nil {
+		panic(fmt.Sprintf("Error waiting for test runs: %s", err.Error()))
+	}
 
 	// Check loaded test runs
 	testRuns, err := getTestRunElements(wd, elementName)
 	if err != nil {
-		panic(err)
+		panic(fmt.Sprintf("Failed to get test runs: %s", err.Error()))
 	}
 	assert.Lenf(t, testRuns, runs, "Expected exactly %v TestRuns search result.", runs)
 	if aligned {


### PR DESCRIPTION
## Description
Our integration tests should cover the full [launch checklist](https://github.com/web-platform-tests/wpt.fyi/issues/561#issuecomment-422177245).

This PR adds coverage for:
- `/results?label=stable&aligned`
- `/interop?label=stable&aligned`

Checks that the SHAs of the loaded test runs match.

## Review Information
    make go_firefox_test USE_FRAME_BUFFER=false FIREFOX_PATH=~/browsers/firefox/firefox FLAGS='-test.run=^TestLabel'

and 

    make go_firefox_test STAGING=true USE_FRAME_BUFFER=false FIREFOX_PATH=~/browsers/firefox/firefox FLAGS='-test.run=^TestLabel'
