### PR TITLE
Spanner push run: Compare result counts

### DIFF
--- a/api/spanner/api.go
+++ b/api/spanner/api.go
@@ -4,10 +4,60 @@
 
 package spanner
 
-type API struct {
+import (
+	"context"
+	"fmt"
+
+	"cloud.google.com/go/datastore"
+	"cloud.google.com/go/spanner"
+	"google.golang.org/api/option"
+)
+
+type API interface {
 	Authenticator
 
-	ProjectID          string
-	Database           string
-	GCPCredentialsFile *string
+	WithCredentialsFile(string) API
+	DatastoreConnect(context.Context) (*datastore.Client, error)
+	SpannerConnect(context.Context) (*spanner.Client, error)
+}
+
+type apiImpl struct {
+	Authenticator
+
+	projectID          string
+	instance           string
+	database           string
+	gcpCredentialsFile *string
+}
+
+func (a *apiImpl) DatastoreConnect(ctx context.Context) (*datastore.Client, error) {
+	if a.gcpCredentialsFile != nil {
+		return datastore.NewClient(ctx, a.projectID, option.WithCredentialsFile(*a.gcpCredentialsFile))
+	}
+
+	return datastore.NewClient(ctx, a.projectID)
+}
+
+func (a *apiImpl) SpannerConnect(ctx context.Context) (*spanner.Client, error) {
+	db := fmt.Sprintf("projects/%s/instances/%s/databases/%s", a.projectID, a.instance, a.database)
+	if a.gcpCredentialsFile != nil {
+		return spanner.NewClient(ctx, db, option.WithCredentialsFile(*a.gcpCredentialsFile))
+	}
+
+	return spanner.NewClient(ctx, db)
+}
+
+func (a *apiImpl) WithCredentialsFile(gcpCredentialsFile string) API {
+	a2 := *a
+	a2.gcpCredentialsFile = &gcpCredentialsFile
+	return &a2
+}
+
+func NewAPI(a Authenticator, projectID, instance, database string) API {
+	return &apiImpl{
+		Authenticator: a,
+		projectID:     projectID,
+		instance:      instance,
+		database:      database,
+	}
 }

--- a/api/spanner/api.go
+++ b/api/spanner/api.go
@@ -33,7 +33,7 @@ type apiImpl struct {
 	gcpCredentialsFile *string
 }
 
-func (a *apiImpl) DatastoreConnect(ctx context.Context) (*datastore.Client, error) {
+func (a apiImpl) DatastoreConnect(ctx context.Context) (*datastore.Client, error) {
 	if a.gcpCredentialsFile != nil {
 		return datastore.NewClient(ctx, a.projectID, option.WithCredentialsFile(*a.gcpCredentialsFile))
 	}
@@ -41,7 +41,7 @@ func (a *apiImpl) DatastoreConnect(ctx context.Context) (*datastore.Client, erro
 	return datastore.NewClient(ctx, a.projectID)
 }
 
-func (a *apiImpl) SpannerConnect(ctx context.Context) (*spanner.Client, error) {
+func (a apiImpl) SpannerConnect(ctx context.Context) (*spanner.Client, error) {
 	db := fmt.Sprintf("projects/%s/instances/%s/databases/%s", a.projectID, a.instance, a.database)
 	if a.gcpCredentialsFile != nil {
 		return spanner.NewClient(ctx, db, option.WithCredentialsFile(*a.gcpCredentialsFile))
@@ -50,17 +50,15 @@ func (a *apiImpl) SpannerConnect(ctx context.Context) (*spanner.Client, error) {
 	return spanner.NewClient(ctx, db)
 }
 
-func (a *apiImpl) WithCredentialsFile(gcpCredentialsFile string) API {
-	// Make a copy of a and store credentials file path in copy.
-	a2 := *a
-	a2.gcpCredentialsFile = &gcpCredentialsFile
-	return &a2
+func (a apiImpl) WithCredentialsFile(gcpCredentialsFile string) API {
+	a.gcpCredentialsFile = &gcpCredentialsFile
+	return a
 }
 
 // NewAPI creates a new API instance bound to the given authenticator and
 // spanner storage location.
 func NewAPI(a Authenticator, projectID, instance, database string) API {
-	return &apiImpl{
+	return apiImpl{
 		Authenticator: a,
 		projectID:     projectID,
 		instance:      instance,

--- a/api/spanner/api.go
+++ b/api/spanner/api.go
@@ -1,0 +1,13 @@
+// Copyright 2018 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package spanner
+
+type API struct {
+	Authenticator
+
+	ProjectID          string
+	Database           string
+	GCPCredentialsFile *string
+}

--- a/api/spanner/api.go
+++ b/api/spanner/api.go
@@ -13,6 +13,9 @@ import (
 	"google.golang.org/api/option"
 )
 
+// API is a wrapper for service configuration that does not change between
+// requests. E.g., information necessary to connect to Datastore and Cloud
+// Spanner.
 type API interface {
 	Authenticator
 
@@ -48,11 +51,14 @@ func (a *apiImpl) SpannerConnect(ctx context.Context) (*spanner.Client, error) {
 }
 
 func (a *apiImpl) WithCredentialsFile(gcpCredentialsFile string) API {
+	// Make a copy of a and store credentials file path in copy.
 	a2 := *a
 	a2.gcpCredentialsFile = &gcpCredentialsFile
 	return &a2
 }
 
+// NewAPI creates a new API instance bound to the given authenticator and
+// spanner storage location.
 func NewAPI(a Authenticator, projectID, instance, database string) API {
 	return &apiImpl{
 		Authenticator: a,

--- a/api/spanner/push_run.go
+++ b/api/spanner/push_run.go
@@ -7,9 +7,23 @@ package spanner
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
 	"net/http"
 	"strconv"
 	"time"
+
+	"cloud.google.com/go/datastore"
+	"cloud.google.com/go/spanner"
+	mapset "github.com/deckarep/golang-set"
+	"github.com/web-platform-tests/results-analysis/metrics"
+	"github.com/web-platform-tests/wpt.fyi/shared"
+	"google.golang.org/api/iterator"
+)
+
+const (
+	countStmt = "SELECT COUNT(*) FROM results-apep WHERE run_id = @run_id"
 )
 
 // PushID is a unique identifier for a request to push a test run to
@@ -48,4 +62,128 @@ func HandlePushRun(ctx context.Context, auth Authenticator, w http.ResponseWrite
 	}
 
 	w.Write(data)
+}
+
+func loadRun(ctx context.Context, client *datastore.Client, id int64) (*shared.TestRun, error) {
+	logger := shared.GetLogger(ctx)
+
+	logger.Infof("Loading TestRun entity with integra key %d", id)
+
+	var run shared.TestRun
+	err := client.Get(ctx, &datastore.Key{
+		Kind: "TestRun",
+		ID:   id,
+	}, &run)
+	if err != nil {
+		logger.Errorf("Failed to load TestRun entity with integral key %d", id)
+		return nil, err
+	}
+	return &run, nil
+}
+
+func loadRunReport(ctx context.Context, run *shared.TestRun) (*metrics.TestResultsReport, error) {
+	logger := shared.GetLogger(ctx)
+
+	if run.RawResultsURL == "" {
+		str := fmt.Sprintf("TestRun entity ID=%d has no RawResultsURL", run.ID)
+		logger.Errorf(str)
+		return nil, errors.New(str)
+	}
+
+	logger.Infof("Reading report from %s", run.RawResultsURL)
+
+	resp, err := http.Get(run.RawResultsURL)
+	if err != nil {
+		logger.Warningf("Failed to load raw results from \"%s\" for run ID=%d", run.RawResultsURL, run.ID)
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		str := fmt.Sprintf("Non-OK HTTP status code of %d from \"%s\" for run ID=%d", resp.StatusCode, run.RawResultsURL, run.ID)
+		logger.Warningf(str)
+		return nil, errors.New(str)
+	}
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		logger.Warningf("Failed to read contents of \"%s\" for run ID=%d", run.RawResultsURL, run.ID)
+		return nil, err
+	}
+	var report metrics.TestResultsReport
+	err = json.Unmarshal(data, &report)
+	if err != nil {
+		logger.Warningf("Failed to unmarshal JSON from \"%s\" for run ID=%d", run.RawResultsURL, run.ID)
+		return nil, err
+	}
+	if len(report.Results) == 0 {
+		str := fmt.Sprintf("Empty report from run ID=%d (%s)", run.ID, run.RawResultsURL)
+		logger.Warningf(str)
+		return nil, errors.New(str)
+	}
+
+	logger.Infof("Read report for run ID=%d", run.ID)
+
+	return &report, nil
+}
+
+func countReportResults(ctx context.Context, report *metrics.TestResultsReport) int64 {
+	count := int64(0)
+	for _, r := range report.Results {
+		if len(r.Subtests) == 0 {
+			count++
+		} else {
+			set := mapset.NewSet()
+			for _, s := range r.Subtests {
+				if set.Contains(s.Name) {
+					shared.GetLogger(ctx).Warningf("Found test \"%s\" contains duplicate subtest name \"%s\"", r.Test, s.Name)
+				} else {
+					set.Add(s.Name)
+				}
+			}
+			count += int64(set.Cardinality())
+		}
+	}
+	return count
+}
+
+func countSpannerResults(ctx context.Context, client *spanner.Client, runID int64) (int64, error) {
+	params := map[string]interface{}{
+		"run_id": runID,
+	}
+	s := spanner.Statement{
+		SQL:    countStmt,
+		Params: params,
+	}
+
+	shared.GetLogger(ctx).Infof("Spanner query: \"%s\" with %v", countStmt, params)
+
+	itr := client.Single().WithTimestampBound(spanner.MaxStaleness(1*time.Minute)).Query(ctx, s)
+	defer itr.Stop()
+	var count int64
+	for {
+		row, err := itr.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return 0, err
+		}
+
+		err = row.Column(0, &count)
+		if err != nil {
+			return 0, err
+		}
+	}
+	return count, nil
+}
+
+func numRowsToUpload(ctx context.Context, client *spanner.Client, runID int64, report *metrics.TestResultsReport) (int64, error) {
+	totalRows := countReportResults(ctx, report)
+	existingRows, err := countSpannerResults(ctx, client, runID)
+	if err != nil {
+		return 0, err
+	}
+
+	shared.GetLogger(ctx).Infof("Run %d contains %d rows (according to GCS); %d found in Spanner", runID, totalRows, existingRows)
+
+	return totalRows - existingRows, nil
 }

--- a/api/spanner/push_run.go
+++ b/api/spanner/push_run.go
@@ -107,6 +107,8 @@ func pushRun(ctx context.Context, api API, id int64) {
 	shared.GetLogger(ctx).Infof("NOT IMPLEMENTED: Spanner push run would now push run if number of missing rows=%d > 0", n)
 }
 
+// loadRun loads shared.TestRun data from datastore, given an integral ID
+// (Datastore key).
 func loadRun(ctx context.Context, client *datastore.Client, id int64) (*shared.TestRun, error) {
 	logger := shared.GetLogger(ctx)
 
@@ -125,6 +127,8 @@ func loadRun(ctx context.Context, client *datastore.Client, id int64) (*shared.T
 	return &run, nil
 }
 
+// loadRunReport loads a metrics.TestResultsReport using the URL specified in
+// run.
 func loadRunReport(ctx context.Context, run *shared.TestRun) (*metrics.TestResultsReport, error) {
 	logger := shared.GetLogger(ctx)
 
@@ -169,6 +173,8 @@ func loadRunReport(ctx context.Context, run *shared.TestRun) (*metrics.TestResul
 	return &report, nil
 }
 
+// countReportResults counts the number of meaningfully distinct test results
+// detailed in report.
 func countReportResults(ctx context.Context, report *metrics.TestResultsReport) int64 {
 	count := int64(0)
 	for _, r := range report.Results {
@@ -189,6 +195,8 @@ func countReportResults(ctx context.Context, report *metrics.TestResultsReport) 
 	return count
 }
 
+// countSpannerResults counts the number of test results bound to the given
+// runID in Cloud Spanner.
 func countSpannerResults(ctx context.Context, client *spanner.Client, runID int64) (int64, error) {
 	params := map[string]interface{}{
 		"run_id": runID,
@@ -220,6 +228,10 @@ func countSpannerResults(ctx context.Context, client *spanner.Client, runID int6
 	return count, nil
 }
 
+// numRowsToUpload delegates to internal counting functions to compare the
+// number of test results in a run report to the number of results stored in
+// Cloud Spanner. The return value is the number of results in the report that
+// do not appear in Cloud Spanner.
 func numRowsToUpload(ctx context.Context, client *spanner.Client, runID int64, report *metrics.TestResultsReport) (int64, error) {
 	totalRows := countReportResults(ctx, report)
 	existingRows, err := countSpannerResults(ctx, client, runID)

--- a/api/spanner/push_run.go
+++ b/api/spanner/push_run.go
@@ -112,7 +112,7 @@ func pushRun(ctx context.Context, api API, id int64) {
 func loadRun(ctx context.Context, client *datastore.Client, id int64) (*shared.TestRun, error) {
 	logger := shared.GetLogger(ctx)
 
-	logger.Infof("Loading TestRun entity with integra key %d", id)
+	logger.Infof("Loading TestRun entity with integral key %d", id)
 
 	var run shared.TestRun
 	err := client.Get(ctx, &datastore.Key{

--- a/api/spanner/service/main.go
+++ b/api/spanner/service/main.go
@@ -27,6 +27,7 @@ const (
 var (
 	port               = flag.Int("port", 8080, "Port to listen on")
 	projectID          = flag.String("project_id", "", "Google Cloud Platform project ID, if different from ID detected from metadata service")
+	spannerInstance    = flag.String("spanner_instance", "wpt-results", "Cloud Spanner instance ID where data are stored")
 	gcpCredentialsFile = flag.String("gcp_credentials_file", "", "Path to Google Cloud Platform credentials file, if necessary")
 	auth               spanner.Authenticator
 	api                spanner.API
@@ -65,13 +66,9 @@ func main() {
 		auth = spanner.NewDatastoreAuthenticator(*projectID)
 	}
 
-	api = spanner.API{
-		Authenticator: auth,
-		ProjectID:     *projectID,
-		Database:      spannerDatabase,
-	}
+	api = spanner.NewAPI(auth, *projectID, *spannerInstance, spannerDatabase)
 	if *gcpCredentialsFile != "" {
-		api.GCPCredentialsFile = gcpCredentialsFile
+		api = api.WithCredentialsFile(*gcpCredentialsFile)
 	}
 
 	http.HandleFunc("/_ah/liveness_check", livenessCheckHandler)


### PR DESCRIPTION
## Description

This implements the initial check for pushing a run to Cloud Spanner: Does the report contain more distinct test results than Cloud Spanner? If `reportResultCount > spannerRowCount` for the given run ID, then (in a follow-up PR) the service will write all results to Cloud Spanner.

## Review Information

If you wish to run locally, make use of the flags defined in `api/spanner/service/main.go` to setup credentials and a port number. If you wish to use a staging instance, then lookup the HTTP basic auth password for the `_spanner` user in Datastore.

`PUT /api/spanner_push_run?run_id=[integral-datastore-id-for-run]`

Logging should show the result of your request.