### PR TITLE
 Receiver create_run: copy datastore key into TestRun.ID in response

### DIFF
--- a/api/receiver/appengine_medium_test.go
+++ b/api/receiver/appengine_medium_test.go
@@ -117,10 +117,10 @@ func TestAddTestRun(t *testing.T) {
 
 	key, err := a.AddTestRun(&testRun)
 	assert.Nil(t, err)
-	assert.Equal(t, "TestRun", key.Kind())
+	assert.Equal(t, "TestRun", key.Kind)
 
 	var testRun2 shared.TestRun
-	datastore.Get(ctx, key, &testRun2)
+	datastore.Get(ctx, datastore.NewKey(ctx, key.Kind, "", key.ID, nil), &testRun2)
 	assert.Equal(t, testRun, testRun2)
 }
 

--- a/api/receiver/appengine_mock.go
+++ b/api/receiver/appengine_mock.go
@@ -8,7 +8,6 @@ import (
 	context "context"
 	gomock "github.com/golang/mock/gomock"
 	shared "github.com/web-platform-tests/wpt.fyi/shared"
-	datastore "google.golang.org/appengine/datastore"
 	taskqueue "google.golang.org/appengine/taskqueue"
 	io "io"
 	reflect "reflect"
@@ -50,9 +49,9 @@ func (mr *MockAppEngineAPIMockRecorder) Context() *gomock.Call {
 }
 
 // AddTestRun mocks base method
-func (m *MockAppEngineAPI) AddTestRun(testRun *shared.TestRun) (*datastore.Key, error) {
+func (m *MockAppEngineAPI) AddTestRun(testRun *shared.TestRun) (*DatastoreKey, error) {
 	ret := m.ctrl.Call(m, "AddTestRun", testRun)
-	ret0, _ := ret[0].(*datastore.Key)
+	ret0, _ := ret[0].(*DatastoreKey)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/api/receiver/create_run.go
+++ b/api/receiver/create_run.go
@@ -53,7 +53,7 @@ func HandleResultsCreate(a AppEngineAPI, w http.ResponseWriter, r *http.Request)
 
 	// Copy int64 representation of key into TestRun.ID so that clients can
 	// inspect/use key value.
-	testRun.ID = key.IntID()
+	testRun.ID = key.ID
 
 	jsonOutput, err := json.Marshal(testRun)
 	if err != nil {

--- a/api/receiver/create_run.go
+++ b/api/receiver/create_run.go
@@ -45,10 +45,15 @@ func HandleResultsCreate(a AppEngineAPI, w http.ResponseWriter, r *http.Request)
 	}
 	testRun.CreatedAt = time.Now()
 
-	if _, err := a.AddTestRun(&testRun); err != nil {
+	key, err := a.AddTestRun(&testRun)
+	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+
+	// Copy int64 representation of key into TestRun.ID so that clients can
+	// inspect/use key value.
+	testRun.ID = key.IntID()
 
 	jsonOutput, err := json.Marshal(testRun)
 	if err != nil {

--- a/api/receiver/create_run_test.go
+++ b/api/receiver/create_run_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
+var testDatastoreKey = &DatastoreKey{"TestRun", 1}
+
 func TestHandleResultsCreate(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
@@ -44,7 +46,7 @@ func TestHandleResultsCreate(t *testing.T) {
 	mockAE := NewMockAppEngineAPI(mockCtrl)
 	gomock.InOrder(
 		mockAE.EXPECT().AuthenticateUploader("_processor", "secret-token").Return(true),
-		mockAE.EXPECT().AddTestRun(gomock.Any()).Return(nil, nil),
+		mockAE.EXPECT().AddTestRun(gomock.Any()).Return(testDatastoreKey, nil),
 	)
 
 	HandleResultsCreate(mockAE, w, req)
@@ -79,7 +81,7 @@ func TestHandleResultsCreate_NoTimestamps(t *testing.T) {
 	mockAE := NewMockAppEngineAPI(mockCtrl)
 	gomock.InOrder(
 		mockAE.EXPECT().AuthenticateUploader("_processor", "secret-token").Return(true),
-		mockAE.EXPECT().AddTestRun(gomock.Any()).Return(nil, nil),
+		mockAE.EXPECT().AddTestRun(gomock.Any()).Return(testDatastoreKey, nil),
 	)
 
 	HandleResultsCreate(mockAE, w, req)


### PR DESCRIPTION
Also contains an ugly custom data type to work around no appengine-context-free mechanism for constructing datastore keys with predefined kind and integral ID.