### PR TITLE
Fix markup structure in wpt-flags.html

### DIFF
--- a/webapp/components/wpt-flags.html
+++ b/webapp/components/wpt-flags.html
@@ -85,9 +85,10 @@ found in the LICENSE file.
         Use pass-rate colors on the homepage
       </paper-checkbox>
     </paper-item>
-    <paper-checkbox checked="{{structuredQueries}}">
-      Interpret query strings as structured queries over test names and test
-      status/result values
+    <paper-item>
+      <paper-checkbox checked="{{structuredQueries}}">
+        Interpret query strings as structured queries over test names and test
+        status/result values
       </paper-checkbox>
     </paper-item>
   </template>


### PR DESCRIPTION
## Description
Introduced in https://github.com/web-platform-tests/wpt.fyi/pull/709
and causes a visual misalignment in /flags.

## Review Information
Check /flags in test deployment.