### PR TITLE
Add 'full' param to TestRun query params

### DIFF
--- a/shared/params.go
+++ b/shared/params.go
@@ -30,7 +30,8 @@ type QueryFilter struct {
 type TestRunFilter struct {
 	SHA      string
 	Labels   mapset.Set
-	Aligned  *bool
+	Aligned  *bool // Runs with the same SHA
+	Full     *bool // Runs which are the full test suite (i.e. labelled 'full')
 	From     *time.Time
 	To       *time.Time
 	MaxCount *int
@@ -178,6 +179,9 @@ func (filter TestRunFilter) ToQuery() (q url.Values) {
 	}
 	if filter.To != nil {
 		q.Set("to", filter.From.Format(time.RFC3339))
+	}
+	if filter.Full != nil {
+		q.Set("full", strconv.FormatBool(*filter.Full))
 	}
 	return q
 }
@@ -679,6 +683,9 @@ func ParseTestRunFilterParams(r *http.Request) (filter TestRunFilter, err error)
 		return filter, err
 	}
 	if filter.To, err = ParseDateTimeParam(r, "to"); err != nil {
+		return filter, err
+	}
+	if filter.Full, err = ParseBooleanParam(r, "full"); err != nil {
 		return filter, err
 	}
 	return filter, nil

--- a/shared/util.go
+++ b/shared/util.go
@@ -23,6 +23,10 @@ const LatestSHA = "latest"
 // StableLabel is the implicit label present for runs marked 'stable'.
 const StableLabel = "stable"
 
+// FullLabel is the label present for full runs (which run the entire WPT suite),
+// as opposed to things like affected tests for PRs.
+const FullLabel = "full"
+
 // GetDefaultProducts returns the default set of products to show on wpt.fyi
 func GetDefaultProducts() ProductSpecs {
 	browserNames := GetDefaultBrowserNames()


### PR DESCRIPTION
## Description
This param will be used by the front page to omit non-full runs (such as PRs)

## Review Information
Not yet utilized in the UI, and loading `/api/runs?full` will be empty results right now - we need to change the infra to flag the full runs as such.