### PR TITLE
Drop redundant `=true` when building a query string

### DIFF
--- a/webapp/components/results-navigation.html
+++ b/webapp/components/results-navigation.html
@@ -21,7 +21,7 @@
             url.searchParams.set(k, params[k]);
           }
         }
-        return url.search;
+        return `${url.search}`.replace(/=true/g, '');
       }
     };
 

--- a/webapp/components/self-navigator.html
+++ b/webapp/components/self-navigator.html
@@ -124,6 +124,7 @@
           this.path = path;
         }
 
+        url.search = url.search.replace(/=true/g, '');
         window.history.pushState(params, '', url);
 
         // Send Google Analytics pageview event


### PR DESCRIPTION
## Description
Makes the query strings a bit more readable.

## Review Information
`searchParams.set(key, value)` _requires_ value, and stringifys it (so undefined doesn't work). An empty string results in 'foo='.

Hence, a hacky replace-all it is.