### PR TITLE
Request-level caching of /api/shas + bug fix

### DIFF
--- a/api/query/autocomplete.go
+++ b/api/query/autocomplete.go
@@ -68,7 +68,8 @@ func apiAutocompleteHandler(w http.ResponseWriter, r *http.Request) {
 		sharedImpl: defaultShared{ctx},
 		dataSource: shared.NewByteCachedStore(ctx, mc, shared.NewHTTPReadable(ctx)),
 	}}
-	ch := shared.NewCachingHandler(sh, mc, isRequestCacheable, getRequestCacheKey)
+	// nils => defaults of: (1) URL string as cache key; (2) cache only HTTP 200.
+	ch := shared.NewCachingHandler(sh, mc, isRequestCacheable, nil, nil)
 	ch.ServeHTTP(w, r)
 }
 

--- a/api/query/autocomplete.go
+++ b/api/query/autocomplete.go
@@ -69,7 +69,7 @@ func apiAutocompleteHandler(w http.ResponseWriter, r *http.Request) {
 		dataSource: shared.NewByteCachedStore(ctx, mc, shared.NewHTTPReadable(ctx)),
 	}}
 	// nils => defaults of: (1) URL string as cache key; (2) cache only HTTP 200.
-	ch := shared.NewCachingHandler(sh, mc, isRequestCacheable, nil, nil)
+	ch := shared.NewCachingHandler(ctx, sh, mc, isRequestCacheable, nil, nil)
 	ch.ServeHTTP(w, r)
 }
 

--- a/api/query/autocomplete.go
+++ b/api/query/autocomplete.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"sort"
 	"strings"
+	"time"
 
 	mapset "github.com/deckarep/golang-set"
 	"github.com/web-platform-tests/wpt.fyi/shared"
