### PR TITLE
Add /api/versions endpoint

### DIFF
--- a/api/routes.go
+++ b/api/routes.go
@@ -23,6 +23,9 @@ func RegisterRoutes() {
 	// API endpoint for listing SHAs for the test runs.
 	shared.AddRoute("/api/shas", "api-shas", shared.WrapPermissiveCORS(apiSHAsHandler))
 
+	// API endpoint for listing SHAs for the test runs.
+	shared.AddRoute("/api/versions", "api-versions", shared.WrapPermissiveCORS(apiVersionsHandler))
+
 	// API endpoints for a single test run, by
 	// ID:
 	shared.AddRoute("/api/runs/{id}", "api-test-run", shared.WrapPermissiveCORS(apiTestRunHandler))

--- a/api/versions.go
+++ b/api/versions.go
@@ -27,15 +27,14 @@ func apiVersionsHandler(w http.ResponseWriter, r *http.Request) {
 
 	ctx := shared.NewAppEngineContext(r)
 	query := datastore.NewQuery("TestRun").Filter("BrowserName =", product.BrowserName)
+	distinctQuery := query.Project("BrowserVersion").Distinct()
 	var queries []*datastore.Query
 	if product.BrowserVersion == "" {
-		queries = []*datastore.Query{query}
+		queries = []*datastore.Query{distinctQuery}
 	} else {
 		queries = []*datastore.Query{
 			query.Filter("BrowserVersion =", product.BrowserVersion).Limit(1),
-			shared.VersionPrefix(query, "BrowserVersion", product.BrowserVersion, false /*desc*/).
-				Project("BrowserVersion").
-				Distinct(),
+			shared.VersionPrefix(distinctQuery, "BrowserVersion", product.BrowserVersion, false /*desc*/),
 		}
 	}
 

--- a/api/versions.go
+++ b/api/versions.go
@@ -1,0 +1,67 @@
+// Copyright 2017 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+
+	"github.com/web-platform-tests/wpt.fyi/shared"
+	"google.golang.org/appengine/datastore"
+)
+
+// apiVersionsHandler is responsible for emitting just the browser versions for the test runs.
+func apiVersionsHandler(w http.ResponseWriter, r *http.Request) {
+	product, err := shared.ParseProductParam(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	} else if product == nil {
+		http.Error(w, fmt.Sprintf("Invalid product param: %s", r.URL.Query().Get("product")), http.StatusBadRequest)
+		return
+	}
+
+	ctx := shared.NewAppEngineContext(r)
+	query := datastore.NewQuery("TestRun").Filter("BrowserName =", product.BrowserName)
+	queries := []*datastore.Query{query}
+	if product.BrowserVersion != "" {
+		queries = make([]*datastore.Query, 2)
+		queries[0] = query.Filter("BrowserVersion =", product.BrowserVersion).Limit(1)
+		queries[1] = shared.VersionPrefix(query, "BrowserVersion", product.BrowserVersion, false).
+			Project("BrowserVersion").
+			Distinct()
+	}
+
+	var runs shared.TestRuns
+	for _, query := range queries {
+		var someRuns shared.TestRuns
+		if _, err := query.GetAll(ctx, &someRuns); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		runs = append(runs, someRuns...)
+	}
+
+	if len(runs) < 1 {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte("[]"))
+		return
+	}
+
+	versions := make([]string, len(runs))
+	for i := range runs {
+		versions[i] = runs[i].BrowserVersion
+	}
+	sort.Sort(sort.Reverse(sort.StringSlice(versions)))
+
+	versionsBytes, err := json.Marshal(versions)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Write(versionsBytes)
+}

