### PR TITLE
Use an explicit app.yaml path in web_server.sh

### DIFF
--- a/util/docker-dev/web_server.sh
+++ b/util/docker-dev/web_server.sh
@@ -46,4 +46,5 @@ wptd_exec_it dev_appserver.py \
    --api_host=$WPTD_CONTAINER_HOST \
    --api_port=9999 \
    -A=wptdashboard \
-   webapp
+   /home/user/wpt.fyi/webapp/app.yaml
+

--- a/webdriver/webapp_server.go
+++ b/webdriver/webapp_server.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"time"
 
@@ -139,6 +140,10 @@ func NewDevAppServer() (s DevAppServerInstance, err error) {
 		apiPort: pickUnusedPort(),
 	}
 
+	absAppYAMLPath, err := filepath.Abs("../webapp")
+	if err != nil {
+		panic(err.Error())
+	}
 	i.cmd = exec.Command(
 		"dev_appserver.py",
 		fmt.Sprintf("--port=%d", i.port),
@@ -156,7 +161,7 @@ func NewDevAppServer() (s DevAppServerInstance, err error) {
 		"--datastore_consistency_policy=consistent",
 		"--clear_search_indexes=true",
 		"-A=wptdashboard",
-		"../webapp",
+		absAppYAMLPath,
 	)
 
 	s = DevAppServerInstance(i)


### PR DESCRIPTION
## Description
Sad fix for https://github.com/web-platform-tests/wpt.fyi/issues/614

## Review Information
Relative paths seem to have stopped working in gcloud 219.0.1