### PR TITLE
Propagate the query param when navigating

### DIFF
--- a/webapp/components/interop.html
+++ b/webapp/components/interop.html
@@ -109,10 +109,10 @@ found in the LICENSE file.
     }
   </style>
 
-  <results-navigation tab="interop"
-                      path="[[encodedPath]]"
-                      query="[[query]]">
-  </results-navigation>
+  <results-tabs tab="interop"
+                path="[[encodedPath]]"
+                query="[[query]]">
+  </results-tabs>
 
   <section class="search">
     <div class="path">
@@ -125,7 +125,7 @@ found in the LICENSE file.
 
     <paper-spinner-lite active="[[isLoading]]" class="blue"></paper-spinner-lite>
 
-    <test-search class$="search-[[pathIsATestFile]]" query="[[search]]">
+    <test-search class$="search-[[pathIsATestFile]]" query="{{search}}">
     </test-search>
 
     <template is="dom-if" if="{{ pathIsATestFile }}">
@@ -214,11 +214,12 @@ found in the LICENSE file.
     [118, 255,   3], // --paper-light-green-a200
   ];
 
-  /* global TestRunsBase, SelfNavigation, LoadingState */
-  class WPTInterop extends SelfNavigation(LoadingState(TestRunsBase)) {
-    static get is() {
-      return 'wpt-interop';
-    }
+  /* global TestRunsBase, SelfNavigation, LoadingState, ResultsNavigation */
+  class WPTInterop extends ResultsNavigation(
+    SelfNavigation(LoadingState(TestRunsBase)),
+    'interopQueryParams(sha, labels, productSpecs, maxCount, search)') {
+    static get is() { return 'wpt-interop'; }
+
     static get properties() {
       return {
         passRateMetadata: Object,
@@ -262,6 +263,9 @@ found in the LICENSE file.
         // passRateMetadata contains the url for the JSON blob of allMetrics;
         // both fetches need to succeed + parse.
         this.interopLoadFailed = !(this.passRateMetadata && this.allMetrics);
+        if (!this.interopLoadFailed && this.search) {
+          this.shadowRoot.querySelector('test-search').commitQuery();
+        }
       }
     }
 
@@ -300,6 +304,14 @@ found in the LICENSE file.
 
     navigationQueryParams() {
       return this.queryParams;
+    }
+
+    interopQueryParams(sha, labels, products, maxCount, search) {
+      const params = this.testRunQueryParams(sha, labels, products, maxCount);
+      if (search) {
+        params.q = search;
+      }
+      return params;
     }
 
     computeThLabels(testRuns) {

--- a/webapp/components/interop.html
+++ b/webapp/components/interop.html
@@ -285,7 +285,7 @@ found in the LICENSE file.
       await super.ready();
       this.loadingCount++;
       try {
-        this.passRateMetadata = await fetch(`/api/interop${this.query}`)
+        this.passRateMetadata = await fetch(`/api/interop${this.testRunQuery}`)
           .then(async r => {
             if (!r.ok || r.status !== 200) {
               Promise.reject('Failed to fetch interop data');
@@ -307,7 +307,7 @@ found in the LICENSE file.
     }
 
     interopQueryParams(sha, labels, products, maxCount, search) {
-      const params = this.testRunQueryParams(sha, labels, products, maxCount);
+      const params = this.computeTestRunQueryParams(sha, labels, products, maxCount);
       if (search) {
         params.q = search;
       }

--- a/webapp/components/interop.html
+++ b/webapp/components/interop.html
@@ -258,13 +258,15 @@ found in the LICENSE file.
 
     constructor() {
       super();
-      this.onSearchCommit = this.handleSearchCommit.bind(this);
+      this.onSearchCommit = (e) => {
+        this.handleSearchCommit(e.detail.query);
+      };
       this.onLoadingComplete = () => {
         // passRateMetadata contains the url for the JSON blob of allMetrics;
         // both fetches need to succeed + parse.
         this.interopLoadFailed = !(this.passRateMetadata && this.allMetrics);
         if (!this.interopLoadFailed && this.search) {
-          this.shadowRoot.querySelector('test-search').commitQuery();
+          this.handleSearchCommit(this.search);
         }
       }
     }
@@ -355,8 +357,7 @@ found in the LICENSE file.
       return `background-color: rgba(${INTEROP_COLORS[browserCount].join(', ')}, ${alpha})`;
     }
 
-    handleSearchCommit(e) {
-      const q = e.detail.query;
+    handleSearchCommit(q) {
       if (!q || q.length < 1) {
         this.searchResults = this.fileMetrics;
         return;
@@ -367,8 +368,6 @@ found in the LICENSE file.
 
       this.searchResults = this.fileMetrics
         .filter(t => t.dir.toLowerCase().includes(q));
-
-      this.refreshDisplayedNodes();
     }
 
     computeDisplayedNodes(path, displayedTests) {

--- a/webapp/components/results-navigation.html
+++ b/webapp/components/results-navigation.html
@@ -4,13 +4,34 @@
 <dom-module id='results-navigation'>
   <script>
     /**
-     * ResultsNavigation contains helper methods for building a query string,
-     * from a more-simple 'params' object. Because Polymer doesn't support
-     * overriding computed property functions, the computer method string must
-     * be passed in by the concrete class.
+     * QueryBuilder contains a helper method for building a query string from
+     * an object of params.
+     */
+    const QueryBuilder = (superClass) => class extends superClass {
+      computeQuery(params) {
+        if (Object.keys(params).length < 1) {
+          return '';
+        }
+        const url = new URL(window.location.origin);
+        for (const k of Object.keys(params)) {
+          const v = params[k];
+          if (Array.isArray(v)) {
+            v.forEach(i => url.searchParams.append(k, i));
+          } else {
+            url.searchParams.set(k, params[k]);
+          }
+        }
+        return url.search;
+      }
+    }
+
+    /**
+     * ResultsNavigation extends QueryBuilder's helper methods. Because Polymer
+     * doesn't support overriding computed property functions, the computer
+     * method string must be passed in by the concrete class.
      */
     const ResultsNavigation =
-      (superClass, queryParamsComputer) => class extends superClass {
+      (superClass, queryParamsComputer) => class extends QueryBuilder(superClass) {
         static get properties() {
           return {
             query: {
@@ -24,22 +45,6 @@
               computed: queryParamsComputer,
             },
           }
-        }
-
-        computeQuery(params) {
-          if (Object.keys(params).length < 1) {
-            return '';
-          }
-          const url = new URL(window.location.origin);
-          for (const k of Object.keys(params)) {
-            const v = params[k];
-            if (Array.isArray(v)) {
-              v.forEach(i => url.searchParams.append(k, i));
-            } else {
-              url.searchParams.set(k, params[k]);
-            }
-          }
-          return url.search;
         }
       }
   </script>

--- a/webapp/components/results-navigation.html
+++ b/webapp/components/results-navigation.html
@@ -2,6 +2,50 @@
 <link rel="import" href="../bower_components/paper-styles/color.html">
 
 <dom-module id='results-navigation'>
+  <script>
+    /**
+     * ResultsNavigation contains helper methods for building a query string,
+     * from a more-simple 'params' object. Because Polymer doesn't support
+     * overriding computed property functions, the computer method string must
+     * be passed in by the concrete class.
+     */
+    const ResultsNavigation =
+      (superClass, queryParamsComputer) => class extends superClass {
+        static get properties() {
+          return {
+            query: {
+              type: String,
+              computed: 'computeQuery(queryParams)',
+              value: '',
+            },
+            queryParams: {
+              type: Object,
+              observe: true,
+              computed: queryParamsComputer,
+            },
+          }
+        }
+
+        computeQuery(params) {
+          if (Object.keys(params).length < 1) {
+            return '';
+          }
+          const url = new URL(window.location.origin);
+          for (const k of Object.keys(params)) {
+            const v = params[k];
+            if (Array.isArray(v)) {
+              v.forEach(i => url.searchParams.append(k, i));
+            } else {
+              url.searchParams.set(k, params[k]);
+            }
+          }
+          return url.search;
+        }
+      }
+  </script>
+</dom-module>
+
+<dom-module id='results-tabs'>
   <template>
     <style>
       paper-tabs {
@@ -39,9 +83,9 @@
   </template>
 
   <script>
-    class ResultsNavigation extends window.Polymer.Element {
+    class ResultsTabs extends window.Polymer.Element {
       static get is() {
-        return 'results-navigation';
+        return 'results-tabs';
       }
 
       static get properties() {
@@ -82,6 +126,6 @@
       }
     }
 
-    window.customElements.define(ResultsNavigation.is, ResultsNavigation);
+    window.customElements.define(ResultsTabs.is, ResultsTabs);
   </script>
 </dom-module>

--- a/webapp/components/test-results-history-grid.html
+++ b/webapp/components/test-results-history-grid.html
@@ -88,7 +88,7 @@ found in the LICENSE file.
         ];
       }
 
-      testRunQueryParams(sha, labels, products, maxCount) {
+      computeTestRunQueryParams(sha, labels, products, maxCount) {
         sha = null;
         const params = super.testRunQueryParams(sha, labels, products, maxCount);
         if (!labels || !labels.length) {

--- a/webapp/components/test-runs-query.html
+++ b/webapp/components/test-runs-query.html
@@ -11,6 +11,10 @@ found in the LICENSE file.
      */
     // eslint-disable-next-line no-unused-vars
     const TestRunsQuery = (superClass) => class extends superClass {
+      static get ParamsComputer() {
+        return 'testRunQueryParams(sha, labels, productSpecs, maxCount)';
+      }
+
       static get properties() {
         return {
           /* Parsed product objects, computed from the spec strings */
@@ -34,14 +38,6 @@ found in the LICENSE file.
             type: Boolean,
             computed: 'computeIsLatest(sha)'
           },
-          queryParams: {
-            type: Object,
-            computed: 'testRunQueryParams(sha, labels, productSpecs, maxCount)',
-          },
-          query: {
-            type: String,
-            computed: 'computeQuery(queryParams)',
-          }
         };
       }
 
@@ -68,22 +64,6 @@ found in the LICENSE file.
           params.aligned = true;
         }
         return params;
-      }
-
-      computeQuery(params) {
-        if (Object.keys(params).length < 1) {
-          return '';
-        }
-        const url = new URL(window.location.origin);
-        for (const k of Object.keys(params)) {
-          const v = params[k];
-          if (Array.isArray(v)) {
-            v.forEach(i => url.searchParams.append(k, i));
-          } else {
-            url.searchParams.set(k, params[k]);
-          }
-        }
-        return url.search;
       }
 
       computeProducts(productSpecs) {

--- a/webapp/components/test-runs-query.html
+++ b/webapp/components/test-runs-query.html
@@ -4,17 +4,15 @@ Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file.
 -->
 
+<link rel="import" href="./results-navigation.html">
+
 <dom-module id="test-runs-query">
   <script>
     /**
      * Behaviour class for re-use of test-runs fetching behaviour.
      */
     // eslint-disable-next-line no-unused-vars
-    const TestRunsQuery = (superClass) => class extends superClass {
-      static get ParamsComputer() {
-        return 'testRunQueryParams(sha, labels, productSpecs, maxCount)';
-      }
-
+    const TestRunsQuery = (superClass) => class extends QueryBuilder(superClass) {
       static get properties() {
         return {
           /* Parsed product objects, computed from the spec strings */
@@ -38,6 +36,14 @@ found in the LICENSE file.
             type: Boolean,
             computed: 'computeIsLatest(sha)'
           },
+          testRunQueryParams: {
+            type: Object,
+            computed: 'computeTestRunQueryParams(sha, labels, productSpecs, maxCount)',
+          },
+          testRunQuery: {
+            type: String,
+            computed: 'computeQuery(testRunQueryParams)',
+          },
         };
       }
 
@@ -45,7 +51,7 @@ found in the LICENSE file.
         return !sha || sha === 'latest';
       }
 
-      testRunQueryParams(sha, labels, productSpecs, maxCount) {
+      computeTestRunQueryParams(sha, labels, productSpecs, maxCount) {
         const params = {};
         if (sha) {
           params.sha = sha;

--- a/webapp/components/test-runs.html
+++ b/webapp/components/test-runs.html
@@ -73,7 +73,8 @@ found in the LICENSE file.
         // Fetch by products (or default products, if nothing else is present).
         if ((this.productSpecs && this.productSpecs.length)
           || (!preloaded && !this.testRunResources)) {
-          runs.push(fetch(`/api/runs${this.query}`).then(r => r.ok && r.json()));
+          runs.push(fetch(`/api/runs${this.testRunQuery}`)
+            .then(r => r.ok && r.json()));
         }
         // Fetch by specific URLs (legacy behaviour)
         if (this.testRunResources) {

--- a/webapp/components/test-search.html
+++ b/webapp/components/test-search.html
@@ -49,8 +49,6 @@ found in the LICENSE file.
             type: String,
             value: 'Search test files, like \'cors/allow-headers.htm\', then press <Enter>',
           },
-          items: Array,
-          itemKey: String,
           q: {
             type: String,
             notify: true,
@@ -85,6 +83,11 @@ found in the LICENSE file.
         this.onChange = this.handleChange.bind(this);
         this.onFocus = this.handleFocus.bind(this);
         this.onBlur = this.handleBlur.bind(this);
+      }
+
+      ready() {
+        super.ready();
+        this.q = this.query;
       }
 
       async observeAutocompleteURL(newValue, oldValue) {

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -121,10 +121,10 @@ found in the LICENSE file.
       }
     </style>
 
-    <results-navigation tab="results"
-                        path="[[encodedPath]]"
-                        query="[[query]]">
-    </results-navigation>
+    <results-tabs tab="results"
+                  path="[[encodedPath]]"
+                  query="[[query]]">
+    </results-tabs>
 
     <section class="search">
       <div class="path">
@@ -258,7 +258,9 @@ found in the LICENSE file.
     const TEST_TYPES = ['manual', 'reftest', 'testharness', 'visual', 'wdspec'];
 
     /* global TestRunsBase, SelfNavigation, LoadingState */
-    class WPTResults extends SelfNavigation(LoadingState(TestRunsBase)) {
+    class WPTResults extends ResultsNavigation(
+        SelfNavigation(LoadingState(TestRunsBase)),
+        'resultsQueryParams(sha, labels, productSpecs, maxCount, diff, search)') {
       static get is() {
         return 'wpt-results';
       }
@@ -299,11 +301,6 @@ found in the LICENSE file.
           diffShown: {
             type: Boolean,
             computed: 'isDiffShown(diff, diffRun)',
-          },
-          // Override TestRunsBase to add diff.
-          queryParams: {
-            type: Object,
-            computed: 'testRunQueryParams(sha, labels, products, maxCount, diff)',
           },
           filter: {
             type: String,
@@ -378,28 +375,29 @@ found in the LICENSE file.
           .filter(name => name.startsWith(path));
       }
 
-      computeSearchURL(testRuns, search) {
-        let url = '/api/search?';
+      computeSearchURL(testRuns, query) {
+        let url = new URL('/api/search', window.location);
         if (testRuns) {
-          url += `run_ids=${
-            window.encodeURIComponent(
-              testRuns.map(r => r.id.toString()).join(','))}&`;
+          url.searchParams.set(
+            'run_ids',
+            testRuns.map(r => r.id.toString()).join(','));
         }
-        if (search) {
-          url += `q=${window.encodeURIComponent(search)}`;
+        if (query) {
+          url.searchParams.set('q', query);
         }
         return url;
       }
 
-      computeAutocompleteURL(testRuns, search) {
-        let url = '/api/autocomplete?limit=10&';
+      computeAutocompleteURL(testRuns, query) {
+        let url = new URL('/api/autocomplete', window.location);
+        url.searchParams.set('limit', 10);
         if (testRuns) {
-          url += `run_ids=${
-            window.encodeURIComponent(
-              testRuns.map(r => r.id.toString()).join(','))}&`;
+          url.searchParams.set(
+            'run_ids',
+            testRuns.map(r => r.id.toString()).join(','));
         }
-        if (search) {
-          url += `q=${window.encodeURIComponent(search)}`;
+        if (query) {
+          url.searchParams.set('q', query);
         }
         return url;
       }
@@ -610,10 +608,13 @@ found in the LICENSE file.
         return testRun && testRun.revision === 'diff';
       }
 
-      testRunQueryParams(sha, labels, products, maxCount, diff) {
-        const params = super.testRunQueryParams(sha, labels, products, maxCount);
+      resultsQueryParams(sha, labels, products, maxCount, diff, search) {
+        const params = this.testRunQueryParams(sha, labels, products, maxCount);
         if (diff || this.diff) {
           params.diff = true;
+        }
+        if (search) {
+          params.q = search;
         }
         return params;
       }

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -609,7 +609,7 @@ found in the LICENSE file.
       }
 
       resultsQueryParams(sha, labels, products, maxCount, diff, search) {
-        const params = this.testRunQueryParams(sha, labels, products, maxCount);
+        const params = this.computeTestRunQueryParams(sha, labels, products, maxCount);
         if (diff || this.diff) {
           params.diff = true;
         }

--- a/webapp/interop_handler.go
+++ b/webapp/interop_handler.go
@@ -20,8 +20,10 @@ func interopHandler(w http.ResponseWriter, r *http.Request) {
 	data := struct {
 		Metadata string
 		Filter   testRunUIFilter
+		Query    string
 	}{
 		Filter: uiFilters,
+		Query:  r.URL.Query().Get("q"),
 	}
 
 	if err := templates.ExecuteTemplate(w, "interoperability.html", data); err != nil {

--- a/webapp/templates/interoperability.html
+++ b/webapp/templates/interoperability.html
@@ -14,7 +14,8 @@
                    {{- if .SHA}} sha="{{ .SHA }}" {{end}}
                    {{- if .Labels}} labels="{{ .Labels }}"{{end}}
                    {{- if .Aligned}} aligned{{end}}
-                 {{- end}}></wpt-interop>
+                 {{- end}}
+                 {{if .Query}} search="{{.Query}}"{{end}}></wpt-interop>
   </div>
 </div>
 {{ template "_ga.html" }}

--- a/webapp/templates/results.html
+++ b/webapp/templates/results.html
@@ -14,7 +14,8 @@
           {{- if .MaxCount}} max-count="{{ .MaxCount }}"{{end}}
           {{- if .Diff}} diff{{end}}
           {{- if .Aligned}} aligned{{end}}
-        {{- end}}></wpt-results>
+        {{- end}}
+        {{- if .Query }} search="{{.Query}}"{{end}}></wpt-results>
   </div>
 </div>
 {{ template "_ga.html" }}

--- a/webapp/test_results_handler.go
+++ b/webapp/test_results_handler.go
@@ -63,8 +63,10 @@ func testResultsHandler(w http.ResponseWriter, r *http.Request) {
 		// diffing), for runs which aren't fetchable via a URL or the api.
 		TestRuns string
 		Filter   testRunUIFilter
+		Query    string
 	}{
 		Filter: filter,
+		Query:  r.URL.Query().Get("q"),
 	}
 
 	// Runs by base64-encoded param or spec param.

--- a/webdriver/label_test.go
+++ b/webdriver/label_test.go
@@ -109,13 +109,13 @@ func getTestRunElements(wd selenium.WebDriver, element string) ([]selenium.WebEl
 func getTabElements(wd selenium.WebDriver, element string) ([]selenium.WebElement, error) {
 	switch *browser {
 	case "firefox":
-		return wd.FindElements(selenium.ByCSSSelector, "results-navigation paper-tab")
+		return wd.FindElements(selenium.ByCSSSelector, "results-tabs paper-tab")
 	default:
 		e, err := wd.FindElement(selenium.ByCSSSelector, element)
 		if err != nil {
 			return nil, err
 		}
-		return FindShadowElements(wd, e, "results-navigation", "paper-tab")
+		return FindShadowElements(wd, e, "results-tabs", "paper-tab")
 	}
 }
 


### PR DESCRIPTION
## Description
Fixes https://github.com/web-platform-tests/wpt.fyi/issues/563

The query param is not part of the test-runs query, but a (separate) filtering query. Additionally, you can't actually override the `computed` field (on a property) value, so we can't branch what constitutes the query.