### PR TITLE
Iterate keys instead of fetching

### DIFF
--- a/shared/datastore.go
+++ b/shared/datastore.go
@@ -79,16 +79,12 @@ func LoadTestRunKeys(
 				break
 			} else if err != nil {
 				return result, err
+			} else if (limit != nil && *limit <= len(keys)) || len(keys) >= MaxCountMaxValue {
+				break
+			} else if prefiltered != nil && !(*prefiltered).Contains(key.String()) {
+				continue
 			}
-			if (limit == nil || *limit > len(keys)) && len(keys) < MaxCountMaxValue {
-				if prefiltered == nil || (*prefiltered).Contains(key.String()) {
-					keys = append(keys, key)
-				}
-			}
-		}
-
-		if limit != nil && len(keys) > *limit {
-			keys = keys[:*limit]
+			keys = append(keys, key)
 		}
 		result = append(result, keys...)
 	}

--- a/shared/datastore.go
+++ b/shared/datastore.go
@@ -79,7 +79,7 @@ func LoadTestRunKeys(
 				break
 			} else if err != nil {
 				return result, err
-			} else if (limit != nil && *limit <= len(keys)) || len(keys) >= MaxCountMaxValue {
+			} else if (limit != nil && len(keys) >= *limit) || len(keys) >= MaxCountMaxValue {
 				break
 			} else if prefiltered != nil && !(*prefiltered).Contains(key.String()) {
 				continue


### PR DESCRIPTION
## Description
Re-fixes #https://github.com/web-platform-tests/wpt.fyi/issues/587 without fixed-limiting the key count.
Fixes https://github.com/web-platform-tests/wpt.fyi/issues/671

Fixes #569 and might help #570 too...

## Review Information
/api/runs?product=chrome-68