### PR TITLE
Drop Selenium and use WebDrivers directly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,9 +82,8 @@ go_large_test:
 go_firefox_test: BROWSER := firefox
 go_firefox_test: firefox | _go_webdriver_test
 
-# TODO(Hexcles): Do not depend on chromedriver once we fix #461.
 go_chrome_test: BROWSER := chrome
-go_chrome_test: chrome chromedriver | _go_webdriver_test
+go_chrome_test: chrome | _go_webdriver_test
 
 # _go_webdriver_test is not intended to be used directly; use go_firefox_test or
 # go_chrome_test instead.
@@ -93,12 +92,10 @@ _go_webdriver_test: var-BROWSER java go_deps xvfb node-web-component-tester webs
 	# The following variables are defined here because we don't know the
 	# paths before installing node-web-component-tester as the paths
 	# include version strings.
-	SELENIUM_SERVER_PATH="$(shell find $(NODE_SELENIUM_PATH)selenium-server/ -type f -name '*server.jar')"; \
 	GECKODRIVER_PATH="$(shell find $(NODE_SELENIUM_PATH)geckodriver/ -type f -name '*geckodriver')"; \
 	CHROMEDRIVER_PATH="$(shell find $(NODE_SELENIUM_PATH)chromedriver/ -type f -name '*chromedriver')"; \
 	cd $(WPTD_PATH)webdriver; \
 	go test -v -tags=large -args \
-		-selenium_path=$$SELENIUM_SERVER_PATH \
 		-firefox_path=$(FIREFOX_PATH) \
 		-geckodriver_path=$$GECKODRIVER_PATH \
 		-chrome_path=$(CHROME_PATH) \
@@ -134,12 +131,6 @@ chrome:
 			make apt-get-chromium; \
 		fi; \
 		sudo ln -s "$$(which chromium)" $(CHROME_PATH); \
-	fi
-
-# TODO(Hexcles): This is only a temporary fix for #461.
-chromedriver:
-	if [[ -z "$$(which chromedriver)" ]]; then \
-		make apt-get-chromedriver; \
 	fi
 
 firefox:

--- a/webdriver/chrome.go
+++ b/webdriver/chrome.go
@@ -14,8 +14,8 @@ var (
 	chromePath       = flag.String("chrome_path", "", "Path to the chrome binary")
 )
 
-// ChromeWebDriver starts up ChromeDriver via Selenium.
-func ChromeWebDriver(options []selenium.ServiceOption) (*selenium.Service, selenium.WebDriver, error) {
+// ChromeWebDriver starts up ChromeDriver on the given port.
+func ChromeWebDriver(port int, options []selenium.ServiceOption) (*selenium.Service, selenium.WebDriver, error) {
 	if *chromePath == "" {
 		panic("-chrome_path not specified")
 	}
@@ -23,9 +23,7 @@ func ChromeWebDriver(options []selenium.ServiceOption) (*selenium.Service, selen
 		panic("-chromedriver_path not specified")
 	}
 
-	// FIXME: chromeDriverPath seems to be ignored?
-
-	service, err := selenium.NewSeleniumService(*seleniumPath, seleniumPort, options...)
+	service, err := selenium.NewChromeDriverService(*chromeDriverPath, port, options...)
 	if err != nil {
 		panic(err)
 	}
@@ -43,8 +41,9 @@ func ChromeWebDriver(options []selenium.ServiceOption) (*selenium.Service, selen
 	ChromeCapabilities.Path = chromeAbsPath
 	seleniumCapabilities.AddChrome(ChromeCapabilities)
 
+	// selenium.NewChromeDriverService unconditionally specifies --url-base=wd/hub.
 	wd, err := selenium.NewRemote(
 		seleniumCapabilities,
-		fmt.Sprintf("http://%s:%d/wd/hub", *seleniumHost, seleniumPort))
+		fmt.Sprintf("http://127.0.0.1:%d/wd/hub", port))
 	return service, wd, err
 }

--- a/webdriver/firefox.go
+++ b/webdriver/firefox.go
@@ -14,8 +14,8 @@ var (
 	firefoxPath     = flag.String("firefox_path", "", "Path to the firefox binary")
 )
 
-// FirefoxWebDriver starts up GeckoDriver via Selenium.
-func FirefoxWebDriver(options []selenium.ServiceOption) (*selenium.Service, selenium.WebDriver, error) {
+// FirefoxWebDriver starts up GeckoDriver on the given port.
+func FirefoxWebDriver(port int, options []selenium.ServiceOption) (*selenium.Service, selenium.WebDriver, error) {
 	if *firefoxPath == "" {
 		panic("-firefox_path not specified")
 	}
@@ -26,7 +26,7 @@ func FirefoxWebDriver(options []selenium.ServiceOption) (*selenium.Service, sele
 	// Specify the path to GeckoDriver in order to use Firefox.
 	options = append(options, selenium.GeckoDriver(*geckoDriverPath))
 
-	service, err := selenium.NewSeleniumService(*seleniumPath, seleniumPort, options...)
+	service, err := selenium.NewGeckoDriverService(*geckoDriverPath, port, options...)
 	if err != nil {
 		panic(err)
 	}
@@ -44,8 +44,9 @@ func FirefoxWebDriver(options []selenium.ServiceOption) (*selenium.Service, sele
 	firefoxCapabilities.Binary = firefoxAbsPath
 	seleniumCapabilities.AddFirefox(firefoxCapabilities)
 
+	// geckodriver does not have a URL prefix.
 	wd, err := selenium.NewRemote(
 		seleniumCapabilities,
-		fmt.Sprintf("http://%s:%d/wd/hub", *seleniumHost, seleniumPort))
+		fmt.Sprintf("http://127.0.0.1:%d", port))
 	return service, wd, err
 }


### PR DESCRIPTION
In an attempt to improve the stability of our integration tests (#566),
this change drops the intermediary Selenium Standalone server, and uses
chromedriver/geckodriver directly in our tests to remove one layer of
indirection.

One observed downside of having Selenium Standalone in between is that
sometimes chromedriver/geckodriver processes, along with the browser
processes, are left behind. (c.f.
https://github.com/SeleniumHQ/selenium/issues/6434 ). Besides, now that
chromedriver/geckodriver are more spec compatible, we don't need
Selenium to smooth over the discrepancies.

Lastly, this also fixes #461 by the way.

## Review Information

Travis should pass.