### PR TITLE
Add env-flags for different default queries

### DIFF
--- a/shared/params.go
+++ b/shared/params.go
@@ -51,12 +51,45 @@ func (filter TestRunFilter) IsDefaultQuery() bool {
 // OrDefault returns the current filter, or, if it is a default query, returns
 // the query used by default in wpt.fyi.
 func (filter TestRunFilter) OrDefault() TestRunFilter {
+	return filter.OrAlignedStableRuns()
+}
+
+// OrAlignedStableRuns returns the current filter, or, if it is a default query, returns
+// a query for stable runs, with an aligned SHA.
+func (filter TestRunFilter) OrAlignedStableRuns() TestRunFilter {
 	if !filter.IsDefaultQuery() {
 		return filter
 	}
 	aligned := true
 	filter.Aligned = &aligned
 	filter.Labels = mapset.NewSetWith(StableLabel)
+	return filter
+}
+
+// OrExperimentalRuns returns the current filter, or, if it is a default query, returns
+// a query for the latest experimental runs.
+func (filter TestRunFilter) OrExperimentalRuns() TestRunFilter {
+	if !filter.IsDefaultQuery() {
+		return filter
+	}
+	filter.Labels = mapset.NewSetWith(ExperimentalLabel)
+	return filter
+}
+
+// OrAlignedExperimentalRunsExceptEdge returns the current filter, or, if it is a default
+// query, returns a query for the latest experimental runs.
+func (filter TestRunFilter) OrAlignedExperimentalRunsExceptEdge() TestRunFilter {
+	if !filter.IsDefaultQuery() {
+		return filter
+	}
+	aligned := true
+	filter.Aligned = &aligned
+	filter.Products = GetDefaultProducts()
+	for i := range filter.Products {
+		if filter.Products[i].BrowserName != "edge" {
+			filter.Products[i].Labels = mapset.NewSetWith("experimental")
+		}
+	}
 	return filter
 }
 

--- a/util/populate_dev_data.go
+++ b/util/populate_dev_data.go
@@ -174,6 +174,8 @@ func main() {
 	addFlag(ctx, "queryBuilder", enabledFlag)
 	addFlag(ctx, "diffFilter", enabledFlag)
 	addFlag(ctx, "diffFromAPI", enabledFlag)
+	addFlag(ctx, "experimentalByDefault", enabledFlag)
+	addFlag(ctx, "experimentalAlignedExceptEdge", enabledFlag)
 
 	log.Print("Adding uploader \"test\"...")
 	addData(ctx, "Uploader", []interface{}{

--- a/webapp/test_results_handler_medium_test.go
+++ b/webapp/test_results_handler_medium_test.go
@@ -1,4 +1,4 @@
-// +build small
+// +build medium
 
 // Copyright 2017 The WPT Dashboard Project. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
@@ -7,30 +7,37 @@
 package webapp
 
 import (
-	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
 )
 
 func TestParseTestResultsUIFilter(t *testing.T) {
-	f, err := parseTestResultsUIFilter(httptest.NewRequest("GET", "/results/?max-count=3", nil))
+	i, err := sharedtest.NewAEInstance(true)
+	assert.Nil(t, err)
+	defer i.Close()
+	r, _ := i.NewRequest("GET", "/results/?max-count=3", nil)
+	assert.Nil(t, err)
+
+	f, err := parseTestResultsUIFilter(r)
 	assert.Nil(t, err)
 	assert.True(t, f.MaxCount != nil && *f.MaxCount == 3)
 
-	f, err = parseTestResultsUIFilter(httptest.NewRequest("GET", "/results/?products=chrome,safari&diff", nil))
+	r, _ = i.NewRequest("GET", "/results/?products=chrome,safari&diff", nil)
+	f, err = parseTestResultsUIFilter(r)
 	assert.Nil(t, err)
 	assert.Equal(t, "[\"chrome\",\"safari\"]", f.Products)
 	assert.Equal(t, true, f.Diff)
-}
 
-func TestParseTestResultsUIFilter_BeforeAfter(t *testing.T) {
-	f, err := parseTestResultsUIFilter(httptest.NewRequest("GET", "/results/?before=chrome&after=chrome[experimental]", nil))
+	r, _ = i.NewRequest("GET", "/results/?before=chrome&after=chrome[experimental]", nil)
+	f, err = parseTestResultsUIFilter(r)
 	assert.Nil(t, err)
 	assert.Equal(t, "[\"chrome\",\"chrome[experimental]\"]", f.Products)
 	assert.Equal(t, true, f.Diff)
 
-	f, err = parseTestResultsUIFilter(httptest.NewRequest("GET", "/results/?after=chrome&before=edge", nil))
+	r, _ = i.NewRequest("GET", "/results/?after=chrome&before=edge", nil)
+	f, err = parseTestResultsUIFilter(r)
 	assert.Nil(t, err)
 	assert.Equal(t, "[\"edge\",\"chrome\"]", f.Products)
 	assert.Equal(t, true, f.Diff)


### PR DESCRIPTION
## Description
Adds 2 flags `experimentalByDefault` and `experimentalAlignedExceptEdge` which allow for some different defaults as we've discussed offline.

## Review Information
A little hard to test without actually enabling them in staging, but locally they're added by default when you run dev_data (against this PR) and you can test that it works to revert back to normal when you delete them from the datastore using the admin console @ 0.0.0.0:8000