### PR TITLE
Do not call VersionID when running locally

### DIFF
--- a/webapp/about_handler.go
+++ b/webapp/about_handler.go
@@ -13,7 +13,12 @@ import (
 
 func aboutHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := appengine.NewContext(r)
-	version := strings.Split(appengine.VersionID(ctx), ".")[0]
+	var version string
+	if appengine.IsDevAppServer() {
+		version = strings.Split(appengine.VersionID(ctx), ".")[0]
+	} else {
+		version = "local-dev"
+	}
 	data := struct {
 		Version string
 	}{


### PR DESCRIPTION
appengine.VersionID will panic when called locally (in dev_appserver),
which breaks the Go tests.

Fixes #614 . Turns out this is a genuine failure, not an infra issue. The failure wasn't caught because the version string and the test were introduced in two different PRs in parallel, and the timing was unfortunate.