### PR TITLE
Add icons to the query builder dropdowns

### DIFF
--- a/webapp/components/test-runs-query-builder.html
+++ b/webapp/components/test-runs-query-builder.html
@@ -14,6 +14,7 @@ found in the LICENSE file.
 <link rel="import" href="../bower_components/paper-dropdown-menu/paper-dropdown-menu.html">
 <link rel="import" href="../bower_components/paper-icon-button/paper-icon-button.html">
 <link rel="import" href="../bower_components/paper-input/paper-input.html">
+<link rel="import" href="../bower_components/paper-item/paper-icon-item.html">
 <link rel="import" href="../bower_components/paper-item/paper-item.html">
 <link rel="import" href="../bower_components/paper-listbox/paper-listbox.html">
 <link rel="import" href="../bower_components/paper-checkbox/paper-checkbox.html">
@@ -195,6 +196,9 @@ found in the LICENSE file.
       paper-icon-button {
         float: right;
       }
+      display-logo[small] {
+        margin-top: 16px;
+      }
     </style>
     <paper-card>
       <div class="card-content">
@@ -209,10 +213,12 @@ found in the LICENSE file.
           <br>
           <paper-dropdown-menu label="Browser" no-animations>
             <paper-listbox slot="dropdown-content" selected="{{ browserName }}" attr-for-selected="value">
-              <paper-item value="chrome">[[displayName("chrome")]]</paper-item>
-              <paper-item value="edge">[[displayName("edge")]]</paper-item>
-              <paper-item value="firefox">[[displayName("firefox")]]</paper-item>
-              <paper-item value="safari">[[displayName("safari")]]</paper-item>
+              <template is="dom-repeat" items="[[defaultProducts]]" as="product">
+                <paper-icon-item value="[[product.browser_name]]">
+                  <display-logo slot="item-icon" product="[[product]]" small></display-logo>
+                  [[displayName(product.browser_name)]]
+                </paper-icon-item>
+              </template>
             </paper-listbox>
           </paper-dropdown-menu>
         </template>
@@ -225,10 +231,12 @@ found in the LICENSE file.
           <paper-dropdown-menu label="Channel" no-animations>
             <paper-listbox slot="dropdown-content" selected="{{ _channel }}" attr-for-selected="value">
               <paper-item value="any">Any</paper-item>
-              <paper-item value="stable">[[displayName("stable")]]</paper-item>
-              <paper-item value="beta">[[displayName("beta")]]</paper-item>
-              <paper-item value="dev">[[displayName("dev")]]</paper-item>
-              <paper-item value="experimental">[[displayName("experimental")]]</paper-item>
+              <template is="dom-repeat" items="[[channels]]" as="channel">
+                <paper-icon-item value="[[channel]]">
+                  <display-logo slot="item-icon" product="[[productWithChannel(_product, channel)]]" small></display-logo>
+                  [[displayName(channel)]]
+                </paper-icon-item>
+              </template>
             </paper-listbox>
           </paper-dropdown-menu>
         </template>
@@ -247,7 +255,7 @@ found in the LICENSE file.
     </paper-card>
   </template>
   <script>
-    /* global ProductInfo, CHANNELS, DEFAULT_BROWSER_NAMES */
+    /* global ProductInfo, CHANNELS, DEFAULT_BROWSER_NAMES, DEFAULT_PRODUCTS */
     class ProductBuilder extends ProductInfo(window.Polymer.Element) {
       static get is() {
         return 'product-builder';
@@ -299,6 +307,14 @@ found in the LICENSE file.
           },
           onDelete: Function,
           onProductChanged: Function,
+          defaultProducts: {
+            type: Array,
+            value: Array.from(DEFAULT_PRODUCTS),
+          },
+          channels: {
+            type: Array,
+            value: Array.from(CHANNELS),
+          },
         };
       }
 
@@ -354,6 +370,12 @@ found in the LICENSE file.
           return;
         }
         this.labels = labels;
+      }
+
+      productWithChannel(product, channel) {
+        return Object.assign({}, product, {
+          labels: (product.labels || []).filter(l => !CHANNELS.has(l)).concat(channel)
+        });
       }
     }
 


### PR DESCRIPTION
## Description
More https://github.com/web-platform-tests/wpt.fyi/issues/535 work.

Cosmetic change to include the product icons in the dropdowns.

## Review Information
Toggle the `Product` and `Channel` dropdowns, see icons.