### PR TITLE
Handle run_id and run_ids

### DIFF
--- a/shared/params.go
+++ b/shared/params.go
@@ -547,6 +547,23 @@ func ParseRepeatedParam(r *http.Request, singular string, plural string) (params
 	return params
 }
 
+// ParseRepeatedInt64Param parses the result of ParseRepeatedParam as int64.
+func ParseRepeatedInt64Param(r *http.Request, singular, plural string) (params []int64, err error) {
+	strs := ParseRepeatedParam(r, singular, plural)
+	if len(strs) < 1 {
+		return nil, nil
+	}
+	ints := make([]int64, len(strs))
+	for i, idStr := range strs {
+		id, err := strconv.ParseInt(idStr, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		ints[i] = id
+	}
+	return ints, err
+}
+
 // ParseQueryParamInt parses the URL query parameter at key. If the parameter is
 // empty or missing, nil is returned.
 func ParseQueryParamInt(r *http.Request, key string) (*int, error) {
@@ -589,20 +606,7 @@ func ParseBooleanParam(r *http.Request, name string) (result *bool, err error) {
 // ParseRunIDsParam parses the "run_ids" parameter. If the ID is not a valid
 // int64, an error will be returned.
 func ParseRunIDsParam(r *http.Request) (ids []int64, err error) {
-	str := r.URL.Query().Get("run_ids")
-	if str == "" {
-		return nil, nil
-	}
-	idStrs := strings.Split(str, ",")
-	ids = make([]int64, 0, len(idStrs))
-	for _, idStr := range idStrs {
-		id, err := strconv.ParseInt(idStr, 10, 64)
-		if err != nil {
-			return nil, err
-		}
-		ids = append(ids, id)
-	}
-	return ids, err
+	return ParseRepeatedInt64Param(r, "run_id", "run_ids")
 }
 
 // ParseQueryFilterParams parses shared params for the search and autocomplete

--- a/shared/params_test.go
+++ b/shared/params_test.go
@@ -428,11 +428,21 @@ func TestParseRunIDsParam_ok(t *testing.T) {
 	runIDs, err := ParseRunIDsParam(r)
 	assert.Equal(t, []int64{1, 2, 3}, runIDs)
 	assert.Nil(t, err)
+
+	r = httptest.NewRequest("GET", "http://wpt.fyi/api/search?run_id=1&run_id=2&run_id=3", nil)
+	runIDs, err = ParseRunIDsParam(r)
+	assert.Equal(t, []int64{1, 2, 3}, runIDs)
+	assert.Nil(t, err)
 }
 
 func TestParseRunIDsParam_err(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/api/search?run_ids=1,notanumber,3", nil)
 	runIDs, err := ParseRunIDsParam(r)
+	assert.Nil(t, runIDs)
+	assert.NotNil(t, err)
+
+	r = httptest.NewRequest("GET", "http://wpt.fyi/api/search?run_id=1&run_id=notanumber&run_id=3", nil)
+	runIDs, err = ParseRunIDsParam(r)
 	assert.Nil(t, runIDs)
 	assert.NotNil(t, err)
 }


### PR DESCRIPTION
## Description
Simplifies the use-case of iteratively appending `run_id=`, and keeps consistency with other plural/repeated params.