@@ -62,7 +63,7 @@ type autocompleteHandler struct {
 
 func apiAutocompleteHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := shared.NewAppEngineContext(r)
-	mc := shared.NewGZReadWritable(shared.NewMemcacheReadWritable(ctx))
+	mc := shared.NewGZReadWritable(shared.NewMemcacheReadWritable(ctx, 48*time.Hour))
 	sh := autocompleteHandler{queryHandler{
 		sharedImpl: defaultShared{ctx},
 		dataSource: shared.NewByteCachedStore(ctx, mc, shared.NewHTTPReadable(ctx)),

--- a/api/query/autocomplete.go
+++ b/api/query/autocomplete.go
@@ -69,7 +69,7 @@ func apiAutocompleteHandler(w http.ResponseWriter, r *http.Request) {
 		dataSource: shared.NewByteCachedStore(ctx, mc, shared.NewHTTPReadable(ctx)),
 	}}
 	// nils => defaults of: (1) URL string as cache key; (2) cache only HTTP 200.
-	ch := shared.NewCachingHandler(ctx, sh, mc, isRequestCacheable, nil, nil)
+	ch := shared.NewCachingHandler(ctx, sh, mc, isRequestCacheable, shared.URLAsCacheKey, shared.CacheStatusOK)
 	ch.ServeHTTP(w, r)
 }
 

--- a/api/query/autocomplete_medium_test.go
+++ b/api/query/autocomplete_medium_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -87,7 +88,7 @@ func TestAutocompleteHandler(t *testing.T) {
 
 	sh := autocompleteHandler{queryHandler{
 		sharedImpl: defaultShared{ctx},
-		dataSource: shared.NewByteCachedStore(ctx, shared.NewMemcacheReadWritable(ctx), store),
+		dataSource: shared.NewByteCachedStore(ctx, shared.NewMemcacheReadWritable(ctx, 48*time.Hour), store),
 	}}
 
 	sh.ServeHTTP(w, r)

--- a/api/query/query.go
+++ b/api/query/query.go
@@ -156,10 +156,3 @@ func isRequestCacheable(r *http.Request) bool {
 	ids, err := shared.ParseRunIDsParam(r)
 	return err == nil && len(ids) > 0
 }
-
-func getRequestCacheKey(r *http.Request) interface{} {
-	// Use full URL string as key. If this string is too long to be a memcache key
-	// then writes to memcache will fail, but that is not a big concern; it simply
-	// means that requests for cacheable long URLs will not be cached.
-	return r.URL.String()
-}

--- a/api/query/search.go
+++ b/api/query/search.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"sort"
 	"strings"
+	time "time"
 
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
@@ -61,7 +62,7 @@ type searchHandler struct {
 func apiSearchHandler(w http.ResponseWriter, r *http.Request) {
 	// Parse query params.
 	ctx := shared.NewAppEngineContext(r)
-	mc := shared.NewGZReadWritable(shared.NewMemcacheReadWritable(ctx))
+	mc := shared.NewGZReadWritable(shared.NewMemcacheReadWritable(ctx, 48*time.Hour))
 	sh := searchHandler{queryHandler{
 		sharedImpl: defaultShared{ctx},
 		dataSource: shared.NewByteCachedStore(ctx, mc, shared.NewHTTPReadable(ctx)),

--- a/api/query/search.go
+++ b/api/query/search.go
@@ -68,7 +68,7 @@ func apiSearchHandler(w http.ResponseWriter, r *http.Request) {
 		dataSource: shared.NewByteCachedStore(ctx, mc, shared.NewHTTPReadable(ctx)),
 	}}
 	// nils => defaults of: (1) URL string as cache key; (2) cache only HTTP 200.
-	ch := shared.NewCachingHandler(ctx, sh, mc, isRequestCacheable, nil, nil)
+	ch := shared.NewCachingHandler(ctx, sh, mc, isRequestCacheable, shared.URLAsCacheKey, shared.CacheStatusOK)
 	ch.ServeHTTP(w, r)
 }
 

--- a/api/query/search.go
+++ b/api/query/search.go
@@ -67,7 +67,8 @@ func apiSearchHandler(w http.ResponseWriter, r *http.Request) {
 		sharedImpl: defaultShared{ctx},
 		dataSource: shared.NewByteCachedStore(ctx, mc, shared.NewHTTPReadable(ctx)),
 	}}
-	ch := shared.NewCachingHandler(sh, mc, isRequestCacheable, getRequestCacheKey)
+	// nils => defaults of: (1) URL string as cache key; (2) cache only HTTP 200.
+	ch := shared.NewCachingHandler(sh, mc, isRequestCacheable, nil, nil)
 	ch.ServeHTTP(w, r)
 }
 

--- a/api/query/search.go
+++ b/api/query/search.go
@@ -68,7 +68,7 @@ func apiSearchHandler(w http.ResponseWriter, r *http.Request) {
 		dataSource: shared.NewByteCachedStore(ctx, mc, shared.NewHTTPReadable(ctx)),
 	}}
 	// nils => defaults of: (1) URL string as cache key; (2) cache only HTTP 200.
-	ch := shared.NewCachingHandler(sh, mc, isRequestCacheable, nil, nil)
+	ch := shared.NewCachingHandler(ctx, sh, mc, isRequestCacheable, nil, nil)
 	ch.ServeHTTP(w, r)
 }
 

--- a/api/query/search_medium_test.go
+++ b/api/query/search_medium_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	time "time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -87,7 +88,7 @@ func TestSearchHandler(t *testing.T) {
 
 	sh := searchHandler{queryHandler{
 		sharedImpl: defaultShared{ctx},
-		dataSource: shared.NewByteCachedStore(ctx, shared.NewMemcacheReadWritable(ctx), store),
+		dataSource: shared.NewByteCachedStore(ctx, shared.NewMemcacheReadWritable(ctx, 48*time.Hour), store),
 	}}
 
 	sh.ServeHTTP(w, r)

