### PR TITLE
Always compute path when value is default

### DIFF
--- a/webapp/components/self-navigator.html
+++ b/webapp/components/self-navigator.html
@@ -3,7 +3,7 @@
 <dom-module id='self-navigator'>
   <script>
     // eslint-disable-next-line no-unused-vars
-    const SelfNavigation = (superClass) => class extends superClass {
+    const SelfNavigation = (superClass) => class SelfNavigation extends superClass {
       static get properties() {
         return {
           path: {
@@ -25,7 +25,7 @@
 
       ready() {
         super.ready();
-        if (!this.path) {
+        if (this.path === SelfNavigation.properties.path.value) {
           this.path = this.urlToPath(window.location);
         }
         window.onpopstate = () => {

--- a/webdriver/path_test.go
+++ b/webdriver/path_test.go
@@ -1,0 +1,56 @@
+// +build large
+
+package webdriver
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tebeka/selenium"
+)
+
+func TestPath_Results(t *testing.T) {
+	testPath(t, "/results/", "wpt-results")
+}
+
+func TestPath_Interop(t *testing.T) {
+	testPath(t, "/interop/", "wpt-interop")
+}
+
+func testPath(t *testing.T, path, elementName string) {
+	app, err := NewWebserver()
+	if err != nil {
+		panic(err)
+	}
+	defer app.Close()
+
+	service, wd, err := GetWebDriver()
+	if err != nil {
+		panic(err)
+	}
+	defer service.Stop()
+	defer wd.Quit()
+
+	// Navigate to the wpt.fyi homepage.
+	if err := wd.Get(app.GetWebappURL(path + "2dcontext/building-paths")); err != nil {
+		panic(err)
+	}
+
+	// Wait for the results view to load.
+	resultsLoadedCondition := func(wd selenium.WebDriver) (bool, error) {
+		pathParts, err := getPathPartElements(wd, elementName)
+		if err != nil {
+			return false, err
+		}
+		return len(pathParts) > 0, nil
+	}
+
+	paths := []string{
+		"canvas_complexshapes_arcto_001.htm",
+		"canvas_complexshapes_beziercurveto_001.htm",
+	}
+	err = wd.WaitWithTimeout(resultsLoadedCondition, time.Second*10)
+	assert.Nil(t, err)
+	assertListIsFiltered(t, wd, elementName, paths...)
+}

--- a/webdriver/search_test.go
+++ b/webdriver/search_test.go
@@ -58,7 +58,7 @@ func testSearch(t *testing.T, path, elementName string) {
 	if err := searchBox.SendKeys(folder + selenium.EnterKey); err != nil {
 		panic(err)
 	}
-	assertListIsFiltered(t, wd, elementName, folder)
+	assertListIsFiltered(t, wd, elementName, folder+"/")
 
 	// Navigate to the wpt.fyi homepage.
 	if err := wd.Get(app.GetWebappURL(path) + "?q=" + folder); err != nil {

--- a/webdriver/search_test.go
+++ b/webdriver/search_test.go
@@ -3,6 +3,7 @@
 package webdriver
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -65,10 +66,10 @@ func testSearch(t *testing.T, path, elementName string) {
 	}
 	err = wd.WaitWithTimeout(resultsLoadedCondition, time.Second*10)
 	assert.Nil(t, err)
-	assertListIsFiltered(t, wd, elementName, folder)
+	assertListIsFiltered(t, wd, elementName, folder+"/")
 }
 
-func assertListIsFiltered(t *testing.T, wd selenium.WebDriver, elementName, folder string) {
+func assertListIsFiltered(t *testing.T, wd selenium.WebDriver, elementName string, paths ...string) {
 	var pathParts []selenium.WebElement
 	var err error
 	filteredPathPartsCondition := func(wd selenium.WebDriver) (bool, error) {
@@ -76,18 +77,20 @@ func assertListIsFiltered(t *testing.T, wd selenium.WebDriver, elementName, fold
 		if err != nil {
 			return false, err
 		}
-		return len(pathParts) == 1, nil
+		return len(pathParts) == len(paths), nil
 	}
 	err = wd.WaitWithTimeout(filteredPathPartsCondition, time.Second*5)
 	if err != nil {
-		assert.Failf(t, "Expected exactly one %s result", folder)
+		assert.Fail(t, fmt.Sprintf("Expected exactly %v results", len(paths)))
 		return
 	}
-	text, err := pathParts[0].Text()
-	if err != nil {
-		assert.Fail(t, err.Error())
+	for i := range paths {
+		text, err := pathParts[i].Text()
+		if err != nil {
+			assert.Fail(t, err.Error())
+		}
+		assert.Equal(t, paths[i], text)
 	}
-	assert.Equal(t, folder+"/", text)
 }
 
 // NOTE(lukebjerring): Firefox, annoyingly, throws a TypeError querying


### PR DESCRIPTION
## Description
Fixes https://github.com/web-platform-tests/wpt.fyi/issues/606

The underlying issue is that we set a default value, which caused the `!this.path` check to be false, and initial computation was stepped over (caused way back in #254)