### PR TITLE
Handle versions with channels better

### DIFF
--- a/shared/models.go
+++ b/shared/models.go
@@ -47,9 +47,27 @@ func (e ByBrowserName) Less(i, j int) bool { return e[i].BrowserName < e[j].Brow
 // Version is a struct for a parsed version string.
 type Version struct {
 	Major    int
-	Minor    int
-	Build    int
-	Revision int
+	Minor    *int
+	Build    *int
+	Revision *int
+	Channel  string
+}
+
+func (v Version) String() string {
+	s := fmt.Sprintf("%v", v.Major)
+	if v.Minor != nil {
+		s = fmt.Sprintf("%s.%v", s, *v.Minor)
+	}
+	if v.Build != nil {
+		s = fmt.Sprintf("%s.%v", s, *v.Build)
+	}
+	if v.Revision != nil {
+		s = fmt.Sprintf("%s.%v", s, *v.Revision)
+	}
+	if v.Channel != "" {
+		s = fmt.Sprintf("%s%s", s, v.Channel)
+	}
+	return s
 }
 
 // ProductAtRevision defines a WPT run for a specific product, at a

--- a/shared/params.go
+++ b/shared/params.go
@@ -330,7 +330,7 @@ func ParseVersion(version string) (result *Version, err error) {
 	}
 
 	// Special case ff's "a1" suffix
-	ffSuffix := regexp.MustCompile("^.*([ab]\\d+)$")
+	ffSuffix := regexp.MustCompile(`^.*([ab]\d+)$`)
 	if match := ffSuffix.FindStringSubmatch(version); match != nil {
 		channel = match[1]
 		version = version[:len(version)-len(channel)]

--- a/shared/params.go
+++ b/shared/params.go
@@ -353,7 +353,7 @@ func ParseVersion(version string) (result *Version, err error) {
 		Channel: channel,
 	}
 	if len(numbers) > 1 {
-		result.Minor = &(numbers[1])
+		result.Minor = &numbers[1]
 	}
 	if len(numbers) > 2 {
 		result.Build = &numbers[2]

--- a/shared/params.go
+++ b/shared/params.go
@@ -320,7 +320,23 @@ func ParseProduct(product string) (result Product, err error) {
 
 // ParseVersion parses the given version as a semantically versioned string.
 func ParseVersion(version string) (result *Version, err error) {
-	pieces := strings.Split(version, ".")
+	pieces := strings.Split(version, " ")
+	channel := ""
+	if len(pieces) > 2 {
+		return nil, fmt.Errorf("Invalid version: %s", version)
+	} else if len(pieces) > 1 {
+		channel = " " + pieces[1]
+		version = pieces[0]
+	}
+
+	// Special case ff's "a1" suffix
+	ffSuffix := regexp.MustCompile("^.*([ab]\\d+)$")
+	if match := ffSuffix.FindStringSubmatch(version); match != nil {
+		channel = match[1]
+		version = version[:len(version)-len(channel)]
+	}
+
+	pieces = strings.Split(version, ".")
 	if len(pieces) > 4 {
 		return nil, fmt.Errorf("Invalid version: %s", version)
 	}
@@ -333,16 +349,17 @@ func ParseVersion(version string) (result *Version, err error) {
 		numbers[i] = int(n)
 	}
 	result = &Version{
-		Major: numbers[0],
+		Major:   numbers[0],
+		Channel: channel,
 	}
 	if len(numbers) > 1 {
-		result.Minor = numbers[1]
+		result.Minor = &(numbers[1])
 	}
 	if len(numbers) > 2 {
-		result.Build = numbers[2]
+		result.Build = &numbers[2]
 	}
 	if len(numbers) > 3 {
-		result.Revision = numbers[3]
+		result.Revision = &numbers[3]
 	}
 	return result, nil
 }

--- a/shared/params_test.go
+++ b/shared/params_test.go
@@ -326,6 +326,34 @@ func TestParseLabelsParam_LabelsAndLabel_Duplicate(t *testing.T) {
 	assert.Len(t, labels, 1)
 }
 
+func TestParseVersion(t *testing.T) {
+	v, err := ParseVersion("63.0")
+	assert.Nil(t, err)
+	assert.Equal(t, 63, v.Major)
+	assert.Equal(t, 0, *v.Minor)
+	assert.Nil(t, v.Build)
+	assert.Nil(t, v.Revision)
+	assert.Empty(t, v.Channel)
+
+	// FF
+	v, err = ParseVersion("65.0a1")
+	assert.Nil(t, err)
+	assert.Equal(t, 65, v.Major)
+	assert.Equal(t, 0, *v.Minor)
+	assert.Nil(t, v.Build)
+	assert.Nil(t, v.Revision)
+	assert.Equal(t, "a1", v.Channel)
+
+	// Chrome
+	v, err = ParseVersion("71.0.3578.20 dev")
+	assert.Nil(t, err)
+	assert.Equal(t, 71, v.Major)
+	assert.Equal(t, 0, *v.Minor)
+	assert.Equal(t, 3578, *v.Build)
+	assert.Equal(t, 20, *v.Revision)
+	assert.Equal(t, " dev", v.Channel)
+}
+
 func TestParseProductSpec(t *testing.T) {
 	productSpec, err := ParseProductSpec("chrome@latest")
 	assert.Nil(t, err)


### PR DESCRIPTION
## Description
Handles more `browser_version` values.
Adding autocomplete using #691 will result in us suggesting version strings that don't even pass, e.g. `75.0a1` or `69.0.1234.20 dev`.
