### PR TITLE
Drop `/api/run` endpoint

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -10,7 +10,6 @@ the endpoints can be found in `routes.go`.
 
  - [/api/runs](#apiruns)
  - [/api/runs/{id}](#apirunsid)
- - [/api/run](#apirun)
  - [/api/shas](#apishas)
  - [/api/diff](#apidiff)
  - [/api/results](#apiresults)
@@ -78,37 +77,6 @@ Gets a specific (single) TestRun metadata by its datastore ID.
 #### Example
 
 https://wpt.fyi/api/runs/5164888561287168
-
-<details><summary><b>Example JSON</b></summary>
-
-    {
-      "id": "5164888561287168",
-      "browser_name": "chrome",
-      "browser_version": "67.0.3396.62",
-      "os_name": "linux",
-      "os_version": "4.4",
-      "revision": "2bd11b91d4",
-      "full_revision_hash": "2bd11b91d490ddd5237bcb6d8149a7f25faaa101",
-      "results_url": "https://storage.googleapis.com/wptd/2bd11b91d4/chrome-stable-linux-summary.json.gz",
-      "created_at": "2018-06-05T08:27:30.627865Z",
-      "raw_results_url": "https://storage.googleapis.com/wptd-results/2bd11b91d490ddd5237bcb6d8149a7f25faaa101/chrome_67.0.3396.62_linux_4.4/report.json"
-    }
-
-</details>
-
-### /api/run
-
-Gets a specific (single) TestRun metadata by `product` and `sha`.
-
-__Parameters__
-
-__`sha`__ :  SHA[0:10] of the runs to get, or the keyword `latest`. Defaults to `latest`.
-
-__`product`__ : browser[version[os[version]]]. e.g. `chrome-63.0-linux`
-
-#### Example
-
-https://wpt.fyi/api/run?sha=latest&product=chrome
 
 <details><summary><b>Example JSON</b></summary>
 

--- a/api/routes.go
+++ b/api/routes.go
@@ -17,17 +17,14 @@ func RegisterRoutes() {
 	// API endpoint for fetching a manifest for a commit SHA.
 	shared.AddRoute("/api/manifest", "api-manifest", shared.WrapPermissiveCORS(apiManifestHandler))
 
-	// API endpoint for listing all test runs for a given SHA.
+	// API endpoint for listing test runs for a set of products, labels, and SHA.
 	shared.AddRoute("/api/runs", "api-test-runs", shared.WrapPermissiveCORS(apiTestRunsHandler))
+
+	// API endpoints for a single test run, by its ID:
+	shared.AddRoute("/api/runs/{id}", "api-test-run", shared.WrapPermissiveCORS(apiTestRunHandler))
 
 	// API endpoint for listing SHAs for the test runs.
 	shared.AddRoute("/api/shas", "api-shas", shared.WrapPermissiveCORS(apiSHAsHandler))
-
-	// API endpoints for a single test run, by
-	// ID:
-	shared.AddRoute("/api/runs/{id}", "api-test-run", shared.WrapPermissiveCORS(apiTestRunHandler))
-	// 'product' param & 'sha' param:
-	shared.AddRoute("/api/run", "api-test-run", shared.WrapPermissiveCORS(apiTestRunHandler))
 
 	// API endpoint for redirecting to a run's summary JSON blob.
 	shared.AddRoute("/api/results", "api-results", shared.WrapPermissiveCORS(apiResultsRedirectHandler))

--- a/api/test_run.go
+++ b/api/test_run.go
@@ -27,47 +27,24 @@ func apiTestRunHandler(w http.ResponseWriter, r *http.Request) {
 	idParam := vars["id"]
 	ctx := shared.NewAppEngineContext(r)
 	var testRun shared.TestRun
-	if idParam != "" {
-		id, err := strconv.ParseInt(idParam, 10, 0)
-		if err != nil {
-			http.Error(w, fmt.Sprintf("Invalid id '%s'", idParam), http.StatusBadRequest)
-			return
-		}
-		run, err := shared.LoadTestRun(ctx, id)
-		if err != nil {
-			if err == datastore.ErrNoSuchEntity {
-				http.NotFound(w, r)
-				return
-			}
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		testRun = *run
-	} else {
-		filters, err := shared.ParseTestRunFilterParams(r)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		} else if len(filters.Products) == 0 {
-			http.Error(w, fmt.Sprintf("Missing required 'product' param"), http.StatusBadRequest)
-			return
-		} else if len(filters.Products) > 1 {
-			http.Error(w, fmt.Sprintf("Only one 'product' param value is allowed"), http.StatusBadRequest)
-			return
-		}
-		one := 1
-		testRuns, err := shared.LoadTestRuns(ctx, filters.Products, filters.Labels, filters.SHA, nil, nil, &one)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		if len(testRuns) == 0 {
+	if idParam == "" {
+		http.Error(w, "Run ID is required", http.StatusBadRequest)
+	}
+	id, err := strconv.ParseInt(idParam, 10, 0)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Invalid id '%s'", idParam), http.StatusBadRequest)
+		return
+	}
+	run, err := shared.LoadTestRun(ctx, id)
+	if err != nil {
+		if err == datastore.ErrNoSuchEntity {
 			http.NotFound(w, r)
 			return
 		}
-		testRun = testRuns[0]
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
+	testRun = *run
 
 	testRunsBytes, err := json.Marshal(testRun)
 	if err != nil {

--- a/api/test_runs.go
+++ b/api/test_runs.go
@@ -20,6 +20,7 @@ import (
 func apiTestRunsHandler(w http.ResponseWriter, r *http.Request) {
 	filters, err := shared.ParseTestRunFilterParams(r)
 	if err != nil {
+		panic(err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}

--- a/api/test_runs_medium_test.go
+++ b/api/test_runs_medium_test.go
@@ -20,7 +20,7 @@ func TestGetTestRuns_VersionPrefix(t *testing.T) {
 	i, err := sharedtest.NewAEInstance(true)
 	assert.Nil(t, err)
 	defer i.Close()
-	r, err := i.NewRequest("GET", "/api/run?product=chrome-66.0", nil)
+	r, err := i.NewRequest("GET", "/api/runs?product=chrome-66.0", nil)
 	assert.Nil(t, err)
 
 	// 'Yesterday', v66...139 earlier version.
@@ -47,37 +47,37 @@ func TestGetTestRuns_VersionPrefix(t *testing.T) {
 	chrome.BrowserVersion = "68.0.3432.3"
 	datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &chrome)
 
-	r, _ = i.NewRequest("GET", "/api/run?product=chrome-6", nil)
+	r, _ = i.NewRequest("GET", "/api/runs?product=chrome-6", nil)
 	resp := httptest.NewRecorder()
-	apiTestRunHandler(resp, r)
+	apiTestRunsHandler(resp, r)
 	assert.Equal(t, http.StatusNotFound, resp.Code)
 
-	r, _ = i.NewRequest("GET", "/api/run?product=chrome-66.0", nil)
+	r, _ = i.NewRequest("GET", "/api/runs?product=chrome-66.0", nil)
 	resp = httptest.NewRecorder()
-	apiTestRunHandler(resp, r)
+	apiTestRunsHandler(resp, r)
 	body, _ := ioutil.ReadAll(resp.Result().Body)
 	assert.Equalf(t, http.StatusOK, resp.Code, string(body))
-	var result66 shared.TestRun
+	var result66 shared.TestRuns
 	json.Unmarshal(body, &result66)
-	assert.Equal(t, "66.0.3359.181", result66.BrowserVersion)
+	assert.Equal(t, "66.0.3359.181", result66[0].BrowserVersion)
 
-	r, _ = i.NewRequest("GET", "/api/run?product=chrome-66.0.3359.139", nil)
+	r, _ = i.NewRequest("GET", "/api/runs?product=chrome-66.0.3359.139", nil)
 	resp = httptest.NewRecorder()
-	apiTestRunHandler(resp, r)
+	apiTestRunsHandler(resp, r)
 	body, _ = ioutil.ReadAll(resp.Result().Body)
 	assert.Equal(t, http.StatusOK, resp.Code)
-	var result66139 shared.TestRun
+	var result66139 shared.TestRuns
 	json.Unmarshal(body, &result66139)
-	assert.Equal(t, "66.0.3359.139", result66139.BrowserVersion)
+	assert.Equal(t, "66.0.3359.139", result66139[0].BrowserVersion)
 
-	r, _ = i.NewRequest("GET", "/api/run?product=chrome-68", nil)
+	r, _ = i.NewRequest("GET", "/api/runs?product=chrome-68", nil)
 	resp = httptest.NewRecorder()
-	apiTestRunHandler(resp, r)
+	apiTestRunsHandler(resp, r)
 	body, _ = ioutil.ReadAll(resp.Result().Body)
 	assert.Equal(t, http.StatusOK, resp.Code)
-	var result68 shared.TestRun
+	var result68 shared.TestRuns
 	json.Unmarshal(body, &result68)
-	assert.Equal(t, "68.0.3432.3", result68.BrowserVersion)
+	assert.Equal(t, "68.0.3432.3", result68[0].BrowserVersion)
 }
 
 func TestGetTestRuns_SHA(t *testing.T) {

--- a/webapp/routes_test.go
+++ b/webapp/routes_test.go
@@ -71,7 +71,6 @@ func TestApiShasBound(t *testing.T) {
 }
 
 func TestApiRunBound(t *testing.T) {
-	assertHandlerIs(t, "/api/run", "api-test-run")
 	assertHandlerIs(t, "/api/runs/123", "api-test-run")
 }
 


### PR DESCRIPTION
## Description
Fixes https://github.com/web-platform-tests/wpt.fyi/issues/285

`/api/run` adds no extra functionality over `/api/runs?max-count=1`