### PR TITLE
Implement and integrate client-side structured query parser/generator

### DIFF
--- a/webapp/components/test-search.html
+++ b/webapp/components/test-search.html
@@ -161,6 +161,12 @@ found in the LICENSE file.
 
     /* global WPTFlags */
     class TestSearch extends WPTFlags(window.Polymer.Element) {
+      static get QUERY_GRAMMAR() {
+        return QUERY_GRAMMAR;
+      }
+      static get QUERY_SEMANTICS() {
+        return QUERY_SEMANTICS;
+      }
       static get is() {
         return 'test-search';
       }

--- a/webapp/components/test-search.html
+++ b/webapp/components/test-search.html
@@ -38,7 +38,126 @@ found in the LICENSE file.
     </div>
   </template>
 
+  <script type="text/javascript" src="https://unpkg.com/ohm-js@latest/dist/ohm.js"></script>
+  <script type="text/ohm-js">
+
+  </script>
   <script>
+    const QUERY_GRAMMAR = ohm.grammar(`
+      Query {
+        Q = ListOf<Exp, space*>
+
+        Exp = NonemptyListOf<OrPart, or>
+
+        OrPart = NonemptyListOf<AndPart, and>
+
+        AndPart
+          = not Exp     -- not
+          | "(" Exp ")" -- paren
+          | Fragment    -- fragment
+
+        or
+          = "|"
+          | caseInsensitive<"or">
+
+        and
+          = "&"
+          | caseInsensitive<"and">
+
+        not
+          = "!"
+          | "not"
+
+        Fragment
+          = nameLiteral
+          | statusExp
+          | nameFragment
+
+        nameLiteral
+          = "\"" nameLiteralInner "\""
+
+        nameLiteralInner
+          = nameLiteralChar*
+
+        nameLiteralChar
+          = "\x00".."\x21"
+          | "\x5D".."\uFFFF"
+          | "\\\\" -- slash
+          | "\\\"" -- quote
+
+        statusExp
+          = browserName ":" statusLiteral
+
+        browserName
+          = caseInsensitive<"chrome">
+          | caseInsensitive<"edge">
+          | caseInsensitive<"firefox">
+          | caseInsensitive<"safari">
+
+        statusLiteral
+          = caseInsensitive<"unknown">
+          | caseInsensitive<"pass">
+          | caseInsensitive<"ok">
+          | caseInsensitive<"fail">
+          | caseInsensitive<"timeout">
+          | caseInsensitive<"not_run">
+          | caseInsensitive<"error">
+
+        nameFragment = nameFragmentChar+
+
+        nameFragmentChar
+          = "\x00".."\x08"
+          | "\x0E".."\x1F"
+          | "\x21".."\uFFFF"
+      }
+    `);
+    const QUERY_SEMANTICS = QUERY_GRAMMAR.createSemantics().addOperation('eval', {
+      _terminal: function() {
+        return this.sourceString;
+      },
+      EmptyListOf: function() {
+        return [];
+      },
+      NonemptyListOf: function(fst, seps, rest) {
+        return [fst.eval()].concat(rest.eval());
+      },
+      Q: l => {
+        const ps = l.eval();
+        return ps.length == 0 ? {pattern: ''} : ps.length === 1 ?
+          ps[0] : {and: ps};
+      },
+      Exp: l => {
+        const ps = l.eval();
+        return ps.length === 1 ? ps[0] : {or: ps};
+      },
+      OrPart: l => {
+        const ps = l.eval();
+        return ps.length === 1 ? ps[0] : {and: ps};
+      },
+      AndPart_not: (n, p) => {
+        return {not: p.eval()};
+      },
+      AndPart_paren: (lp, p, rp) => p.eval(),
+      AndPart_fragment: p => p.eval(),
+      Fragment: f => f.eval(),
+      nameLiteral: (q1, l, q2) => {
+        return {pattern: l.eval().join('')};
+      },
+      nameLiteralInner: (chars) => {
+        return chars.eval();
+      },
+      nameLiteralChar_slash: (v) => '\\',
+      nameLiteralChar_quote: (v) => '"',
+      statusExp: (l, colon, r) => {
+        return {
+          browserName: l.sourceString.toLowerCase(),
+          status: r.sourceString.toUpperCase(),
+        };
+      },
+      nameFragment: (chars) => {
+        return {pattern: chars.eval().join('')};
+      },
+    });
     const QUERY_DEBOUNCE_ID = Symbol('query_debounce_timeout');
 
     /* global WPTFlags */
@@ -152,8 +271,25 @@ found in the LICENSE file.
       }
 
       commitQueryStructured() {
-        // TODO: Operate over query parse result.
-        return this.commitQueryUnstructured();
+        const p = QUERY_GRAMMAR.match(this.queryInput);
+        if (!p.succeeded()) {
+          // TODO: Interpret error and add toast to UI.
+          return;
+        }
+        try {
+          const q = QUERY_SEMANTICS(p).eval();
+
+          this.query = this.queryInput;
+          this.dispatchEvent(new CustomEvent('commit', {
+            detail: {
+              query: this.query,
+              structuredQuery: q,
+            },
+          }));
+          this.shadowRoot.querySelector('.query').blur();
+        } catch (err) {
+          // TODO: Interpret error and add toast to UI.
+        }
       }
 
       handleKeyUpUnstructured(e) {

--- a/webapp/components/test-search.html
+++ b/webapp/components/test-search.html
@@ -38,11 +38,12 @@ found in the LICENSE file.
     </div>
   </template>
 
-  <script type="text/javascript" src="https://unpkg.com/ohm-js@latest/dist/ohm.js"></script>
+  <script type="text/javascript" src="https://unpkg.com/ohm-js@latest/dist/ohm.min.js"></script>
   <script type="text/ohm-js">
 
   </script>
   <script>
+    /* global ohm */
     const QUERY_GRAMMAR = ohm.grammar(`
       Query {
         Q = ListOf<Exp, space*>
@@ -74,16 +75,16 @@ found in the LICENSE file.
           | nameFragment
 
         nameLiteral
-          = "\"" nameLiteralInner "\""
+          = "\\"" nameLiteralInner "\\""
 
         nameLiteralInner
           = nameLiteralChar*
 
         nameLiteralChar
-          = "\x00".."\x21"
-          | "\x5D".."\uFFFF"
+          = "\\x00".."\\x21"
+          | "\\x5D".."\\uFFFF"
           | "\\\\" -- slash
-          | "\\\"" -- quote
+          | "\\"" -- quote
 
         statusExp
           = browserName ":" statusLiteral
@@ -106,9 +107,9 @@ found in the LICENSE file.
         nameFragment = nameFragmentChar+
 
         nameFragmentChar
-          = "\x00".."\x08"
-          | "\x0E".."\x1F"
-          | "\x21".."\uFFFF"
+          = "\\x00".."\\x08"
+          | "\\x0E".."\\x1F"
+          | "\\x21".."\\uFFFF"
       }
     `);
     const QUERY_SEMANTICS = QUERY_GRAMMAR.createSemantics().addOperation('eval', {
@@ -123,7 +124,7 @@ found in the LICENSE file.
       },
       Q: l => {
         const ps = l.eval();
-        return ps.length == 0 ? {pattern: ''} : ps.length === 1 ?
+        return ps.length === 0 ? {pattern: ''} : ps.length === 1 ?
           ps[0] : {and: ps};
       },
       Exp: l => {
@@ -137,15 +138,13 @@ found in the LICENSE file.
       AndPart_not: (n, p) => {
         return {not: p.eval()};
       },
-      AndPart_paren: (lp, p, rp) => p.eval(),
+      AndPart_paren: (_, p, __) => p.eval(),
       AndPart_fragment: p => p.eval(),
       Fragment: f => f.eval(),
-      nameLiteral: (q1, l, q2) => {
+      nameLiteral: (_, l, __) => {
         return {pattern: l.eval().join('')};
       },
-      nameLiteralInner: (chars) => {
-        return chars.eval();
-      },
+      nameLiteralInner: chars => chars.eval(),
       nameLiteralChar_slash: (v) => '\\',
       nameLiteralChar_quote: (v) => '"',
       statusExp: (l, colon, r) => {

--- a/webapp/components/test-search.html
+++ b/webapp/components/test-search.html
@@ -39,9 +39,6 @@ found in the LICENSE file.
   </template>
 
   <script type="text/javascript" src="https://unpkg.com/ohm-js@latest/dist/ohm.min.js"></script>
-  <script type="text/ohm-js">
-
-  </script>
   <script>
     /* global ohm */
     const QUERY_GRAMMAR = ohm.grammar(`

--- a/webapp/components/test-search.html
+++ b/webapp/components/test-search.html
@@ -188,7 +188,7 @@ found in the LICENSE file.
             notify: true,
             observer: 'queryUpdated',
           },
-          parsedQuery: Object,
+          structuredQuery: Object,
           results: {
             type: Array,
             notify: true,
@@ -202,7 +202,6 @@ found in the LICENSE file.
           onChange: Function,
           onFocus: Function,
           onBlur: Function,
-          commitQuery: Function,
         };
       }
 
@@ -212,14 +211,7 @@ found in the LICENSE file.
         this.onChange = this.handleChange.bind(this);
         this.onFocus = this.handleFocus.bind(this);
         this.onBlur = this.handleBlur.bind(this);
-
-        if (this.structuredQueries) {
-          this.onKeyUp = this.handleKeyUpStructured.bind(this);
-          this.commitQuery = this.commitQueryStructured;
-        } else {
-          this.onKeyUp = this.handleKeyUpUnstructured.bind(this);
-          this.commitQuery = this.commitQueryUnstructured;
-        }
+        this.onKeyUp = this.handleKeyUp.bind(this);
       }
 
       ready() {
@@ -228,8 +220,24 @@ found in the LICENSE file.
         this.queryInput = this.query;
       }
 
-      queryUpdated(query) {
+      queryUpdated(query, oldQuery) {
         this.queryInput = query;
+        if (this.structuredQueries) {
+          try {
+            this.structuredQuery = this.parseAndInterpretQuery(query);
+          } catch (err) {
+            // TODO: Handle query parse/interpret error.
+          }
+        }
+      }
+
+      parseAndInterpretQuery(query) {
+        const p = QUERY_GRAMMAR.match(query);
+        if (!p.succeeded()) {
+          throw new Error(`Failed to parse query: ${query}`);
+        }
+
+        return QUERY_SEMANTICS(p).eval();
       }
 
       updateDatalist(query, paths) {
@@ -267,47 +275,23 @@ found in the LICENSE file.
         this.query = (this.queryInput || '').toLowerCase();
       }
 
-      commitQueryUnstructured() {
+      commitQuery() {
         this.query = this.queryInput;
         this.dispatchEvent(new CustomEvent('commit', {
-          detail: {query: this.query},
+          detail: {
+            query: this.query,
+            structuredQuery: this.structuredQuery,
+          },
         }));
         this.shadowRoot.querySelector('.query').blur();
       }
 
-      commitQueryStructured() {
-        const p = QUERY_GRAMMAR.match(this.queryInput);
-        if (!p.succeeded()) {
-          // TODO: Interpret error and add toast to UI.
-          return;
-        }
-        try {
-          const q = QUERY_SEMANTICS(p).eval();
-
-          this.query = this.queryInput;
-          this.dispatchEvent(new CustomEvent('commit', {
-            detail: {
-              query: this.query,
-              structuredQuery: q,
-            },
-          }));
-          this.shadowRoot.querySelector('.query').blur();
-        } catch (err) {
-          // TODO: Interpret error and add toast to UI.
-        }
-      }
-
-      handleKeyUpUnstructured(e) {
+      handleKeyUp(e) {
         if (e.keyCode !== 13) {
           return;
         }
 
         this.commitQuery();
-      }
-
-      handleKeyUpStructured(e) {
-        // TODO: Parse query.
-        return this.handleKeyUpUnstructured(e);
       }
 
       handleChange(e) {

--- a/webapp/components/test-search.html
+++ b/webapp/components/test-search.html
@@ -112,6 +112,7 @@ found in the LICENSE file.
           | "\\x21".."\\uFFFF"
       }
     `);
+    /* eslint-disable */
     const QUERY_SEMANTICS = QUERY_GRAMMAR.createSemantics().addOperation('eval', {
       _terminal: function() {
         return this.sourceString;
@@ -157,6 +158,8 @@ found in the LICENSE file.
         return {pattern: chars.eval().join('')};
       },
     });
+    /* eslint-enable */
+
     const QUERY_DEBOUNCE_ID = Symbol('query_debounce_timeout');
 
     /* global WPTFlags */

--- a/webapp/components/test-search.html
+++ b/webapp/components/test-search.html
@@ -220,7 +220,7 @@ found in the LICENSE file.
         this.queryInput = this.query;
       }
 
-      queryUpdated(query, oldQuery) {
+      queryUpdated(query) {
         this.queryInput = query;
         if (this.structuredQueries) {
           try {

--- a/webapp/components/test/test-search.html
+++ b/webapp/components/test/test-search.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="../../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../bower_components/web-component-tester/browser.js"></script>
+
+  <link rel="import" href="util/helpers.html">
+  <link rel="import" href="../test-search.html">
+</head>
+<body>
+  <test-fixture id="test-search-fixture">
+    <template>
+      <test-search></test-search>
+    </template>
+  </test-fixture>
+
+  <script>
+    /* global waitingOn */
+    suite('<test-search>', () => {
+      let tsf = null;
+
+      setup(() => {
+        tsf = fixture('test-search-fixture');
+      });
+
+      suite('Parser/interpreter', () => {
+        let q;
+        const commitListener = e => {
+          q = e.detail.structuredQuery;
+        };
+
+        setup(() => {
+          tsf.addEventListener('commit', commitListener);
+        });
+        teardown(() => {
+          tsf.removeEventListener('commit', commitListener);
+          q = undefined;
+        });
+
+        const assertQueryEqual = (str, structuredQuery) => {
+          return waitingOn(() => q && assert.equal(structuredQuery, q));
+        };
+
+        test('simple pattern', () => {
+          return assertQueryEqual('2dcontext', {pattern: '2dcontext'});
+        });
+      });
+    });
+  </script>
+</body>
+</html>

--- a/webapp/components/test/test-search.html
+++ b/webapp/components/test/test-search.html
@@ -111,8 +111,12 @@
                   {
                     and: [
                       {browserName: 'chrome', status: 'FAIL'},
-                      {pattern: 'b'},
-                      {pattern: 'c'},
+                      {
+                        and: [
+                          {pattern: 'b'},
+                          {pattern: 'c'},
+                        ],
+                      },
                     ],
                   },
                 ],

--- a/webapp/components/test/test-search.html
+++ b/webapp/components/test/test-search.html
@@ -18,12 +18,6 @@
   <script>
     /* global TestSearch */
     suite('<test-search>', () => {
-      let tsf = null;
-
-      setup(() => {
-        tsf = fixture('test-search-fixture');
-      });
-
       suite('Parser/interpreter', () => {
         const G = TestSearch.QUERY_GRAMMAR;
         const S = TestSearch.QUERY_SEMANTICS;
@@ -123,7 +117,7 @@
               },
             ],
           });
-        })
+        });
       });
     });
   </script>

