### PR TITLE
Fix function/property name clash

### DIFF
--- a/webapp/components/test-runs-query.html
+++ b/webapp/components/test-runs-query.html
@@ -74,10 +74,6 @@ found in the LICENSE file.
           this.productSpecs = (products || []).map(p => this.getSpec(p));
         }
 
-        computeIsLatest(sha) {
-          return !sha || sha === 'latest';
-        }
-
         computeTestRunQueryParams(sha, aligned, labels, productSpecs, maxCount) {
           const params = {};
           if (!this.computeIsLatest(sha)) {


### PR DESCRIPTION
## Description
Fixes /results on staging for any product-spec query that includes a SHA (e.g. /results?product=chrome@latest).