### PR TITLE
Add default flags in datastore

### DIFF
--- a/shared/datastore.go
+++ b/shared/datastore.go
@@ -261,3 +261,13 @@ func GetAlignedRunSHAs(
 func getTestRunMemcacheKey(id int64) string {
 	return "TEST_RUN-" + strconv.FormatInt(id, 10)
 }
+
+// GetFeatureFlags returns all feature flag defaults set in the datastore.
+func GetFeatureFlags(ctx context.Context) (flags []Flag, err error) {
+	var keys []*datastore.Key
+	keys, err = datastore.NewQuery("Flag").GetAll(ctx, &flags)
+	for i := range keys {
+		flags[i].Name = keys[i].StringID()
+	}
+	return flags, err
+}

--- a/shared/models.go
+++ b/shared/models.go
@@ -225,3 +225,9 @@ type Uploader struct {
 	Username string
 	Password string
 }
+
+// Flag represents an enviroment feature flag's default state.
+type Flag struct {
+	Name    string `datastore:"-"` // Name is the key in datastore.
+	Enabled bool
+}

--- a/util/populate_dev_data.go
+++ b/util/populate_dev_data.go
@@ -41,6 +41,7 @@ func main() {
 	}
 
 	emptySecretToken := &shared.Token{}
+	enabledFlag := &shared.Flag{Enabled: true}
 	staticDataTime, _ := time.Parse(time.RFC3339, "2017-10-18T00:00:00Z")
 
 	// Follow pattern established in run/*.py data collection code.
@@ -169,6 +170,11 @@ func main() {
 	addSecretToken(ctx, "upload-token", emptySecretToken)
 	addSecretToken(ctx, "github-api-token", emptySecretToken)
 
+	log.Print("Adding flag defaults...")
+	addFlag(ctx, "queryBuilder", enabledFlag)
+	addFlag(ctx, "diffFilter", enabledFlag)
+	addFlag(ctx, "diffFromAPI", enabledFlag)
+
 	log.Print("Adding uploader \"test\"...")
 	addData(ctx, "Uploader", []interface{}{
 		&shared.Uploader{Username: "test", Password: "123"},
@@ -279,6 +285,14 @@ func addSecretToken(ctx context.Context, id string, data interface{}) {
 		log.Fatalf("Failed to add %s secret: %s", id, err.Error())
 	}
 	log.Printf("Added %s secret", id)
+}
+
+func addFlag(ctx context.Context, id string, data interface{}) {
+	key := datastore.NewKey(ctx, "Flag", id, 0, nil)
+	if _, err := datastore.Put(ctx, key, data); err != nil {
+		log.Fatalf("Failed to add %s flag: %s", id, err.Error())
+	}
+	log.Printf("Added %s flag", id)
 }
 
 func addData(ctx context.Context, kindName string, data []interface{}) (keys []*datastore.Key) {

--- a/webapp/app.yaml
+++ b/webapp/app.yaml
@@ -10,6 +10,10 @@ builtins:
 - remote_api: on
 
 handlers:
+  # Couple of special-case dynamic components.
+- url: /components/wpt-env-flags.html
+  script: _go_app
+  secure: always
 - url: /components
   static_dir: components
   secure: always

--- a/webapp/components/wpt-flags.html
+++ b/webapp/components/wpt-flags.html
@@ -7,6 +7,7 @@ found in the LICENSE file.
 <link rel="import" href="../bower_components/polymer/polymer-element.html">
 <link rel="import" href="../bower_components/paper-item/paper-item.html">
 <link rel="import" href="../bower_components/paper-checkbox/paper-checkbox.html">
+<link rel="import" href="../components/wpt-env-flags.html">
 
 <!--
 `<wpt-flags>` is a component for checking wpt.fyi feature flags.
@@ -24,7 +25,12 @@ found in the LICENSE file.
         const props = {};
         for (const feature of WPT_FYI_FEATURES) {
           const stored = localStorage.getItem(`features.${feature}`);
-          const value = stored && JSON.parse(stored);
+          let value = stored && JSON.parse(stored);
+          // Fall back to env default.
+          if (value === null) {
+            value = window.WPTEnvironmentFlags
+              && window.WPTEnvironmentFlags[feature];
+          }
           props[feature] = {
             type: Boolean,
             readOnly: readOnly,

--- a/webapp/dynamic-components/wpt-env-flags.html
+++ b/webapp/dynamic-components/wpt-env-flags.html
@@ -1,0 +1,30 @@
+<!--
+Copyright 2018 The WPT Dashboard Project. All rights reserved.
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file.
+-->
+
+<!--
+`<wpt-env-flags>` is a component for checking default enviroment wpt.fyi
+  feature flags.
+-->
+<dom-module id="wpt-env-flags">
+  <script>
+    (() => {
+      // eslint-disable-next-line no-unused-vars
+      const DEFAULTS = JSON.parse({{ .Flags }});
+
+      window.WPTEnvironmentFlags = class WPTEnvironmentFlags {};
+      for (const feature of DEFAULTS) {
+        Object.defineProperty(
+          window.WPTEnvironmentFlags,
+          feature.Name,
+          {
+            writable: false,
+            configurable: false,
+            value: feature.Enabled,
+          });
+      }
+    })();
+  </script>
+</dom-module>

--- a/webapp/dynamic_components_handler.go
+++ b/webapp/dynamic_components_handler.go
@@ -1,0 +1,27 @@
+package webapp
+
+import (
+	"encoding/json"
+	"html/template"
+	"net/http"
+
+	"github.com/web-platform-tests/wpt.fyi/shared"
+	"google.golang.org/appengine"
+)
+
+var componentTemplates = template.Must(template.ParseGlob("dynamic-components/*.html"))
+
+func flagsComponentHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := appengine.NewContext(r)
+	flags, _ := shared.GetFeatureFlags(ctx) // Errors aren't a big deal.
+	flagsBytes, err := json.Marshal(flags)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if len(flags) < 1 {
+		flagsBytes = []byte("[]")
+	}
+	data := struct{ Flags string }{string(flagsBytes)}
+	componentTemplates.ExecuteTemplate(w, "wpt-env-flags.html", data)
+}

--- a/webapp/routes.go
+++ b/webapp/routes.go
@@ -33,6 +33,7 @@ func RegisterRoutes() {
 
 	// Feature flags for wpt.fyi
 	shared.AddRoute("/flags", "flags", flagsHandler)
+	shared.AddRoute("/components/wpt-env-flags.html", "flags-component", flagsComponentHandler)
 
 	// Test run results, viewed by pass-rate across the browsers
 	shared.AddRoute("/interop/", "interop", interopHandler)


### PR DESCRIPTION
## Description
Supports us toggling a flag without the need for re-deploying the project, and allows us to toggle a flag for a whole environment instead of per-user.

## Review Information
Note that I've added a `Flag` entity for enabling `queryBuilder` in staging, so you should be able to see the query builder on the landing page, and ticked in `/flags`, in the auto-deployed env.