### PR TITLE
Add field for a SHA, with autocomplete

### DIFF
--- a/webapp/components/test-runs-query-builder.html
+++ b/webapp/components/test-runs-query-builder.html
@@ -176,20 +176,23 @@ found in the LICENSE file.
         this.set(`products.${i}`, product);
       }
 
+      // Respond to query changes by computing a new shas URL.
       computeSHAsURL(query) {
         const url = new URL(`/api/shas${query || ''}`, window.location);
         url.searchParams.delete('sha');
         return url;
       }
 
+      // Respond to shas URL changing by fetching the shas
       shasURLUpdated(url) {
         fetch(url).then(r => r.json()).then(s => {
           this.shas = s;
         });
       }
 
+      // Respond to newly fetched shas, or user input, by filtering the autocomplete list.
       shasUpdated(sha, shas) {
-        if (!shas || !this.queryBuilderSHA) {
+        if (!shas || !shas.length || !this.queryBuilderSHA) {
           return;
         }
         if (sha) {
@@ -197,17 +200,9 @@ found in the LICENSE file.
         }
         shas = shas.slice(0, 10);
         // Check actually different from current.
-        const curr = this.shasAutocomplete || [];
-        if (curr.length === shas.length) {
-          let same = true;
-          for (let i = 0; i < shas.length && same; i++) {
-            if (i >= curr.length || shas[i] !== curr[i]) {
-              same = false;
-            }
-          }
-          if (same) {
-            return;
-          }
+        const current = new Set(this.shasAutocomplete || []);
+        if (current.size === shas.length && !shas.find(v => !current.has(v))) {
+          return;
         }
         this.shasAutocomplete = shas;
       }
@@ -503,7 +498,7 @@ found in the LICENSE file.
         versions = versions.slice(0, 10);
         // Check actually different from current.
         const current = new Set(this.versionsAutocomplete || []);
-        if (!versions.find(v => !current.has(v))) {
+        if (current.size === versions.length && !versions.find(v => !current.has(v))) {
           return;
         }
         this.versionsAutocomplete = versions;

--- a/webapp/components/test-runs-query-builder.html
+++ b/webapp/components/test-runs-query-builder.html
@@ -69,7 +69,7 @@ found in the LICENSE file.
       </template>
     </div>
     <paper-item>
-      <paper-checkbox id="aligned-checkbox">Align runs</paper-checkbox>
+      <paper-checkbox id="aligned-checkbox" checked="{{aligned}}">Align runs</paper-checkbox>
     </paper-item>
     <paper-item>
       <paper-input label="Labels"

--- a/webapp/components/test-runs-query-builder.html
+++ b/webapp/components/test-runs-query-builder.html
@@ -21,6 +21,7 @@ found in the LICENSE file.
 <link rel="import" href="./info-banner.html">
 <link rel="import" href="./product-info.html">
 <link rel="import" href="./test-runs-query.html">
+<link rel="import" href="./wpt-flags.html">
 
 <dom-module id="test-runs-query-builder">
   <template>
@@ -77,6 +78,19 @@ found in the LICENSE file.
                    value="{{ labelsString::input }}">
       </paper-input>
     </paper-item>
+    <template is="dom-if" if="[[queryBuilderSHA]]">
+      <paper-item>
+        <paper-input-container always-float-label>
+          <label slot="label">SHA</label>
+          <input name="os_version"
+                 placeholder="(Latest)"
+                 list="shas-datalist"
+                 value="{{ sha::input }}"
+                 slot="input">
+          <datalist id="shas-datalist"></datalist>
+        </paper-input-container>
+      </paper-item>
+    </template>
     <br>
     <paper-button raised id="add-button" onclick="[[addProduct]]">
       <iron-icon icon="add"></iron-icon> Add product
@@ -93,8 +107,8 @@ found in the LICENSE file.
      * Base class for re-use of results-fetching behaviour, between
      * multi-item (wpt-results) and single-test (test-file-results) views.
      */
-    /* global TestRunsQuery, DEFAULT_BROWSER_NAMES */
-    class TestRunsQueryBuilder extends TestRunsQuery(window.Polymer.Element) {
+    /* global WPTFlags, TestRunsQuery, DEFAULT_BROWSER_NAMES */
+    class TestRunsQueryBuilder extends WPTFlags(TestRunsQuery(window.Polymer.Element)) {
       static get is() {
         return 'test-runs-query-builder';
       }
@@ -113,6 +127,18 @@ found in the LICENSE file.
           labelsString: {
             type: String,
             observer: 'labelsStringUpdated',
+          },
+          shasURL: {
+            type: String,
+            computed: 'computeSHAsURL(testRunQuery)',
+            observer: 'shasURLUpdated',
+          },
+          shas: {
+            type: Array,
+          },
+          shasAutocomplete: {
+            type: Array,
+            observer: 'shasAutocompleteUpdated'
           },
         };
       }
@@ -136,6 +162,7 @@ found in the LICENSE file.
           this.onSubmit && this.onSubmit();
         };
         this._createMethodObserver('labelsUpdated(labels, labels.*)');
+        this._createMethodObserver('shasUpdated(sha, shas)');
       }
 
       onToggleEdit() {
@@ -148,6 +175,52 @@ found in the LICENSE file.
 
       handleProductChanged(i, product) {
         this.set(`products.${i}`, product);
+      }
+
+      computeSHAsURL(query) {
+        const url = new URL(`/api/shas${query || ''}`, window.location);
+        url.searchParams.delete('sha');
+        return url;
+      }
+
+      shasURLUpdated(url) {
+        fetch(url).then(r => r.json()).then(s => {
+          this.shas = s;
+        });
+      }
+
+      shasUpdated(sha, shas) {
+        if (!shas || !this.queryBuilderSHA) {
+          return;
+        }
+        if (sha) {
+          shas = shas.filter(s => s.startsWith(sha));
+        }
+        shas = shas.slice(0, 10);
+        // Check actually different from current.
+        const curr = this.shasAutocomplete || [];
+        if (curr.length === shas.length) {
+          let same = true;
+          for (let i = 0; i < shas.length && same; i++) {
+            if (i >= curr.length || shas[i] !== curr[i]) {
+              same = false;
+            }
+          }
+          if (same) {
+            return;
+          }
+        }
+        this.shasAutocomplete = shas;
+      }
+
+      shasAutocompleteUpdated(shasAutocomplete) {
+        const datalist = this.shadowRoot.querySelector('datalist');
+        datalist.innerHTML = '';
+        for (const sha of shasAutocomplete) {
+          const option = document.createElement('option');
+          option.setAttribute('value', sha);
+          datalist.appendChild(option);
+        }
       }
 
       labelsUpdated(labels) {

--- a/webapp/components/test-runs-query-builder.html
+++ b/webapp/components/test-runs-query-builder.html
@@ -69,7 +69,7 @@ found in the LICENSE file.
       </template>
     </div>
     <paper-item>
-      <paper-checkbox checked="{{aligned}}">Align runs</paper-checkbox>
+      <paper-checkbox id="aligned-checkbox">Align runs</paper-checkbox>
     </paper-item>
     <paper-item>
       <paper-input label="Labels"

--- a/webapp/components/test-runs-query.html
+++ b/webapp/components/test-runs-query.html
@@ -139,7 +139,7 @@ found in the LICENSE file.
           this.products = DEFAULT_PRODUCTS.map(p => Object.assign({}, p));
           this.labels = [];
           this.maxCount = undefined;
-          this.sha = 'latest';
+          this.sha = '';
           this.aligned = undefined;
         }
 

--- a/webapp/components/test-runs-query.html
+++ b/webapp/components/test-runs-query.html
@@ -136,49 +136,57 @@ found in the LICENSE file.
             || DEFAULT_PRODUCT_SPECS.join(',') === (productSpecs || []).join(',');
         }
 
+        get emptyQuery() {
+          return {
+            products: DEFAULT_PRODUCTS.map(p => Object.assign({}, p)),
+            labels: [],
+            maxCount: undefined,
+            sha: '',
+            aligned: undefined,
+          };
+        }
+
         clearQuery() {
-          this.products = DEFAULT_PRODUCTS.map(p => Object.assign({}, p));
-          this.labels = [];
-          this.maxCount = undefined;
-          this.sha = '';
-          this.aligned = undefined;
+          this.setProperties(this.emptyQuery);
         }
 
         /**
          * Update this builder's properties to match the given query params.
          */
         updateQueryParams(params) {
-          this.clearQuery();
           if (!params) {
+            this.clearQuery();
             return;
           }
+          const batchUpdate = this.emptyQuery;
           if (!this.computeIsLatest(params.sha)) {
-            this.sha = params.sha;
+            batchUpdate.sha = params.sha;
           }
           if ('product' in params) {
-            this.products = params.product.map(p => this.parseProductSpec(p));
+            batchUpdate.products = params.product.map(p => this.parseProductSpec(p));
           }
           // Expand any global channel labels into the separate products
           let sharedChannel;
           if ('label' in params) {
             sharedChannel = params.label.find(l => CHANNELS.has(l));
-            this.labels = params.label.filter(l => !CHANNELS.has(l));
+            batchUpdate.labels = params.label.filter(l => !CHANNELS.has(l));
           }
           if (sharedChannel) {
-            for (const i in this.products) {
-              const labels = this.products[i].labels.filter(l => !CHANNELS.has(l) || l === sharedChannel);
-              if (!this.products[i].labels.includes(sharedChannel)) {
+            for (const i in batchUpdate.products) {
+              const labels = batchUpdate.products[i].labels.filter(l => !CHANNELS.has(l) || l === sharedChannel);
+              if (!batchUpdate.products[i].labels.includes(sharedChannel)) {
                 labels.push(sharedChannel);
               }
-              this.set(`products.${i}.labels`, labels);
+              batchUpdate.products[i].labels = labels;
             }
           }
           if ('max-count' in params) {
-            this.maxCount = params['max-count'];
+            batchUpdate.maxCount = params['max-count'];
           }
           if ('aligned' in params) {
-            this.aligned = params.aligned;
+            batchUpdate.aligned = params.aligned;
           }
+          this.setProperties(batchUpdate);
         }
       };
   </script>

--- a/webapp/components/test-runs-query.html
+++ b/webapp/components/test-runs-query.html
@@ -88,9 +88,6 @@ found in the LICENSE file.
           if (maxCount) {
             params['max-count'] = maxCount;
           }
-          if (aligned) {
-            params.aligned = true;
-          }
           if (from) {
             params.from = from.toISOString();
           }
@@ -122,6 +119,10 @@ found in the LICENSE file.
             if (!this.computeIsDefaultProducts(productSpecs)) {
               params.product = productSpecs;
             }
+          }
+          // Requesting a specific SHA makes aligned redundant.
+          if (aligned && this.computeIsLatest(sha)) {
+            params.aligned = true;
           }
           return params;
         }

