### PR TITLE
Plumb diff filter params through the UI

### DIFF
--- a/api/diff.go
+++ b/api/diff.go
@@ -60,7 +60,7 @@ func handleAPIDiffGet(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	} else if len(runs) != 2 {
-		http.Error(w, fmt.Sprintf("Diffing requires exactly 2 runs, but found %v", len(runFilter.Products)), http.StatusBadRequest)
+		http.Error(w, fmt.Sprintf("Diffing requires exactly 2 runs, but found %v", len(runs)), http.StatusBadRequest)
 		return
 	}
 

--- a/shared/params.go
+++ b/shared/params.go
@@ -553,15 +553,29 @@ type DiffFilterParam struct {
 	// Unchanged tests are present in both the 'before' and 'after' states of the diff,
 	// and the number of passes, failures, or total tests is unchanged.
 	Unchanged bool
+}
 
-	// Set of test paths to include, or include all tests if nil.
-	Paths mapset.Set
+func (d DiffFilterParam) String() string {
+	s := ""
+	if d.Added {
+		s += "A"
+	}
+	if d.Deleted {
+		s += "D"
+	}
+	if d.Changed {
+		s += "C"
+	}
+	if d.Unchanged {
+		s += "U"
+	}
+	return s
 }
 
 // ParseDiffFilterParams collects the diff filtering params for the given request.
 // It splits the filter param into the differences to include. The filter param is inspired by Git's --diff-filter flag.
 // It also adds the set of test paths to include; see ParsePathsParam below.
-func ParseDiffFilterParams(r *http.Request) (param DiffFilterParam, err error) {
+func ParseDiffFilterParams(r *http.Request) (param DiffFilterParam, paths mapset.Set, err error) {
 	param = DiffFilterParam{
 		Added:   true,
 		Deleted: true,
@@ -580,12 +594,11 @@ func ParseDiffFilterParams(r *http.Request) (param DiffFilterParam, err error) {
 			case 'U':
 				param.Unchanged = true
 			default:
-				return param, fmt.Errorf("invalid filter character %c", char)
+				return param, nil, fmt.Errorf("invalid filter character %c", char)
 			}
 		}
 	}
-	param.Paths = NewSetFromStringSlice(ParsePathsParam(r))
-	return param, nil
+	return param, NewSetFromStringSlice(ParsePathsParam(r)), nil
 }
 
 // ParsePathsParam returns a set list of test paths to include, or nil if no

