### PR TITLE
Fall back to default max count

### DIFF
--- a/webapp/test_runs_handler.go
+++ b/webapp/test_runs_handler.go
@@ -28,6 +28,9 @@ func testRunsHandler(w http.ResponseWriter, r *http.Request) {
 	if testRunFilter.IsDefaultQuery() {
 		aMonthAgo := time.Now().Truncate(time.Hour*24).AddDate(0, -1, 0)
 		testRunFilter.From = &aMonthAgo
+	} else if testRunFilter.MaxCount == nil {
+		oneHundred := 100
+		testRunFilter.MaxCount = &oneHundred
 	}
 
 	filter := parseTestRunUIFilter(testRunFilter)


### PR DESCRIPTION
## Description
Use a default `max-count` of 100 for non-default `/runs` queries.

## Review Information
e.g. [/?product=chrome-68](https://test-runs-dot-wptdashboard-staging.appspot.com/runs?product=chrome-68)