--- a/webapp/components/test/test-runs-query-builder.html
+++ b/webapp/components/test/test-runs-query-builder.html
@@ -29,9 +29,19 @@
     /* global CHANNELS */
     document.addEventListener('WebComponentsReady', () => {
       suite('TestRunsQueryBuilder', () => {
-        let queryBuilder;
+        let queryBuilder, sandbox;
 
         setup(() => {
+          sandbox = sinon.sandbox.create();
+          // Spoof an empty result for /api/shas to speed up tests.
+          const realFetch = window.fetch;
+          sandbox.stub(window, 'fetch', url => {
+            if (url.pathname === '/api/shas') {
+              return Promise.resolve(new Response('[]'));
+            }
+            return realFetch(url);
+          });
+
           queryBuilder = fixture('query-builder-fixture');
           queryBuilder.products = ['chrome', 'edge']
             .map(s => queryBuilder.parseProductSpec(s));
@@ -76,6 +86,13 @@
           queryBuilder.aligned = false;
           expect(queryBuilder.testRunQuery).to.not.contain('aligned');
           queryBuilder.aligned = true;
+          expect(queryBuilder.testRunQuery).to.contain('aligned');
+
+          const alignedCB = queryBuilder.shadowRoot.querySelector('#aligned-checkbox');
+          expect(alignedCB.checked).to.be.true;
+          alignedCB.checked = false;
+          expect(queryBuilder.testRunQuery).to.not.contain('aligned');
+          alignedCB.checked = true;
           expect(queryBuilder.testRunQuery).to.contain('aligned');
         });
 
@@ -142,6 +159,10 @@
             sandbox.restore();
             queryBuilder.queryBuilderSHA = queryBuilderSHAState;
           });
+        });
+
+        teardown(() => {
+          sandbox.restore();
         });
       });
 

