### PR TITLE
Consolidate the channels + channel-labels

### DIFF
--- a/webapp/components/test-runs-query.html
+++ b/webapp/components/test-runs-query.html
@@ -132,7 +132,7 @@ found in the LICENSE file.
         }
 
         clearQuery() {
-          this.products = Array.from(DEFAULT_PRODUCTS);
+          this.products = DEFAULT_PRODUCTS.map(p => Object.assign({}, p));
           this.labels = [];
           this.maxCount = undefined;
           this.sha = 'latest';
@@ -143,12 +143,6 @@ found in the LICENSE file.
          * Update this builder's properties to match the given query params.
          */
         updateQueryParams(params) {
-          // Expand a global channel label into the separate products
-          let sharedChannel = (params.label || []).find(l => CHANNELS.has(l));
-          if (sharedChannel) {
-            params.label = params.label.filter(l => !CHANNELS.has(l));
-          }
-
           this.clearQuery();
           if (!params) {
             return;
@@ -156,17 +150,21 @@ found in the LICENSE file.
           if (!this.computeIsLatest(params.sha)) {
             this.sha = params.sha;
           }
-          if ('label' in params) {
-            this.labels = params.label;
-          }
           if ('product' in params) {
             this.products = params.product.map(p => this.parseProductSpec(p));
           }
+          // Expand a global channel label into the separate products
+          let sharedChannel = (params.label || []).find(l => CHANNELS.has(l));
+          if ('label' in params) {
+            this.labels = params.label.filter(l => !CHANNELS.has(l));
+          }
           if (sharedChannel) {
             for (const i in this.products) {
+              const labels = this.products[i].labels.filter(l => !CHANNELS.has(l) || l === sharedChannel);
               if (!this.products[i].labels.includes(sharedChannel)) {
-                this.splice(`products.${i}.labels`, 0, 0, sharedChannel);
+                labels.push(sharedChannel);
               }
+              this.set(`products.${i}.labels`, labels);
             }
           }
           if ('max-count' in params) {

--- a/webapp/components/test-runs-query.html
+++ b/webapp/components/test-runs-query.html
@@ -12,7 +12,7 @@ found in the LICENSE file.
     /**
      * Behaviour class for re-use of test-runs fetching behaviour.
      */
-    /* global QueryBuilder, ProductInfo, DEFAULT_PRODUCTS, DEFAULT_PRODUCT_SPECS */
+    /* global QueryBuilder, ProductInfo, CHANNELS, DEFAULT_PRODUCTS, DEFAULT_PRODUCT_SPECS */
     // eslint-disable-next-line no-unused-vars
     const TestRunsQuery =
       (superClass) => class extends QueryBuilder(ProductInfo(superClass)) {
@@ -65,6 +65,8 @@ found in the LICENSE file.
             this.products = this.productSpecs.map(p => this.parseProductSpec(p));
           }
           this._createMethodObserver('productsUpdated(products, products.*)');
+          // Force-trigger a channel label expansion.
+          this.updateQueryParams(this.testRunQueryParams);
         }
 
         // eslint-disable-next-line no-unused-vars
@@ -84,15 +86,37 @@ found in the LICENSE file.
           if (labels && labels.length) {
             params.label = labels;
           }
-          if (productSpecs && productSpecs.length && !this.isDefaultProducts) {
-            params.product = productSpecs;
-          }
           maxCount = maxCount || this.defaultMaxCount;
           if (maxCount) {
             params['max-count'] = maxCount;
           }
           if (aligned) {
             params.aligned = true;
+          }
+
+          // Collapse a globally shared channel into a single label.
+          if (this.products.length) {
+            let allChannelsSame = true;
+            const channel = this.products[0].labels.find(l => CHANNELS.has(l));
+            for (const p of this.products) {
+              if (!p.labels.find(l => l === channel)) {
+                allChannelsSame = false;
+              }
+            }
+            if (allChannelsSame) {
+              const channelless = this.products.map(p => Object.assign(
+                {}, p, {labels: p.labels.filter(l => !CHANNELS.has(l)) }))
+                .map(p => this.getSpec(p));
+              if (!this.computeIsDefaultProducts(channelless)) {
+                params.product = channelless;
+              }
+              const labels = params.label || [];
+              if (!labels.includes(channel)) {
+                params.label = [...labels, channel];
+              }
+            } else {
+              params.product = this.products.map(p => this.getSpec(p));
+            }
           }
           return params;
         }
@@ -118,6 +142,12 @@ found in the LICENSE file.
          * Update this builder's properties to match the given query params.
          */
         updateQueryParams(params) {
+          // Expand a global channel label into the separate products
+          let sharedChannel = (params.label || []).find(l => CHANNELS.has(l));
+          if (sharedChannel) {
+            params.label = params.label.filter(l => !CHANNELS.has(l));
+          }
+
           this.clearQuery();
           if (!params) {
             return;
@@ -130,6 +160,13 @@ found in the LICENSE file.
           }
           if ('product' in params) {
             this.products = params.product.map(p => this.parseProductSpec(p));
+          }
+          if (sharedChannel) {
+            for (const i in this.products) {
+              if (!this.products[i].labels.includes(sharedChannel)) {
+                this.splice(`products.${i}.labels`, 0, 0, sharedChannel);
+              }
+            }
           }
           if ('max-count' in params) {
             this.maxCount = params['max-count'];

--- a/webapp/components/test-runs-query.html
+++ b/webapp/components/test-runs-query.html
@@ -97,15 +97,15 @@ found in the LICENSE file.
           // Collapse a globally shared channel into a single label.
           if (this.products.length) {
             let allChannelsSame = true;
-            const channel = this.products[0].labels.find(l => CHANNELS.has(l));
+            const channel = (this.products[0].labels || []).find(l => CHANNELS.has(l));
             for (const p of this.products) {
-              if (!p.labels.find(l => l === channel)) {
+              if (!(p.labels || []).find(l => l === channel)) {
                 allChannelsSame = false;
               }
             }
             if (allChannelsSame) {
               const channelless = this.products.map(p => Object.assign(
-                {}, p, {labels: p.labels.filter(l => !CHANNELS.has(l)) }))
+                {}, p, {labels: (p.labels || []).filter(l => !CHANNELS.has(l)) }))
                 .map(p => this.getSpec(p));
               if (!this.computeIsDefaultProducts(channelless)) {
                 params.product = channelless;

--- a/webapp/components/test-runs-query.html
+++ b/webapp/components/test-runs-query.html
@@ -103,19 +103,20 @@ found in the LICENSE file.
                 allChannelsSame = false;
               }
             }
+            let productSpecs;
             if (allChannelsSame) {
-              const channelless = this.products.map(p => Object.assign(
+              productSpecs = this.products.map(p => Object.assign(
                 {}, p, {labels: (p.labels || []).filter(l => !CHANNELS.has(l)) }))
                 .map(p => this.getSpec(p));
-              if (!this.computeIsDefaultProducts(channelless)) {
-                params.product = channelless;
-              }
               const labels = params.label || [];
               if (!labels.includes(channel)) {
                 params.label = [...labels, channel];
               }
             } else {
-              params.product = this.products.map(p => this.getSpec(p));
+              productSpecs = this.products.map(p => this.getSpec(p));
+            }
+            if (!this.computeIsDefaultProducts(productSpecs)) {
+              params.product = productSpecs;
             }
           }
           return params;

--- a/webapp/components/test-runs-query.html
+++ b/webapp/components/test-runs-query.html
@@ -153,9 +153,10 @@ found in the LICENSE file.
           if ('product' in params) {
             this.products = params.product.map(p => this.parseProductSpec(p));
           }
-          // Expand a global channel label into the separate products
-          let sharedChannel = (params.label || []).find(l => CHANNELS.has(l));
+          // Expand any global channel labels into the separate products
+          let sharedChannel;
           if ('label' in params) {
+            sharedChannel = params.label.find(l => CHANNELS.has(l));
             this.labels = params.label.filter(l => !CHANNELS.has(l));
           }
           if (sharedChannel) {

--- a/webapp/components/test-runs-query.html
+++ b/webapp/components/test-runs-query.html
@@ -59,12 +59,12 @@ found in the LICENSE file.
 
         ready() {
           super.ready();
+          this._createMethodObserver('productsUpdated(products, products.*)');
           // Convert any initial product specs to products, if provided.
           if (this.productSpecs && this.productSpecs.length
             && !(this.products && this.products.length)) {
             this.products = this.productSpecs.map(p => this.parseProductSpec(p));
           }
-          this._createMethodObserver('productsUpdated(products, products.*)');
           // Force-trigger a channel label expansion.
           this.updateQueryParams(this.testRunQueryParams);
         }

--- a/webapp/components/test-runs.html
+++ b/webapp/components/test-runs.html
@@ -13,7 +13,7 @@ found in the LICENSE file.
      * Base class for re-use of results-fetching behaviour, between
      * multi-item (wpt-results) and single-test (test-file-results) views.
      */
-    /* global TestRunsQuery, DEFAULT_PRODUCTS */
+    /* global TestRunsQuery */
     class TestRunsBase extends TestRunsQuery(window.Polymer.Element) {
       static get is() {
         return 'wpt-results-base';
@@ -44,15 +44,6 @@ found in the LICENSE file.
             computed: 'computePathIsATestFile(path)'
           },
         };
-      }
-
-      ready() {
-        super.ready();
-        // Fall back to the default product set.
-        if (!(this.products && this.products.length)
-            && !this.testRunResources) {
-          this.products = Array.from(DEFAULT_PRODUCTS);
-        }
       }
 
       computeTestScheme(path) {

--- a/webapp/components/test/test-runs-query-builder.html
+++ b/webapp/components/test/test-runs-query-builder.html
@@ -100,13 +100,13 @@
           });
 
           for (const channel of CHANNELS) {
-            test(channel, () => {
-              for (const productBuilder of queryBuilder.shadowRoot.querySelectorAll('product-builder')) {
-                productBuilder._channel = channel;
-              }
-              queryBuilder.submit();
+            test(channel, done => {
               flush(() => {
+                for (const productBuilder of queryBuilder.shadowRoot.querySelectorAll('product-builder')) {
+                  productBuilder._channel = channel;
+                }
                 expect(queryBuilder.testRunQueryParams.label).to.contain(channel);
+                done();
               });
             });
           }

--- a/webapp/components/test/test-runs-query-builder.html
+++ b/webapp/components/test/test-runs-query-builder.html
@@ -26,6 +26,7 @@
   </test-fixture>
 
   <script>
+    /* global CHANNELS */
     document.addEventListener('WebComponentsReady', () => {
       suite('TestRunsQueryBuilder', () => {
         let queryBuilder;
@@ -87,6 +88,28 @@
           queryBuilder.labels = ['foo', 'bar'];
           expect(queryBuilder.testRunQuery).to.contain('label=foo');
           expect(queryBuilder.testRunQuery).to.contain('label=bar');
+        });
+
+        suite('shared channels', () => {
+          setup(() => {
+            queryBuilder.clearAll();
+            queryBuilder.updateQueryParams({
+              label: ['stable'],
+              product: ['chrome', 'safari'],
+            });
+          });
+
+          for (const channel of CHANNELS) {
+            test(channel, () => {
+              for (const productBuilder of queryBuilder.shadowRoot.querySelectorAll('product-builder')) {
+                productBuilder._channel = channel;
+              }
+              queryBuilder.submit();
+              flush(() => {
+                expect(queryBuilder.testRunQueryParams.label).to.contain(channel);
+              });
+            });
+          }
         });
       });
 

--- a/webapp/components/test/test-runs-query.html
+++ b/webapp/components/test/test-runs-query.html
@@ -29,7 +29,7 @@
 
 <body>
   <script>
-    /* global DEFAULT_PRODUCTS */
+    /* global DEFAULT_PRODUCTS, CHANNELS */
     suite('TestRunsQuery', () => {
       let testRunsQuery;
 
@@ -52,7 +52,7 @@
         for (const channel of CHANNELS) {
           test(channel, () => {
             testRunsQuery.products = DEFAULT_PRODUCTS
-            .map(p => Object.assign({}, p, { labels: [channel] }));
+              .map(p => Object.assign({}, p, { labels: [channel] }));
             expect(testRunsQuery.testRunQuery).to.equal(`?label=${channel}`);
           });
         }

--- a/webapp/components/test/test-runs-query.html
+++ b/webapp/components/test/test-runs-query.html
@@ -29,111 +29,113 @@
 
 <body>
   <script>
-    /* global DEFAULT_PRODUCTS, CHANNELS */
-    suite('TestRunsQuery', () => {
-      let testRunsQuery;
+    document.addEventListener('WebComponentsReady', () => {
+      /* global DEFAULT_PRODUCTS, CHANNELS */
+      suite('TestRunsQuery', () => {
+        let testRunsQuery;
 
-      setup(() => {
-        testRunsQuery = fixture('test-runs-query-fixture');
-      });
+        setup(() => {
+          testRunsQuery = fixture('test-runs-query-fixture');
+        });
 
-      test('instanceof Polymer.Element', () => {
-        assert.isTrue(testRunsQuery instanceof window.Polymer.Element);
-      });
+        test('instanceof Polymer.Element', () => {
+          assert.isTrue(testRunsQuery instanceof window.Polymer.Element);
+        });
 
-      test('isDefaultProducts', () => {
-        testRunsQuery.products = Array.from(DEFAULT_PRODUCTS);
-        expect(testRunsQuery.isDefaultProducts).to.equal(true);
-        testRunsQuery.products = Array.from([DEFAULT_PRODUCTS[0]]);
-        expect(testRunsQuery.isDefaultProducts).to.equal(false);
-      });
+        test('isDefaultProducts', () => {
+          testRunsQuery.products = Array.from(DEFAULT_PRODUCTS);
+          expect(testRunsQuery.isDefaultProducts).to.equal(true);
+          testRunsQuery.products = Array.from([DEFAULT_PRODUCTS[0]]);
+          expect(testRunsQuery.isDefaultProducts).to.equal(false);
+        });
 
-      suite('collapses shared channels', () => {
-        for (const channel of CHANNELS) {
-          test(channel, () => {
-            testRunsQuery.products = DEFAULT_PRODUCTS
-              .map(p => Object.assign({}, p, { labels: [channel] }));
-            expect(testRunsQuery.testRunQuery).to.equal(`?label=${channel}`);
-          });
-        }
-      });
-
-      suite('expands channel labels', () => {
-        for (const channel of CHANNELS) {
-          test(channel, () => {
-            testRunsQuery.updateQueryParams({ label: [channel] });
-            expect(testRunsQuery.products.length).to.equal(DEFAULT_PRODUCTS.length);
-            for (const product of testRunsQuery.products) {
-              expect(product.labels).to.contain(channel);
-            }
-            expect(testRunsQuery.labels).to.not.contain(channel);
-          });
-        }
-      });
-
-      suite('TestRunsQuery.prototype.*', () => {
-
-        const revision = '1234512345';
-        const chrome = 'chrome';
-        const labels = ['foo', 'bar'];
-        const specStr = `${chrome}[${labels.join(',')}]@${revision}`;
-        test(`parseProductSpec("${specStr}")`, () => {
-          const parsed = testRunsQuery.parseProductSpec(specStr);
-          assert.equal(parsed.browser_name, chrome);
-          assert.equal(parsed.revision, revision);
-          for (const label of labels) {
-            expect(Array.from(parsed.labels)).to.include(label);
+        suite('collapses shared channels', () => {
+          for (const channel of CHANNELS) {
+            test(channel, () => {
+              testRunsQuery.products = DEFAULT_PRODUCTS
+                .map(p => Object.assign({}, p, { labels: [channel] }));
+              expect(testRunsQuery.testRunQuery).to.equal(`?label=${channel}`);
+            });
           }
         });
 
-        const version63 = '63.0';
-        const chrome63 = `chrome-${version63}`;
-        test(`parseProduct(${chrome63})`, () => {
-          const parsed = testRunsQuery.parseProduct(chrome63);
-          assert.equal(parsed.browser_name, chrome);
-          assert.equal(parsed.browser_version, version63);
+        suite('expands channel labels', () => {
+          for (const channel of CHANNELS) {
+            test(channel, () => {
+              testRunsQuery.updateQueryParams({ label: [channel] });
+              expect(testRunsQuery.products.length).to.equal(DEFAULT_PRODUCTS.length);
+              for (const product of testRunsQuery.products) {
+                expect(product.labels).to.contain(channel);
+              }
+              expect(testRunsQuery.labels).to.not.contain(channel);
+            });
+          }
         });
 
-        test('no closing bracket', () => {
-          expect(() => testRunsQuery.parseProductSpec('chrome[foo')).to.throw();
-          expect(() => testRunsQuery.parseProductSpec('chrome[foo]')).to.not.throw();
-        });
+        suite('TestRunsQuery.prototype.*', () => {
 
-        suite('updateQueryParams', () => {
-          test('product', () => {
-            const params = {
-              product: ['safari', 'safari[experimental]'],
-            };
-            testRunsQuery.updateQueryParams(params);
-            expect(testRunsQuery.products[0].browser_name).to.equal('safari');
-            expect(testRunsQuery.products[1].browser_name).to.equal('safari');
-            expect(testRunsQuery.products[1].labels).to.contain('experimental');
-          });
-
-          test('label', () => {
-            testRunsQuery.products =
-              DEFAULT_PRODUCTS.map(p => Object.assign({}, p, { labels: ['experimental'] }));
-            for (const channel of CHANNELS) {
-              testRunsQuery.updateQueryParams({
-                label: [channel],
-              });
-              expect(testRunsQuery.productSpecs.join(',')).to.equal(
-                DEFAULT_PRODUCTS
-                  .map(p => Object.assign({}, p, { labels: [channel] }))
-                  .map(p => testRunsQuery.getSpec(p))
-                  .join(',')
-              );
+          const revision = '1234512345';
+          const chrome = 'chrome';
+          const labels = ['foo', 'bar'];
+          const specStr = `${chrome}[${labels.join(',')}]@${revision}`;
+          test(`parseProductSpec("${specStr}")`, () => {
+            const parsed = testRunsQuery.parseProductSpec(specStr);
+            assert.equal(parsed.browser_name, chrome);
+            assert.equal(parsed.revision, revision);
+            for (const label of labels) {
+              expect(Array.from(parsed.labels)).to.include(label);
             }
           });
-        });
 
-        test('testRunQueryParams', () => {
-          testRunsQuery.products = [
-            Object.assign({}, DEFAULT_PRODUCTS[0], { labels: ['experimental'] }),
-            Object.assign({}, DEFAULT_PRODUCTS[1], { labels: ['stable'] })
-          ];
-          expect(testRunsQuery.testRunQueryParams.product).to.contain(`${DEFAULT_PRODUCTS[0].browser_name}[experimental]`);
-          expect(testRunsQuery.testRunQueryParams.product).to.contain(`${DEFAULT_PRODUCTS[1].browser_name}[stable]`);
+          const version63 = '63.0';
+          const chrome63 = `chrome-${version63}`;
+          test(`parseProduct(${chrome63})`, () => {
+            const parsed = testRunsQuery.parseProduct(chrome63);
+            assert.equal(parsed.browser_name, chrome);
+            assert.equal(parsed.browser_version, version63);
+          });
+
+          test('no closing bracket', () => {
+            expect(() => testRunsQuery.parseProductSpec('chrome[foo')).to.throw();
+            expect(() => testRunsQuery.parseProductSpec('chrome[foo]')).to.not.throw();
+          });
+
+          suite('updateQueryParams', () => {
+            test('product', () => {
+              const params = {
+                product: ['safari', 'safari[experimental]'],
+              };
+              testRunsQuery.updateQueryParams(params);
+              expect(testRunsQuery.products[0].browser_name).to.equal('safari');
+              expect(testRunsQuery.products[1].browser_name).to.equal('safari');
+              expect(testRunsQuery.products[1].labels).to.contain('experimental');
+            });
+
+            test('label', () => {
+              testRunsQuery.products =
+                DEFAULT_PRODUCTS.map(p => Object.assign({}, p, { labels: ['experimental'] }));
+              for (const channel of CHANNELS) {
+                testRunsQuery.updateQueryParams({
+                  label: [channel],
+                });
+                expect(testRunsQuery.productSpecs.join(',')).to.equal(
+                  DEFAULT_PRODUCTS
+                    .map(p => Object.assign({}, p, { labels: [channel] }))
+                    .map(p => testRunsQuery.getSpec(p))
+                    .join(',')
+                );
+              }
+            });
+          });
+
+          test('testRunQueryParams', () => {
+            testRunsQuery.products = [
+              Object.assign({}, DEFAULT_PRODUCTS[0], { labels: ['experimental'] }),
+              Object.assign({}, DEFAULT_PRODUCTS[1], { labels: ['stable'] })
+            ];
+            expect(testRunsQuery.testRunQueryParams.product).to.contain(`${DEFAULT_PRODUCTS[0].browser_name}[experimental]`);
+            expect(testRunsQuery.testRunQueryParams.product).to.contain(`${DEFAULT_PRODUCTS[1].browser_name}[stable]`);
+          });
         });
       });
     });

--- a/webapp/components/test/test-runs-query.html
+++ b/webapp/components/test/test-runs-query.html
@@ -48,6 +48,29 @@
         expect(testRunsQuery.isDefaultProducts).to.equal(false);
       });
 
+      suite('collapses shared channels', () => {
+        for (const channel of CHANNELS) {
+          test(channel, () => {
+            testRunsQuery.products = DEFAULT_PRODUCTS
+            .map(p => Object.assign({}, p, { labels: [channel] }));
+            expect(testRunsQuery.testRunQuery).to.equal(`?label=${channel}`);
+          });
+        }
+      });
+
+      suite('expands channel labels', () => {
+        for (const channel of CHANNELS) {
+          test(channel, () => {
+            testRunsQuery.updateQueryParams({ label: [channel] });
+            expect(testRunsQuery.products.length).to.equal(DEFAULT_PRODUCTS.length);
+            for (const product of testRunsQuery.products) {
+              expect(product.labels).to.contain(channel);
+            }
+            expect(testRunsQuery.labels).to.not.contain(channel);
+          });
+        }
+      });
+
       suite('TestRunsQuery.prototype.*', () => {
 
         const revision = '1234512345';

--- a/webapp/components/test/test-runs-query.html
+++ b/webapp/components/test/test-runs-query.html
@@ -108,6 +108,15 @@
           expect(testRunsQuery.products[1].browser_name).to.equal('safari');
           expect(testRunsQuery.products[1].labels).to.contain('experimental');
         });
+
+        test('testRunQueryParams', () => {
+          testRunsQuery.products = [
+            Object.assign({}, DEFAULT_PRODUCTS[0], { labels: ['experimental'] }),
+            Object.assign({}, DEFAULT_PRODUCTS[1], { labels: ['stable'] })
+          ];
+          expect(testRunsQuery.testRunQueryParams.product).to.contain(`${DEFAULT_PRODUCTS[0].browser_name}[experimental]`);
+          expect(testRunsQuery.testRunQueryParams.product).to.contain(`${DEFAULT_PRODUCTS[1].browser_name}[stable]`);
+        });
       });
     });
   </script>

--- a/webapp/components/test/test-runs-query.html
+++ b/webapp/components/test/test-runs-query.html
@@ -99,14 +99,32 @@
           expect(() => testRunsQuery.parseProductSpec('chrome[foo]')).to.not.throw();
         });
 
-        test('updateQueryParams', () => {
-          const params = {
-            product: ['safari', 'safari[experimental]'],
-          };
-          testRunsQuery.updateQueryParams(params);
-          expect(testRunsQuery.products[0].browser_name).to.equal('safari');
-          expect(testRunsQuery.products[1].browser_name).to.equal('safari');
-          expect(testRunsQuery.products[1].labels).to.contain('experimental');
+        suite('updateQueryParams', () => {
+          test('product', () => {
+            const params = {
+              product: ['safari', 'safari[experimental]'],
+            };
+            testRunsQuery.updateQueryParams(params);
+            expect(testRunsQuery.products[0].browser_name).to.equal('safari');
+            expect(testRunsQuery.products[1].browser_name).to.equal('safari');
+            expect(testRunsQuery.products[1].labels).to.contain('experimental');
+          });
+
+          test('label', () => {
+            testRunsQuery.products =
+              DEFAULT_PRODUCTS.map(p => Object.assign({}, p, { labels: ['experimental'] }));
+            for (const channel of CHANNELS) {
+              testRunsQuery.updateQueryParams({
+                label: [channel],
+              });
+              expect(testRunsQuery.productSpecs.join(',')).to.equal(
+                DEFAULT_PRODUCTS
+                  .map(p => Object.assign({}, p, { labels: [channel] }))
+                  .map(p => testRunsQuery.getSpec(p))
+                  .join(',')
+              );
+            }
+          });
         });
 
         test('testRunQueryParams', () => {

--- a/webapp/components/test/test-runs.html
+++ b/webapp/components/test/test-runs.html
@@ -11,7 +11,7 @@
 <body>
   <test-fixture id="wpt-results-base-fixture">
     <template>
-      <wpt-results-base test-run-resources="[&#34;/api/runs?sha=latest&#34;]"></wpt-results-base>
+      <wpt-results-base aligned></wpt-results-base>
     </template>
   </test-fixture>
   <script>
@@ -69,7 +69,7 @@
             return waitingOn(() => window.fetch.called)
               .then(() => {
                 assert.equal(window.fetch.callCount, 1);
-                assert.equal(window.fetch.firstCall.args[0], '/api/runs?sha=latest');
+                assert.equal(window.fetch.firstCall.args[0], '/api/runs?aligned');
               });
           });
 

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -493,7 +493,7 @@ found in the LICENSE file.
           if (state) {
             const builder = this.shadowRoot.querySelector('test-runs-query-builder');
             if (builder) {
-              builder.submitQueryParams(state);
+              builder.updateQueryParams(state);
               builder.submit();
             }
           }

--- a/webdriver/product_test.go
+++ b/webdriver/product_test.go
@@ -5,6 +5,7 @@ package webdriver
 import (
 	"fmt"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -73,8 +74,17 @@ func testProduct(
 		assert.NotNil(t, a)
 		href, err := a.GetAttribute("href")
 		assert.Nil(t, err)
-		for _, p := range productSpecs {
-			assert.Contains(t, href, "product="+url.QueryEscape(p))
+		for _, p := range products {
+			label := ""
+			if p.Labels != nil {
+				label = p.Labels.ToSlice()[0].(string)
+			}
+			// Shared channels can get pulled into the label param.
+			hasLabelAndHasProduct :=
+				label != "" && strings.Contains(href, "label="+url.QueryEscape(label)) &&
+					strings.Contains(href, "product="+p.BrowserName)
+			hasFullProductSpec := strings.Contains(href, "product="+url.QueryEscape(p.String()))
+			assert.True(t, hasLabelAndHasProduct || hasFullProductSpec)
 		}
 	}
 


### PR DESCRIPTION
## Description
Further work on https://github.com/web-platform-tests/wpt.fyi/issues/535 

Changes the TestRunQuery to expand channel-labels onto the products during the building phase, and collapse them off of the products when producing the query-string.

## Review Information
- Visit /flags, enable queryBuilder
- Load /results, open the query builder with the pencil icon
- Observe that the Channel is `Stable` for all products
- Submit the query
- Observe that the query is ?aligned&label=stable, not ?product=chrome[stable]&product=...