### PR TITLE
Double the timeout for search_test

### DIFF
--- a/webdriver/search_test.go
+++ b/webdriver/search_test.go
@@ -45,7 +45,7 @@ func testSearch(t *testing.T, path, elementName string) {
 		}
 		return len(pathParts) > 0, nil
 	}
-	err = wd.WaitWithTimeout(resultsLoadedCondition, time.Second*5)
+	err = wd.WaitWithTimeout(resultsLoadedCondition, time.Second*10)
 	assert.Nil(t, err)
 
 	// Run the search.
@@ -63,7 +63,7 @@ func testSearch(t *testing.T, path, elementName string) {
 	if err := wd.Get(app.GetWebappURL(path) + "?q=" + folder); err != nil {
 		panic(err)
 	}
-	err = wd.WaitWithTimeout(resultsLoadedCondition, time.Second*5)
+	err = wd.WaitWithTimeout(resultsLoadedCondition, time.Second*10)
 	assert.Nil(t, err)
 	assertListIsFiltered(t, wd, elementName, folder)
 }


### PR DESCRIPTION
Today I've observed search_test timed out a few times, especially on staging,
when the new staging version was just starting up.

Other integration tests have a longer 10s timeout. Let's double the timeout
for search_test to 10s and see if things improve.