--- a/webapp/components/test/test-runs-query-builder.html
+++ b/webapp/components/test/test-runs-query-builder.html
@@ -111,6 +111,15 @@
             });
           }
         });
+
+        test('sha', () => {
+          const sha = '1234567890';
+          queryBuilder.sha = sha;
+          expect(queryBuilder.testRunQuery).to.contain(`sha=${sha}`);
+
+          queryBuilder.sha = 'latest';
+          expect(queryBuilder.testRunQuery).to.not.contain('sha');
+        });
       });
 
       suite('ProductBuilder', () => {

--- a/webapp/components/test/test-runs-query-builder.html
+++ b/webapp/components/test/test-runs-query-builder.html
@@ -120,6 +120,29 @@
           queryBuilder.sha = 'latest';
           expect(queryBuilder.testRunQuery).to.not.contain('sha');
         });
+
+        suite('shas autocomplete', () => {
+          let sandbox, queryBuilderSHAState;
+
+          setup(() => {
+            sandbox = sinon.sandbox.create();
+            sandbox.spy(queryBuilder, 'shasURLUpdated');
+
+            queryBuilderSHAState = queryBuilder.queryBuilderSHA;
+            queryBuilder.queryBuilderSHA = true;
+          });
+
+          test('/api/shas fetches', () => {
+            // Should only trigger a single update, in spite of many params changing.
+            queryBuilder.updateQueryParams({ product: ['chrome'], aligned: true, label: ['dev'] });
+            expect(queryBuilder.shasURLUpdated.callCount).to.equal(1);
+          });
+
+          teardown(() => {
+            sandbox.restore();
+            queryBuilder.queryBuilderSHA = queryBuilderSHAState;
+          });
+        });
       });
 
       suite('ProductBuilder', () => {

--- a/webapp/components/test/test-runs-query.html
+++ b/webapp/components/test/test-runs-query.html
@@ -136,14 +136,19 @@
               ];
               expect(testRunsQuery.testRunQueryParams.product).to.contain(`${DEFAULT_PRODUCTS[0].browser_name}[experimental]`);
               expect(testRunsQuery.testRunQueryParams.product).to.contain(`${DEFAULT_PRODUCTS[1].browser_name}[stable]`);
-            })
+            });
+
+            test('aligned', () => {
+              testRunsQuery.aligned = true;
+              expect(testRunsQuery.testRunQueryParams.aligned).to.be.true;
+            });
 
             test('sha', () => {
               testRunsQuery.sha = '1234567890';
               testRunsQuery.aligned = true;
               expect(testRunsQuery.testRunQueryParams.sha).to.equal(testRunsQuery.sha);
               expect(testRunsQuery.testRunQueryParams.aligned).to.not.be.defined;
-            })
+            });
           });
         });
       });

