### PR TITLE
Announcer change detection

### DIFF
--- a/revisions/api/handlers/latest.go
+++ b/revisions/api/handlers/latest.go
@@ -16,16 +16,19 @@ func LatestHandler(a api.API, w http.ResponseWriter, r *http.Request) {
 	ancr := a.GetAnnouncer()
 	if ancr == nil {
 		http.Error(w, a.ErrorJSON("Announcer not yet initialized"), http.StatusServiceUnavailable)
+		return
 	}
 
 	epochs := a.GetEpochs()
 	if len(epochs) == 0 {
 		http.Error(w, a.ErrorJSON("No epochs"), http.StatusInternalServerError)
+		return
 	}
 
 	response, err := push.GetLatestRevisions(a, ancr, epochs)
 	if err != nil {
 		http.Error(w, a.ErrorJSON(err.Error()), http.StatusInternalServerError)
+		return
 	}
 
 	bytes, err := a.Marshal(*response)

--- a/revisions/api/handlers/latest.go
+++ b/revisions/api/handlers/latest.go
@@ -6,10 +6,9 @@ package handlers
 
 import (
 	"net/http"
-	"time"
 
-	"github.com/web-platform-tests/wpt.fyi/revisions/announcer"
 	"github.com/web-platform-tests/wpt.fyi/revisions/api"
+	"github.com/web-platform-tests/wpt.fyi/revisions/api/push"
 )
 
 // LatestHandler handles HTTP requests for the latest epochal revisions.
@@ -17,32 +16,19 @@ func LatestHandler(a api.API, w http.ResponseWriter, r *http.Request) {
 	ancr := a.GetAnnouncer()
 	if ancr == nil {
 		http.Error(w, a.ErrorJSON("Announcer not yet initialized"), http.StatusServiceUnavailable)
-		return
 	}
 
 	epochs := a.GetEpochs()
 	if len(epochs) == 0 {
 		http.Error(w, a.ErrorJSON("No epochs"), http.StatusInternalServerError)
-		return
 	}
 
-	now := time.Now()
-	revs, err := ancr.GetRevisions(a.GetLatestGetRevisionsInput(), announcer.Limits{
-		At:    now,
-		Start: now.Add(-2 * epochs[0].GetData().MaxDuration),
-	})
+	response, err := push.GetLatestRevisions(a, ancr, epochs)
 	if err != nil {
 		http.Error(w, a.ErrorJSON(err.Error()), http.StatusInternalServerError)
-		return
 	}
 
-	response, err := api.LatestFromEpochs(revs)
-	if err != nil {
-		http.Error(w, string(a.ErrorJSON(err.Error())), http.StatusInternalServerError)
-		return
-	}
-
-	bytes, err := a.Marshal(response)
+	bytes, err := a.Marshal(*response)
 	if err != nil {
 		http.Error(w, a.ErrorJSON("Failed to marshal latest epochal revisions JSON"), http.StatusInternalServerError)
 		return

--- a/revisions/api/handlers/latest_test.go
+++ b/revisions/api/handlers/latest_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/web-platform-tests/wpt.fyi/revisions/api/handlers"
 	"github.com/web-platform-tests/wpt.fyi/revisions/epoch"
 	agit "github.com/web-platform-tests/wpt.fyi/revisions/git"
+
 	"github.com/web-platform-tests/wpt.fyi/revisions/test"
 )
 
@@ -61,63 +62,6 @@ func TestLatestHandler_NoEpochs(t *testing.T) {
 	a.EXPECT().GetAnnouncer().Return(ancr)
 	a.EXPECT().GetEpochs().Return([]epoch.Epoch{})
 	a.EXPECT().ErrorJSON(icMatcher{"epochs"}).Return("")
-
-	req := httptest.NewRequest("GET", "/api/revisions/latest", new(strings.Reader))
-	resp := httptest.NewRecorder()
-
-	handlers.LatestHandler(a, resp, req)
-
-	assert.Equal(t, http.StatusInternalServerError, resp.Code)
-}
-
-func TestLatestHandler_FailedGetRevisions(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	a := api.NewMockAPI(mockCtrl)
-	ancr := announcer.NewMockAnnouncer(mockCtrl)
-
-	epochs := []epoch.Epoch{epoch.Hourly{}}
-	latestInput := make(map[epoch.Epoch]int)
-	err := errors.New("GetRevisions error")
-	a.EXPECT().GetAnnouncer().Return(ancr)
-	a.EXPECT().GetEpochs().Return(epochs)
-	a.EXPECT().GetLatestGetRevisionsInput().Return(latestInput)
-	ancr.EXPECT().GetRevisions(latestInput, gomock.Any()).Return(nil, err)
-	a.EXPECT().ErrorJSON(icMatcher{"getrevisions"}).Return("")
-
-	req := httptest.NewRequest("GET", "/api/revisions/latest", new(strings.Reader))
-	resp := httptest.NewRecorder()
-
-	handlers.LatestHandler(a, resp, req)
-
-	assert.Equal(t, http.StatusInternalServerError, resp.Code)
-}
-
-func TestLatestHandler_FailedLatestFromEpochs(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	a := api.NewMockAPI(mockCtrl)
-	ancr := announcer.NewMockAnnouncer(mockCtrl)
-
-	epochs := []epoch.Epoch{epoch.Hourly{}}
-	latestInput := make(map[epoch.Epoch]int)
-
-	// Empty list filed under epoch triggers error in LatestFromEpochs.
-	//
-	// TODO(markdittmer): Perhaps functions in revisions/api/types.go should be
-	// wrapped in an interface or struct so that they can be mocked.
-	revs := map[epoch.Epoch][]agit.Revision{
-		epoch.Hourly{}: []agit.Revision{},
-	}
-
-	a.EXPECT().GetAnnouncer().Return(ancr)
-	a.EXPECT().GetEpochs().Return(epochs)
-	a.EXPECT().GetLatestGetRevisionsInput().Return(latestInput)
-
-	ancr.EXPECT().GetRevisions(latestInput, gomock.Any()).Return(revs, nil)
-	a.EXPECT().ErrorJSON(icMatcher{"missing"}).Return("")
 
 	req := httptest.NewRequest("GET", "/api/revisions/latest", new(strings.Reader))
 	resp := httptest.NewRecorder()

--- a/revisions/api/push/latest.go
+++ b/revisions/api/push/latest.go
@@ -1,0 +1,78 @@
+// Copyright 2018 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package push
+
+import (
+	"time"
+
+	"github.com/web-platform-tests/wpt.fyi/revisions/announcer"
+	"github.com/web-platform-tests/wpt.fyi/revisions/api"
+	"github.com/web-platform-tests/wpt.fyi/revisions/epoch"
+)
+
+// GetLatestRevisions fetches the latest revisions from ancr using configration
+// from a and epochs. Note that epochs is assumed to be sorted by epoch
+// duration, descending.
+func GetLatestRevisions(a api.API, ancr announcer.Announcer, epochs []epoch.Epoch) (*api.LatestResponse, error) {
+	now := time.Now()
+	revs, err := ancr.GetRevisions(a.GetLatestGetRevisionsInput(), announcer.Limits{
+		At:    now,
+		Start: now.Add(-2 * epochs[0].GetData().MaxDuration),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := api.LatestFromEpochs(revs)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}
+
+// DiffLatest returns an api.LatestResponse that contains the new values for
+// given epochs that changed in value between prev and next.
+func DiffLatest(prev *api.LatestResponse, next *api.LatestResponse, epochs []epoch.Epoch) []api.Diff {
+	changes := make([]api.Diff, 0, len(epochs))
+
+	if prev == nil && next == nil {
+		return changes
+	}
+
+	if prev == nil {
+		for _, epoch := range epochs {
+			e := api.FromEpoch(epoch)
+			key := e.ID
+			r := next.Revisions[key]
+			changes = append(changes, api.Diff{e.ID, nil, &r})
+		}
+
+		return changes
+	}
+
+	if next == nil {
+		for _, epoch := range epochs {
+			e := api.FromEpoch(epoch)
+			key := e.ID
+			r := prev.Revisions[key]
+			changes = append(changes, api.Diff{e.ID, &r, nil})
+		}
+
+		return changes
+	}
+
+	for _, epoch := range epochs {
+		e := api.FromEpoch(epoch)
+		key := e.ID
+		if prev.Revisions[key] != next.Revisions[key] {
+			pr := prev.Revisions[key]
+			nr := next.Revisions[key]
+			changes = append(changes, api.Diff{e.ID, &pr, &nr})
+		}
+	}
+
+	return changes
+}

--- a/revisions/api/push/latest.go
+++ b/revisions/api/push/latest.go
@@ -67,10 +67,12 @@ func DiffLatest(prev *api.LatestResponse, next *api.LatestResponse, epochs []epo
 	for _, epoch := range epochs {
 		e := api.FromEpoch(epoch)
 		key := e.ID
-		if prev.Revisions[key] != next.Revisions[key] {
+		if !prev.Revisions[key].Equal(next.Revisions[key]) {
 			pr := prev.Revisions[key]
 			nr := next.Revisions[key]
-			changes = append(changes, api.Diff{e.ID, &pr, &nr})
+			if pr != nr {
+				changes = append(changes, api.Diff{e.ID, &pr, &nr})
+			}
 		}
 	}
 

--- a/revisions/api/push/latest_test.go
+++ b/revisions/api/push/latest_test.go
@@ -1,0 +1,109 @@
+// +build small
+
+// Copyright 2018 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package push
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/web-platform-tests/wpt.fyi/revisions/announcer"
+	"github.com/web-platform-tests/wpt.fyi/revisions/api"
+	"github.com/web-platform-tests/wpt.fyi/revisions/epoch"
+	agit "github.com/web-platform-tests/wpt.fyi/revisions/git"
+)
+
+func TestGetLatestRevisions_FailedGetRevisions(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	a := api.NewMockAPI(mockCtrl)
+	ancr := announcer.NewMockAnnouncer(mockCtrl)
+
+	epochs := []epoch.Epoch{epoch.Hourly{}}
+	latestInput := make(map[epoch.Epoch]int)
+	err := errors.New("GetRevisions error")
+	a.EXPECT().GetLatestGetRevisionsInput().Return(latestInput)
+	ancr.EXPECT().GetRevisions(latestInput, gomock.Any()).Return(nil, err)
+
+	_, glrErr := GetLatestRevisions(a, ancr, epochs)
+	assert.Equal(t, err, glrErr)
+}
+
+func TestGetLatestRevisions_FailedLatestFromEpochs(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	a := api.NewMockAPI(mockCtrl)
+	ancr := announcer.NewMockAnnouncer(mockCtrl)
+
+	epochs := []epoch.Epoch{epoch.Hourly{}}
+	latestInput := make(map[epoch.Epoch]int)
+
+	// Empty list filed under epoch triggers error in LatestFromEpochs.
+	//
+	// TODO(markdittmer): Perhaps functions in revisions/api/types.go should be
+	// wrapped in an interface or struct so that they can be mocked.
+	revs := map[epoch.Epoch][]agit.Revision{
+		epoch.Hourly{}: []agit.Revision{},
+	}
+
+	a.EXPECT().GetLatestGetRevisionsInput().Return(latestInput)
+
+	ancr.EXPECT().GetRevisions(latestInput, gomock.Any()).Return(revs, nil)
+
+	_, err := GetLatestRevisions(a, ancr, epochs)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(strings.ToLower(err.Error()), "missing"))
+}
+
+func TestDiffLatest(t *testing.T) {
+	t0 := time.Now()
+	t1 := api.UTCTime(t0)
+	t2 := api.UTCTime(t0.Add(time.Hour))
+	t3 := api.UTCTime(t0.Add(time.Hour * 2))
+	r1 := api.Revision{"01", t1}
+	r2 := api.Revision{"02", t2}
+	r3 := api.Revision{"03", t3}
+	prev := map[string]api.Revision{
+		api.FromEpoch(epoch.Weekly{}).ID: r1,
+		api.FromEpoch(epoch.Daily{}).ID:  r2,
+	}
+	next := map[string]api.Revision{
+		api.FromEpoch(epoch.Daily{}).ID:  r3,
+		api.FromEpoch(epoch.Hourly{}).ID: r3,
+	}
+	epochs := []epoch.Epoch{
+		epoch.Weekly{},
+		epoch.Daily{},
+		epoch.Hourly{},
+	}
+	expected := []api.Diff{
+		api.Diff{api.FromEpoch(epoch.Weekly{}).ID, &r1, nil},
+		api.Diff{api.FromEpoch(epoch.Daily{}).ID, &r2, &r3},
+		api.Diff{api.FromEpoch(epoch.Hourly{}).ID, nil, &r3},
+	}
+
+	actual := DiffLatest(prev, next, epochs)
+	assert.Equal(t, len(expected), len(actual))
+	for i := range expected {
+		assert.Equal(t, expected[i].Epoch, actual[i].Epoch)
+		if expected[i].Prev == nil {
+			assert.Nil(t, actual[i].Prev)
+		} else {
+			assert.Equal(t, expected[i].Prev, actual[i].Prev)
+		}
+		if expected[i].Next == nil {
+			assert.Nil(t, actual[i].Next)
+		} else {
+			assert.Equal(t, expected[i].Next, actual[i].Next)
+		}
+	}
+}

--- a/revisions/api/types.go
+++ b/revisions/api/types.go
@@ -185,3 +185,17 @@ func RevisionsFromEpochs(revs map[epoch.Epoch][]agit.Revision, apiErr error) Rev
 
 	return response
 }
+
+// Diff contains a change in epoch revision where the epoch is identified by an
+// Epoch.ID.
+type Diff struct {
+	Epoch string    `json:"epoch"`
+	Prev  *Revision `json:"prev,omitempty"`
+	Next  *Revision `json:"next,omitempty"`
+}
+
+// DiffPayload contains the data pushed to a subscriber to epochal revision
+// changes.
+type DiffPayload struct {
+	Changes []Diff `json:"changes"`
+}

--- a/revisions/api/types.go
+++ b/revisions/api/types.go
@@ -70,6 +70,11 @@ type Revision struct {
 	CommitTime UTCTime `json:"commit_time"`
 }
 
+// Equal returns true iff r and r2 represent the same revision.
+func (r Revision) Equal(r2 Revision) bool {
+	return r.Hash == r2.Hash && time.Time(r.CommitTime).Equal(time.Time(r2.CommitTime))
+}
+
 // FromRevision converts an agit.Revision to a revision exposed via the public API.
 func FromRevision(rev agit.Revision) Revision {
 	return Revision{


### PR DESCRIPTION
## Description

Implement detection of changes in the announcer and log them. This is towards #551. Eventually, some model of "subscriptions" will be notified of subscribed changes.

## Review Information

```
go run go run github.com/web-platform-tests/wpt.fyi/revisions/service -port=[some-unused-port]
```

Wait for the announcer to update twice _after it has been initialized_. The first update should log a bunch of `Epoch [ID] changed from <nil> to [value]`. The second update (unless you are very unlucky) should contain no `Epoch [...] changed [...]` logs.

If you leave it running for a long time, subsequent epoch updates are also logged.

## Changes

Some logic that used to live in the `handlers` package is moved to `push`; the "latest" handler delegates to the shared logic in `push`.