### PR TITLE
Show diff passes/regression numbers separately

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -196,8 +196,8 @@ https://wpt.fyi/api/results?product=chrome
 
 ### /api/diff
 
-Computes a TestRun summary JSON blob of the differences between two TestRun
-summary blobs.
+Computes a summary JSON blob of the differences between two TestRun summary blobs,
+in the format of an array of [improved, regressed, total-delta].
 
 __Parameters__
 

--- a/shared/run_diff.go
+++ b/shared/run_diff.go
@@ -104,16 +104,16 @@ func GetResultsDiff(before map[string][]int, after map[string][]int, filter Diff
 				if !filter.Deleted {
 					continue
 				}
-				diff[test] = []int{resultsBefore[0], resultsBefore[1] - resultsBefore[0], resultsBefore[1]}
+				diff[test] = []int{resultsBefore[0], resultsBefore[1] - resultsBefore[0], -resultsBefore[1]}
 			} else {
 				if !filter.Changed && !filter.Unchanged {
 					continue
 				}
 				improved, regressed, delta := 0, 0, resultsBefore[0]-resultsAfter[0]
-				if delta >= 0 {
-					improved = delta
+				if delta < 0 {
+					improved = abs(delta)
 				} else {
-					regressed = abs(delta)
+					regressed = delta
 				}
 				countDiff := abs(resultsBefore[1] - resultsAfter[1])
 				changed := delta != 0 || countDiff != 0
@@ -125,7 +125,7 @@ func GetResultsDiff(before map[string][]int, after map[string][]int, filter Diff
 				diff[test] = []int{
 					improved,
 					regressed,
-					abs(resultsBefore[1] - resultsAfter[1]),
+					resultsAfter[1] - resultsBefore[1],
 				}
 			}
 		}

--- a/shared/run_diff_test.go
+++ b/shared/run_diff_test.go
@@ -23,44 +23,44 @@ func TestDiffResults_NoDifference(t *testing.T) {
 
 func TestDiffResults_Difference(t *testing.T) {
 	// One test now passing
-	assertDelta(t, []int{0, 1}, []int{1, 1}, []int{1, 1})
+	assertDelta(t, []int{0, 1}, []int{1, 1}, []int{1, 0, 0})
 
 	// One test now failing
-	assertDelta(t, []int{1, 1}, []int{0, 1}, []int{1, 1})
+	assertDelta(t, []int{1, 1}, []int{0, 1}, []int{0, 1, 0})
 
 	// Two tests, one now failing
-	assertDelta(t, []int{2, 2}, []int{1, 2}, []int{1, 2})
+	assertDelta(t, []int{2, 2}, []int{1, 2}, []int{0, 1, 0})
 
 	// Three tests, two now passing
-	assertDelta(t, []int{1, 3}, []int{3, 3}, []int{2, 3})
+	assertDelta(t, []int{1, 3}, []int{3, 3}, []int{2, 0, 0})
 }
 
 func TestDiffResults_Added(t *testing.T) {
 	// One new test, all passing
-	assertDelta(t, []int{1, 1}, []int{2, 2}, []int{1, 2})
+	assertDelta(t, []int{1, 1}, []int{2, 2}, []int{1, 0, 1})
 
 	// One new test, all failing
-	assertDelta(t, []int{0, 1}, []int{0, 2}, []int{1, 2})
+	assertDelta(t, []int{0, 1}, []int{0, 2}, []int{0, 0, 1})
 
 	// One new test, new test passing
-	assertDelta(t, []int{0, 1}, []int{1, 2}, []int{1, 2})
+	assertDelta(t, []int{0, 1}, []int{1, 2}, []int{1, 0, 1})
 
 	// One new test, new test failing
-	assertDelta(t, []int{1, 1}, []int{1, 2}, []int{1, 2})
+	assertDelta(t, []int{1, 1}, []int{1, 2}, []int{0, 0, 1})
 }
 
 func TestDiffResults_Removed(t *testing.T) {
 	// One removed test, all passing
-	assertDelta(t, []int{2, 2}, []int{1, 1}, []int{1, 2})
+	assertDelta(t, []int{2, 2}, []int{1, 1}, []int{0, 1, -1})
 
 	// One removed test, all failing
-	assertDelta(t, []int{0, 2}, []int{0, 1}, []int{1, 2})
+	assertDelta(t, []int{0, 2}, []int{0, 1}, []int{0, 0, -1})
 
 	// One removed test, deleted test passing
-	assertDelta(t, []int{1, 2}, []int{0, 1}, []int{1, 2})
+	assertDelta(t, []int{1, 2}, []int{0, 1}, []int{0, 1, -1})
 
 	// One removed test, deleted test failing
-	assertDelta(t, []int{1, 2}, []int{1, 1}, []int{1, 2})
+	assertDelta(t, []int{1, 2}, []int{1, 1}, []int{0, 0, -1})
 }
 
 func TestDiffResults_Filtered(t *testing.T) {
@@ -79,16 +79,16 @@ func TestDiffResults_Filtered(t *testing.T) {
 		changedPath: {3, 5},
 		addedPath:   {1, 3},
 	}
-	assert.Equal(t, map[string][]int{changedPath: {1, 5}}, GetResultsDiff(before, after, changedFilter))
-	assert.Equal(t, map[string][]int{addedPath: {3, 3}}, GetResultsDiff(before, after, addedFilter))
-	assert.Equal(t, map[string][]int{removedPath: {2, 2}}, GetResultsDiff(before, after, deletedFilter))
+	assert.Equal(t, map[string][]int{changedPath: {1, 0, 0}}, GetResultsDiff(before, after, changedFilter))
+	assert.Equal(t, map[string][]int{addedPath: {1, 2, 3}}, GetResultsDiff(before, after, addedFilter))
+	assert.Equal(t, map[string][]int{removedPath: {1, 1, -2}}, GetResultsDiff(before, after, deletedFilter))
 
 	// Test filtering by each /, /mock/, and /mock/path.html
 	pieces := strings.SplitAfter(mockTestPath, "/")
 	for i := 1; i < len(pieces); i++ {
 		paths := mapset.NewSet(strings.Join(pieces[:i], ""))
 		filter := DiffFilterParam{Changed: true, Paths: paths}
-		assertDeltaWithFilter(t, []int{0, 5}, []int{5, 5}, []int{5, 5}, filter)
+		assertDeltaWithFilter(t, []int{1, 3}, []int{2, 4}, []int{1, 0, 1}, filter)
 	}
 
 	// Filter where none match
@@ -110,7 +110,7 @@ func TestDiffResults_Filtered(t *testing.T) {
 	delta := GetResultsDiff(rBefore, rAfter, filter)
 	assert.NotContains(t, delta, mockPath2)
 	assert.Contains(t, delta, mockPath1)
-	assert.Equal(t, []int{2, 2}, delta[mockPath1])
+	assert.Equal(t, []int{2, 0, 1}, delta[mockPath1])
 }
 
 func assertNoDeltaDifferences(t *testing.T, before []int, after []int) {

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -621,10 +621,11 @@ found in the LICENSE file.
       getDiffDelta(node, prop) {
         const [before, after] = node.results;
         switch (prop) {
-        case 'regressions':
+        case 'regressions': {
           const failingBefore = before.total - before.passes;
           const failingAfter = after.total - after.passes;
           return Math.min(failingBefore - failingAfter, 0);
+        }
         case 'total':
           return before.total - after.total;
         case 'passes':

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -90,10 +90,10 @@ found in the LICENSE file.
       .passes-80 { background-color: hsl(0, 85%, 85%); }
       .passes-100 { background-color: var(--paper-light-green-a400); }
 
-      span.delta.negative {
+      span.delta.regressions {
         color: var(--paper-red-700);
       }
-      span.delta.positive {
+      span.delta.passes {
         color: var(--paper-green-700);
       }
       td.none {
@@ -237,9 +237,11 @@ found in the LICENSE file.
                 </template>
                 <template is="dom-if" if="[[diffShown]]">
                   <td class$="numbers [[ testResultClass(node, index, diffRun, 'passes') ]]">
-                    <span class$="passes [[ testResultClass(node, index, diffRun, 'passes') ]]">{{ getNodeResultDataByPropertyName(node, -1, diffRun, 'passes') }}</span>
+                    <span class="delta passes">{{ getNodeResultDataByPropertyName(node, -1, diffRun, 'passes') }}</span>
                     /
-                    <span class$="total [[ testResultClass(node, index, diffRun, 'total') ]]">{{ getNodeResultDataByPropertyName(node, -1, diffRun, 'total') }}</span>
+                    <span class="delta regressions">{{ getNodeResultDataByPropertyName(node, -1, diffRun, 'regressions') }}</span>
+                    /
+                    <span class="delta total">{{ getNodeResultDataByPropertyName(node, -1, diffRun, 'total') }}</span>
                   </td>
                 </template>
               </tr>
@@ -617,8 +619,18 @@ found in the LICENSE file.
       }
 
       getDiffDelta(node, prop) {
-        return node.results[1][prop || 'passes'] -
-          node.results[0][prop || 'passes'];
+        const [before, after] = node.results;
+        switch (prop) {
+        case 'regressions':
+          const failingBefore = before.total - before.passes;
+          const failingAfter = after.total - after.passes;
+          return Math.min(failingBefore - failingAfter, 0);
+        case 'total':
+          return before.total - after.total;
+        case 'passes':
+        default:
+          return Math.max(after.passes - before.passes, 0);
+        }
       }
 
       getDiffDeltaStr(node, prop) {


### PR DESCRIPTION
## Description
See https://github.com/web-platform-tests/wpt.fyi/issues/411

Separates the `delta` number into 2 numbers (pass increases, pass decreases), such that a new pass and a new fail don't cancel each other out.

## Review Information
Visit a diff view, e.g. /results?label=taskcluster&product=chrome[beta]&product=chrome[stable]&diff