--- a/webapp/components/test/test-runs-query.html
+++ b/webapp/components/test/test-runs-query.html
@@ -128,13 +128,22 @@
             });
           });
 
-          test('testRunQueryParams', () => {
-            testRunsQuery.products = [
-              Object.assign({}, DEFAULT_PRODUCTS[0], { labels: ['experimental'] }),
-              Object.assign({}, DEFAULT_PRODUCTS[1], { labels: ['stable'] })
-            ];
-            expect(testRunsQuery.testRunQueryParams.product).to.contain(`${DEFAULT_PRODUCTS[0].browser_name}[experimental]`);
-            expect(testRunsQuery.testRunQueryParams.product).to.contain(`${DEFAULT_PRODUCTS[1].browser_name}[stable]`);
+          suite('testRunQueryParams', () => {
+            test('products', () => {
+              testRunsQuery.products = [
+                Object.assign({}, DEFAULT_PRODUCTS[0], { labels: ['experimental'] }),
+                Object.assign({}, DEFAULT_PRODUCTS[1], { labels: ['stable'] })
+              ];
+              expect(testRunsQuery.testRunQueryParams.product).to.contain(`${DEFAULT_PRODUCTS[0].browser_name}[experimental]`);
+              expect(testRunsQuery.testRunQueryParams.product).to.contain(`${DEFAULT_PRODUCTS[1].browser_name}[stable]`);
+            })
+
+            test('sha', () => {
+              testRunsQuery.sha = '1234567890';
+              testRunsQuery.aligned = true;
+              expect(testRunsQuery.testRunQueryParams.sha).to.equal(testRunsQuery.sha);
+              expect(testRunsQuery.testRunQueryParams.aligned).to.not.be.defined;
+            })
           });
         });
       });

