### PR TITLE
Use -moz-max-content so that cells show up on hover on Firefox.

### DIFF
--- a/webapp/components/test-file-results-table-terse.html
+++ b/webapp/components/test-file-results-table-terse.html
@@ -32,6 +32,7 @@ found in the LICENSE file.
         z-index: 1;
         text-overflow: initial;
         background-color: inherit;
+        width: -moz-max-content;
         width: max-content;
       }
     </style>


### PR DESCRIPTION
We're working on unprefixing these keywords in:

  https://bugzilla.mozilla.org/show_bug.cgi?id=1322780

But it'd be nice if it worked before that's fixed :)