### PR TITLE
Switch date of runs to time_start and show execution time

### DIFF
--- a/webapp/components/test-run.html
+++ b/webapp/components/test-run.html
@@ -62,7 +62,7 @@ See models.go for more details.
         <paper-tooltip offset=0>
           {{displayName(testRun.browser_name)}} {{testRun.browser_version}}<br>
           Labels: {{displayLabels(testRun.labels)}}<br>
-          Started {{timeFormat(testRun.time_start)}} (took {{timeTaken(testRun)}})<br>
+          Started {{timeFormat(testRun.time_start)}} {{timeTaken(testRun)}}<br>
           {{moreTooltip(testRun)}}
         </paper-tooltip>
       </template>
@@ -113,9 +113,11 @@ See models.go for more details.
       }
 
       timeTaken(testRun) {
+        // NOTE: We don't always have a real start/end time.
         const hour = 1000*60*60;
         const elapsed = new Date(testRun.time_end) - new Date(testRun.time_start);
-        return `${(elapsed / hour).toFixed(1)}h`;
+        const oneDP = (elapsed / hour).toFixed(1);
+        return oneDP < 0.1 ? '' : `(took ${oneDP}h)`;
       }
 
       isDiff(browserName) {

--- a/webapp/components/test-run.html
+++ b/webapp/components/test-run.html
@@ -115,7 +115,7 @@ See models.go for more details.
       timeTaken(testRun) {
         const hour = 1000*60*60;
         const elapsed = new Date(testRun.time_end) - new Date(testRun.time_start);
-        return `${Math.round(elapsed / hour * 10) / 10}h`;
+        return `${(elapsed / hour).toFixed(1)}h`;
       }
 
       isDiff(browserName) {

--- a/webapp/components/test-run.html
+++ b/webapp/components/test-run.html
@@ -54,7 +54,7 @@ See models.go for more details.
         <template is="dom-if" if="{{ !isDiff(testRun.browser_name) }}">
           <div>{{displayName(testRun.os_name)}} {{testRun.os_version}}</div>
           <div class="revision">@<a href="?sha={{testRun.revision}}">{{testRun.revision}}</a></div>
-          <div>{{dateFormat(testRun.created_at)}}</div>
+          <div>{{dateFormat(testRun.time_start)}}</div>
         </template>
       </template>
 
@@ -62,6 +62,7 @@ See models.go for more details.
         <paper-tooltip offset=0>
           {{displayName(testRun.browser_name)}} {{testRun.browser_version}}<br>
           Labels: {{displayLabels(testRun.labels)}}<br>
+          Started {{timeFormat(testRun.time_start)}} (took {{timeTaken(testRun)}})<br>
           {{moreTooltip(testRun)}}
         </paper-tooltip>
       </template>
@@ -92,7 +93,29 @@ See models.go for more details.
       }
 
       dateFormat(isoDate) {
-        return String(new Date(isoDate)).match(/^\w+ (\w+ \w+ \w+)/)[1];
+        return new Date(isoDate).toLocaleDateString('en-US', {
+          month: 'short',
+          day: 'numeric',
+          year: 'numeric',
+        });
+      }
+
+      timeFormat(isoDate) {
+        const date = new Date(isoDate).toLocaleDateString('en-US', {
+          month: 'short',
+          day: 'numeric',
+        });
+        const time = new Date(isoDate).toLocaleTimeString('en-US', {
+          hour: 'numeric',
+          minute: 'numeric',
+        });
+        return `${date} at ${time}`;
+      }
+
+      timeTaken(testRun) {
+        const hour = 1000*60*60;
+        const elapsed = new Date(testRun.time_end) - new Date(testRun.time_start);
+        return `${Math.round(elapsed / hour * 10) / 10}h`;
       }
 
       isDiff(browserName) {

--- a/webapp/components/test/test-run.html
+++ b/webapp/components/test/test-run.html
@@ -38,7 +38,23 @@
       suite('TestRunsBase.prototype.*', () => {
         suite('dateFormat()', () => {
           test('dateFormat(iso string)', () => {
-            assert.equal(trf.dateFormat('2018-01-12T12:00:00Z'), 'Jan 12 2018');
+            assert.equal(trf.dateFormat('2018-01-12T12:00:00Z'), 'Jan 12, 2018');
+          });
+        });
+        suite('timeFormat()', () => {
+          let sandbox;
+
+          setup(() => {
+            sandbox = sinon.sandbox.create();
+            sandbox.stub(Date.prototype, 'getTimezoneOffset').returns(240);
+          });
+
+          test('timeFormat(iso string)', () => {
+            assert.equal(trf.timeFormat('2018-01-12T12:00:00Z'), 'Jan 12 at 7:00 AM');
+          });
+
+          teardown(() => {
+            sandbox.restore();
           });
         });
         suite('isDiff()', () => {

--- a/webapp/components/test/test-run.html
+++ b/webapp/components/test/test-run.html
@@ -23,7 +23,8 @@
         trf = fixture('test-run-fixture');
         trf.set('testRun', {
           browser_name: 'firefox',
-          created_at: '2018-01-12T12:00:00Z'
+          time_start: '2018-01-12T12:00:00Z',
+          time_end: '2018-01-12T13:20:00Z',
         });
       });
 
@@ -36,27 +37,27 @@
       });
 
       suite('TestRunsBase.prototype.*', () => {
+        let sandbox;
+
+        setup(() => {
+          sandbox = sinon.sandbox.create();
+          sandbox.stub(Date.prototype, 'getTimezoneOffset').returns(240);
+        });
+
         suite('dateFormat()', () => {
           test('dateFormat(iso string)', () => {
             assert.equal(trf.dateFormat('2018-01-12T12:00:00Z'), 'Jan 12, 2018');
           });
         });
-        suite('timeFormat()', () => {
-          let sandbox;
 
-          setup(() => {
-            sandbox = sinon.sandbox.create();
-            sandbox.stub(Date.prototype, 'getTimezoneOffset').returns(240);
-          });
-
-          test('timeFormat(iso string)', () => {
-            assert.equal(trf.timeFormat('2018-01-12T12:00:00Z'), 'Jan 12 at 7:00 AM');
-          });
-
-          teardown(() => {
-            sandbox.restore();
-          });
+        test('timeFormat(iso string)', () => {
+          assert.equal(trf.timeFormat('2018-01-12T12:00:00Z'), 'Jan 12 at 7:00 AM');
         });
+
+        test('timeTaken(testRun Object)', () => {
+          assert.equal(trf.timeTaken(trf.testRun), '1.3h');
+        });
+
         suite('isDiff()', () => {
           test('isDiff("Diff|diff")', () => {
             assert.isTrue(trf.isDiff('Diff'));
@@ -66,50 +67,41 @@
             assert.isFalse(trf.isDiff('literally anything'));
           });
         });
+
         suite('shortVersion', () => {
           test('valid, major only', () => {
-
             assert.equal(trf.shortVersion('chrome', '1'), '1');
-
             assert.equal(trf.shortVersion('chrome', '2.3'), '2');
-
             assert.equal(trf.shortVersion('chrome', '3.4.5'), '3');
-
             assert.equal(trf.shortVersion('chrome', '4.5.6.7'), '4');
-
             assert.equal(trf.shortVersion('chrome', '765.687'), '765');
-
             assert.equal(trf.shortVersion('chrome', '   11.0 '), '11');
-
             assert.equal(trf.shortVersion('chrome', '56.0a'), '56');
           });
+
           test('valid, major and minor', () => {
             assert.equal(trf.shortVersion('safari', '1'), '1');
-
             assert.equal(trf.shortVersion('safari', '2.3'), '2.3');
-
             assert.equal(trf.shortVersion('safari', '3.4.5'), '3.4');
-
             assert.equal(trf.shortVersion('safari', '4.5.6.7'), '4.5');
-
             assert.equal(trf.shortVersion('safari', '765.687'), '765.687');
-
             assert.equal(trf.shortVersion('safari', '   11.0 '), '11.0');
-
             assert.equal(trf.shortVersion('safari', '56.0a'), '56.0');
           });
+
           test('invalid', () => {
             assert.equal(trf.shortVersion('chrome', 'five'), 'five');
-
             assert.equal(trf.shortVersion('chrome', ''), '');
-
             assert.equal(trf.shortVersion('safari', 'five'), 'five');
-
             assert.equal(trf.shortVersion('safari', ''), '');
           });
         });
+
+        teardown(() => {
+          sandbox.restore();
+        });
       });
     });
-  </script>
+    </script>
 </body>
 </html>

--- a/webapp/components/test/test-run.html
+++ b/webapp/components/test/test-run.html
@@ -54,8 +54,22 @@
           assert.equal(trf.timeFormat('2018-01-12T12:00:00Z'), 'Jan 12 at 7:00 AM');
         });
 