--- a/webapp/components/test/test-runs-query.html
+++ b/webapp/components/test/test-runs-query.html
@@ -161,15 +161,15 @@
             });
           });
         });
-      });
 
-      suite('TestRunsUIQuery.prototype.*', () => {
-        test('diff', () => {
-          testRunsUIQuery.diff = true;
-          expect(testRunsUIQuery.query).to.contain('diff');
+        suite('TestRunsUIQuery.prototype.*', () => {
+          test('diff', () => {
+            testRunsUIQuery.diff = true;
+            expect(testRunsUIQuery.query).to.contain('diff');
 
-          testRunsUIQuery.diff = false;
-          expect(testRunsUIQuery.query).to.not.contain('diff');
+            testRunsUIQuery.diff = false;
+            expect(testRunsUIQuery.query).to.not.contain('diff');
+          });
         });
       });
 

--- a/webapp/components/wpt-flags.html
+++ b/webapp/components/wpt-flags.html
@@ -14,7 +14,12 @@ found in the LICENSE file.
 -->
 <dom-module id="wpt-flags">
   <script>
-    const WPT_FYI_FEATURES = ['queryBuilder', 'diffFromAPI', 'diffFilter'];
+    const WPT_FYI_FEATURES = [
+      'queryBuilder',
+      'queryBuilderSHA',
+      'diffFromAPI',
+      'diffFilter',
+    ];
 
     const _wptFlags = (superClass, readOnly) => class extends superClass {
       static get is() {
@@ -52,6 +57,11 @@ found in the LICENSE file.
       <paper-checkbox checked="{{queryBuilder}}">
         Query Builder component
       </paper-checkbox>
+      <paper-item>
+        <paper-checkbox checked="{{queryBuilderSHA}}">
+          SHA input
+        </paper-checkbox>
+      </paper-item>
     </paper-item>
     <paper-item>
       <paper-checkbox checked="{{diffFromAPI}}">

--- a/webapp/components/wpt-flags.html
+++ b/webapp/components/wpt-flags.html
@@ -53,15 +53,20 @@ found in the LICENSE file.
 
 <dom-module id="wpt-flags-editor">
   <template>
+    <style>
+      paper-item[sub-item] {
+        margin-left: 32px;
+      }
+    </style>
     <paper-item>
       <paper-checkbox checked="{{queryBuilder}}">
         Query Builder component
       </paper-checkbox>
-      <paper-item>
-        <paper-checkbox checked="{{queryBuilderSHA}}">
-          SHA input
-        </paper-checkbox>
-      </paper-item>
+    </paper-item>
+    <paper-item sub-item>
+      <paper-checkbox checked="{{queryBuilderSHA}}">
+        SHA input
+      </paper-checkbox>
     </paper-item>
     <paper-item>
       <paper-checkbox checked="{{diffFromAPI}}">


### PR DESCRIPTION
## Description
Starting towards #687 (for the all-the-same SHA case)

Adds a WPT flag for `queryBuilderSHA` which supports fetching the `/api/shas` endpoint for the current query, and populating the autocomplete of the SHA field using possibilities.

## Review Information
Visit `/flags`, enable both `queryBuilder` and `queryBuilderSHA`, type stuff.
