### PR TITLE
Handle the standard test run query params in /api/diff

### DIFF
--- a/api/diff.go
+++ b/api/diff.go
@@ -29,7 +29,8 @@ func apiDiffHandler(w http.ResponseWriter, r *http.Request) {
 func handleAPIDiffGet(w http.ResponseWriter, r *http.Request) {
 	ctx := shared.NewAppEngineContext(r)
 
-	// /results has the same params (before + after), so we re-use the logic there.
+	// NOTE: We use the same params as /results, but also support
+	// 'before' and 'after' and 'filter'.
 	runFilter, err := shared.ParseTestRunFilterParams(r)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)

--- a/shared/params.go
+++ b/shared/params.go
@@ -644,3 +644,33 @@ func ParseTestRunFilterParams(r *http.Request) (filter TestRunFilter, err error)
 	}
 	return filter, nil
 }
+
+// ParseBeforeAndAfterParams parses the before and after params used when
+// intending to diff two test runs. Either both or neither of the params
+// must be present.
+func ParseBeforeAndAfterParams(r *http.Request) (ProductSpecs, error) {
+	before := r.URL.Query().Get("before")
+	after := r.URL.Query().Get("after")
+	if before == "" && after == "" {
+		return nil, nil
+	}
+	if before == "" {
+		return nil, errors.New("after param provided, but before param missing")
+	} else if after == "" {
+		return nil, errors.New("before param provided, but after param missing")
+	}
+
+	specs := make(ProductSpecs, 2)
+	beforeSpec, err := ParseProductSpec(before)
+	if err != nil {
+		return nil, fmt.Errorf("invalid before param: %s", err.Error())
+	}
+	specs[0] = beforeSpec
+
+	afterSpec, err := ParseProductSpec(after)
+	if err != nil {
+		return nil, fmt.Errorf("invalid after param: %s", err.Error())
+	}
+	specs[1] = afterSpec
+	return specs, nil
+}

--- a/webapp/templates/results.html
+++ b/webapp/templates/results.html
@@ -6,7 +6,6 @@
   {{ template "_header.html" }}
   <div>
     <wpt-results
-        {{- if .TestRuns}} test-runs="{{ .TestRuns }}"{{end}}
         {{- with .Filter}}
           {{- if .Products}} product-specs="{{ .Products }}"{{end}}
           {{- if .SHA}} sha="{{ .SHA }}" {{end}}

--- a/webapp/test_results_handler_test.go
+++ b/webapp/test_results_handler_test.go
@@ -7,7 +7,6 @@
 package webapp
 
 import (
-	"fmt"
 	"net/http/httptest"
 	"testing"
 
@@ -34,15 +33,5 @@ func TestParseTestRunUIFilter_BeforeAfter(t *testing.T) {
 	f, err = parseTestRunUIFilter(httptest.NewRequest("GET", "/results/?after=chrome&before=edge", nil))
 	assert.Nil(t, err)
 	assert.Equal(t, "[\"edge\",\"chrome\"]", f.Products)
-	assert.Equal(t, true, f.Diff)
-}
-
-func TestParseTestRunUIFilter_BeforeAfter_Base64(t *testing.T) {
-	enc := "eyJicm93c2VyX25hbWUiOiJGaXJlZm94IiwiYnJvd3Nlcl92ZXJzaW9uIjoiTmlnaHRseSIsIm9zX25hbWUiOiJUcmF2aXMiLCJvc192ZXJzaW9uIjoiSm9iIDU0LjQiLCJyZXZpc2lvbiI6ImYwNzdlMjQyZGUiLCJyZXN1bHRzX3VybCI6Imh0dHBzOi8vcHVsbHMtc3RhZ2luZy53ZWItcGxhdGZvcm0tdGVzdHMub3JnL2pvYi81NC40L3N1bW1hcnkiLCJjcmVhdGVkX2F0IjoiMjAxOC0wMS0wNFQwMDowMDowMFoifQ=="
-	f, err := parseTestRunUIFilter(
-		httptest.NewRequest("GET", fmt.Sprintf("/results/?before=chrome&after=%s", enc), nil))
-	assert.Nil(t, err)
-	assert.Equal(t, "[\"chrome\"]", f.Products)
-	assert.Equal(t, "Firefox", f.AfterTestRun.BrowserName)
 	assert.Equal(t, true, f.Diff)
 }


### PR DESCRIPTION
## Description
Ensures that params like `aligned` and `labels` are respected.

Also drops the base64 behaviour for the `before` and `after` params (a speculative, unused feature).

## Review Information
- Visit https://diff-dot-wptdashboard-staging.appspot.com/results?before=chrome[stable]&after=chrome[experimental]&aligned
- In another tab, visit https://diff-dot-wptdashboard-staging.appspot.com/results?product=chrome[stable]&product=chrome[experimental]&diff
- Find a row with a diff count that differs between the 2 diffs
- Ensure the same test's diff value is correctly calculated by https://diff-dot-wptdashboard-staging.appspot.com/api/diff (for the same params) for the row that would otherwise be wrong.
  - https://diff-dot-wptdashboard-staging.appspot.com/api/diff?before=chrome[stable]&after=chrome[experimental]&aligned
  - vs https://diff-dot-wptdashboard-staging.appspot.com/api/diff?before=chrome[stable]&after=chrome[experimental]