### PR TITLE
Compute autocomplete client-side + navigate on selection

### DIFF
--- a/webapp/components/interop.html
+++ b/webapp/components/interop.html
@@ -127,7 +127,8 @@ found in the LICENSE file.
 
     <test-search class$="search-[[pathIsATestFile]]"
                  query="{{search}}"
-                 test-runs="[[testRuns]]">
+                 test-runs="[[testRuns]]"
+                 test-paths="[[testPaths]]">
     </test-search>
 
     <template is="dom-if" if="{{ pathIsATestFile }}">
@@ -257,6 +258,10 @@ found in the LICENSE file.
         searchResults: Array,
         onSearchCommit: Function,
         interopLoadFailed: Boolean,
+        testPaths: {
+          type: Set,
+          computed: 'computeTestPaths(fileMetrics)',
+        },
       };
     }
 
@@ -264,6 +269,9 @@ found in the LICENSE file.
       super();
       this.onSearchCommit = (e) => {
         this.handleSearchCommit(e.detail.query);
+      };
+      this.onSearchAutocomplete = (e) => {
+        this.handleSearchAutocomplete(e.detail.path);
       };
       this.onLoadingComplete = () => {
         // passRateMetadata contains the url for the JSON blob of allMetrics;
@@ -279,6 +287,8 @@ found in the LICENSE file.
       super.connectedCallback();
       this.shadowRoot.querySelector('test-search')
         .addEventListener('commit', this.onSearchCommit);
+      this.shadowRoot.querySelector('test-search')
+        .addEventListener('autocomplete', this.onSearchAutocomplete);
     }
 
     disconnectedCallback() {
@@ -333,6 +343,13 @@ found in the LICENSE file.
       return metadata && metadata.test_runs;
     }
 
+    computeTestPaths(fileMetrics) {
+      if (!fileMetrics) {
+        return [];
+      }
+      return new Set(fileMetrics.map(m => m.dir));
+    }
+
     computeFileMetrics(allMetrics) {
       let fileMetrics = [];
       for (const metric of allMetrics.data) {
@@ -369,6 +386,11 @@ found in the LICENSE file.
 
       this.searchResults = this.fileMetrics
         .filter(t => t.dir.toLowerCase().includes(q));
+    }
+
+    handleSearchAutocomplete(path) {
+      this.shadowRoot.querySelector('test-search').clear();
+      this.navigateToPath(path);
     }
 
     computeDisplayedNodes(path, displayedTests) {

--- a/webapp/components/self-navigator.html
+++ b/webapp/components/self-navigator.html
@@ -132,6 +132,12 @@
           window.ga('send', 'pageview', path);
         }
       }
+
+      navigateToPath(testPath) {
+        const url = new URL(window.location);
+        url.pathname = this.navigationPathPrefix() + testPath;
+        this.navigateToLocation(url);
+      }
     };
   </script>
 </dom-module>

--- a/webapp/components/test-runs-query.html
+++ b/webapp/components/test-runs-query.html
@@ -216,6 +216,7 @@ found in the LICENSE file.
 
         updateQueryParams(params) {
           super.updateQueryParams(params);
+          this.search = params.q;
           this.diff = params.diff;
         }
       };

--- a/webapp/components/test-search.html
+++ b/webapp/components/test-search.html
@@ -19,10 +19,11 @@ found in the LICENSE file.
     </style>
 
     <div>
-      <input value="{{ q::input }}"
+      <input value="{{ queryInput::input }}"
              class="query"
              list="query-list"
              placeholder="[[queryPlaceholder]]"
+             onchange="[[onChange]]"
              onkeyup="[[onKeyUp]]"
              onkeydown="[[onKeyDown]]"
              onfocus="[[onFocus]]"
@@ -49,14 +50,17 @@ found in the LICENSE file.
             type: String,
             value: 'Search test files, like \'cors/allow-headers.htm\', then press <Enter>',
           },
