### PR TITLE
Add spinner to /test-runs

### DIFF
--- a/webapp/components/interop.html
+++ b/webapp/components/interop.html
@@ -279,16 +279,16 @@ found in the LICENSE file.
 
     async ready() {
       await super.ready();
-      this.load(async () => {
-        this.passRateMetadata = await fetch(`/api/interop${this.query}`)
+      this.load(
+        fetch(`/api/interop${this.query}`)
           .then(async r => {
             if (!r.ok || r.status !== 200) {
               Promise.reject('Failed to fetch interop data');
             }
-            return r.json();
-          });
-        this.allMetrics = await fetch(this.passRateMetadata.url).then(r => r.json());
-      });
+            this.passRateMetadata = await r.json();
+            this.allMetrics = await fetch(this.passRateMetadata.url).then(r => r.json());
+          })
+      );
     }
 
     navigationPathPrefix() {

--- a/webapp/components/interop.html
+++ b/webapp/components/interop.html
@@ -279,8 +279,7 @@ found in the LICENSE file.
 
     async ready() {
       await super.ready();
-      this.loadingCount++;
-      try {
+      this.load(async () => {
         this.passRateMetadata = await fetch(`/api/interop${this.query}`)
           .then(async r => {
             if (!r.ok || r.status !== 200) {
@@ -289,9 +288,7 @@ found in the LICENSE file.
             return r.json();
           });
         this.allMetrics = await fetch(this.passRateMetadata.url).then(r => r.json());
-      } finally {
-        this.loadingCount--;
-      }
+      });
     }
 
     navigationPathPrefix() {

--- a/webapp/components/loading-state.html
+++ b/webapp/components/loading-state.html
@@ -36,6 +36,15 @@ still being loaded (generally, fetched).
           this.onLoadingComplete();
         }
       }
+
+      async load(promise) {
+        this.loadingCount++;
+        try {
+          return await promise;
+        } finally {
+          this.loadingCount--;
+        }
+      }
     };
   </script>
 </dom-module>

--- a/webapp/components/test/loading-state.html
+++ b/webapp/components/test/loading-state.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <script src="../../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../bower_components/web-component-tester/browser.js"></script>
+
+  <link rel="import" href="../../bower_components/polymer/polymer-element.html">
+  <link rel="import" href="../loading-state.html">
+</head>
+
+<dom-module id="loading-state-concrete">
+  <script>
+    /* global LoadingState */
+    class ConcreteType extends LoadingState(window.Polymer.Element) {}
+
+    window.customElements.define('loading-state-concrete', ConcreteType);
+  </script>
+</dom-module>
+
+<test-fixture id="loading-state-fixture">
+  <template>
+    <loading-state-concrete></loading-state-concrete>
+  </template>
+</test-fixture>
+
+<body>
+  <script>
+    suite('LoadingState', () => {
+      let state;
+
+      setup(() => {
+        state = fixture('loading-state-fixture');
+      });
+
+      suite('LoadingState.prototype.*', () => {
+        suite('onLoadingComplete', () => {
+          let completeCallback;
+
+          setup(() => {
+            completeCallback = sinon.spy();
+            state.onLoadingComplete = completeCallback;
+          });
+
+          test('executed when count reaches zero', async() => {
+            state.loadingCount++;
+            state.loadingCount--;
+            assert.isTrue(completeCallback.calledOnce);
+          });
+
+          test('executed when load returns', async() => {
+            await state.load(Promise.resolve());
+            assert.isTrue(completeCallback.calledOnce);
+          });
+
+          test('but not when already zero', () => {
+            state.loadingCount = 0;
+            assert.isTrue(completeCallback.notCalled);
+          });
+        });
+      });
+    });
+  </script>
+</body>
+
+</html>

--- a/webapp/components/test/loading-state.html
+++ b/webapp/components/test/loading-state.html
@@ -12,10 +12,13 @@
 
 <dom-module id="loading-state-concrete">
   <script>
-    /* global LoadingState */
-    class ConcreteType extends LoadingState(window.Polymer.Element) {}
+    // Needed for FF, which doesn't block on the imports above.
+    document.addEventListener('WebComponentsReady', () => {
+      /* global LoadingState */
+      class ConcreteType extends LoadingState(window.Polymer.Element) {}
 
-    window.customElements.define('loading-state-concrete', ConcreteType);
+      window.customElements.define('loading-state-concrete', ConcreteType);
+    });
   </script>
 </dom-module>
 

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -437,9 +437,8 @@ found in the LICENSE file.
           this.showHistory = false;
         };
 