--- a/webapp/components/test/test-search.html
+++ b/webapp/components/test/test-search.html
@@ -16,7 +16,7 @@
   </test-fixture>
 
   <script>
-    /* global waitingOn */
+    /* global TestSearch */
     suite('<test-search>', () => {
       let tsf = null;
 
@@ -25,26 +25,101 @@
       });
 
       suite('Parser/interpreter', () => {
-        let q;
-        const commitListener = e => {
-          q = e.detail.structuredQuery;
-        };
-
-        setup(() => {
-          tsf.addEventListener('commit', commitListener);
-        });
-        teardown(() => {
-          tsf.removeEventListener('commit', commitListener);
-          q = undefined;
-        });
-
-        const assertQueryEqual = (str, structuredQuery) => {
-          return waitingOn(() => q && assert.equal(structuredQuery, q));
+        const G = TestSearch.QUERY_GRAMMAR;
+        const S = TestSearch.QUERY_SEMANTICS;
+        const assertQueryParse = (query, structuredQuery) => {
+          const p = G.match(query);
+          assert.isTrue(p.succeeded());
+          assert.deepEqual(structuredQuery, S(p).eval());
         };
 
         test('simple pattern', () => {
-          return assertQueryEqual('2dcontext', {pattern: '2dcontext'});
+          assertQueryParse('2dcontext', {pattern: '2dcontext'});
         });
+
+        test('browser test status', () => {
+          assertQueryParse('cHrOmE:oK', {browserName: 'chrome', status: 'OK'});
+        });
+
+        test('pattern + test status', () => {
+          assertQueryParse('cssom firefox:timeout', {
+            and: [
+              {pattern: 'cssom'},
+              {browserName: 'firefox', status: 'TIMEOUT'},
+            ],
+          });
+        });
+
+        test('pattern | test status', () => {
+          assertQueryParse('cssom or firefox:timeout', {
+            or: [
+              {pattern: 'cssom'},
+              {browserName: 'firefox', status: 'TIMEOUT'},
+            ],
+          });
+        });
+
+        test('implicit and, or', () => {
+          assertQueryParse('a b or c', {
+            and: [
+              {pattern: 'a'},
+              {
+                or: [
+                  {pattern: 'b'},
+                  {pattern: 'c'},
+                ],
+              },
+            ],
+          });
+        });
+
+        test('explicit and, or', () => {
+          assertQueryParse('a and b or c', {
+            or: [
+              {
+                and: [
+                  {pattern: 'a'},
+                  {pattern: 'b'},
+                ],
+              },
+              {pattern: 'c'},
+            ],
+          });
+        });
+
+        test('parens', () => {
+          assertQueryParse('a and ( b or c )', {
+            and: [
+              {pattern: 'a'},
+              {
+                or: [
+                  {pattern: 'b'},
+                  {pattern: 'c'},
+                ],
+              },
+            ],
+          });
+        });
+
+        test('all features', () => {
+          assertQueryParse('firefox:pass a | chrome:fail and ( b & c )', {
+            and: [
+              {browserName: 'firefox', status: 'PASS'},
+              {
+                or: [
+                  {pattern: 'a'},
+                  {
+                    and: [
+                      {browserName: 'chrome', status: 'FAIL'},
+                      {pattern: 'b'},
+                      {pattern: 'c'},
+                    ],
+                  },
+                ],
+              },
+            ],
+          });
+        })
       });
     });
   </script>

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -519,7 +519,7 @@ found in the LICENSE file.
         } else {
           url.searchParams.set(
             'run_ids',
-            testRuns.map(r => r.id.toString()).join(','));
+            this.testRuns.map(r => r.id.toString()).join(','));
           if (this.query) {
             url.searchParams.set('q', q);
           }

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -778,8 +778,9 @@ found in the LICENSE file.
         const detail = e.detail;
         // Fetch search results when test-search signals that user has committed
         // to search string (by pressing <Enter>).
