### PR TITLE
Handle errors from Close() in results receiver

### DIFF
--- a/api/receiver/appengine.go
+++ b/api/receiver/appengine.go
@@ -101,7 +101,9 @@ func (a *appEngineAPIImpl) uploadToGCS(fileName string, f io.Reader, gzipped boo
 	if err != nil {
 		return "", err
 	}
-	w.Close()
+	if err := w.Close(); err != nil {
+		return "", err
+	}
 
 	gcsPath = fmt.Sprintf("/%s/%s", BufferBucket, fileName)
 	return gcsPath, nil

--- a/api/receiver/appengine_medium_test.go
+++ b/api/receiver/appengine_medium_test.go
@@ -34,11 +34,11 @@ type mockGcsWriter struct {
 
 func (m *mockGcsWriter) Close() error {
 	m.finalContent = m.Bytes()
-	return errOnClose
+	return m.errOnClose
 }
 
 func (m *mockGcs) NewWriter(bucketName, fileName, contentType, contentEncoding string) (io.WriteCloser, error) {
-	return &m.mockWriter, nil
+	return &m.mockWriter, m.errOnNew
 }
 
 func TestUploadToGCS(t *testing.T) {
@@ -61,7 +61,7 @@ func TestUploadToGCS_handlesErrors(t *testing.T) {
 	assert.Equal(t, errNew, err)
 
 	errClose := fmt.Errorf("error closing writer")
-	a.gcs = &mockGcs{mockWrit: mockGcsWrit{errOnClose: errClose}}
+	a.gcs = &mockGcs{mockWriter: mockGcsWriter{errOnClose: errClose}}
 	_, err = a.uploadToGCS("test.json", strings.NewReader(""), false)
 	assert.Equal(t, errClose, err)
 }


### PR DESCRIPTION
Previously, errors from closing a GCS object were discarded, which might
be the cause of #559. This commit hopefully fixes #559.

## Review Information

See the new tests.