### PR TITLE
[webhook] Upload test results in parallel

### DIFF
--- a/api/webhook/taskcluster.go
+++ b/api/webhook/taskcluster.go
@@ -60,6 +60,8 @@ func tcWebhookHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	log.Debugf("GitHub Delivery: %s", r.Header.Get("X-GitHub-Delivery"))
+
 	processed, err := handleStatusEvent(ctx, payload)
 	if err != nil {
 		log.Errorf("%v", err)


### PR DESCRIPTION
This PR changes the Taskcluster webhook to upload test results to the
results receiver API in parallel in order to reduce the webhook response
time (in half, as we currently run two browsers in each task group).

The goroutine and error handling are tested with simple HTTP testing
servers.

Part of #604 .
