### PR TITLE
Process non-master branch Taskcluster results (with flag)

### DIFF
--- a/api/webhook/taskcluster.go
+++ b/api/webhook/taskcluster.go
@@ -323,8 +323,9 @@ func createAllRuns(log shared.Logger,
 func createRun(client *http.Client, sha, api string, username string, password string, reportURLs []string, labels []string) error {
 	// https://github.com/web-platform-tests/wpt.fyi/blob/master/api/README.md#url-payload
 	payload := make(url.Values)
-	payload.Add("revision", sha[:10])
-	payload.Add("full_revision_hash", sha)
+	// Not to be confused with `revision` in the wpt.fyi TestRun model, this
+	// parameter is the full revision hash.
+	payload.Add("revision", sha)
 	for _, url := range reportURLs {
 		payload.Add("result_url", url)
 	}

--- a/api/webhook/taskcluster.go
+++ b/api/webhook/taskcluster.go
@@ -130,7 +130,8 @@ func handleStatusEvent(ctx context.Context, payload []byte) (bool, error) {
 		return false, err
 	}
 
-	if !shouldProcessStatus(shared.IsFeatureEnabled(ctx, flagTaskclusterAllBranches), &status) {
+	masterOnly := !shared.IsFeatureEnabled(ctx, flagTaskclusterAllBranches)
+	if !shouldProcessStatus(masterOnly, &status) {
 		return false, nil
 	}
 

--- a/api/webhook/taskcluster.go
+++ b/api/webhook/taskcluster.go
@@ -130,8 +130,8 @@ func handleStatusEvent(ctx context.Context, payload []byte) (bool, error) {
 		return false, err
 	}
 
-	masterOnly := !shared.IsFeatureEnabled(ctx, flagTaskclusterAllBranches)
-	if !shouldProcessStatus(masterOnly, &status) {
+	processAllBranches := shared.IsFeatureEnabled(ctx, flagTaskclusterAllBranches)
+	if !shouldProcessStatus(processAllBranches, &status) {
 		return false, nil
 	}
 
@@ -178,11 +178,11 @@ func handleStatusEvent(ctx context.Context, payload []byte) (bool, error) {
 	return true, nil
 }
 
-func shouldProcessStatus(masterOnly bool, status *statusEventPayload) bool {
+func shouldProcessStatus(processAllBranches bool, status *statusEventPayload) bool {
 	if !status.IsSuccess() || !status.IsTaskcluster() {
 		return false
 	}
-	return !masterOnly || status.IsOnMaster()
+	return processAllBranches || status.IsOnMaster()
 }
 
 func extractTaskGroupID(targetURL string) string {

--- a/api/webhook/taskcluster_test.go
+++ b/api/webhook/taskcluster_test.go
@@ -28,7 +28,7 @@ func TestShouldProcessStatus_ok(t *testing.T) {
 	status.State = strPtr("success")
 	status.Context = strPtr("Taskcluster")
 	status.Branches = branchInfos{&github.Branch{Name: strPtr("master")}}
-	assert.True(t, shouldProcessStatus(true, &status))
+	assert.True(t, shouldProcessStatus(false, &status))
 }
 
 func TestShouldProcessStatus_unsuccessful(t *testing.T) {
@@ -36,7 +36,7 @@ func TestShouldProcessStatus_unsuccessful(t *testing.T) {
 	status.State = strPtr("error")
 	status.Context = strPtr("Taskcluster")
 	status.Branches = branchInfos{&github.Branch{Name: strPtr("master")}}
-	assert.False(t, shouldProcessStatus(true, &status))
+	assert.False(t, shouldProcessStatus(false, &status))
 }
 
 func TestShouldProcessStatus_notTaskcluster(t *testing.T) {
@@ -44,7 +44,7 @@ func TestShouldProcessStatus_notTaskcluster(t *testing.T) {
 	status.State = strPtr("success")
 	status.Context = strPtr("Travis")
 	status.Branches = branchInfos{&github.Branch{Name: strPtr("master")}}
-	assert.False(t, shouldProcessStatus(true, &status))
+	assert.False(t, shouldProcessStatus(false, &status))
 }
 
 func TestShouldProcessStatus_notOnMaster(t *testing.T) {
@@ -52,8 +52,8 @@ func TestShouldProcessStatus_notOnMaster(t *testing.T) {
 	status.State = strPtr("success")
 	status.Context = strPtr("Taskcluster")
 	status.Branches = branchInfos{&github.Branch{Name: strPtr("gh-pages")}}
-	assert.False(t, shouldProcessStatus(true, &status))
-	assert.True(t, shouldProcessStatus(false, &status))
+	assert.False(t, shouldProcessStatus(false, &status))
+	assert.True(t, shouldProcessStatus(true, &status))
 }
 
 func TestIsOnMaster(t *testing.T) {

--- a/api/webhook/taskcluster_test.go
+++ b/api/webhook/taskcluster_test.go
@@ -200,3 +200,10 @@ func TestCreateAllRuns_all_errors(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Equal(t, 2, strings.Count(err.Error(), "Client.Timeout"))
 }
+
+func TestTaskNameRegex(t *testing.T) {
+	assert.Len(t, taskNameRegex.FindStringSubmatch("wpt-chrome-dev-results"), 4)
+	assert.Len(t, taskNameRegex.FindStringSubmatch("wpt-chrome-dev-reftest-1"), 4)
+	assert.Len(t, taskNameRegex.FindStringSubmatch("wpt-chrome-dev-testharness-5"), 4)
+	assert.Len(t, taskNameRegex.FindStringSubmatch("wpt-chrome-dev-wdspec-1"), 4)
+}

--- a/api/webhook/taskcluster_test.go
+++ b/api/webhook/taskcluster_test.go
@@ -24,7 +24,7 @@ func TestShouldProcessStatus_ok(t *testing.T) {
 		Context:  "Taskcluster",
 		Branches: []branchInfo{branchInfo{Name: "master"}},
 	}
-	assert.True(t, shouldProcessStatus(&status))
+	assert.True(t, shouldProcessStatus(true, &status))
 }
 
 func TestShouldProcessStatus_unsuccessful(t *testing.T) {
@@ -33,7 +33,7 @@ func TestShouldProcessStatus_unsuccessful(t *testing.T) {
 		Context:  "Taskcluster",
 		Branches: []branchInfo{branchInfo{Name: "master"}},
 	}
-	assert.False(t, shouldProcessStatus(&status))
+	assert.False(t, shouldProcessStatus(true, &status))
 }
 
 func TestShouldProcessStatus_notTaskcluster(t *testing.T) {
@@ -42,7 +42,7 @@ func TestShouldProcessStatus_notTaskcluster(t *testing.T) {
 		Context:  "Travis",
 		Branches: []branchInfo{branchInfo{Name: "master"}},
 	}
-	assert.False(t, shouldProcessStatus(&status))
+	assert.False(t, shouldProcessStatus(true, &status))
 }
 
 func TestShouldProcessStatus_notOnMaster(t *testing.T) {
@@ -51,7 +51,8 @@ func TestShouldProcessStatus_notOnMaster(t *testing.T) {
 		Context:  "Taskcluster",
 		Branches: []branchInfo{branchInfo{Name: "gh-pages"}},
 	}
-	assert.False(t, shouldProcessStatus(&status))
+	assert.False(t, shouldProcessStatus(true, &status))
+	assert.True(t, shouldProcessStatus(false, &status))
 }
 
 func TestIsOnMaster(t *testing.T) {
@@ -141,6 +142,7 @@ func TestCreateAllRuns_success(t *testing.T) {
 	err := createAllRuns(logrus.New(),
 		&http.Client{},
 		server.URL,
+		"abcdef1234abcdef1234abcdef1234abcdef1234",
 		"username",
 		"password",
 		map[string][]string{"chrome": []string{"1"}, "firefox": []string{"1", "2"}},
@@ -168,6 +170,7 @@ func TestCreateAllRuns_one_error(t *testing.T) {
 	err := createAllRuns(logrus.New(),
 		&http.Client{},
 		server.URL,
+		"abcdef1234abcdef1234abcdef1234abcdef1234",
 		"username",
 		"password",
 		map[string][]string{"chrome": []string{"1"}, "firefox": []string{"1", "2"}},
@@ -188,6 +191,7 @@ func TestCreateAllRuns_all_errors(t *testing.T) {
 	err := createAllRuns(logrus.New(),
 		&http.Client{Timeout: time.Second},
 		server.URL,
+		"abcdef1234abcdef1234abcdef1234abcdef1234",
 		"username",
 		"password",
 		map[string][]string{"chrome": []string{"1"}, "firefox": []string{"1", "2"}},

--- a/api/webhook/taskcluster_test.go
+++ b/api/webhook/taskcluster_test.go
@@ -28,7 +28,7 @@ func TestShouldProcessStatus_ok(t *testing.T) {
 	status.State = strPtr("success")
 	status.Context = strPtr("Taskcluster")
 	status.Branches = branchInfos{&github.Branch{Name: strPtr("master")}}
-	assert.True(t, shouldProcessStatus(&status))
+	assert.True(t, shouldProcessStatus(true, &status))
 }
 
 func TestShouldProcessStatus_unsuccessful(t *testing.T) {
@@ -36,7 +36,7 @@ func TestShouldProcessStatus_unsuccessful(t *testing.T) {
 	status.State = strPtr("error")
 	status.Context = strPtr("Taskcluster")
 	status.Branches = branchInfos{&github.Branch{Name: strPtr("master")}}
-	assert.False(t, shouldProcessStatus(&status))
+	assert.False(t, shouldProcessStatus(true, &status))
 }
 
 func TestShouldProcessStatus_notTaskcluster(t *testing.T) {
@@ -44,7 +44,7 @@ func TestShouldProcessStatus_notTaskcluster(t *testing.T) {
 	status.State = strPtr("success")
 	status.Context = strPtr("Travis")
 	status.Branches = branchInfos{&github.Branch{Name: strPtr("master")}}
-	assert.False(t, shouldProcessStatus(&status))
+	assert.False(t, shouldProcessStatus(true, &status))
 }
 
 func TestShouldProcessStatus_notOnMaster(t *testing.T) {
@@ -52,7 +52,8 @@ func TestShouldProcessStatus_notOnMaster(t *testing.T) {
 	status.State = strPtr("success")
 	status.Context = strPtr("Taskcluster")
 	status.Branches = branchInfos{&github.Branch{Name: strPtr("gh-pages")}}
-	assert.False(t, shouldProcessStatus(&status))
+	assert.False(t, shouldProcessStatus(true, &status))
+	assert.True(t, shouldProcessStatus(false, &status))
 }
 
 func TestIsOnMaster(t *testing.T) {

--- a/shared/datastore.go
+++ b/shared/datastore.go
@@ -268,3 +268,14 @@ func GetFeatureFlags(ctx context.Context) (flags []Flag, err error) {
 	}
 	return flags, err
 }
+
+// IsFeatureEnabled returns true if a feature with the given flag name exists,
+// and Enabled is set to true.
+func IsFeatureEnabled(ctx context.Context, flagName string) bool {
+	key := datastore.NewKey(ctx, "Flag", flagName, 0, nil)
+	flag := Flag{}
+	if err := datastore.Get(ctx, key, &flag); err != nil {
+		return false
+	}
+	return flag.Enabled
+}

--- a/shared/datastore_medium_test.go
+++ b/shared/datastore_medium_test.go
@@ -421,3 +421,24 @@ func TestGetAlignedRunSHAs(t *testing.T) {
 	shas, _, _ = shared.GetAlignedRunSHAs(ctx, shared.GetDefaultProducts(), nil, &from, nil, nil)
 	assert.Equal(t, []string{"abcdef0123"}, shas)
 }
+
+func TestIsFeatureEnabled(t *testing.T) {
+	i, err := sharedtest.NewAEInstance(true)
+	assert.Nil(t, err)
+	defer i.Close()
+	r, err := i.NewRequest("GET", "/", nil)
+	assert.Nil(t, err)
+
+	flagName := "foo"
+	ctx := shared.NewAppEngineContext(r)
+	key := datastore.NewKey(ctx, "Flag", flagName, 0, nil)
+
+	// No flag value.
+	assert.False(t, shared.IsFeatureEnabled(ctx, flagName))
+	// Disabled flag.
+	datastore.Put(ctx, key, &shared.Flag{Enabled: false})
+	assert.False(t, shared.IsFeatureEnabled(ctx, flagName))
+	// Enabled flag.
+	datastore.Put(ctx, key, &shared.Flag{Enabled: true})
+	assert.True(t, shared.IsFeatureEnabled(ctx, flagName))
+}


### PR DESCRIPTION
## Description
Changes the `/api/webhook/taskcluster` handler to not ignore non-master branches when `taskclusterAllBranches` flag is enabled.

Working towards #712 

This requires a tweak to the logic for task names (we want to ignore `stability`, but process `results`).
It also requires us to override what Taskcluster's wpt-report says was the SHA, since that SHA is a squash-commit over `master` and doesn't match the GitHub SHA for the PR results.

## Review Information
While difficult to confirm this works locally, it's a copy of the code from my [prototype](https://github.com/lukebjerring/web-platform-tests/pull/8/checks) for which you can see `change` branch results have made it into staging: https://staging.wpt.fyi/test-runs?label=change