### PR TITLE
Preserve product order

### DIFF
--- a/api/manifest.go
+++ b/api/manifest.go
@@ -15,7 +15,6 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/deckarep/golang-set"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 	"google.golang.org/appengine/datastore"
 	"google.golang.org/appengine/memcache"
@@ -211,12 +210,12 @@ func getGitHubReleaseAssetForSHA(client gitHubClient, sha string) (fetchedSHA st
 
 // filterManifest filters items in the the given manifest JSON, omitting anything that isn't an
 // item which has a URL beginning with one of the given paths.
-func filterManifest(manifestBytes []byte, paths mapset.Set) (result []byte, err error) {
+func filterManifest(manifestBytes []byte, paths []string) (result []byte, err error) {
 	var manifest shared.Manifest
 	if err = json.Unmarshal(manifestBytes, &manifest); err != nil {
 		return nil, err
 	}
-	if manifest, err = manifest.FilterByPath(paths); err != nil {
+	if manifest, err = manifest.FilterByPath(paths...); err != nil {
 		return nil, err
 	}
 	return json.Marshal(manifest)

--- a/api/manifest_test.go
+++ b/api/manifest_test.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/deckarep/golang-set"
 	"github.com/stretchr/testify/assert"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
@@ -132,7 +131,7 @@ func TestFilterManifest_Reftest(t *testing.T) {
 }`)
 
 	// Specific file
-	filtered, err := filterManifest(bytes, mapset.NewSet("/css/css-images/tiled-gradients.html"))
+	filtered, err := filterManifest(bytes, []string{"/css/css-images/tiled-gradients.html"})
 	assert.Nil(t, err)
 	unmarshalled := shared.Manifest{}
 	json.Unmarshal(filtered, &unmarshalled)
@@ -140,7 +139,7 @@ func TestFilterManifest_Reftest(t *testing.T) {
 	assert.Equal(t, 1, len(unmarshalled.Items.Reftest))
 
 	// Prefix
-	filtered, err = filterManifest(bytes, mapset.NewSet("/css/css-images/"))
+	filtered, err = filterManifest(bytes, []string{"/css/css-images/"})
 	assert.Nil(t, err)
 	unmarshalled = shared.Manifest{}
 	json.Unmarshal(filtered, &unmarshalled)
@@ -148,7 +147,7 @@ func TestFilterManifest_Reftest(t *testing.T) {
 	assert.Equal(t, 2, len(unmarshalled.Items.Reftest))
 
 	// No matches
-	filtered, err = filterManifest(bytes, mapset.NewSet("/not-a-folder/test.html"))
+	filtered, err = filterManifest(bytes, []string{"/not-a-folder/test.html"})
 	assert.Nil(t, err)
 	unmarshalled = shared.Manifest{}
 	json.Unmarshal(filtered, &unmarshalled)

--- a/shared/models.go
+++ b/shared/models.go
@@ -162,18 +162,18 @@ type Manifest struct {
 }
 
 // FilterByPath filters all the manifest items by path.
-func (m Manifest) FilterByPath(paths mapset.Set) (result Manifest, err error) {
+func (m Manifest) FilterByPath(paths ...string) (result Manifest, err error) {
 	result = m
-	if result.Items.Manual, err = m.Items.Manual.FilterByPath(paths); err != nil {
+	if result.Items.Manual, err = m.Items.Manual.FilterByPath(paths...); err != nil {
 		return result, err
 	}
-	if result.Items.Reftest, err = m.Items.Reftest.FilterByPath(paths); err != nil {
+	if result.Items.Reftest, err = m.Items.Reftest.FilterByPath(paths...); err != nil {
 		return result, err
 	}
-	if result.Items.TestHarness, err = m.Items.TestHarness.FilterByPath(paths); err != nil {
+	if result.Items.TestHarness, err = m.Items.TestHarness.FilterByPath(paths...); err != nil {
 		return result, err
 	}
-	if result.Items.WDSpec, err = m.Items.WDSpec.FilterByPath(paths); err != nil {
+	if result.Items.WDSpec, err = m.Items.WDSpec.FilterByPath(paths...); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -192,7 +192,7 @@ type ManifestItem map[string][][]*json.RawMessage
 
 // FilterByPath culls out entries in the ManifestItem that don't have any items with
 // a URL that starts with the given path.
-func (m ManifestItem) FilterByPath(paths mapset.Set) (item ManifestItem, err error) {
+func (m ManifestItem) FilterByPath(paths ...string) (item ManifestItem, err error) {
 	if m == nil {
 		return nil, nil
 	}
@@ -204,8 +204,8 @@ func (m ManifestItem) FilterByPath(paths mapset.Set) (item ManifestItem, err err
 			if err = json.Unmarshal(*item[0], &url); err != nil {
 				return nil, err
 			}
-			for prefix := range paths.Iter() {
-				if strings.Index(url, prefix.(string)) == 0 {
+			for _, prefix := range paths {
+				if strings.Index(url, prefix) == 0 {
 					match = true
 					break
 				}

--- a/shared/params_test.go
+++ b/shared/params_test.go
@@ -114,13 +114,13 @@ func TestGetProductsOrDefault_BrowserParam_ChromeInvalid(t *testing.T) {
 }
 
 func TestGetProductsOrDefault_BrowserParam_EmptyCommas(t *testing.T) {
-	r := httptest.NewRequest("GET", "http://wpt.fyi/?browsers=,chrome,,,,safari,,", nil)
+	r := httptest.NewRequest("GET", "http://wpt.fyi/?browsers=,edge,,,,chrome,,", nil)
 	filters, err := ParseTestRunFilterParams(r)
 	products := filters.GetProductsOrDefault()
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(products))
-	assert.Equal(t, "chrome", products[0].BrowserName) // Alphabetical
-	assert.Equal(t, "safari", products[1].BrowserName)
+	assert.Equal(t, "edge", products[0].BrowserName)
+	assert.Equal(t, "chrome", products[1].BrowserName)
 }
 
 func TestGetProductsOrDefault_BrowserParam_SafariChrome(t *testing.T) {
@@ -129,8 +129,8 @@ func TestGetProductsOrDefault_BrowserParam_SafariChrome(t *testing.T) {
 	products := filters.GetProductsOrDefault()
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(products))
-	assert.Equal(t, "chrome", products[0].BrowserName) // Alphabetical
-	assert.Equal(t, "safari", products[1].BrowserName)
+	assert.Equal(t, "safari", products[0].BrowserName)
+	assert.Equal(t, "chrome", products[1].BrowserName)
 }
 
 func TestGetProductsOrDefault_BrowserParam_MultiBrowserParam_SafariChrome(t *testing.T) {
@@ -139,8 +139,8 @@ func TestGetProductsOrDefault_BrowserParam_MultiBrowserParam_SafariChrome(t *tes
 	products := filters.GetProductsOrDefault()
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(products))
-	assert.Equal(t, "chrome", products[0].BrowserName) // Alphabetical
-	assert.Equal(t, "safari", products[1].BrowserName)
+	assert.Equal(t, "safari", products[0].BrowserName)
+	assert.Equal(t, "chrome", products[1].BrowserName)
 }
 
 func TestGetProductsOrDefault_BrowserParam_MultiBrowserParam_SafariInvalid(t *testing.T) {
@@ -155,9 +155,9 @@ func TestGetProductsOrDefault_BrowserAndProductParam(t *testing.T) {
 	products := filters.GetProductsOrDefault()
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(products))
-	assert.Equal(t, "chrome", products[0].BrowserName)
-	assert.Equal(t, "edge", products[1].BrowserName)
-	assert.Equal(t, "16", products[1].BrowserVersion)
+	assert.Equal(t, "edge", products[0].BrowserName)
+	assert.Equal(t, "16", products[0].BrowserVersion)
+	assert.Equal(t, "chrome", products[1].BrowserName)
 }
 
 func TestGetProductsOrDefault_BrowsersAndProductsParam(t *testing.T) {
@@ -166,11 +166,11 @@ func TestGetProductsOrDefault_BrowsersAndProductsParam(t *testing.T) {
 	products := filters.GetProductsOrDefault()
 	assert.Nil(t, err)
 	assert.Equal(t, 4, len(products))
-	assert.Equal(t, "chrome", products[0].BrowserName)
-	assert.Equal(t, "edge", products[1].BrowserName)
-	assert.Equal(t, "16", products[1].BrowserVersion)
-	assert.Equal(t, "firefox", products[2].BrowserName)
-	assert.Equal(t, "safari", products[3].BrowserName)
+	assert.Equal(t, "edge", products[0].BrowserName)
+	assert.Equal(t, "16", products[0].BrowserVersion)
+	assert.Equal(t, "safari", products[1].BrowserName)
+	assert.Equal(t, "chrome", products[2].BrowserName)
+	assert.Equal(t, "firefox", products[3].BrowserName)
 }
 
 func TestParseMaxCountParam_Missing(t *testing.T) {
@@ -234,19 +234,19 @@ func TestParsePathsParam_Empty(t *testing.T) {
 func TestParsePathsParam_Path_Duplicate(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/api/diff?path=/css&path=/css", nil)
 	paths := ParsePathsParam(r)
-	assert.Equal(t, 1, paths.Cardinality())
+	assert.Len(t, paths, 1)
 }
 
 func TestParsePathsParam_Paths_Duplicate(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/api/diff?paths=/css,/css", nil)
 	paths := ParsePathsParam(r)
-	assert.Equal(t, 1, paths.Cardinality())
+	assert.Len(t, paths, 1)
 }
 
 func TestParsePathsParam_PathsAndPath_Duplicate(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/api/diff?paths=/css&path=/css", nil)
 	paths := ParsePathsParam(r)
-	assert.Equal(t, 1, paths.Cardinality())
+	assert.Len(t, paths, 1)
 }
 
 func TestParsePathsParam_Paths_DiffFilter(t *testing.T) {
@@ -318,19 +318,19 @@ func TestParseLabelsParam_Empty(t *testing.T) {
 func TestParseLabelsParam_Label_Duplicate(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/api/runs?label=experimental&label=experimental", nil)
 	labels := ParseLabelsParam(r)
-	assert.Equal(t, 1, labels.Cardinality())
+	assert.Len(t, labels, 1)
 }
 
 func TestParseLabelsParam_Labels_Duplicate(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/api/runs?labels=experimental,experimental", nil)
 	labels := ParseLabelsParam(r)
-	assert.Equal(t, 1, labels.Cardinality())
+	assert.Len(t, labels, 1)
 }
 
 func TestParseLabelsParam_LabelsAndLabel_Duplicate(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/api/runs?labels=experimental&label=experimental", nil)
 	labels := ParseLabelsParam(r)
-	assert.Equal(t, 1, labels.Cardinality())
+	assert.Len(t, labels, 1)
 }
 
 func TestParseProductSpec(t *testing.T) {

--- a/shared/util.go
+++ b/shared/util.go
@@ -186,3 +186,15 @@ func NewTestContext() context.Context {
 	ctx = context.WithValue(ctx, DefaultLoggerCtxKey(), NewNilLogger())
 	return ctx
 }
+
+// NewSetFromStringSlice is a helper for the inability to cast []string to []interface{}
+func NewSetFromStringSlice(items []string) mapset.Set {
+	if items == nil {
+		return nil
+	}
+	set := mapset.NewSet()
+	for _, i := range items {
+		set.Add(i)
+	}
+	return set
+}


### PR DESCRIPTION
## Description
Fixes https://github.com/web-platform-tests/wpt.fyi/issues/408

Uses `[]string`, instead of `mapset.Set` which has [deliberately non-deterministic ordering (in Golang)](https://blog.golang.org/go-maps-in-action#TOC_7.)

Also fixes support for `before` and `after` params that are spec strings (not base64 TestRun entities).

## Review Information
- Visit /results?product=safari&product=chrome&diff
  - Observe safari on the left
- Visit /results?before=edge&after=chrome
  - Observe edge on the left