### PR TITLE
Show error message in verbose table view

### DIFF
--- a/webapp/components/abstract-test-file-results-table.html
+++ b/webapp/components/abstract-test-file-results-table.html
@@ -29,7 +29,7 @@ found in the LICENSE file.
       td.result.OK, td.result.PASS {
         background-color: rgb(90, 242, 113);
       }
-      td.result.FAIL {
+      td.result.FAIL, td.result.ERROR {
         background-color: rgb(242, 90, 90);
       }
       tbody tr:first-child {

--- a/webapp/components/abstract-test-file-results-table.html
+++ b/webapp/components/abstract-test-file-results-table.html
@@ -27,12 +27,6 @@ found in the LICENSE file.
       td.result {
         background-color: #eee;
       }
-      td.result.OK, td.result.PASS {
-        background-color: rgb(90, 242, 113);
-      }
-      td.result.FAIL, td.result.ERROR {
-        background-color: rgb(242, 90, 90);
-      }
       tbody tr:first-child {
         border-bottom: 8px solid white;
       }

--- a/webapp/components/test-file-results-table-terse.html
+++ b/webapp/components/test-file-results-table-terse.html
@@ -98,8 +98,17 @@ found in the LICENSE file.
       }
 
       subtestMessage(result) {
-        return super.subtestMessage(result) ||
-          this.parseFailureMessage(result.message);
+        let msg = super.subtestMessage(result);
+        if (msg) {
+          return msg;
+        }
+
+        // Terse table only: Display "ERROR" without message on harness error.
+        if (result.status === 'ERROR') {
+          return 'ERROR';
+        }
+
+        return this.parseFailureMessage(result.message);
       }
 
       parseFailureMessage(msg) {

--- a/webapp/components/test-file-results-table-verbose.html
+++ b/webapp/components/test-file-results-table-verbose.html
@@ -21,7 +21,7 @@ found in the LICENSE file.
 
       subtestMessage(result) {
         return super.subtestMessage(result)  ||
-          `Failure message: ${result.message}`;
+          `${result.status} message: ${result.message}`;
       }
     }
 

--- a/webapp/components/test-file-results.html
+++ b/webapp/components/test-file-results.html
@@ -99,7 +99,10 @@ found in the LICENSE file.
         // resultsTable[0].name set after discovering subtests.
         let resultsTable = [{
           results: resultsPerTestRun.map(data => {
-            return {status: data && data.status};
+            return {
+              status: data && data.status,
+              message: data && data.message,
+            };
           }),
         }];
 


### PR DESCRIPTION
Fixes #681 and turns 'Failure message: [msg]' into '(ERROR|FAIL) message: [msg]'

cc @foolip