### PR TITLE
Add component for configuring features

### DIFF
--- a/webapp/.eslintrc.json
+++ b/webapp/.eslintrc.json
@@ -11,6 +11,7 @@
   },
   "globals": {
     "assert": true,
+    "expect": true,
     "fixture": true,
     "sandbox": true,
     "sinon": true

--- a/webapp/bower.json
+++ b/webapp/bower.json
@@ -14,7 +14,8 @@
     "paper-tooltip": "@Polymer/paper-tooltip#^2.1.1",
     "google-chart": "^2.0.0",
     "paper-toggle-button": "PolymerElements/paper-toggle-button#^2.1.1",
-    "paper-spinner": "PolymerElements/paper-spinner#2.1.0"
+    "paper-spinner": "PolymerElements/paper-spinner#2.1.0",
+    "paper-checkbox": "2"
   },
   "devDependencies": {
     "web-component-tester": "^6.4.3"

--- a/webapp/components/test/wpt-flags.html
+++ b/webapp/components/test/wpt-flags.html
@@ -10,30 +10,51 @@
 <body>
   <wpt-flags-editor id="playground"></wpt-flags-editor>
 
-  <test-fixture id="wpt-flags-fixture">
+  <test-fixture id="wpt-flags-editor-fixture">
     <template>
-      <wpt-flags></wpt-flags>
+      <wpt-flags-editor></wpt-flags-editor>
     </template>
   </test-fixture>
 
   <script>
-    suite('WPTFlags', () => {
-      let flags, queryBuilderStateBefore;
+    /* global WPTFlags */
+    suite('wpt-flags', () => {
+      suite('WPTFlags', () => {
+        let flags;
 
-      setup(() => {
-        flags = fixture('wpt-flags-fixture');
-        queryBuilderStateBefore = flags.queryBuilder;
+        setup(() => {
+          if (!window.customElements.get('wpt-flags')) {
+            class ConcreteClass extends WPTFlags(window.Polymer.Element) {}
+            window.customElements.define('wpt-flags', ConcreteClass);
+          }
+          flags = document.createElement('wpt-flags');
+        });
+
+        test('queryBuilder', () => {
+          const before = flags.queryBuilder;
+          flags.queryBuilder = !flags.queryBuilder;
+          expect(flags.queryBuilder).to.equal(before);
+        });
       });
 
-      test('queryBuilder', () => {
-        flags.queryBuilder = true;
-        expect(flags.queryBuilder).to.equal(true);
-        flags.queryBuilder = false;
-        expect(flags.queryBuilder).to.equal(false);
-      });
+      suite('WPTFlagsEditor', () => {
+        let editor, queryBuilderStateBefore;
 
-      teardown(() => {
-        flags.queryBuilder = queryBuilderStateBefore;
+        setup(() => {
+          editor = fixture('wpt-flags-editor-fixture');
+          queryBuilderStateBefore = editor.queryBuilder;
+        });
+
+        test('queryBuilder', () => {
+          editor.queryBuilder = true;
+          expect(editor.queryBuilder).to.equal(true);
+          editor.queryBuilder = false;
+          expect(editor.queryBuilder).to.equal(false);
+        });
+
+        teardown(() => {
+          editor.queryBuilder = queryBuilderStateBefore;
+        });
       });
     });
   </script>

--- a/webapp/components/test/wpt-flags.html
+++ b/webapp/components/test/wpt-flags.html
@@ -8,6 +8,8 @@
   <link rel="import" href="../wpt-flags.html">
 </head>
 <body>
+  <wpt-flags-editor id="playground"></wpt-flags-editor>
+
   <test-fixture id="wpt-flags-fixture">
     <template>
       <wpt-flags></wpt-flags>
@@ -16,10 +18,11 @@
 
   <script>
     suite('WPTFlags', () => {
-      let flags;
+      let flags, queryBuilderStateBefore;
 
       setup(() => {
         flags = fixture('wpt-flags-fixture');
+        queryBuilderStateBefore = flags.queryBuilder;
       });
 
       test('queryBuilder', () => {
@@ -27,6 +30,10 @@
         expect(flags.queryBuilder).to.equal(true);
         flags.queryBuilder = false;
         expect(flags.queryBuilder).to.equal(false);
+      });
+
+      teardown(() => {
+        flags.queryBuilder = queryBuilderStateBefore;
       });
     });
   </script>

--- a/webapp/components/test/wpt-flags.html
+++ b/webapp/components/test/wpt-flags.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="../../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../bower_components/web-component-tester/browser.js"></script>
+
+  <link rel="import" href="../wpt-flags.html">
+</head>
+<body>
+  <test-fixture id="wpt-flags-fixture">
+    <template>
+      <wpt-flags></wpt-flags>
+    </template>
+  </test-fixture>
+
+  <script>
+    suite('WPTFlags', () => {
+      let flags;
+
+      setup(() => {
+        flags = fixture('wpt-flags-fixture');
+      });
+
+      test('queryBuilder', () => {
+        flags.queryBuilder = true;
+        expect(flags.queryBuilder).to.equal(true);
+        flags.queryBuilder = false;
+        expect(flags.queryBuilder).to.equal(false);
+      });
+    });
+  </script>
+</body>
+</html>

--- a/webapp/components/wpt-flags.html
+++ b/webapp/components/wpt-flags.html
@@ -12,51 +12,30 @@ found in the LICENSE file.
 `<wpt-flags>` is a component for checking wpt.fyi feature flags.
 -->
 <dom-module id="wpt-flags">
-  <template>
-    <style>
-    </style>
-
-  </template>
-
   <script>
     const WPT_FYI_FEATURES = ['queryBuilder'];
 
-    class WPTFlags extends window.Polymer.Element {
+    const _wptFlags = (superClass, opt_writable) => class extends superClass {
       static get is() {
         return 'wpt-flags';
       }
 
       static get properties() {
-        const props = {
-        };
-
+        const props = {};
         for (const feature of WPT_FYI_FEATURES) {
           const stored = localStorage.getItem(`features.${feature}`);
           const value = stored && JSON.parse(stored);
           props[feature] = {
             type: Boolean,
+            readOnly: !opt_writable,
             notify: true,
             value: value,
           };
         }
         return props;
       }
-
-      ready() {
-        super.ready();
-        for (const feature of WPT_FYI_FEATURES) {
-          this._createMethodObserver(`valueChanged(${feature}, '${feature}')`);
-        }
-      }
-
-      valueChanged(value, feature) {
-        return localStorage.setItem(
-          `features.${feature}`,
-          JSON.stringify(value));
-      }
     }
-
-    window.customElements.define(WPTFlags.is, WPTFlags);
+    const WPTFlags = (superClass) => _wptFlags(superClass, false);
   </script>
 </dom-module>
 
@@ -70,12 +49,20 @@ found in the LICENSE file.
   </template>
 
   <script>
-    class WPTFlagsEditor extends WPTFlags {
+    class WPTFlagsEditor extends _wptFlags(window.Polymer.Element, /*writable*/ true) {
       static get is() { return 'wpt-flags-editor'; }
 
-      static get properties() {
-        return {
-        };
+      ready() {
+        super.ready();
+        for (const feature of WPT_FYI_FEATURES) {
+          this._createMethodObserver(`valueChanged(${feature}, '${feature}')`);
+        }
+      }
+
+      valueChanged(value, feature) {
+        return localStorage.setItem(
+          `features.${feature}`,
+          JSON.stringify(value));
       }
     }
 

--- a/webapp/components/wpt-flags.html
+++ b/webapp/components/wpt-flags.html
@@ -1,0 +1,52 @@
+<!--
+Copyright 2018 The WPT Dashboard Project. All rights reserved.
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file.
+-->
+
+<link rel="import" href="../bower_components/polymer/polymer-element.html">
+
+<!--
+`<wpt-flags>` is a component for checking wpt.fyi feature flags.
+-->
+<dom-module id="wpt-flags">
+  <template>
+    <style>
+    </style>
+
+  </template>
+
+  <script>
+    const WPT_FYI_FEATURES = ['queryBuilder'];
+
+    class WPTFlags extends window.Polymer.Element {
+      static get is() {
+        return 'wpt-flags';
+      }
+
+      static get properties() {
+        return {
+        };
+      }
+
+      constructor() {
+        super();
+        for (const feature of WPT_FYI_FEATURES) {
+          Object.defineProperty(this, feature, {
+            get: () => {
+              let result = localStorage.getItem(`features.${feature}`);
+              return result && JSON.parse(result);
+            },
+            set: (value) => {
+              return localStorage.setItem(
+                `features.${feature}`,
+                JSON.stringify(value));
+            }
+          })
+        }
+      }
+    }
+
+    window.customElements.define(WPTFlags.is, WPTFlags);
+  </script>
+</dom-module>

--- a/webapp/components/wpt-flags.html
+++ b/webapp/components/wpt-flags.html
@@ -15,7 +15,7 @@ found in the LICENSE file.
   <script>
     const WPT_FYI_FEATURES = ['queryBuilder'];
 
-    const _wptFlags = (superClass, opt_writable) => class extends superClass {
+    const _wptFlags = (superClass, readOnly) => class extends superClass {
       static get is() {
         return 'wpt-flags';
       }
@@ -27,7 +27,7 @@ found in the LICENSE file.
           const value = stored && JSON.parse(stored);
           props[feature] = {
             type: Boolean,
-            readOnly: !opt_writable,
+            readOnly: readOnly,
             notify: true,
             value: value,
           };
@@ -35,7 +35,7 @@ found in the LICENSE file.
         return props;
       }
     }
-    const WPTFlags = (superClass) => _wptFlags(superClass, false);
+    const WPTFlags = (superClass) => _wptFlags(superClass, /*readOnly*/ true);
   </script>
 </dom-module>
 
@@ -49,7 +49,7 @@ found in the LICENSE file.
   </template>
 
   <script>
-    class WPTFlagsEditor extends _wptFlags(window.Polymer.Element, /*writable*/ true) {
+    class WPTFlagsEditor extends _wptFlags(window.Polymer.Element, /*readOnly*/ false) {
       static get is() { return 'wpt-flags-editor'; }
 
       ready() {

--- a/webapp/components/wpt-flags.html
+++ b/webapp/components/wpt-flags.html
@@ -5,6 +5,8 @@ found in the LICENSE file.
 -->
 
 <link rel="import" href="../bower_components/polymer/polymer-element.html">
+<link rel="import" href="../bower_components/paper-item/paper-item.html">
+<link rel="import" href="../bower_components/paper-checkbox/paper-checkbox.html">
 
 <!--
 `<wpt-flags>` is a component for checking wpt.fyi feature flags.
@@ -25,28 +27,58 @@ found in the LICENSE file.
       }
 
       static get properties() {
-        return {
+        const props = {
         };
+
+        for (const feature of WPT_FYI_FEATURES) {
+          const stored = localStorage.getItem(`features.${feature}`);
+          const value = stored && JSON.parse(stored);
+          props[feature] = {
+            type: Boolean,
+            notify: true,
+            value: value,
+          };
+        }
+        return props;
       }
 
-      constructor() {
-        super();
+      ready() {
+        super.ready();
         for (const feature of WPT_FYI_FEATURES) {
-          Object.defineProperty(this, feature, {
-            get: () => {
-              let result = localStorage.getItem(`features.${feature}`);
-              return result && JSON.parse(result);
-            },
-            set: (value) => {
-              return localStorage.setItem(
-                `features.${feature}`,
-                JSON.stringify(value));
-            }
-          })
+          this._createMethodObserver(`valueChanged(${feature}, '${feature}')`);
         }
+      }
+
+      valueChanged(value, feature) {
+        return localStorage.setItem(
+          `features.${feature}`,
+          JSON.stringify(value));
       }
     }
 
     window.customElements.define(WPTFlags.is, WPTFlags);
+  </script>
+</dom-module>
+
+<dom-module id="wpt-flags-editor">
+  <template>
+    <paper-item>
+      <paper-checkbox checked="{{queryBuilder}}">
+        Query Builder component
+      </paper-checkbox>
+    </paper-item>
+  </template>
+
+  <script>
+    class WPTFlagsEditor extends WPTFlags {
+      static get is() { return 'wpt-flags-editor'; }
+
+      static get properties() {
+        return {
+        };
+      }
+    }
+
+    window.customElements.define(WPTFlagsEditor.is, WPTFlagsEditor);
   </script>
 </dom-module>

--- a/webapp/flags_handler.go
+++ b/webapp/flags_handler.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The WPT Dashboard Project. All rights reserved.
+// Copyright 2018 The WPT Dashboard Project. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/webapp/flags_handler.go
+++ b/webapp/flags_handler.go
@@ -1,0 +1,15 @@
+// Copyright 2017 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package webapp
+
+import (
+	"net/http"
+)
+
+func flagsHandler(w http.ResponseWriter, r *http.Request) {
+	if err := templates.ExecuteTemplate(w, "flags.html", nil); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}

--- a/webapp/routes.go
+++ b/webapp/routes.go
@@ -31,6 +31,9 @@ func RegisterRoutes() {
 	// Lists of test run results which have poor interoperability
 	shared.AddRoute("/anomalies", "anomaly", anomalyHandler)
 
+	// Feature flags for wpt.fyi
+	shared.AddRoute("/flags", "flags", flagsHandler)
+
 	// Test run results, viewed by pass-rate across the browsers
 	shared.AddRoute("/interop/", "interop", interopHandler)
 	shared.AddRoute("/interop/{path:.*}", "interop", interopHandler)

--- a/webapp/routes_test.go
+++ b/webapp/routes_test.go
@@ -29,6 +29,10 @@ func TestAboutBound(t *testing.T) {
 	assertHandlerIs(t, "/about", "about")
 }
 
+func TestFlagsBound(t *testing.T) {
+	assertHandlerIs(t, "/flags", "flags")
+}
+
 func TestInteropBound(t *testing.T) {
 	assertHandlerIs(t, "/interop", "interop")
 	assertHandlerIs(t, "/interop/", "interop")

--- a/webapp/templates/flags.html
+++ b/webapp/templates/flags.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  {{ template "_head_common.html" }}
+  <link rel="import" href="/components/wpt-flags.html">
+</head>
+<body>
+<div id="content">
+  {{ template "_header.html" }}
+  <article>
+    <h1>Features</h1>
+    <wpt-flags-editor></wpt-flags-editor>
+  </article>
+</div>
+{{ template "_ga.html" }}
+</body>
+</html>


### PR DESCRIPTION
## Description
As discussed in https://github.com/web-platform-tests/wpt.fyi/issues/440, we should be putting new features behind flags by default.

This PR adds an `wpt-flags` component which uses `window.localStorage` to store feature state.
Also configurable with `wpt-flags-editor` component, which uses checkboxes.

## Review Information
Visit [/flags](https://flags-dot-wptdashboard-staging.appspot.com/flags) (might need a query parameter if your browser's stored a redirect from `/flags` -> `/results/flags`.