### PR TITLE
Handle full SHAs in product specs

### DIFF
--- a/shared/params.go
+++ b/shared/params.go
@@ -202,7 +202,7 @@ func ParseSHAParam(r *http.Request) (runSHA string, err error) {
 }
 
 // ParseSHA validates the given 'sha' value, cropping it to 10 chars.
-// It returns "latest" by default. (and in error cases).
+// It returns "latest" by default (and in error cases).
 func ParseSHA(sha string) (runSHA string, err error) {
 	sha, err = ParseSHAFull(sha)
 	if err != nil || !SHARegex.MatchString(sha) {

--- a/shared/params.go
+++ b/shared/params.go
@@ -215,7 +215,6 @@ func ParseSHA(sha string) (runSHA string, err error) {
 // It returns "latest" by default (and in error cases).
 func ParseSHAParamFull(r *http.Request) (runSHA string, err error) {
 	// Get the SHA for the run being loaded (the first part of the path.)
-	runSHA = "latest"
 	return ParseSHAFull(r.URL.Query().Get("sha"))
 }
 

--- a/shared/params.go
+++ b/shared/params.go
@@ -201,17 +201,29 @@ func ParseSHAParam(r *http.Request) (runSHA string, err error) {
 	return sha[:10], nil
 }
 
+// ParseSHA validates the given 'sha' value, cropping it to 10 chars.
+// It returns "latest" by default. (and in error cases).
+func ParseSHA(sha string) (runSHA string, err error) {
+	sha, err = ParseSHAFull(sha)
+	if err != nil || !SHARegex.MatchString(sha) {
+		return sha, err
+	}
+	return sha[:10], nil
+}
+
 // ParseSHAParamFull parses and validates the 'sha' param for the request.
 // It returns "latest" by default (and in error cases).
 func ParseSHAParamFull(r *http.Request) (runSHA string, err error) {
 	// Get the SHA for the run being loaded (the first part of the path.)
 	runSHA = "latest"
-	params, err := url.ParseQuery(r.URL.RawQuery)
-	if err != nil {
-		return runSHA, err
-	}
+	return ParseSHAFull(r.URL.Query().Get("sha"))
+}
 
-	runParam := params.Get("sha")
+// ParseSHAFull parses and validates the given 'sha'.
+// It returns "latest" by default (and in error cases).
+func ParseSHAFull(runParam string) (runSHA string, err error) {
+	// Get the SHA for the run being loaded (the first part of the path.)
+	runSHA = "latest"
 	if runParam != "" && runParam != "latest" {
 		runSHA = runParam
 		if !SHARegex.MatchString(runParam) {
@@ -245,7 +257,9 @@ func ParseProductSpec(spec string) (productSpec ProductSpec, err error) {
 		return productSpec, errors.New(errMsg)
 	} else if len(atSHAPieces) == 2 {
 		name = atSHAPieces[0]
-		productSpec.Revision = atSHAPieces[1]
+		if productSpec.Revision, err = ParseSHA(atSHAPieces[1]); err != nil {
+			return productSpec, errors.New(errMsg)
+		}
 	}
 	// [foo,bar] labels syntax (optional)
 	labelPieces := strings.Split(name, "[")

--- a/shared/params_test.go
+++ b/shared/params_test.go
@@ -344,6 +344,18 @@ func TestParseProductSpec(t *testing.T) {
 	assert.Equal(t, "edge", productSpec.BrowserName)
 }
 
+func TestParseProductSpec_FullSHA(t *testing.T) {
+	sha := "0123456789aaaaabbbbbcccccdddddeeeeefffff"
+	r := httptest.NewRequest("GET", "http://wpt.fyi/?product=chrome@"+sha, nil)
+	filters, err := ParseTestRunFilterParams(r)
+	assert.Nil(t, err)
+	products := filters.GetProductsOrDefault()
+	assert.Len(t, products, 1)
+	if len(products) > 0 {
+		assert.Equal(t, sha[:10], products[0].Revision)
+	}
+}
+
 func TestParseProductSpec_BrowserVersion(t *testing.T) {
 	productSpec, err := ParseProductSpec("chrome-63.0@latest")
 	assert.Nil(t, err)

--- a/shared/params_test.go
+++ b/shared/params_test.go
@@ -44,13 +44,6 @@ func TestParseSHAParam_FullSHA(t *testing.T) {
 	assert.Equal(t, sha[:10], runSHA)
 }
 
-func TestParseSHAParam_BadRequest(t *testing.T) {
-	r := httptest.NewRequest("GET", "http://wpt.fyi/?sha=%zz", nil)
-	runSHA, err := ParseSHAParam(r)
-	assert.NotNil(t, err)
-	assert.Equal(t, "latest", runSHA)
-}
-
 func TestParseSHAParam_NonSHA(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?sha=123", nil)
 	_, err := ParseSHAParam(r)


### PR DESCRIPTION
## Description
Fixes https://github.com/web-platform-tests/wpt.fyi/issues/672 by re-using Full SHA parsing on the product SHA part.