### PR TITLE
Use go-github protos instead of local structs

### DIFF
--- a/api/webhook/taskcluster.go
+++ b/api/webhook/taskcluster.go
@@ -10,6 +10,7 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -23,6 +24,7 @@ import (
 	"google.golang.org/appengine/datastore"
 	"google.golang.org/appengine/urlfetch"
 
+	"github.com/google/go-github/github"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
@@ -81,24 +83,20 @@ func tcWebhookHandler(w http.ResponseWriter, r *http.Request) {
 
 // https://developer.github.com/v3/activity/events/types/#statusevent
 type statusEventPayload struct {
-	SHA       string      `json:"sha"`
-	State     string      `json:"state"`
-	Context   string      `json:"context"`
-	TargetURL string      `json:"target_url"`
-	Branches  branchInfos `json:"branches"`
+	github.StatusEvent
 }
 
 func (s statusEventPayload) IsSuccess() bool {
-	return s.State == "success"
+	return s.State != nil && *s.State == "success"
 }
 
 func (s statusEventPayload) IsTaskcluster() bool {
-	return strings.HasPrefix(s.Context, "Taskcluster")
+	return s.Context != nil && strings.HasPrefix(*s.Context, "Taskcluster")
 }
 
 func (s statusEventPayload) IsOnMaster() bool {
 	for _, branch := range s.Branches {
-		if branch.Name == "master" {
+		if branch.Name != nil && *branch.Name == "master" {
 			return true
 		}
 	}
@@ -109,29 +107,20 @@ func (s statusEventPayload) HeadingBranches() branchInfos {
 	var branches branchInfos
 	for _, branch := range s.Branches {
 		if branch.Commit.SHA == s.SHA {
-			branches = append(branches, branch)
+			branches = append(branches, *branch)
 		}
 	}
 	return branches
 }
 
-type branchInfo struct {
-	Name   string     `json:"name"`
-	Commit commitInfo `json:"commit"`
-}
-
-type branchInfos []branchInfo
+type branchInfos []github.Branch
 
 func (b branchInfos) GetNames() []string {
 	names := make([]string, len(b))
 	for i := range b {
-		names[i] = b[i].Name
+		names[i] = *b[i].Name
 	}
 	return names
-}
-
-type commitInfo struct {
-	SHA string `json:"sha"`
 }
 
 func handleStatusEvent(ctx context.Context, payload []byte) (bool, error) {
@@ -145,9 +134,12 @@ func handleStatusEvent(ctx context.Context, payload []byte) (bool, error) {
 		return false, nil
 	}
 
-	taskGroupID := extractTaskGroupID(status.TargetURL)
+	if status.TargetURL == nil {
+		return false, errors.New("No target_url on taskcluster status event")
+	}
+	taskGroupID := extractTaskGroupID(*status.TargetURL)
 	if taskGroupID == "" {
-		return false, fmt.Errorf("unrecognized target_url: %s", status.TargetURL)
+		return false, fmt.Errorf("unrecognized target_url: %s", *status.TargetURL)
 	}
 
 	log.Infof("Processing task group %s", taskGroupID)

--- a/api/webhook/taskcluster.go
+++ b/api/webhook/taskcluster.go
@@ -82,9 +82,7 @@ func tcWebhookHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // https://developer.github.com/v3/activity/events/types/#statusevent
-type statusEventPayload struct {
-	github.StatusEvent
-}
+type statusEventPayload github.StatusEvent
 
 func (s statusEventPayload) IsSuccess() bool {
 	return s.State != nil && *s.State == "success"

--- a/api/webhook/taskcluster.go
+++ b/api/webhook/taskcluster.go
@@ -106,14 +106,14 @@ func (s statusEventPayload) IsOnMaster() bool {
 func (s statusEventPayload) HeadingBranches() branchInfos {
 	var branches branchInfos
 	for _, branch := range s.Branches {
-		if branch.Commit.SHA == s.SHA {
-			branches = append(branches, *branch)
+		if *branch.Commit.SHA == *s.SHA {
+			branches = append(branches, branch)
 		}
 	}
 	return branches
 }
 
-type branchInfos []github.Branch
+type branchInfos []*github.Branch
 
 func (b branchInfos) GetNames() []string {
 	names := make([]string, len(b))

--- a/api/webhook/taskcluster_test.go
+++ b/api/webhook/taskcluster_test.go
@@ -14,64 +14,64 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-github/github"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
+func strPtr(s string) *string {
+	return &s
+}
+
 func TestShouldProcessStatus_ok(t *testing.T) {
-	status := statusEventPayload{
-		State:    "success",
-		Context:  "Taskcluster",
-		Branches: []branchInfo{branchInfo{Name: "master"}},
-	}
+	status := statusEventPayload{}
+	status.State = strPtr("success")
+	status.Context = strPtr("Taskcluster")
+	status.Branches = branchInfos{&github.Branch{Name: strPtr("master")}}
 	assert.True(t, shouldProcessStatus(&status))
 }
 
 func TestShouldProcessStatus_unsuccessful(t *testing.T) {
-	status := statusEventPayload{
-		State:    "error",
-		Context:  "Taskcluster",
-		Branches: []branchInfo{branchInfo{Name: "master"}},
-	}
+	status := statusEventPayload{}
+	status.State = strPtr("error")
+	status.Context = strPtr("Taskcluster")
+	status.Branches = branchInfos{&github.Branch{Name: strPtr("master")}}
 	assert.False(t, shouldProcessStatus(&status))
 }
 
 func TestShouldProcessStatus_notTaskcluster(t *testing.T) {
-	status := statusEventPayload{
-		State:    "success",
-		Context:  "Travis",
-		Branches: []branchInfo{branchInfo{Name: "master"}},
-	}
+	status := statusEventPayload{}
+	status.State = strPtr("success")
+	status.Context = strPtr("Travis")
+	status.Branches = branchInfos{&github.Branch{Name: strPtr("master")}}
 	assert.False(t, shouldProcessStatus(&status))
 }
 
 func TestShouldProcessStatus_notOnMaster(t *testing.T) {
-	status := statusEventPayload{
-		State:    "success",
-		Context:  "Taskcluster",
-		Branches: []branchInfo{branchInfo{Name: "gh-pages"}},
-	}
+	status := statusEventPayload{}
+	status.State = strPtr("success")
+	status.Context = strPtr("Taskcluster")
+	status.Branches = branchInfos{&github.Branch{Name: strPtr("gh-pages")}}
 	assert.False(t, shouldProcessStatus(&status))
 }
 
 func TestIsOnMaster(t *testing.T) {
-	status := statusEventPayload{
-		SHA:     "a10867b14bb761a232cd80139fbd4c0d33264240",
-		State:   "success",
-		Context: "Taskcluster",
-		Branches: []branchInfo{
-			branchInfo{
-				Name:   "master",
-				Commit: commitInfo{SHA: "a10867b14bb761a232cd80139fbd4c0d33264240"},
-			},
-			branchInfo{
-				Name:   "changes",
-				Commit: commitInfo{SHA: "34c5c7793cb3b279e22454cb6750c80560547b3a"},
-			},
-			branchInfo{
-				Name:   "gh-pages",
-				Commit: commitInfo{SHA: "fd353d4ae7c19d2268397459524f849c129944a7"},
-			},
+	status := statusEventPayload{}
+	status.SHA = strPtr("a10867b14bb761a232cd80139fbd4c0d33264240")
+	status.State = strPtr("success")
+	status.Context = strPtr("Taskcluster")
+	status.Branches = branchInfos{
+		&github.Branch{
+			Name:   strPtr("master"),
+			Commit: &github.RepositoryCommit{SHA: strPtr("a10867b14bb761a232cd80139fbd4c0d33264240")},
+		},
+		&github.Branch{
+			Name:   strPtr("changes"),
+			Commit: &github.RepositoryCommit{SHA: strPtr("34c5c7793cb3b279e22454cb6750c80560547b3a")},
+		},
+		&github.Branch{
+			Name:   strPtr("gh-pages"),
+			Commit: &github.RepositoryCommit{SHA: strPtr("fd353d4ae7c19d2268397459524f849c129944a7")},
 		},
 	}
 	assert.Equal(t, []string{"master"}, status.HeadingBranches().GetNames())


### PR DESCRIPTION
## Description
go-github defines these protos already, so can reduce our code lines, and future code-churn.