### PR TITLE
Handle to/from UI query params

### DIFF
--- a/shared/params.go
+++ b/shared/params.go
@@ -176,6 +176,9 @@ func (filter TestRunFilter) ToQuery() (q url.Values) {
 	if filter.From != nil {
 		q.Set("from", filter.From.Format(time.RFC3339))
 	}
+	if filter.To != nil {
+		q.Set("to", filter.From.Format(time.RFC3339))
+	}
 	return q
 }
 

--- a/webapp/components/interop.html
+++ b/webapp/components/interop.html
@@ -219,7 +219,7 @@ found in the LICENSE file.
   /* global TestRunsBase, SelfNavigation, LoadingState, ResultsNavigation */
   class WPTInterop extends ResultsNavigation(
     SelfNavigation(LoadingState(TestRunsBase)),
-    'interopQueryParams(sha, aligned, labels, productSpecs, maxCount, search)') {
+    'interopQueryParams(sha, aligned, labels, productSpecs, maxCount, from, to, search)') {
     static get is() {
       return 'wpt-interop';
     }

--- a/webapp/components/test-runs-query.html
+++ b/webapp/components/test-runs-query.html
@@ -41,13 +41,15 @@ found in the LICENSE file.
             maxCount: Number,
             sha: String,
             aligned: Boolean,
+            from: Date,
+            to: Date,
             isLatest: {
               type: Boolean,
               computed: 'computeIsLatest(sha)'
             },
             testRunQueryParams: {
               type: Object,
-              computed: 'computeTestRunQueryParams(sha, aligned, labels, productSpecs, maxCount)',
+              computed: 'computeTestRunQueryParams(sha, aligned, labels, productSpecs, maxCount, from, to)',
             },
             testRunQuery: {
               type: String,
@@ -78,7 +80,7 @@ found in the LICENSE file.
           return !sha || sha === 'latest';
         }
 
-        computeTestRunQueryParams(sha, aligned, labels, productSpecs, maxCount) {
+        computeTestRunQueryParams(sha, aligned, labels, productSpecs, maxCount, from, to) {
           const params = {};
           if (!this.computeIsLatest(sha)) {
             params.sha = sha;
@@ -92,6 +94,12 @@ found in the LICENSE file.
           }
           if (aligned) {
             params.aligned = true;
+          }
+          if (from) {
+            params.from = from.toISOString();
+          }
+          if (to) {
+            params.to = to.toISOString();
           }
 
           // Collapse a globally shared channel into a single label.

--- a/webapp/components/test-runs.html
+++ b/webapp/components/test-runs.html
@@ -26,10 +26,6 @@ found in the LICENSE file.
             type: String,
             computed: 'encodeTestPath(path)'
           },
-          // URLs for TestRuns to load.
-          testRunResources: {
-            type: Array
-          },
           // Fetched + parsed JSON blobs for the runs
           testRuns: {
             type: Array,
@@ -75,13 +71,6 @@ found in the LICENSE file.
         if (this.productSpecs && this.productSpecs.length) {
           runs.push(fetch(`/api/runs${this.testRunQuery}`)
             .then(r => r.ok && r.json()));
-        }
-        // Fetch by specific URLs (legacy behaviour)
-        if (this.testRunResources) {
-          const byUrl = this.testRunResources
-            .map(url => fetch(url).then(r => r.ok && r.json()));
-          runs.push(...byUrl);
-          this.testRunResources = null;
         }
         const fetches = await Promise.all(runs);
 

--- a/webapp/components/test/test-runs.html
+++ b/webapp/components/test/test-runs.html
@@ -40,11 +40,6 @@
       });
 
       suite('static get properties()', () => {
-        test('testRunResources', () => {
-          assert.property(TestRunsBase.properties, 'testRunResources');
-          assert.property(TestRunsBase.properties.testRunResources, 'type');
-          assert.equal(TestRunsBase.properties.testRunResources.type, Array);
-        });
         test('testRuns', () => {
           assert.property(TestRunsBase.properties, 'testRuns');
           assert.property(TestRunsBase.properties.testRuns, 'type');
@@ -79,14 +74,6 @@
               .then(() => {
                 assert.equal(wrbf.testRuns.length, 4);
                 assert.equal(wrbf.testRuns[0], TEST_RUNS_DATA[0]);
-              });
-          });
-
-          test('sets testRunResources to null when done', () => {
-            assert.equal(wrbf.testRuns, null);
-            return waitingOn(() => wrbf.testRuns && wrbf.testRuns.length)
-              .then(() => {
-                assert.equal(wrbf.testRunResources, null);
               });
           });
         });

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -302,7 +302,7 @@ found in the LICENSE file.
     /* global TestRunsBase, SelfNavigation, LoadingState, ResultsNavigation, WPTFlags */
     class WPTResults extends ResultsNavigation(
       WPTFlags(SelfNavigation(LoadingState(TestRunsBase))),
-      'resultsQueryParams(sha, aligned, labels, productSpecs, maxCount, diff, search)') {
+      'resultsQueryParams(sha, aligned, labels, productSpecs, maxCount, from, to, diff, search)') {
 
       static get is() {
         return 'wpt-results';

--- a/webapp/interop_handler.go
+++ b/webapp/interop_handler.go
@@ -6,16 +6,21 @@ package webapp
 
 import (
 	"net/http"
+
+	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
 // interopHandler handles the view of test results broken down by the
 // number of browsers for which the test passes.
 func interopHandler(w http.ResponseWriter, r *http.Request) {
-	uiFilters, err := parseTestRunUIFilter(r)
+	testRunFilter, err := shared.ParseTestRunFilterParams(r)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+	testRunFilter = testRunFilter.OrDefault()
+
+	uiFilters := parseTestRunUIFilter(testRunFilter)
 
 	data := struct {
 		Metadata string

--- a/webapp/templates/_test_run_query_params.html
+++ b/webapp/templates/_test_run_query_params.html
@@ -1,0 +1,7 @@
+          {{- if .Products}} product-specs="{{ .Products }}"{{end}}
+          {{- if .SHA}} sha="{{ .SHA }}" {{end}}
+          {{- if .Labels}} labels="{{ .Labels }}"{{end}}
+          {{- if .MaxCount}} max-count="{{ .MaxCount }}"{{end}}
+          {{- if .From}} from="{{ .From }}"{{end}}
+          {{- if .To}} to="{{ .To }}"{{end}}
+          {{- if .Aligned}} aligned{{end}}

--- a/webapp/templates/results.html
+++ b/webapp/templates/results.html
@@ -6,13 +6,9 @@
   {{ template "_header.html" }}
   <div>
     <wpt-results
+        {{ template "_test_run_query_params.html" .Filter }}
         {{- with .Filter}}
-          {{- if .Products}} product-specs="{{ .Products }}"{{end}}
-          {{- if .SHA}} sha="{{ .SHA }}" {{end}}
-          {{- if .Labels}} labels="{{ .Labels }}"{{end}}
-          {{- if .MaxCount}} max-count="{{ .MaxCount }}"{{end}}
           {{- if .Diff}} diff{{end}}
-          {{- if .Aligned}} aligned{{end}}
         {{- end}}
         {{- if .Query }} search="{{.Query}}"{{end}}></wpt-results>
   </div>

--- a/webapp/templates/test-runs.html
+++ b/webapp/templates/test-runs.html
@@ -9,7 +9,7 @@
 <div id="content">
   {{ template "_header.html" }}
   <div>
-    <wpt-runs test-run-resources="{{ .TestRunSources }}"></wpt-runs>
+    <wpt-runs {{ template "_test_run_query_params.html" .Filter }}></wpt-runs>
   </div>
 </div>
 {{ template "_ga.html" }}

--- a/webapp/test_results_handler_test.go
+++ b/webapp/test_results_handler_test.go
@@ -13,24 +13,24 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestParseTestRunUIFilter(t *testing.T) {
-	f, err := parseTestRunUIFilter(httptest.NewRequest("GET", "/results/?max-count=3", nil))
+func TestParseTestResultsUIFilter(t *testing.T) {
+	f, err := parseTestResultsUIFilter(httptest.NewRequest("GET", "/results/?max-count=3", nil))
 	assert.Nil(t, err)
 	assert.True(t, f.MaxCount != nil && *f.MaxCount == 3)
 
-	f, err = parseTestRunUIFilter(httptest.NewRequest("GET", "/results/?products=chrome,safari&diff", nil))
+	f, err = parseTestResultsUIFilter(httptest.NewRequest("GET", "/results/?products=chrome,safari&diff", nil))
 	assert.Nil(t, err)
 	assert.Equal(t, "[\"chrome\",\"safari\"]", f.Products)
 	assert.Equal(t, true, f.Diff)
 }
 
-func TestParseTestRunUIFilter_BeforeAfter(t *testing.T) {
-	f, err := parseTestRunUIFilter(httptest.NewRequest("GET", "/results/?before=chrome&after=chrome[experimental]", nil))
+func TestParseTestResultsUIFilter_BeforeAfter(t *testing.T) {
+	f, err := parseTestResultsUIFilter(httptest.NewRequest("GET", "/results/?before=chrome&after=chrome[experimental]", nil))
 	assert.Nil(t, err)
 	assert.Equal(t, "[\"chrome\",\"chrome[experimental]\"]", f.Products)
 	assert.Equal(t, true, f.Diff)
 
-	f, err = parseTestRunUIFilter(httptest.NewRequest("GET", "/results/?after=chrome&before=edge", nil))
+	f, err = parseTestResultsUIFilter(httptest.NewRequest("GET", "/results/?after=chrome&before=edge", nil))
 	assert.Nil(t, err)
 	assert.Equal(t, "[\"edge\",\"chrome\"]", f.Products)
 	assert.Equal(t, true, f.Diff)


### PR DESCRIPTION
## Description
Fixes https://github.com/web-platform-tests/wpt.fyi/issues/656

- Changes the UI query param plumbing to include `to` and `from` RFC3339 timestamp params
- Plumbs the default, 1-month `from` param value in `/test-runs` UI
- Deletes the now-unused `test-run-resources` full-url attribute that was causing a double-fetch

## Review Information
Open the devtools, visit /test-runs, observe a single fetch to the `/api/runs` endpoint (with a from param)