### PR TITLE
Add flag for structured queries

### DIFF
--- a/util/populate_dev_data.go
+++ b/util/populate_dev_data.go
@@ -173,7 +173,7 @@ func main() {
 	log.Print("Adding flag defaults...")
 	addFlag(ctx, "queryBuilder", enabledFlag)
 	addFlag(ctx, "diffFilter", enabledFlag)
-  addFlag(ctx, "diffFromAPI", enabledFlag)
+	addFlag(ctx, "diffFromAPI", enabledFlag)
 	addFlag(ctx, "experimentalByDefault", enabledFlag)
 	addFlag(ctx, "experimentalAlignedExceptEdge", enabledFlag)
 	addFlag(ctx, "structuredQueries", enabledFlag)

--- a/util/populate_dev_data.go
+++ b/util/populate_dev_data.go
@@ -174,6 +174,7 @@ func main() {
 	addFlag(ctx, "queryBuilder", enabledFlag)
 	addFlag(ctx, "diffFilter", enabledFlag)
 	addFlag(ctx, "diffFromAPI", enabledFlag)
+	addFlag(ctx, "structuredQueries", enabledFlag)
 
 	log.Print("Adding uploader \"test\"...")
 	addData(ctx, "Uploader", []interface{}{

--- a/webapp/components/test-search.html
+++ b/webapp/components/test-search.html
@@ -6,6 +6,7 @@ found in the LICENSE file.
 
 <link rel="import" href="../bower_components/paper-tooltip/paper-tooltip.html">
 <link rel="import" href="../bower_components/polymer/polymer-element.html">
+<link rel="import" href="wpt-flags.html">
 
 <dom-module id="test-search">
   <template>
@@ -39,7 +40,8 @@ found in the LICENSE file.
   <script>
     const QUERY_DEBOUNCE_ID = Symbol('query_debounce_timeout');
 
-    class TestSearch extends window.Polymer.Element {
+    /* global WPTFlags */
+    class TestSearch extends WPTFlags(window.Polymer.Element) {
       static get is() {
         return 'test-search';
       }
@@ -58,6 +60,7 @@ found in the LICENSE file.
             type: String,
             notify: true,
           },
+          parsedQuery: Object,
           results: {
             type: Array,
             notify: true,
@@ -75,15 +78,24 @@ found in the LICENSE file.
           onChange: Function,
           onFocus: Function,
           onBlur: Function,
+          commitQuery: Function,
         };
       }
 
       constructor() {
         super();
-        this.onKeyUp = this.handleKeyUp.bind(this);
+
         this.onChange = this.handleChange.bind(this);
         this.onFocus = this.handleFocus.bind(this);
         this.onBlur = this.handleBlur.bind(this);
+
+        if (this.structuredQueries) {
+          this.onKeyUp = this.handleKeyUpStructured.bind(this);
+          this.commitQuery = this.commitQueryStructured;
+        } else {
+          this.onKeyUp = this.handleKeyUpUnstructured.bind(this);
+          this.commitQuery = this.commitQueryUnstructured;
+        }
       }
 
       computeAutocompleteURL(testRuns, q) {
@@ -144,7 +156,7 @@ found in the LICENSE file.
         this.query = this.q.toLowerCase();
       }
 
-      commitQuery() {
+      commitQueryUnstructured() {
         this.query = this.q;
         this.dispatchEvent(new CustomEvent('commit', {
           detail: {query: this.query},
@@ -152,12 +164,22 @@ found in the LICENSE file.
         this.shadowRoot.querySelector('.query').blur();
       }
 
-      handleKeyUp(e) {
+      commitQueryStructured() {
+        // TODO: Operate over query parse result.
+        return this.commitQueryUnstructured();
+      }
+
+      handleKeyUpUnstructured(e) {
         if (e.keyCode !== 13) {
           return;
         }
 
         this.commitQuery();
+      }
+
+      handleKeyUpStructured(e) {
+        // TODO: Parse query.
+        return this.handleKeyUpUnstructured(e);
       }
 
       handleChange(e) {

--- a/webapp/components/wpt-flags.html
+++ b/webapp/components/wpt-flags.html
@@ -7,14 +7,19 @@ found in the LICENSE file.
 <link rel="import" href="../bower_components/polymer/polymer-element.html">
 <link rel="import" href="../bower_components/paper-item/paper-item.html">
 <link rel="import" href="../bower_components/paper-checkbox/paper-checkbox.html">
-<link rel="import" href="../components/wpt-env-flags.html">
+<link rel="import" href="wpt-env-flags.html">
 
 <!--
 `<wpt-flags>` is a component for checking wpt.fyi feature flags.
 -->
 <dom-module id="wpt-flags">
   <script>
-    const WPT_FYI_FEATURES = ['queryBuilder', 'diffFromAPI', 'diffFilter'];
+    const WPT_FYI_FEATURES = [
+      'queryBuilder',
+      'diffFromAPI',
+      'diffFilter',
+      'structuredQueries',
+    ];
 
     const _wptFlags = (superClass, readOnly) => class extends superClass {
       static get is() {
@@ -61,6 +66,12 @@ found in the LICENSE file.
     <paper-item>
       <paper-checkbox checked="{{diffFilter}}">
         Filter toggle for diff view
+      </paper-checkbox>
+    </paper-item>
+    <paper-item>
+      <paper-checkbox checked="{{structuredQueries}}">
+        Interpret query strings as structured queries over test names and test
+        status/result values
       </paper-checkbox>
     </paper-item>
   </template>


### PR DESCRIPTION
The flag is a no-op for now; I defined methods in the `test-runs` component for diverging query processing behaviour, but they contain a `TODO` and delegate to the unstructured query behaviour for now.