### PR TITLE
Drop comments about 'nils' that no longer apply

### DIFF
--- a/api/query/autocomplete.go
+++ b/api/query/autocomplete.go
@@ -68,7 +68,6 @@ func apiAutocompleteHandler(w http.ResponseWriter, r *http.Request) {
 		sharedImpl: defaultShared{ctx},
 		dataSource: shared.NewByteCachedStore(ctx, mc, shared.NewHTTPReadable(ctx)),
 	}}
-	// nils => defaults of: (1) URL string as cache key; (2) cache only HTTP 200.
 	ch := shared.NewCachingHandler(ctx, sh, mc, isRequestCacheable, shared.URLAsCacheKey, shared.CacheStatusOK)
 	ch.ServeHTTP(w, r)
 }

--- a/api/query/search.go
+++ b/api/query/search.go
@@ -67,7 +67,6 @@ func apiSearchHandler(w http.ResponseWriter, r *http.Request) {
 		sharedImpl: defaultShared{ctx},
 		dataSource: shared.NewByteCachedStore(ctx, mc, shared.NewHTTPReadable(ctx)),
 	}}
-	// nils => defaults of: (1) URL string as cache key; (2) cache only HTTP 200.
 	ch := shared.NewCachingHandler(ctx, sh, mc, isRequestCacheable, shared.URLAsCacheKey, shared.CacheStatusOK)
 	ch.ServeHTTP(w, r)
 }

--- a/api/shas.go
+++ b/api/shas.go
@@ -23,10 +23,6 @@ type SHAsHandler struct {
 func apiSHAsHandler(w http.ResponseWriter, r *http.Request) {
 	// Serve cached with 5 minute expiry. Delegate to SHAsHandler on cache miss.
 	ctx := shared.NewAppEngineContext(r)
-	// nils => defaults of:
-	// (1) all URLs to this handler are cacheable;
-	// (2) URL string as cache key;
-	// (3) cache only HTTP 200.
 	shared.NewCachingHandler(ctx, SHAsHandler{ctx}, shared.NewGZReadWritable(shared.NewMemcacheReadWritable(ctx, 5*time.Minute)), shared.AlwaysCachable, shared.URLAsCacheKey, shared.CacheStatusOK).ServeHTTP(w, r)
 }
 

--- a/api/versions.go
+++ b/api/versions.go
@@ -26,10 +26,6 @@ func apiVersionsHandler(w http.ResponseWriter, r *http.Request) {
 	// Serve cached with 5 minute expiry. Delegate to VersionsHandler on cache
 	// miss.
 	ctx := shared.NewAppEngineContext(r)
-	// nils => defaults of:
-	// (1) all URLs to this handler are cacheable;
-	// (2) URL string as cache key;
-	// (3) cache only HTTP 200.
 	shared.NewCachingHandler(ctx, VersionsHandler{ctx}, shared.NewGZReadWritable(shared.NewMemcacheReadWritable(ctx, 5*time.Minute)), shared.AlwaysCachable, shared.URLAsCacheKey, shared.CacheStatusOK).ServeHTTP(w, r)
 }
 


### PR DESCRIPTION
A previous strategy for cache handlers was to implement default helper functions and allow nil values on construction. Helper function parameters are now required and comments about using nil and defaults no longer apply.