### PR TITLE
Tweak Travis retry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,12 +40,8 @@ before_install: |
   # Decrypt client-secret.json for Appengine.
   openssl aes-256-cbc -K $encrypted_c8659b25fe66_key -iv $encrypted_c8659b25fe66_iv -in client-secret.json.enc -out client-secret.json -d
 
-  docker build -t "${DOCKER_IMAGE}" .
-  bash ./util/docker-dev/run.sh -d -q
-
-install:
-  - | # Set the user as home dir owner in the docker instance
-    docker exec -u 0:0 "${DOCKER_INSTANCE}" chown -R $(id -u $USER):$(id -g $USER) /home/user
+  travis_retry docker build -t "${DOCKER_IMAGE}" .
+  travis_retry bash ./util/docker-dev/run.sh -d -q
 
 script:
   - |
@@ -65,5 +61,6 @@ script:
     fi
   - | # Run tests
     if [ "${MAKE_TEST_TARGET}" != "" ]; then
-      travis_retry docker exec -t -u $(id -u $USER):$(id -g $USER) "${DOCKER_INSTANCE}" make "${MAKE_TEST_TARGET}" ${MAKE_TEST_FLAGS}
+      travis_retry docker exec -t "${DOCKER_INSTANCE}" make go_packages;
+      docker exec -t "${DOCKER_INSTANCE}" make "${MAKE_TEST_TARGET}" ${MAKE_TEST_FLAGS};
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,10 @@ before_install: |
   travis_retry docker build -t "${DOCKER_IMAGE}" .
   travis_retry bash ./util/docker-dev/run.sh -d -q
 
+install: |
+  # FIXME: go_packages is required by many, but not all make targets.
+  travis_retry docker exec -t "${DOCKER_INSTANCE}" make go_packages
+
 script:
   - |
     # Deploy PR to staging environment (only when Travis secrets are available).
@@ -59,8 +63,8 @@ script:
     else
       echo "Not on master or a PR. Skipping deployment.";
     fi
-  - | # Run tests
+  - |
+    # Run tests
     if [ "${MAKE_TEST_TARGET}" != "" ]; then
-      travis_retry docker exec -t "${DOCKER_INSTANCE}" make go_packages;
       docker exec -t "${DOCKER_INSTANCE}" make "${MAKE_TEST_TARGET}" ${MAKE_TEST_FLAGS};
     fi

--- a/util/docker-dev/run.sh
+++ b/util/docker-dev/run.sh
@@ -40,7 +40,8 @@ while getopts ':dhaq' FLAG; do
     d)
       DAEMON="true" ;;
     q)
-      QUIET="true" ;;
+      QUIET="true"
+      PR="r" ;;
     a)
       RESULTS_ANALYSIS="true" ;;
     h|*) usage && exit 0 ;;
@@ -69,7 +70,7 @@ function stop() {
   info "Stopping ${DOCKER_INSTANCE}..."
   wptd_stop
   info ""${DOCKER_INSTANCE}" stopped."
-  if [[ "${QUIET}" != "true" ]] && [[ "${PR}" != "r" ]]; then
+  if [[ "${PR}" == "" ]]; then
     confirm_preserve_remove "Docker instance ${DOCKER_INSTANCE} still exists"
   fi
   if [[ "${PR}" == "r" ]]; then
@@ -86,7 +87,9 @@ function quit() {
 }
 
 if [ "${INSPECT_STATUS}" == "0" ]; then
-  confirm_preserve_remove "Found existing docker instance ${DOCKER_INSTANCE}"
+  if [[ "${PR}" == "" ]]; then
+    confirm_preserve_remove "Found existing docker instance ${DOCKER_INSTANCE}"
+  fi
   if [[ "${PR}" == "r" ]]; then
     stop
   fi


### PR DESCRIPTION
Retry more network-related operations (namely building the Docker image,
installing system dependencies and pulling Go packages). Stop retrying
the test itself.

This is yet another effort towards #566 .

## Review Information

Travis should pass.

## Changes

The core change is in `.travis.yml`. However, to make it possible to retry `util/docker-dev/run.sh` (which includes installing system dependencies), `util/docker-dev/run.sh` needs to be changed so that `-q` implies removing existing instances.

Also removed `-u $(id -u $USER):$(id -g $USER)` from `.travis.yml` as it's not necessary anymore (it's the default user).