### PR TITLE
Add autocomplete to the Version query builder field

### DIFF
--- a/api/test_runs_medium_test.go
+++ b/api/test_runs_medium_test.go
@@ -39,7 +39,7 @@ func TestGetTestRuns_VersionPrefix(t *testing.T) {
 	datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &chrome)
 
 	// 'Today', v66...181 (revision increased)
-	chrome.BrowserVersion = "66.0.3359.181"
+	chrome.BrowserVersion = "66.0.3359.181 beta"
 	chrome.CreatedAt = now
 	datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &chrome)
 
@@ -59,7 +59,7 @@ func TestGetTestRuns_VersionPrefix(t *testing.T) {
 	assert.Equalf(t, http.StatusOK, resp.Code, string(body))
 	var result66 shared.TestRun
 	json.Unmarshal(body, &result66)
-	assert.Equal(t, "66.0.3359.181", result66.BrowserVersion)
+	assert.Equal(t, "66.0.3359.181 beta", result66.BrowserVersion)
 
 	r, _ = i.NewRequest("GET", "/api/run?product=chrome-66.0.3359.139", nil)
 	resp = httptest.NewRecorder()
@@ -69,6 +69,14 @@ func TestGetTestRuns_VersionPrefix(t *testing.T) {
 	var result66139 shared.TestRun
 	json.Unmarshal(body, &result66139)
 	assert.Equal(t, "66.0.3359.139", result66139.BrowserVersion)
+
+	r, _ = i.NewRequest("GET", "/api/run?product=chrome-66.0.3359.181 beta", nil)
+	resp = httptest.NewRecorder()
+	apiTestRunHandler(resp, r)
+	body, _ = ioutil.ReadAll(resp.Result().Body)
+	assert.Equal(t, http.StatusOK, resp.Code)
+	json.Unmarshal(body, &result66139)
+	assert.Equal(t, "66.0.3359.181 beta", result66139.BrowserVersion)
 
 	r, _ = i.NewRequest("GET", "/api/run?product=chrome-68", nil)
 	resp = httptest.NewRecorder()

--- a/api/versions.go
+++ b/api/versions.go
@@ -45,6 +45,11 @@ func (h VersionsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	ctx := h.ctx
 	query := datastore.NewQuery("TestRun").Filter("BrowserName =", product.BrowserName)
+	if product.Labels != nil {
+		for label := range product.Labels.Iter() {
+			query = query.Filter("Labels =", label)
+		}
+	}
 	distinctQuery := query.Project("BrowserVersion").Distinct()
 	var queries []*datastore.Query
 	if product.BrowserVersion == "" {

--- a/shared/params.go
+++ b/shared/params.go
@@ -430,12 +430,12 @@ func ParseBrowsersParam(r *http.Request) (browsers []string, err error) {
 }
 
 // ParseProductParam parses and validates the 'product' param for the request.
-func ParseProductParam(r *http.Request) (product *Product, err error) {
+func ParseProductParam(r *http.Request) (product *ProductSpec, err error) {
 	productParam := r.URL.Query().Get("product")
 	if "" == productParam {
 		return nil, nil
 	}
-	parsed, err := ParseProduct(productParam)
+	parsed, err := ParseProductSpec(productParam)
 	if err != nil {
 		return nil, err
 	}

--- a/webapp/components/test-runs-query-builder.html
+++ b/webapp/components/test-runs-query-builder.html
@@ -248,10 +248,15 @@ found in the LICENSE file.
         </paper-dropdown-menu>
 
         <br>
-        <paper-input always-float-label
-                      label="Version"
-                      placeholder="(Any version)"
-                      value="{{ browserVersion::input }}"></paper-input>
+        <paper-input-container always-float-label>
+          <label slot="label">Version</label>
+          <input slot="input"
+                  placeholder="(Any version)"
+                  list="versions-datalist"
+                  value="{{ browserVersion::input }}">
+          <datalist id="versions-datalist"></datalist>
+        </paper-input-container>
+      </template>
       </div>
     </paper-card>
   </template>
@@ -317,6 +322,18 @@ found in the LICENSE file.
             type: Array,
             value: Array.from(CHANNELS),
           },
+          versionsURL: {
+            type: String,
+            computed: 'computeVersionsURL(browserName)',
+            observer: 'versionsURLUpdated',
+          },
+          versions: {
+            type: Array,
+          },
+          versionsAutocomplete: {
+            type: Array,
+            observer: 'versionsAutocompleteUpdated'
+          },
         };
       }
 
@@ -325,6 +342,7 @@ found in the LICENSE file.
         this.deleteProduct = () => {
           this.onDelete && this.onDelete(this.product);
         };
+        this._createMethodObserver('versionsUpdated(browserVersion, versions)');
       }
 
       static get SemanticLabels() {
@@ -382,6 +400,52 @@ found in the LICENSE file.
         return Object.assign({}, product, {
           labels: (product.labels || []).filter(l => !CHANNELS.has(l)).concat(channel)
         });
+      }
+
+      computeVersionsURL(browserName) {
+        const url = new URL('/api/versions', window.location);
+        url.searchParams.set('product', browserName);
+        return url;
+      }
+
+      versionsURLUpdated(url) {
+        fetch(url).then(r => r.json()).then(v => {
+          this.versions = v;
+        });
+      }
+
+      versionsUpdated(version, versions) {
+        if (!versions) {
+          return;
+        }
+        if (version) {
+          versions = versions.filter(s => s.startsWith(version));
+        }
+        versions = versions.slice(0, 10);
+        // Check actually different from current.
+        const curr = this.versionsAutocomplete || [];
+        if (curr.length === versions.length) {
+          let same = true;
+          for (let i = 0; i < versions.length && same; i++) {
+            if (i >= curr.length || versions[i] !== curr[i]) {
+              same = false;
+            }
+          }
+          if (same) {
+            return;
+          }
+        }
+        this.versionsAutocomplete = versions;
+      }
+
+      versionsAutocompleteUpdated(versionsAutocomplete) {
+        const datalist = this.shadowRoot.querySelector('datalist');
+        datalist.innerHTML = '';
+        for (const sha of versionsAutocomplete) {
+          const option = document.createElement('option');
+          option.setAttribute('value', sha);
+          datalist.appendChild(option);
+        }
       }
     }
 

--- a/webapp/components/test-runs-query-builder.html
+++ b/webapp/components/test-runs-query-builder.html
@@ -324,7 +324,7 @@ found in the LICENSE file.
           },
           versionsURL: {
             type: String,
-            computed: 'computeVersionsURL(browserName)',
+            computed: 'computeVersionsURL(_product)',
             observer: 'versionsURLUpdated',
           },
           versions: {
@@ -402,18 +402,23 @@ found in the LICENSE file.
         });
       }
 