--- a/api/versions_medium_test.go
+++ b/api/versions_medium_test.go
@@ -33,7 +33,7 @@ func TestApiVersionsHandler(t *testing.T) {
 	json.Unmarshal(bytes, &versions)
 	assert.Equal(t, []string{}, versions)
 
-	// Add test runs (duplicating 1.1 is deliberate)
+	// Add test runs (duplicating 1.1 is deliberate).
 	someVersions := []string{"2", "1.1.1", "1.1", "1.1", "1.0", "1"}
 	run := shared.TestRun{}
 	browserNames := shared.GetDefaultBrowserNames()

--- a/api/versions_medium_test.go
+++ b/api/versions_medium_test.go
@@ -1,0 +1,78 @@
+// +build medium
+
+package api
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/web-platform-tests/wpt.fyi/shared"
+	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
+	"google.golang.org/appengine/datastore"
+)
+
+func TestApiVersionsHandler(t *testing.T) {
+	i, err := sharedtest.NewAEInstance(true)
+	assert.Nil(t, err)
+	defer i.Close()
+	r, err := i.NewRequest("GET", "/api/versions", nil)
+	assert.Nil(t, err)
+	ctx := shared.NewAppEngineContext(r)
+
+	// No results - empty JSON array, 404
+	var versions []string
+	r, err = i.NewRequest("GET", "/api/versions?product=chrome-999", nil)
+	w := httptest.NewRecorder()
+	apiVersionsHandler(w, r)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	bytes, _ := ioutil.ReadAll(w.Result().Body)
+	json.Unmarshal(bytes, &versions)
+	assert.Equal(t, []string{}, versions)
+
+	// Add test runs
+	someVersions := []string{"2", "1.1.1", "1.1", "1.0", "1"}
+	run := shared.TestRun{}
+	browserNames := shared.GetDefaultBrowserNames()
+	for _, browser := range browserNames {
+		run.BrowserName = browser
+		for _, version := range someVersions {
+			run.BrowserVersion = version
+			datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
+		}
+	}
+
+	// Chrome
+	versions = nil
+	r, err = i.NewRequest("GET", "/api/versions?product=chrome", nil)
+	w = httptest.NewRecorder()
+	apiVersionsHandler(w, r)
+	assert.Equal(t, http.StatusOK, w.Code)
+	bytes, _ = ioutil.ReadAll(w.Result().Body)
+	json.Unmarshal(bytes, &versions)
+	assert.Equal(t, someVersions, versions)
+
+	// Chrome 1.1
+	r, err = i.NewRequest("GET", "/api/versions?product=chrome-1", nil)
+	w = httptest.NewRecorder()
+	apiVersionsHandler(w, r)
+	assert.Equal(t, http.StatusOK, w.Code)
+	bytes, _ = ioutil.ReadAll(w.Result().Body)
+	json.Unmarshal(bytes, &versions)
+	assert.Equal(t, []string{"1.1.1", "1.1", "1.0", "1"}, versions)
+
+	// No product param
+	r, err = i.NewRequest("GET", "/api/versions", nil)
+	w = httptest.NewRecorder()
+	apiVersionsHandler(w, r)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	// Bad param
+	r, err = i.NewRequest("GET", "/api/versions?product=chrome-not.a.version", nil)
+	w = httptest.NewRecorder()
+	apiVersionsHandler(w, r)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}

--- a/api/versions_medium_test.go
+++ b/api/versions_medium_test.go
@@ -33,8 +33,8 @@ func TestApiVersionsHandler(t *testing.T) {
 	json.Unmarshal(bytes, &versions)
 	assert.Equal(t, []string{}, versions)
 
-	// Add test runs
-	someVersions := []string{"2", "1.1.1", "1.1", "1.0", "1"}
+	// Add test runs (duplicating 1.1 is deliberate)
+	someVersions := []string{"2", "1.1.1", "1.1", "1.1", "1.0", "1"}
 	run := shared.TestRun{}
 	browserNames := shared.GetDefaultBrowserNames()
 	for _, browser := range browserNames {
@@ -53,7 +53,8 @@ func TestApiVersionsHandler(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	bytes, _ = ioutil.ReadAll(w.Result().Body)
 	json.Unmarshal(bytes, &versions)
-	assert.Equal(t, someVersions, versions)
+	// Duplication should be removed.
+	assert.Equal(t, []string{"2", "1.1.1", "1.1", "1.0", "1"}, versions)
 
 	// Chrome 1.1
 	r, err = i.NewRequest("GET", "/api/versions?product=chrome-1", nil)


### PR DESCRIPTION
## Description
Lists the versions that we have for a given product. Fairly sure `Distinct` means the sheer quantity of runs (>1000) won't be a problem.

Relates to being consistent with the autocomplete work in #689 

## Review Information
Visit `/api/versions?product=chrome-70`