-          q: {
+          // Query input string
+          queryInput: {
             type: String,
             notify: true,
-            observer: 'queryChanged'
+            observer: 'queryInputChanged'
           },
+          // Debounced + normalized query string.
           query: {
             type: String,
             notify: true,
+            observer: 'queryUpdated',
           },
           results: {
             type: Array,
@@ -66,11 +70,7 @@ found in the LICENSE file.
             type: String,
             computed: 'computeQueryPlaceholder()'
           },
-          autocompleteURL: {
-            type: String,
-            computed: 'computeAutocompleteURL(testRuns, q)',
-            observer: 'observeAutocompleteURL',
-          },
+          testPaths: Array,
           onKeyUp: Function,
           onChange: Function,
           onFocus: Function,
@@ -86,50 +86,36 @@ found in the LICENSE file.
         this.onBlur = this.handleBlur.bind(this);
       }
 
-      computeAutocompleteURL(testRuns, q) {
-        if (!testRuns || !testRuns.length) {
-          return '';
-        }
-        let url = new URL('/api/autocomplete', window.location);
-        url.searchParams.set('limit', 10);
-        url.searchParams.set(
-          'run_ids',
-          testRuns.map(r => r.id.toString()).join(','));
-        if (q) {
-          url.searchParams.set('q', q);
-        }
-        return url;
-      }
-
       ready() {
         super.ready();
-        this.q = this.query;
+        this._createMethodObserver('pathsUpdated(query, testPaths)');
+        this.queryInput = this.query;
       }
 
