### PR TITLE
Fix navigation

### DIFF
--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -494,7 +494,7 @@ found in the LICENSE file.
             const builder = this.shadowRoot.querySelector('test-runs-query-builder');
             if (builder) {
               builder.updateQueryParams(state);
-              builder.submit();
+              this.handleSubmitQuery();
             }
           }
         };
@@ -788,8 +788,11 @@ found in the LICENSE file.
 
       handleSubmitQuery() {
         const builder = this.shadowRoot.querySelector('test-runs-query-builder');
-        this.updateQueryParams(builder.testRunQueryParams);
         this.editingQuery = false;
+        if (this.testRunQuery === builder.testRunQuery) {
+          return;
+        }
+        this.updateQueryParams(builder.testRunQueryParams);
         // Trigger a virtual navigation.
         this.navigateToLocation(window.location);
         this.testRuns = [];


### PR DESCRIPTION
## Description
Fixes https://github.com/web-platform-tests/wpt.fyi/issues/653

When handling a change in navigation state, we are force-submitting on _all_ changes, to ensure the builder always reflects the right state, and thus state is "submitted" as the current query. This is overkill for the case that only the path changes (no reload needed), so this PR checks that the _query_ is actually different, before triggering a data load (which was clobbering the path in the process).