-      computeVersionsURL(browserName) {
+      // Respond to product spec changing by computing a new versions URL.
+      computeVersionsURL(product) {
+        product = Object.assign({}, product);
+        delete product.browser_version;
         const url = new URL('/api/versions', window.location);
-        url.searchParams.set('product', browserName);
+        url.searchParams.set('product', this.getSpec(product));
         return url;
       }
 
+      // Respond to version URL changing by fetching the versions
       versionsURLUpdated(url) {
         fetch(url).then(r => r.json()).then(v => {
           this.versions = v;
         });
       }
 
+      // Respond to newly fetched versions, or user input, by filtering the autocomplete list.
       versionsUpdated(version, versions) {
         if (!versions) {
           return;
@@ -423,17 +428,9 @@ found in the LICENSE file.
         }
         versions = versions.slice(0, 10);
         // Check actually different from current.
-        const curr = this.versionsAutocomplete || [];
-        if (curr.length === versions.length) {
-          let same = true;
-          for (let i = 0; i < versions.length && same; i++) {
-            if (i >= curr.length || versions[i] !== curr[i]) {
-              same = false;
-            }
-          }
-          if (same) {
-            return;
-          }
+        const current = new Set(this.versionsAutocomplete || []);
+        if (!versions.find(v => !current.has(v))) {
+          return;
         }
         this.versionsAutocomplete = versions;
       }

--- a/webapp/components/test-runs-query-builder.html
+++ b/webapp/components/test-runs-query-builder.html
@@ -420,7 +420,8 @@ found in the LICENSE file.
 
       // Respond to newly fetched versions, or user input, by filtering the autocomplete list.
       versionsUpdated(version, versions) {
-        if (!versions) {
+        if (!versions || !versions.length) {
+          this.versionsAutocomplete = [];
           return;
         }
         if (version) {


### PR DESCRIPTION
## Description
Builds on https://github.com/web-platform-tests/wpt.fyi/pull/689, using the same technique as SHA.

## Review Information
Open the query builder, see autocomplete in the `Version` field for each product.