-        this.loadingCount++;
-        try {
-          await this.loadRuns().then(async runs => {
+        this.load(
+          this.loadRuns().then(async runs => {
             this.fetchResults();
 
             // Load a diff data into this.diffRun, if needed.
@@ -449,10 +448,8 @@ found in the LICENSE file.
                 browser_name: 'diff',
               };
             }
-          });
-        } finally {
-          this.loadingCount--;
-        }
+          })
+        );
       }
 
       async fetchResults() {

--- a/webapp/components/wpt-runs.html
+++ b/webapp/components/wpt-runs.html
@@ -8,9 +8,11 @@ found in the LICENSE file.
 <link rel="import" href="../bower_components/polymer/lib/elements/dom-if.html">
 <link rel="import" href="../bower_components/polymer/lib/elements/dom-repeat.html">
 <link rel="import" href="../bower_components/paper-styles/color.html">
-<link rel="import" href="info-banner.html">
-<link rel="import" href="test-runs.html">
-<link rel="import" href="test-run.html">
+<link rel="import" href="../bower_components/paper-spinner/paper-spinner-lite.html">
+<link rel="import" href="./info-banner.html">
+<link rel="import" href="./test-runs.html">
+<link rel="import" href="./test-run.html">
+<link rel="import" href="./loading-state.html">
 
 <dom-module id="wpt-runs">
   <template>
@@ -23,6 +25,7 @@ found in the LICENSE file.
       table {
         width: 100%;
         border-collapse: separate;
+        margin-bottom: 2em;
       }
       td {
         padding: 0 0.5em;
@@ -43,6 +46,10 @@ found in the LICENSE file.
       .runs.present {
         background-color: var(--paper-blue-100);
       }
+      paper-spinner-lite {
+        display: block;
+        margin: auto;
+      }
 
       @media (max-width: 800px) {
         table tr td:first-child::after {
@@ -58,45 +65,49 @@ found in the LICENSE file.
       Showing the last month of test runs.
     </info-banner>
 
-    <table>
-      <thead>
-        <tr>
-          <th width="[[computeThWidth(browsers)]]">SHA</th>
-          <template is="dom-repeat" items="{{ browsers }}" as="browser">
-            <th width="[[computeThWidth(browsers)]]">[[browser]]</th>
-          </template>
-        </tr>
-      </thead>
-      <tbody>
+    <paper-spinner-lite active="[[isLoading]]" class="blue"></paper-spinner-lite>
 
-      <template is="dom-repeat" items="{{ testResults }}" as="results">
-        <tr data-boundary$="{{ results.month_boundary }}">
-          <td>
-            <a href="/?sha={{ results.sha }}" title="{{ computeDateTooltip(results.date) }}">{{ results.sha }}</a>
-          </td>
-          <template is="dom-repeat" items="{{ browsers }}" as="browser">
-            <td class$="runs [[ runClass(results.runs, browser) ]]">
-              <template is="dom-repeat" items="[[runList(results.runs, browser)]]" as="run">
-                <a href="[[runLink(run)]]">
-                  <test-run small show-source test-run="[[run]]"></test-run>
-                </a>
-              </template>
+    <template is="dom-if" if="[[testResults]]">
+      <table>
+        <thead>
+          <tr>
+            <th width="[[computeThWidth(browsers)]]">SHA</th>
+            <template is="dom-repeat" items="{{ browsers }}" as="browser">
+              <th width="[[computeThWidth(browsers)]]">[[browser]]</th>
+            </template>
+          </tr>
+        </thead>
+        <tbody>
+
+        <template is="dom-repeat" items="{{ testResults }}" as="results">
+          <tr data-boundary$="{{ results.month_boundary }}">
+            <td>
+              <a href="/?sha={{ results.sha }}" title="{{ computeDateTooltip(results.date) }}">{{ results.sha }}</a>
             </td>
-          </template>
-          <template is="dom-if" if="{{ results.month_boundary }}">
-            <td class="month">{{ computeMonthName(results.date) }}</td>
-          </template>
-        </tr>
-      </template>
+            <template is="dom-repeat" items="{{ browsers }}" as="browser">
+              <td class$="runs [[ runClass(results.runs, browser) ]]">
+                <template is="dom-repeat" items="[[runList(results.runs, browser)]]" as="run">
+                  <a href="[[runLink(run)]]">
+                    <test-run small show-source test-run="[[run]]"></test-run>
+                  </a>
+                </template>
+              </td>
+            </template>
+            <template is="dom-if" if="{{ results.month_boundary }}">
+              <td class="month">{{ computeMonthName(results.date) }}</td>
+            </template>
+          </tr>
+        </template>
 
-      </tbody>
-    </table>
+        </tbody>
+      </table>
+    </template>
 
   </template>
 
   <script>
     /* global TestRunsBase */
-    class WPTRuns extends TestRunsBase {
+    class WPTRuns extends LoadingState(TestRunsBase) {
       static get is() {
         return 'wpt-runs';
       }
@@ -140,7 +151,7 @@ found in the LICENSE file.
 
       async ready() {
         super.ready();
-        await this.loadRuns();
+        await this.load(this.loadRuns());
 
         let browsers = new Set();
         // Group the runs by their revision/SHA

--- a/webapp/components/wpt-runs.html
+++ b/webapp/components/wpt-runs.html
@@ -61,13 +61,19 @@ found in the LICENSE file.
       }
     </style>
 
-    <info-banner>
-      Showing the last month of test runs.
-    </info-banner>
-
     <paper-spinner-lite active="[[isLoading]]" class="blue"></paper-spinner-lite>
 
-    <template is="dom-if" if="[[testResults]]">
+    <template is="dom-if" if="[[loadingFailed]]">
+      <info-banner type="error">
+        Failed to load test runs.
+      </info-banner>
+    </template>
+
+    <template is="dom-if" if="[[testResults.length]]">
+      <info-banner>
+        Showing the last month of test runs.
+      </info-banner>
+
       <table>
         <thead>
           <tr>
@@ -124,7 +130,11 @@ found in the LICENSE file.
           displayedNodes: {
             type: Array,
             value: []
-          }
+          },
+          loadingFailed: {
+            type: Boolean,
+            value: false,
+          },
         };
       }
 
@@ -149,44 +159,51 @@ found in the LICENSE file.
         return date && date.toDateString();
       }
 
+      constructor() {
+        super();
+        this.onLoadingComplete = () => {
+          this.loadingFailed = !this.testResults;
+        }
+      }
+
       async ready() {
         super.ready();
-        await this.load(this.loadRuns());
-
-        let browsers = new Set();
-        // Group the runs by their revision/SHA
-        let testRunsBySha = this.testRuns.reduce((accum, results) => {
-          browsers.add(results.browser_name);
-          if (!accum[results.revision]) {
-            accum[results.revision] = {};
-          }
-          if (!accum[results.revision][results.browser_name]) {
-            accum[results.revision][results.browser_name] = [];
-          }
-          accum[results.revision][results.browser_name].push(results);
-          return accum;
-        }, {});
-
-        // We flatten into an array of objects so Polymer can deal with them.
-        const firstRunTime = x => Object.values(x.runs)[0][0].created_at;
-        const flattened = Object.entries(testRunsBySha)
-          .map(({0: sha, 1: runs}) => ({ sha, runs }))
-          .sort((a, b) => firstRunTime(a) < firstRunTime(b) ? 1 : -1);
-
-        // Append time (month) metadata.
-        if (flattened.length > 1) {
-          let previousMonth = -1;
-          for (let i = 0; i < flattened.length; i++) {
-            let current = new Date(firstRunTime(flattened[i]));
-            flattened[i].date = current;
-            if (previousMonth !== current.getMonth()) {
-              flattened[i].month_boundary = true;
+        await this.load(this.loadRuns().then(testRuns => {
+          let browsers = new Set();
+          // Group the runs by their revision/SHA
+          let testRunsBySha = this.testRuns.reduce((accum, results) => {
+            browsers.add(results.browser_name);
+            if (!accum[results.revision]) {
+              accum[results.revision] = {};
             }
-            previousMonth = current.getMonth();
+            if (!accum[results.revision][results.browser_name]) {
+              accum[results.revision][results.browser_name] = [];
+            }
+            accum[results.revision][results.browser_name].push(results);
+            return accum;
+          }, {});
+
+          // We flatten into an array of objects so Polymer can deal with them.
+          const firstRunTime = x => Object.values(x.runs)[0][0].created_at;
+          const flattened = Object.entries(testRunsBySha)
+            .map(({0: sha, 1: runs}) => ({ sha, runs }))
+            .sort((a, b) => firstRunTime(a) < firstRunTime(b) ? 1 : -1);
+
+          // Append time (month) metadata.
+          if (flattened.length > 1) {
+            let previousMonth = -1;
+            for (let i = 0; i < flattened.length; i++) {
+              let current = new Date(firstRunTime(flattened[i]));
+              flattened[i].date = current;
+              if (previousMonth !== current.getMonth()) {
+                flattened[i].month_boundary = true;
+              }
+              previousMonth = current.getMonth();
+            }
           }
-        }
-        this.testResults = flattened;
-        this.browsers = Array.from(browsers).sort();
+          this.testResults = flattened;
+          this.browsers = Array.from(browsers).sort();
+        }));
       }
 
       runClass(testRuns, browser) {


### PR DESCRIPTION
## Description
Leverages (and extends) the `LoadingState` behaviour to display a spinner while the runs in `/test-runs` are being fetched.

Also adds a WCT test suite for the basic behaviour.

## Review Information
Visit `/test-runs`, observe a spinner.