-      async observeAutocompleteURL(newValue, oldValue) {
-        if (newValue === oldValue || !newValue) {
+      queryUpdated(query) {
+        this.queryInput = query;
+      }
+
+      pathsUpdated(query, paths) {
+        if (!paths) {
           return;
         }
-
-        const response = await window.fetch(newValue);
-        if (response.status !== 200) {
-          throw response;
-        }
-        const json = await response.json();
-
         const datalist = this.shadowRoot.querySelector('datalist');
         datalist.innerHTML = '';
-        if (!json.results) {
-          return;
+        let matches = Array.from(paths);
+        if (query) {
+          matches = matches
+            .filter(p => p.indexOf(query) >= 0)
+            .sort((p1, p2) => p1.indexOf(query) - p2.indexOf(query));
         }
-        for (const result of json.results) {
+        for (const match of matches.slice(0, 10)) {
           const option = document.createElement('option');
-          option.setAttribute('value', result.query_string);
+          option.setAttribute('value', match);
           datalist.appendChild(option);
         }
       }
 
-      queryChanged(_, oldQuery) {
+      queryInputChanged(_, oldQuery) {
         // Debounce first initialization.
         if (typeof(oldQuery) === 'undefined') {
           return;
@@ -141,11 +127,11 @@ found in the LICENSE file.
       }
 
       latchQuery() {
-        this.query = this.q.toLowerCase();
+        this.query = this.queryInput.toLowerCase();
       }
 
       commitQuery() {
-        this.query = this.q;
+        this.query = this.queryInput;
         this.dispatchEvent(new CustomEvent('commit', {
           detail: {query: this.query},
         }));
@@ -170,7 +156,10 @@ found in the LICENSE file.
         const value = e.target.value.toLowerCase();
 
         if (opts.includes(value)) {
-          this.commitQuery();
+          this.dispatchEvent(new CustomEvent('autocomplete', {
+            detail: {path: value},
+          }));
+          this.shadowRoot.querySelector('.query').blur();
         }
       }
 
@@ -180,6 +169,10 @@ found in the LICENSE file.
 
       handleBlur() {
         this.shadowRoot.querySelector('paper-tooltip').hide();
+      }
+
+      clear() {
+        this.query = '';
       }
     }
     window.customElements.define(TestSearch.is, TestSearch);

--- a/webapp/components/test-search.html
+++ b/webapp/components/test-search.html
@@ -173,6 +173,7 @@ found in the LICENSE file.
 
       clear() {
         this.query = '';
+        this.queryInput = '';
       }
     }
     window.customElements.define(TestSearch.is, TestSearch);

--- a/webapp/components/test-search.html
+++ b/webapp/components/test-search.html
@@ -127,7 +127,7 @@ found in the LICENSE file.
       }
 
       latchQuery() {
-        this.query = this.queryInput.toLowerCase();
+        this.query = (this.queryInput || '').toLowerCase();
       }
 
       commitQuery() {

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -151,7 +151,8 @@ found in the LICENSE file.
 
       <test-search class$="search-[[pathIsATestFile]]"
                    query='{{search}}'
-                   test-runs="[[testRuns]]">
+                   test-runs="[[testRuns]]"
+                   test-paths="[[testPaths]]">
       </test-search>
 
       <template is="dom-if" if="{{ pathIsATestFile }}">
@@ -322,6 +323,10 @@ found in the LICENSE file.
             type: Array,
             value: [],
           },
+          testPaths: {
+            type: Set,
+            computed: 'computeTestPaths(searchResults)',
+          },
           displayedNodes: {
             type: Array,
             value: [],
@@ -412,6 +417,16 @@ found in the LICENSE file.
         return true;
       }
 
+      computeTestPaths(searchResults) {
+        if (!searchResults) {
+          return [];
+        }
+        return searchResults.reduce((sum, next) => {
+          sum.add(next.test);
+          return sum;
+        }, new Set());
+      }
+
       computeDisplayedTests(path, searchResults) {
         return searchResults.map(r => r.test)
           .filter(name => name.startsWith(path));
@@ -450,6 +465,7 @@ found in the LICENSE file.
       constructor() {
         super();
         this.onSearchCommit = this.handleSearchCommit.bind(this);
+        this.onSearchAutocomplete = this.handleSearchAutocomplete.bind(this);
         this.onLoadingComplete = () => {
           this.resultsLoadFailed = !(this.testRuns && this.testRuns.length);
           this.noResults = !this.resultsLoadFailed
@@ -467,8 +483,9 @@ found in the LICENSE file.
 
       connectedCallback() {
         super.connectedCallback();
-        this.shadowRoot.querySelector('test-search')
-          .addEventListener('commit', this.onSearchCommit);
+        const search = this.shadowRoot.querySelector('test-search');
+        search.addEventListener('commit', this.onSearchCommit);
+        search.addEventListener('autocomplete', this.onSearchAutocomplete);
       }
 
       disconnectedCallback() {
@@ -765,25 +782,33 @@ found in the LICENSE file.
         };
       }
 
+      handleSearchAutocomplete(e) {
+        this.shadowRoot.querySelector('test-search').clear();
+        this.navigateToPath(e.detail.path);
+      }
+
       handleSearchCommit() {
         // Fetch search results when test-search signals that user has committed
         // to search string (by pressing <Enter>).
         this.fetchResults();
+        // Trigger a virtual navigation.
+        this.navigateToLocation(window.location);
       }
 
       handleSubmitQuery() {
+        const queryBefore = this.query;
         const builder = this.shadowRoot.querySelector('test-runs-query-builder');
         this.editingQuery = false;
-        if (this.query === builder.query) {
-          return;
-        }
-
         this.updateQueryParams(builder.queryParams);
-        if (!this.diff) {
-          this.diffRun = null;
+        if (queryBefore === this.query) {
+          return;
         }
         // Trigger a virtual navigation.
         this.navigateToLocation(window.location);
+        // Reload the data.
+        if (!this.diff) {
+          this.diffRun = null;
+        }
         this.testRuns = [];
         this.searchResults = [];
         this.refreshDisplayedNodes();


### PR DESCRIPTION
## Description
Fixes #643 and #679

Compute the autocomplete options from the set of test results paths available on the client, reducing latency.
Add an event hook for changing the input value to the exact value of an autocomplete item, and leverage that to navigate to the file. 

## Review Information
@mdittmer, I've picked you for this because you know the effect of executing a search, and can deem whether this is problematic (autocompleting based on a subset of paths when doing a search).

I think this fixes a current bug with `history` push/pop too (clicking 'back' was causing a push to the stack).