### PR TITLE
Request-level caching for query APIs

### DIFF
--- a/shared/request_caching.go
+++ b/shared/request_caching.go
@@ -1,0 +1,159 @@
+// Copyright 2018 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package shared
+
+import (
+	"bytes"
+	"fmt"
+	io "io"
+	"io/ioutil"
+	"net/http"
+)
+
+// CachingResponseWriter is an http.ResponseWriter that can produce a new
+// io.Reader instances that can replay the response.
+type CachingResponseWriter interface {
+	http.ResponseWriter
+
+	WriteTo(io.Writer) (int64, error)
+}
+
+type cachingResponseWriter struct {
+	delegate   http.ResponseWriter
+	b          *bytes.Buffer
+	statusCode int
+}
+
+func (w *cachingResponseWriter) Header() http.Header {
+	return w.delegate.Header()
+}
+
+func (w *cachingResponseWriter) Write(data []byte) (int, error) {
+	if w.statusCode == 0 {
+		w.statusCode = http.StatusOK
+	}
+
+	var err error
+	i := 0
+	for err == nil && i < len(data) {
+		var n int
+		n, err = w.b.Write(data[i:])
+		i += n
+	}
+	if err != nil {
+		w.b.Reset()
+		return 0, err
+	}
+
+	i = 0
+	for err == nil && i < len(data) {
+		var n int
+		n, err = w.delegate.Write(data[i:])
+		i += n
+	}
+	if err != nil {
+		w.b.Reset()
+		return i, err
+	}
+
+	return i, nil
+}
+
+func (w *cachingResponseWriter) WriteHeader(statusCode int) {
+	w.statusCode = statusCode
+	w.delegate.WriteHeader(statusCode)
+}
+
+func (w *cachingResponseWriter) WriteTo(wtr io.Writer) (int64, error) {
+	if w.statusCode != http.StatusOK {
+		return 0, fmt.Errorf("Attempt to cache response with bad status code: %d", w.statusCode)
+	}
+
+	return w.b.WriteTo(wtr)
+}
+
+// NewCachingResponseWriter wraps the input http.ResponseWriter with a caching implementation.
+func NewCachingResponseWriter(delegate http.ResponseWriter) CachingResponseWriter {
+	return &cachingResponseWriter{
+		delegate: delegate,
+		b:        &bytes.Buffer{},
+	}
+}
+
+type cachingHandler struct {
+	delegate    http.Handler
+	cache       ReadWritable
+	isCacheable func(*http.Request) bool
+	getCacheKey func(*http.Request) interface{}
+}
+
+func (h cachingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := NewAppEngineContext(r)
+	logger := GetLogger(ctx)
+
+	// Case 1: Not cacheable.
+	if !h.isCacheable(r) {
+		logger.Infof("Not cacheable: %s", r.URL.String())
+		h.delegate.ServeHTTP(w, r)
+		return
+	}
+
+	key := h.getCacheKey(r)
+	rc, err := h.cache.NewReadCloser(key)
+	// Case 2: Cache read setup error.
+	if err != nil {
+		logger.Warningf("Failed to get ReadCloser for cache key %v: %v", key, err)
+		h.delegateAndCache(w, r, logger, key)
+		return
+	}
+	defer func() {
+		err := rc.Close()
+		if err != nil {
+			logger.Warningf("Failed to close WriteCloser for %v: %v", key, err)
+		}
+	}()
+
+	data, err := ioutil.ReadAll(rc)
+	// Case 3: Cache read error.
+	if err != nil {
+		logger.Infof("Cache read failed for key %v: %v", key, err)
+		h.delegateAndCache(w, r, logger, key)
+		return
+	}
+
+	// Case 4: Cache hit.
+	logger.Infof("Serving cached data from cache key: %v", key)
+	w.Write(data)
+}
+
+func (h cachingHandler) delegateAndCache(w http.ResponseWriter, r *http.Request, logger Logger, key interface{}) {
+	cw := NewCachingResponseWriter(w)
+	h.delegate.ServeHTTP(cw, r)
+
+	wc, err := h.cache.NewWriteCloser(key)
+	if err != nil {
+		logger.Warningf("Failed to get WriteCloser for cache key: %v", key)
+		return
+	}
+	defer func() {
+		err := wc.Close()
+		if err != nil {
+			logger.Warningf("Failed to close WriteCloser for %v: %v", key, err)
+		}
+	}()
+
+	n, err := cw.WriteTo(wc)
+	if err != nil {
+		logger.Warningf("Failed to write response to cache: %v", err)
+	} else {
+		logger.Infof("Cached %d-byte response at key: %v", n, key)
+	}
+}
+
+// NewCachingHandler produces a caching handler with an underlying delegate
+// handler, cache, cacheability decision function, and cache key producer.
+func NewCachingHandler(delegate http.Handler, cache ReadWritable, isCacheable func(*http.Request) bool, getCacheKey func(*http.Request) interface{}) http.Handler {
+	return cachingHandler{delegate, cache, isCacheable, getCacheKey}
+}