-        this.fetchResults(this.structuredQueries ?
-          detail.structuredQuery : detail.query);
+        this.fetchResults(this.structuredQueries
+          ? detail.structuredQuery
+          : detail.query);
         // Trigger a virtual navigation.
         this.navigateToLocation(window.location);
       }

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -487,7 +487,10 @@ found in the LICENSE file.
       loadData() {
         this.load(
           this.loadRuns().then(async runs => {
-            this.fetchResults();
+            // Pass current (un)structured query is passed to fetchResults().
+            const search = this.shadowRoot.querySelector('test-search');
+            this.fetchResults(
+              this.structuredQueries && search.structuredQuery || this.search);
 
             // Load a diff data into this.diffRun, if needed.
             if (this.diff && runs && runs.length === 2) {
@@ -520,7 +523,7 @@ found in the LICENSE file.
           url.searchParams.set(
             'run_ids',
             this.testRuns.map(r => r.id.toString()).join(','));
-          if (this.query) {
+          if (q) {
             url.searchParams.set('q', q);
           }
         }

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -353,10 +353,6 @@ found in the LICENSE file.
             type: Boolean,
             value: false,
           },
-          searchURL: {
-            type: String,
-            computed: 'computeSearchURL(testRuns, search)',
-          },
           resultsLoadFailed: Boolean,
           noResults: Boolean,
           onSearchCommit: Function,
@@ -421,23 +417,6 @@ found in the LICENSE file.
       computeDisplayedTests(path, searchResults) {
         return searchResults.map(r => r.test)
           .filter(name => name.startsWith(path));
-      }
-
-      computeSearchURL(testRuns, query) {
-        if (!testRuns || testRuns.length === 0) {
-          return '';
-        }
-
-        let url = new URL('/api/search', window.location);
-        if (testRuns) {
-          url.searchParams.set(
-            'run_ids',
-            testRuns.map(r => r.id.toString()).join(','));
-        }
-        if (query) {
-          url.searchParams.set('q', query);
-        }
-        return url;
       }
 
       computeDiffURL(productSpecs, query) {
@@ -522,20 +501,39 @@ found in the LICENSE file.
         );
       }
 
-      fetchResults() {
-        this.load(
-          window.fetch(this.searchURL)
-            .then(r => {
-              if (!r.ok || r.status !== 200) {
-                return Promise.reject('Failed to fetch results data.');
-              }
-              return r.json();
-            })
-            .then(json => {
-              this.searchResults = json.results;
-              this.refreshDisplayedNodes();
-            })
-        );
+      fetchResults(q) {
+        if (!this.testRuns || !this.testRuns.length) {
+          return;
+        }
+
+        let url = new URL('/api/search', window.location);
+        let fetchOpts;
+        if (this.structuredQueries) {
+          fetchOpts = {
+            method: 'POST',
+            body: JSON.stringify({
+              run_ids: this.testRuns.map(r => r.id),
+              query: q,
+            }),
+          };
+        } else {
+          url.searchParams.set(
+            'run_ids',
+            testRuns.map(r => r.id.toString()).join(','));
+          if (this.query) {
+            url.searchParams.set('q', q);
+          }
+        }
+
+        this.load(window.fetch(url, fetchOpts).then(r => {
+          if (!r.ok || r.status !== 200) {
+            return Promise.reject('Failed to fetch results data.');
+          }
+          return r.json();
+        }).then(json => {
+          this.searchResults = json.results;
+          this.refreshDisplayedNodes();
+        }));
       }
 
       fetchDiff() {
@@ -776,10 +774,12 @@ found in the LICENSE file.
         this.navigateToPath(e.detail.path);
       }
 
-      handleSearchCommit() {
+      handleSearchCommit(e) {
+        const detail = e.detail;
         // Fetch search results when test-search signals that user has committed
         // to search string (by pressing <Enter>).
-        this.fetchResults();
+        this.fetchResults(this.structuredQueries ?
+          detail.structuredQuery : detail.query);
         // Trigger a virtual navigation.
         this.navigateToLocation(window.location);
       }


### PR DESCRIPTION
This changes uses [ohm](https://github.com/harc/ohm) to define structured queries compatible with server-side parsing articulated in #713. It also integrates the queries by using `POST`-with-body rather than `GET`-with-query-params on `/api/search`.