### PR TITLE
Handle multiple labels for products

### DIFF
--- a/shared/params.go
+++ b/shared/params.go
@@ -383,8 +383,8 @@ func ParseProductsParam(r *http.Request) (ProductSpecs, error) {
 	repeatedParam := r.URL.Query()["product"]
 	pluralParam := r.URL.Query().Get("products")
 	// Replace nested ',' in the label part with a placeholder
-	nestedCommas := regexp.MustCompile("(\\[[^\\]]*),")
-	const comma = "%COMMA%"
+	nestedCommas := regexp.MustCompile(`(\[[^\]]*),`)
+	const comma = `%COMMA%`
 	for nestedCommas.MatchString(pluralParam) {
 		pluralParam = nestedCommas.ReplaceAllString(pluralParam, "$1"+comma)
 	}

--- a/shared/params.go
+++ b/shared/params.go
@@ -380,9 +380,21 @@ func ParseProductParam(r *http.Request) (product *Product, err error) {
 // It parses the 'products' parameter, split on commas, and also checks for the (repeatable)
 // 'product' params.
 func ParseProductsParam(r *http.Request) (ProductSpecs, error) {
-	productParams := ParseRepeatedParam(r, "product", "products")
+	repeatedParam := r.URL.Query()["product"]
+	pluralParam := r.URL.Query().Get("products")
+	// Replace nested ',' in the label part with a placeholder
+	nestedCommas := regexp.MustCompile("(\\[[^\\]]*),")
+	const comma = "%COMMA%"
+	for nestedCommas.MatchString(pluralParam) {
+		pluralParam = nestedCommas.ReplaceAllString(pluralParam, "$1"+comma)
+	}
+	productParams := parseRepeatedParamValues(repeatedParam, pluralParam)
 	if productParams == nil {
 		return nil, nil
+	}
+	// Revert placeholder to ',' and parse.
+	for i := range productParams {
+		productParams[i] = strings.Replace(productParams[i], comma, ",", -1)
 	}
 	return ParseProductSpecs(productParams...)
 }
@@ -529,6 +541,10 @@ func ParseLabelsParam(r *http.Request) []string {
 func ParseRepeatedParam(r *http.Request, singular string, plural string) (params []string) {
 	repeatedParam := r.URL.Query()[singular]
 	pluralParam := r.URL.Query().Get(plural)
+	return parseRepeatedParamValues(repeatedParam, pluralParam)
+}
+
+func parseRepeatedParamValues(repeatedParam []string, pluralParam string) (params []string) {
 	if len(repeatedParam) == 0 && pluralParam == "" {
 		return nil
 	}

--- a/shared/params_test.go
+++ b/shared/params_test.go
@@ -407,6 +407,22 @@ func TestParseProductSpec_String(t *testing.T) {
 	assert.Equal(t, "chrome-64[bar,foo]@1234512345", productSpec.String())
 }
 
+func TestParseProductSpec_Plural(t *testing.T) {
+	r := httptest.NewRequest("GET", "http://wpt.fyi/api/runs?products=chrome[stable],chrome[experimental]", nil)
+	products, err := ParseProductsParam(r)
+	assert.Nil(t, err)
+	assert.Len(t, products, 2)
+	assert.Equal(t, "chrome[stable]", products[0].String())
+	assert.Equal(t, "chrome[experimental]", products[1].String())
+
+	r = httptest.NewRequest("GET", "http://wpt.fyi/api/runs?products=chrome[foo,bar,baz],chrome[qux]", nil)
+	products, err = ParseProductsParam(r)
+	assert.Nil(t, err)
+	assert.Len(t, products, 2)
+	assert.Equal(t, "chrome[bar,baz,foo]", products[0].String()) // Labels alphabeticized.
+	assert.Equal(t, "chrome[qux]", products[1].String())
+}
+
 func TestParseAligned(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/api/runs", nil)
 	aligned, _ := ParseAlignedParam(r)


### PR DESCRIPTION
## Description
Step towards resolving https://github.com/web-platform-tests/wpt.fyi/issues/639

Hackily avoids having to properly parse multiple `products` values by replacing the nested commas temporarily.