--- a/shared/storage.go
+++ b/shared/storage.go
@@ -224,28 +224,28 @@ func (cs byteCachedStore) Get(cacheID, storeID, iValue interface{}) error {
 	if err == nil {
 		defer func() {
 			if err := cr.Close(); err != nil {
-				logger.Warningf("Error closing cache reader for key %s: %v", cacheID, err)
+				logger.Warningf("Error closing cache reader for key %v: %v", cacheID, err)
 			}
 		}()
 		cached, err := ioutil.ReadAll(cr)
 		if err == nil {
-			logger.Infof("Serving data from cache: %s", cacheID)
+			logger.Infof("Serving data from cache: %v", cacheID)
 			*valuePtr = cached
 			return nil
 		}
 	}
 
-	logger.Warningf("Error fetching cache key %s: %v", cacheID, err)
+	logger.Warningf("Error fetching cache key %v: %v", cacheID, err)
 	err = nil
 
-	logger.Infof("Loading data from store: %s", storeID)
+	logger.Infof("Loading data from store: %v", storeID)
 	sr, err := cs.store.NewReadCloser(storeID)
 	if err != nil {
 		return err
 	}
 	defer func() {
 		if err := sr.Close(); err != nil {
-			logger.Warningf("Error closing store reader for key %s: %v", storeID, err)
+			logger.Warningf("Error closing store reader for key %v: %v", storeID, err)
 		}
 	}()
 
@@ -255,26 +255,28 @@ func (cs byteCachedStore) Get(cacheID, storeID, iValue interface{}) error {
 	}
 
 	// Cache result.
-	go func() {
+	func() {
 		w, err := cs.cache.NewWriteCloser(cacheID)
 		if err != nil {
-			logger.Warningf("Error cache writer for key %s: %v", cacheID, err)
+			logger.Warningf("Error cache writer for key %v: %v", cacheID, err)
 			return
 		}
 		defer func() {
 			if err := w.Close(); err != nil {
-				logger.Warningf("Error cache writer for key %s: %v", cacheID, err)
+				logger.Warningf("Error cache writer for key %v: %v", cacheID, err)
 			}
 		}()
 		n, err := w.Write(data)
 		if err != nil {
-			logger.Warningf("Failed to write to cache key %s: %v", cacheID, err)
+			logger.Warningf("Failed to write to cache key %v: %v", cacheID, err)
 			return
 		}
 		if n != len(data) {
 			logger.Warningf("Failed to write to cache key %s: attempt to write %d bytes, but wrote %d bytes instead", cacheID, len(data), n)
 			return
 		}
+
+		logger.Infof("Cached store value for key: %v", cacheID)
 	}()
 
 	*valuePtr = data
@@ -397,7 +399,15 @@ func (cs objectCachedStore) Get(cacheID, storeID, value interface{}) error {
 
 	err = cs.store.Get(storeID, value)
 	if err == nil {
-		logger.Infof("Serving object for store: %v", storeID)
+		logger.Infof("Serving object from store: %v", storeID)
+		go func() {
+			err := cs.cache.Put(cacheID, value)
+			if err != nil {
+				logger.Warningf("Error caching to key %v: %v", cacheID, err)
+			} else {
+				logger.Infof("Cached object at key: %v", cacheID)
+			}
+		}()
 	}
 
 	return err

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -379,6 +379,10 @@ found in the LICENSE file.
       }
 
       computeSearchURL(testRuns, search) {
+        if (!testRuns || testRuns.length === 0) {
+          return '';
+        }
+
         let url = '/api/search?';
         if (testRuns) {
           url += `run_ids=${
@@ -392,6 +396,10 @@ found in the LICENSE file.
       }
 
       computeAutocompleteURL(testRuns, search) {
+        if (!testRuns || testRuns.length === 0) {
+          return '';
+        }
+
         let url = '/api/autocomplete?limit=10&';
         if (testRuns) {
           url += `run_ids=${


### PR DESCRIPTION
## Description

This PR introduces request-level caching and integrates it into the search and autocomplete APIs.

## Review Information

- Load any "results" (not "runs" or "interop") page with the Network tab open in DevTools

  - Observe at most 1 `/api/search` and `/api/autocomplete` request

  - Reload

    - Observe `/api/search` and `/api/autocomplete` requests take 300-800ms

    - Observe two server-side logs: `Serving cached data from cache key: URL-/api/[...]`

  - Type and commit a search query; type and commit a different search query; type and commit first search query again

    - Observe second load of same query'ified `/api/search` and`/api/autocomplete` faster (200-500ms, depending on query)

    - Observe two server-side logs: `Serving cached data from cache key: URL-/api/[...]` with query

## Changes

- Ensure `wpt-results` component waits for run IDs to commit search+autocomplete queries

- Implement `cachingHandler`, a `http.Handler` implementation, and `cachingResponseWriter`, an `http.ResponseWriter` implementation

- Decorate search and autocomplete HTTP handlers with `cachingHandler` instances

  - Reuse memcache `ReadWritable` from entity-level caching for request-level caching