--- a/shared/params_test.go
+++ b/shared/params_test.go
@@ -244,51 +244,51 @@ func TestParsePathsParam_PathsAndPath_Duplicate(t *testing.T) {
 
 func TestParsePathsParam_Paths_DiffFilter(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/api/diff?paths=/css&path=/css", nil)
-	filter, err := ParseDiffFilterParams(r)
+	_, paths, err := ParseDiffFilterParams(r)
 	assert.Nil(t, err)
-	assert.Equal(t, 1, filter.Paths.Cardinality())
+	assert.Equal(t, 1, paths.Cardinality())
 }
 
 func TestParseDiffFilterParam(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/api/diff?filter=A", nil)
-	filter, _ := ParseDiffFilterParams(r)
+	filter, _, _ := ParseDiffFilterParams(r)
 	assert.Equal(t, DiffFilterParam{Added: true, Deleted: false, Changed: false}, filter)
 
 	r = httptest.NewRequest("GET", "http://wpt.fyi/api/diff?filter=D", nil)
-	filter, _ = ParseDiffFilterParams(r)
+	filter, _, _ = ParseDiffFilterParams(r)
 	assert.Equal(t, DiffFilterParam{Added: false, Deleted: true, Changed: false}, filter)
 
 	r = httptest.NewRequest("GET", "http://wpt.fyi/api/diff?filter=C", nil)
-	filter, _ = ParseDiffFilterParams(r)
+	filter, _, _ = ParseDiffFilterParams(r)
 	assert.Equal(t, DiffFilterParam{Added: false, Deleted: false, Changed: true}, filter)
 
 	r = httptest.NewRequest("GET", "http://wpt.fyi/api/diff?filter=CAD", nil)
-	filter, _ = ParseDiffFilterParams(r)
+	filter, _, _ = ParseDiffFilterParams(r)
 	assert.Equal(t, DiffFilterParam{Added: true, Deleted: true, Changed: true}, filter)
 
 	r = httptest.NewRequest("GET", "http://wpt.fyi/api/diff?filter=CD", nil)
-	filter, _ = ParseDiffFilterParams(r)
+	filter, _, _ = ParseDiffFilterParams(r)
 	assert.Equal(t, DiffFilterParam{Added: false, Deleted: true, Changed: true}, filter)
 
 	r = httptest.NewRequest("GET", "http://wpt.fyi/api/diff?filter=CACA", nil)
-	filter, _ = ParseDiffFilterParams(r)
+	filter, _, _ = ParseDiffFilterParams(r)
 	assert.Equal(t, DiffFilterParam{Added: true, Deleted: false, Changed: true}, filter)
 
 	r = httptest.NewRequest("GET", "http://wpt.fyi/api/diff?filter=U", nil)
-	filter, _ = ParseDiffFilterParams(r)
+	filter, _, _ = ParseDiffFilterParams(r)
 	assert.Equal(t, DiffFilterParam{Unchanged: true}, filter)
 }
 
 func TestParseDiffFilterParam_Empty(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/api/diff", nil)
-	filter, err := ParseDiffFilterParams(r)
+	filter, _, err := ParseDiffFilterParams(r)
 	assert.Nil(t, err)
 	assert.Equal(t, DiffFilterParam{Added: true, Deleted: true, Changed: true, Unchanged: false}, filter)
 }
 
 func TestParseDiffFilterParam_Invalid(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/api/diff?filter=Z", nil)
-	_, err := ParseDiffFilterParams(r)
+	_, _, err := ParseDiffFilterParams(r)
 	assert.NotNil(t, err)
 }
 

--- a/shared/run_diff.go
+++ b/shared/run_diff.go
@@ -91,11 +91,11 @@ func FetchRunResultsJSON(ctx context.Context, r *http.Request, run TestRun) (res
 // GetResultsDiff returns a map of test name to an array of [newly-passing, newly-failing, total-delta], for tests which had
 // different results counts in their map (which is test name to array of [count-passed, total]).
 //
-func GetResultsDiff(before map[string][]int, after map[string][]int, filter DiffFilterParam) map[string][]int {
+func GetResultsDiff(before map[string][]int, after map[string][]int, filter DiffFilterParam, paths mapset.Set) map[string][]int {
 	diff := make(map[string][]int)
 	if filter.Deleted || filter.Changed {
 		for test, resultsBefore := range before {
-			if !anyPathMatches(filter.Paths, test) {
+			if !anyPathMatches(paths, test) {
 				continue
 			}
 
@@ -135,7 +135,7 @@ func GetResultsDiff(before map[string][]int, after map[string][]int, filter Diff
 	}
 	if filter.Added {
 		for test, resultsAfter := range after {
-			if !anyPathMatches(filter.Paths, test) {
+			if !anyPathMatches(paths, test) {
 				continue
 			}
 

--- a/webapp/components/wpt-flags.html
+++ b/webapp/components/wpt-flags.html
@@ -18,7 +18,7 @@ found in the LICENSE file.
       'queryBuilder',
       'queryBuilderSHA',
       'diffFromAPI',
-      'diffFilter',
+      'diffFilterUIToggle',
       'colorHomepage',
       'structuredQueries',
     ];
@@ -76,7 +76,7 @@ found in the LICENSE file.
       </paper-checkbox>
     </paper-item>
     <paper-item>
-      <paper-checkbox checked="{{diffFilter}}">
+      <paper-checkbox checked="{{diffFilterUIToggle}}">
         Filter toggle for diff view
       </paper-checkbox>
     </paper-item>

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -213,7 +213,7 @@ found in the LICENSE file.
               <template is="dom-if" if="[[diffShown]]">
                 <th>
                   <test-run test-run="[[diffRun]]"></test-run>
-                  <template is="dom-if" if="[[diffFilter]]">
+                  <template is="dom-if" if="[[diffFilterUIToggle]]">
                     <paper-icon-button icon="filter-list" onclick="[[toggleDiffFilter]]"></paper-icon-button>
                   </template>
                 </th>
@@ -345,7 +345,7 @@ found in the LICENSE file.
             type: String,
             computed: 'computeDiffURL(testRuns, query)',
           },
-          filter: {
+          diffFilter: {
             type: String,
             value: 'ADC', // Added, Deleted, Changed
           },
@@ -445,11 +445,15 @@ found in the LICENSE file.
           return;
         }
         let url = new URL('/api/diff', window.location);
-        url.search = query
-          .replace('product', 'before')
-          .replace('product', 'after');
+        url.search = query;
+        const productParams = url.searchParams.getAll('product');
+        if (productParams && productParams.length === 2) {
+          url.searchParams.delete('product');
+          url.searchParams.set('before', productParams[0]);
+          url.searchParams.set('after', productParams[1]);
+        }
         url.searchParams.delete('diff');
-        url.searchParams.set('filter', this.filter);
+        url.searchParams.set('filter', this.diffFilter);
         return url;
       }
 
@@ -629,8 +633,8 @@ found in the LICENSE file.
               }
               if (this.diff && rs.length === 2) {
                 let diff = [];
-                if (this.diffResults && r.test in this.diffResults) {
-                  diff = this.diffResults[r.test];
+                if (this.diffResults) {
+                  diff = this.diffResults[r.test] || [0, 0, 0];
                 } else {
                   const [before, after] = rs;
                   const failingBefore = before.total - before.passes;

--- a/webapp/routes_test.go
+++ b/webapp/routes_test.go
@@ -51,7 +51,6 @@ func TestRunsBoundHSTS(t *testing.T) {
 
 func TestApiDiffBoundCORS(t *testing.T) {
 	assertHandlerIs(t, "/api/diff", "api-diff")
-	assertCORS(t, "/api/diff")
 }
 
 func TestApiInteropBound(t *testing.T) {

--- a/webapp/templates/results.html
+++ b/webapp/templates/results.html
@@ -9,6 +9,7 @@
         {{ template "_test_run_query_params.html" .Filter }}
         {{- with .Filter}}
           {{- if .Diff}} diff{{end}}
+          {{- if .DiffFilter}} diff-filter="{{.DiffFilter}}"{{end}}
         {{- end}}
         {{- if .Query }} search="{{.Query}}"{{end}}></wpt-results>
   </div>

--- a/webapp/test_results_handler.go
+++ b/webapp/test_results_handler.go
@@ -32,7 +32,8 @@ type testRunUIFilter struct {
 
 type testResultsUIFilter struct {
 	testRunUIFilter
-	Diff bool
+	Diff       bool
+	DiffFilter string
 }
 
 // This handler is responsible for all pages that display test results.
@@ -110,6 +111,11 @@ func parseTestResultsUIFilter(r *http.Request) (filter testResultsUIFilter, err 
 		return filter, err
 	}
 	filter.Diff = diff != nil && *diff
+	diffFilter, _, err := shared.ParseDiffFilterParams(r)
+	if err != nil {
+		return filter, err
+	}
+	filter.DiffFilter = diffFilter.String()
 
 	var beforeAndAfter shared.ProductSpecs
 	if beforeAndAfter, err = shared.ParseBeforeAndAfterParams(r); err != nil {


### PR DESCRIPTION
## Description
Splits `path` param from `filter` for parsing, and plumbs the value to the webcomponent.
We'll need this to make the UI ignore tests that didn't run on a PR.

Also changes the `/api/diff` endpoint to allow anything that produces exactly 2 results, e.g. `?product=chrome&max-count=2`

## Review Information
Load some filtered view, e.g. `/results?products=chrome[experimental],chrome[stable]&diff&filter=U` will only show unchanged things (kinda useless, but easy to tell it works).