### PR TITLE
Double one more timeout in search_test.go

### DIFF
--- a/webdriver/search_test.go
+++ b/webdriver/search_test.go
@@ -79,7 +79,7 @@ func assertListIsFiltered(t *testing.T, wd selenium.WebDriver, elementName strin
 		}
 		return len(pathParts) == len(paths), nil
 	}
-	err = wd.WaitWithTimeout(filteredPathPartsCondition, time.Second*5)
+	err = wd.WaitWithTimeout(filteredPathPartsCondition, time.Second*10)
 	if err != nil {
 		assert.Fail(t, fmt.Sprintf("Expected exactly %v results", len(paths)))
 		return


### PR DESCRIPTION
I missed this one in #600. And I saw flaky failures from this very test
today, so let's double the timeout for this one, too.

Fixes #614 .