-        test('timeTaken(testRun Object)', () => {
-          assert.equal(trf.timeTaken(trf.testRun), '1.3h');
+        suite('timeTaken(testRun Object)', () => {
+          test('1h 20m', () => {
+            const testRun = {
+              time_start: '2018-01-12T12:00:00Z',
+              time_end: '2018-01-12T13:20:00Z',
+            };
+            assert.equal(trf.timeTaken(testRun), '(took 1.3h)');
+          });
+
+          test('0m', () => {
+            const testRun = {
+              time_start: '2018-01-12T12:00:00Z',
+              time_end: '2018-01-12T12:00:00Z',
+            };
+            assert.equal(trf.timeTaken(testRun), '');
+          });
         });
 
         suite('isDiff()', () => {

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -67,6 +67,9 @@ found in the LICENSE file.
         padding: 0.2em 0.5em;
         border: solid 1px var(--paper-grey-300);
       }
+      thead {
+        border-bottom: 8px solid white;
+      }
       .path {
         margin-bottom: 16px;
       }


### PR DESCRIPTION
## Description
Improves https://github.com/web-platform-tests/wpt.fyi/issues/204 and adds run execution-time data for a misinterpretation of https://github.com/web-platform-tests/wpt.fyi/issues/282

Changes the hover content to show how long a run took (and what time it started). This disambiguates the date shown.