--- a/api/shas.go
+++ b/api/shas.go
@@ -23,12 +23,11 @@ type SHAsHandler struct {
 func apiSHAsHandler(w http.ResponseWriter, r *http.Request) {
 	// Serve cached with 5 minute expiry. Delegate to SHAsHandler on cache miss.
 	ctx := shared.NewAppEngineContext(r)
-	shared.NewCachingHandler(
-		SHAsHandler{ctx},
-		shared.NewGZReadWritable(shared.NewMemcacheReadWritable(ctx, 5*time.Minute)),
-		shasIsCacheable,
-		shasGetCacheKey,
-	).ServeHTTP(w, r)
+	// nils => defaults of:
+	// (1) all URLs to this handler are cacheable;
+	// (2) URL string as cache key;
+	// (3) cache only HTTP 200.
+	shared.NewCachingHandler(SHAsHandler{ctx}, shared.NewGZReadWritable(shared.NewMemcacheReadWritable(ctx, 5*time.Minute)), nil, nil, nil).ServeHTTP(w, r)
 }
 func shasIsCacheable(*http.Request) bool          { return true }
 func shasGetCacheKey(r *http.Request) interface{} { return r.URL.String() }

--- a/api/shas.go
+++ b/api/shas.go
@@ -27,10 +27,8 @@ func apiSHAsHandler(w http.ResponseWriter, r *http.Request) {
 	// (1) all URLs to this handler are cacheable;
 	// (2) URL string as cache key;
 	// (3) cache only HTTP 200.
-	shared.NewCachingHandler(ctx, SHAsHandler{ctx}, shared.NewGZReadWritable(shared.NewMemcacheReadWritable(ctx, 5*time.Minute)), nil, nil, nil).ServeHTTP(w, r)
+	shared.NewCachingHandler(ctx, SHAsHandler{ctx}, shared.NewGZReadWritable(shared.NewMemcacheReadWritable(ctx, 5*time.Minute)), shared.AlwaysCachable, shared.URLAsCacheKey, shared.CacheStatusOK).ServeHTTP(w, r)
 }
-func shasIsCacheable(*http.Request) bool          { return true }
-func shasGetCacheKey(r *http.Request) interface{} { return r.URL.String() }
 
 func (h SHAsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	filters, err := shared.ParseTestRunFilterParams(r)

--- a/api/shas.go
+++ b/api/shas.go
@@ -27,7 +27,7 @@ func apiSHAsHandler(w http.ResponseWriter, r *http.Request) {
 	// (1) all URLs to this handler are cacheable;
 	// (2) URL string as cache key;
 	// (3) cache only HTTP 200.
-	shared.NewCachingHandler(SHAsHandler{ctx}, shared.NewGZReadWritable(shared.NewMemcacheReadWritable(ctx, 5*time.Minute)), nil, nil, nil).ServeHTTP(w, r)
+	shared.NewCachingHandler(ctx, SHAsHandler{ctx}, shared.NewGZReadWritable(shared.NewMemcacheReadWritable(ctx, 5*time.Minute)), nil, nil, nil).ServeHTTP(w, r)
 }
 func shasIsCacheable(*http.Request) bool          { return true }
 func shasGetCacheKey(r *http.Request) interface{} { return r.URL.String() }

--- a/shared/datastore.go
+++ b/shared/datastore.go
@@ -15,7 +15,7 @@ import (
 // LoadTestRun loads the TestRun entity for the given key.
 func LoadTestRun(ctx context.Context, id int64) (*TestRun, error) {
 	var testRun TestRun
-	cs := NewObjectCachedStore(ctx, NewJSONObjectCache(ctx, NewMemcacheReadWritable(ctx)), NewDatastoreObjectStore(ctx, "TestRun"))
+	cs := NewObjectCachedStore(ctx, NewJSONObjectCache(ctx, NewMemcacheReadWritable(ctx, 48*time.Hour)), NewDatastoreObjectStore(ctx, "TestRun"))
 	err := cs.Get(getTestRunMemcacheKey(id), id, &testRun)
 	if err != nil {
 		return nil, err
@@ -113,7 +113,7 @@ func LoadTestRuns(
 // ID to the TestRun entity.
 func LoadTestRunsByKeys(ctx context.Context, keys []*datastore.Key) (result TestRuns, err error) {
 	result = make(TestRuns, len(keys))
-	cs := NewObjectCachedStore(ctx, NewJSONObjectCache(ctx, NewMemcacheReadWritable(ctx)), NewDatastoreObjectStore(ctx, "TestRun"))
+	cs := NewObjectCachedStore(ctx, NewJSONObjectCache(ctx, NewMemcacheReadWritable(ctx, 48*time.Hour)), NewDatastoreObjectStore(ctx, "TestRun"))
 	var wg sync.WaitGroup
 	for i := range keys {
 		wg.Add(1)

--- a/shared/request_caching.go
+++ b/shared/request_caching.go
@@ -157,15 +157,6 @@ func (h cachingHandler) delegateAndCache(w http.ResponseWriter, r *http.Request,
 // NewCachingHandler produces a caching handler with an underlying delegate
 // handler, cache, cacheability decision function, and cache key producer.
 func NewCachingHandler(ctx context.Context, delegate http.Handler, cache ReadWritable, isCacheable func(*http.Request) bool, getCacheKey func(*http.Request) interface{}, shouldCache func(int, []byte) bool) http.Handler {
-	if isCacheable == nil {
-		isCacheable = AlwaysCachable
-	}
-	if getCacheKey == nil {
-		getCacheKey = URLAsCacheKey
-	}
-	if shouldCache == nil {
-		shouldCache = CacheStatusOK
-	}
 	return cachingHandler{ctx, delegate, cache, isCacheable, getCacheKey, shouldCache}
 }
 

--- a/shared/request_caching_test.go
+++ b/shared/request_caching_test.go
@@ -1,0 +1,62 @@
+// +build small
+
+// Copyright 2018 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package shared
+
+import (
+	"context"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
+)
+
+type failReader struct{}
+type okHandler struct{}
+
+var (
+	errFailRead = errors.New("Failed read")
+	ok          = []byte("OK")
+)
+
+func (failReader) Read([]byte) (int, error) { return 0, errFailRead }
+
+func (okHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Write(ok)
+}
+
+func TestNoCaching404(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	cache := NewMockReadWritable(mockCtrl)
+	cache.EXPECT().NewReadCloser("/some/url").Return(ioutil.NopCloser(failReader{}), nil)
+	h := NewCachingHandler(context.Background(), http.NotFoundHandler(), cache, AlwaysCachable, URLAsCacheKey, CacheStatusOK)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/some/url", nil)
+	h.ServeHTTP(w, r)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestCaching200(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	cache := NewMockReadWritable(mockCtrl)
+	cache.EXPECT().NewReadCloser("/some/url").Return(ioutil.NopCloser(failReader{}), nil)
+	wc := sharedtest.NewMockWriteCloser(t)
+	cache.EXPECT().NewWriteCloser("/some/url").Return(wc, nil)
+	h := NewCachingHandler(context.Background(), okHandler{}, cache, AlwaysCachable, URLAsCacheKey, CacheStatusOK)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/some/url", nil)
+	h.ServeHTTP(w, r)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.True(t, wc.IsClosed())
+	assert.Equal(t, ok, wc.Bytes())
+}

--- a/shared/sharedtest/io.go
+++ b/shared/sharedtest/io.go
@@ -31,6 +31,16 @@ func (mwc *MockWriteCloser) Close() error {
 	return nil
 }
 
+// IsClosed indicates whether the WriteCloser has been closed.
+func (mwc *MockWriteCloser) IsClosed() bool {
+	return mwc.closed
+}
+
+// Bytes returns the bytes written to the WriteCloser.
+func (mwc *MockWriteCloser) Bytes() []byte {
+	return mwc.b.Bytes()
+}
+
 // NewMockWriteCloser creates a new MockWriteCloser.
 func NewMockWriteCloser(t *testing.T) *MockWriteCloser {
 	return &MockWriteCloser{


### PR DESCRIPTION
## Description

Add request-level caching to `/api/shas`. To keep tests happy, also apply a bug fix detailed in b4392d9.

## Review Information

Observe logging about cache missing and serving from cache when visiting any `/api/shas?[params]` URL.
