### PR TITLE
Add feature flag for fetching master branch runs only

### DIFF
--- a/shared/datastore.go
+++ b/shared/datastore.go
@@ -268,3 +268,14 @@ func GetFeatureFlags(ctx context.Context) (flags []Flag, err error) {
 	}
 	return flags, err
 }
+
+// IsFeatureEnabled returns true if a feature with the given flag name exists,
+// and Enabled is set to true.
+func IsFeatureEnabled(ctx context.Context, flagName string) bool {
+	key := datastore.NewKey(ctx, "Flag", flagName, 0, nil)
+	flag := Flag{}
+	if err := datastore.Get(ctx, key, &flag); err != nil {
+		return false
+	}
+	return flag.Enabled
+}

--- a/shared/datastore_medium_test.go
+++ b/shared/datastore_medium_test.go
@@ -421,3 +421,22 @@ func TestGetAlignedRunSHAs(t *testing.T) {
 	shas, _, _ = shared.GetAlignedRunSHAs(ctx, shared.GetDefaultProducts(), nil, &from, nil, nil)
 	assert.Equal(t, []string{"abcdef0123"}, shas)
 }
+
+func TestIsFeatureEnabled(t *testing.T) {
+	i, err := sharedtest.NewAEInstance(true)
+	assert.Nil(t, err)
+	defer i.Close()
+	r, err := i.NewRequest("GET", "/", nil)
+	assert.Nil(t, err)
+	flagName := "foo"
+	ctx := shared.NewAppEngineContext(r)
+	key := datastore.NewKey(ctx, "Flag", flagName, 0, nil)
+	// No flag value.
+	assert.False(t, shared.IsFeatureEnabled(ctx, flagName))
+	// Disabled flag.
+	datastore.Put(ctx, key, &shared.Flag{Enabled: false})
+	assert.False(t, shared.IsFeatureEnabled(ctx, flagName))
+	// Enabled flag.
+	datastore.Put(ctx, key, &shared.Flag{Enabled: true})
+	assert.True(t, shared.IsFeatureEnabled(ctx, flagName))
+}

--- a/util/populate_dev_data.go
+++ b/util/populate_dev_data.go
@@ -177,6 +177,7 @@ func main() {
 	addFlag(ctx, "experimentalByDefault", enabledFlag)
 	addFlag(ctx, "experimentalAlignedExceptEdge", enabledFlag)
 	addFlag(ctx, "structuredQueries", enabledFlag)
+	addFlag(ctx, "masterRunsOnly", enabledFlag)
 
 	log.Print("Adding uploader \"test\"...")
 	addData(ctx, "Uploader", []interface{}{

--- a/webapp/components/interop.html
+++ b/webapp/components/interop.html
@@ -212,7 +212,7 @@ found in the LICENSE file.
   /* global WPTColors, TestRunsBase, SelfNavigation, LoadingState, QueryBuilder */
   class WPTInterop extends QueryBuilder(
     WPTColors(SelfNavigation(LoadingState(TestRunsBase))),
-    'interopQueryParams(sha, aligned, labels, productSpecs, maxCount, from, to, search)') {
+    'interopQueryParams(sha, aligned, master, labels, productSpecs, maxCount, from, to, search)') {
     static get is() {
       return 'wpt-interop';
     }
@@ -312,8 +312,8 @@ found in the LICENSE file.
       return this.queryParams;
     }
 
-    interopQueryParams(sha, aligned, labels, products, maxCount, search) {
-      const params = this.computeTestRunQueryParams(sha, aligned, labels, products, maxCount);
+    interopQueryParams(sha, aligned, master, labels, products, maxCount, search) {
+      const params = this.computeTestRunQueryParams(sha, aligned, master, labels, products, maxCount);
       if (search) {
         params.q = search;
       }

--- a/webapp/components/test-results-history-grid.html
+++ b/webapp/components/test-results-history-grid.html
@@ -88,8 +88,8 @@ found in the LICENSE file.
         ];
       }
 
-      computeTestRunQueryParams(sha, aligned, labels, products, maxCount) {
-        return super.computeTestRunQueryParams(/*sha*/ null, aligned, labels, products, maxCount);
+      computeTestRunQueryParams(sha, aligned, master, labels, products, maxCount) {
+        return super.computeTestRunQueryParams(/*sha*/ null, aligned, master, labels, products, maxCount);
       }
 
       bindResultHover(run, subTestName) {

--- a/webapp/components/test-runs-query-builder.html
+++ b/webapp/components/test-runs-query-builder.html
@@ -71,6 +71,11 @@ found in the LICENSE file.
     <paper-item>
       <paper-checkbox checked="{{diff}}" disabled="{{!canShowDiff}}">Show diff</paper-checkbox>
     </paper-item>
+    <template is="dom-if" if="[[masterRunsOnly]]">
+      <paper-item>
+        <paper-checkbox id="master-checkbox" checked="{{master}}">Only master</paper-checkbox>
+      </paper-item>
+    </template>
     <paper-item>
       <paper-input label="Labels"
                    always-float-label

--- a/webapp/components/test-runs-query.html
+++ b/webapp/components/test-runs-query.html
@@ -73,16 +73,20 @@ found in the LICENSE file.
           this.productSpecs = (products || []).map(p => this.getSpec(p));
         }
 
+        /**
+        * Convert the UI property values into their equivalent URI query params.
+        */
         computeTestRunQueryParams(sha, aligned, master, labels, productSpecs, maxCount, from, to) {
           const params = {};
           if (!this.computeIsLatest(sha)) {
             params.sha = sha;
           }
-          if (this.masterRunsOnly && master
-              && (!labels || !labels.includes('master'))) {
-            labels = (labels || []).concat('master');
+          // Convert bool master to label 'master'
+          labels = labels && Array.from(labels) || [];
+          if (this.masterRunsOnly && master && !labels.includes('master')) {
+            labels.push('master');
           }
-          if (labels && labels.length) {
+          if (labels.length) {
             params.label = labels;
           }
           maxCount = maxCount || this.defaultMaxCount;
@@ -107,12 +111,12 @@ found in the LICENSE file.
             }
             let productSpecs;
             if (allChannelsSame) {
-              productSpecs = this.products.map(p => Object.assign(
-                {}, p, {labels: (p.labels || []).filter(l => !CHANNELS.has(l)) }))
-                .map(p => this.getSpec(p));
-              const labels = params.label || [];
+              productSpecs = this.products.map(p => {
+                const nonChannel = (p.labels || []).filter(l => !CHANNELS.has(l));
+                return this.getSpec(Object.assign({}, p, {labels: nonChannel}));
+              });
               if (!labels.includes(channel)) {
-                params.label = [...labels, channel];
+                params.label = labels.concat(channel);
               }
             } else {
               productSpecs = this.products.map(p => this.getSpec(p));
@@ -152,7 +156,7 @@ found in the LICENSE file.
         }
 
         /**
-        * Update this builder's properties to match the given query params.
+        * Update this component's UI properties to match the given query params.
         */
         updateQueryParams(params) {
           if (!params) {

--- a/webapp/components/test-runs-query.html
+++ b/webapp/components/test-runs-query.html
@@ -78,7 +78,8 @@ found in the LICENSE file.
           if (!this.computeIsLatest(sha)) {
             params.sha = sha;
           }
-          if (this.master) {
+          if (this.masterRunsOnly && master
+              && (!labels || !labels.includes('master'))) {
             labels = (labels || []).concat('master');
           }
           if (labels && labels.length) {
@@ -186,7 +187,8 @@ found in the LICENSE file.
           if ('aligned' in params) {
             batchUpdate.aligned = params.aligned;
           }
-          if (batchUpdate.labels && batchUpdate.labels.includes('master')) {
+          if (this.masterRunsOnly
+              && batchUpdate.labels && batchUpdate.labels.includes('master')) {
             batchUpdate.master = true;
             batchUpdate.labels = batchUpdate.labels.filter(l => l !== 'master');
           }

--- a/webapp/components/test-runs-query.html
+++ b/webapp/components/test-runs-query.html
@@ -187,10 +187,12 @@ found in the LICENSE file.
           if ('aligned' in params) {
             batchUpdate.aligned = params.aligned;
           }
-          if (this.masterRunsOnly
-              && batchUpdate.labels && batchUpdate.labels.includes('master')) {
-            batchUpdate.master = true;
-            batchUpdate.labels = batchUpdate.labels.filter(l => l !== 'master');
+          if (this.masterRunsOnly) {
+            batchUpdate.master = batchUpdate.labels
+              && batchUpdate.labels.includes('master');
+            if (batchUpdate.master) {
+              batchUpdate.labels = batchUpdate.labels.filter(l => l !== 'master');
+            }
           }
           this.setProperties(batchUpdate);
         }

--- a/webapp/components/test-runs-query.html
+++ b/webapp/components/test-runs-query.html
@@ -16,7 +16,7 @@ found in the LICENSE file.
     // eslint-disable-next-line no-unused-vars
     (() => {
       const testRunsQueryComputer =
-        'computeTestRunQueryParams(sha, aligned, labels, productSpecs, maxCount, from, to)';
+        'computeTestRunQueryParams(sha, aligned, master, labels, productSpecs, maxCount, from, to)';
       window.TestRunsQuery = (superClass, opt_queryCompute) => class extends QueryBuilder(
         ProductInfo(superClass),
         opt_queryCompute || testRunsQueryComputer) {
@@ -46,6 +46,7 @@ found in the LICENSE file.
             maxCount: Number,
             sha: String,
             aligned: Boolean,
+            master: Boolean,
             from: Date,
             to: Date,
             isLatest: {
@@ -72,10 +73,13 @@ found in the LICENSE file.
           this.productSpecs = (products || []).map(p => this.getSpec(p));
         }
 
-        computeTestRunQueryParams(sha, aligned, labels, productSpecs, maxCount, from, to) {
+        computeTestRunQueryParams(sha, aligned, master, labels, productSpecs, maxCount, from, to) {
           const params = {};
           if (!this.computeIsLatest(sha)) {
             params.sha = sha;
+          }
+          if (this.master) {
+            labels = (labels || []).concat('master');
           }
           if (labels && labels.length) {
             params.label = labels;
@@ -182,6 +186,10 @@ found in the LICENSE file.
           if ('aligned' in params) {
             batchUpdate.aligned = params.aligned;
           }
+          if (batchUpdate.labels && batchUpdate.labels.includes('master')) {
+            batchUpdate.master = true;
+            batchUpdate.labels = batchUpdate.labels.filter(l => l !== 'master');
+          }
           this.setProperties(batchUpdate);
         }
       };
@@ -191,7 +199,7 @@ found in the LICENSE file.
     (() => {
       // TODO(lukebjerring): Support to & from in the builder.
       const testRunsUIQueryComputer =
-        'computeTestRunUIQueryParams(sha, aligned, labels, productSpecs, maxCount, diff, search)';
+        'computeTestRunUIQueryParams(sha, aligned, master, labels, productSpecs, maxCount, diff, search)';
       /* global TestRunsQuery */
       window.TestRunsUIQuery = (superClass, opt_queryCompute) => class extends TestRunsQuery(
         superClass,
@@ -212,8 +220,8 @@ found in the LICENSE file.
           };
         }
 
-        computeTestRunUIQueryParams(sha, aligned, labels, productSpecs, maxCount, diff, search) {
-          const params = this.computeTestRunQueryParams(sha, aligned, labels, productSpecs, maxCount);
+        computeTestRunUIQueryParams(sha, aligned, master, labels, productSpecs, maxCount, diff, search) {
+          const params = this.computeTestRunQueryParams(sha, aligned, master, labels, productSpecs, maxCount);
           if (diff || this.diff) {
             params.diff = true;
           }

--- a/webapp/components/test/test-runs-query-builder.html
+++ b/webapp/components/test/test-runs-query-builder.html
@@ -5,6 +5,11 @@
   <script src="../../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../bower_components/web-component-tester/browser.js"></script>
 
+  <script>
+    window.wpt = window.wpt || {};
+    window.wpt.MUTABLE_FLAGS = true;
+  </script>
+
   <link rel="import" href="../test-runs-query-builder.html">
 </head>
 <body>
@@ -139,14 +144,11 @@
         });
 
         suite('shas autocomplete', () => {
-          let sandbox, queryBuilderSHAState;
+          let sandbox;
 
           setup(() => {
             sandbox = sinon.sandbox.create();
             sandbox.spy(queryBuilder, 'shasURLUpdated');
-
-            queryBuilderSHAState = queryBuilder.queryBuilderSHA;
-            queryBuilder.queryBuilderSHA = true;
           });
 
           test('/api/shas fetches', () => {
@@ -157,7 +159,28 @@
 
           teardown(() => {
             sandbox.restore();
-            queryBuilder.queryBuilderSHA = queryBuilderSHAState;
+          });
+        });
+
+        suite('master runs only', () => {
+          setup(() => {
+            queryBuilder.masterRunsOnly = true;
+          });
+
+          test('updateQueryParams', () => {
+            queryBuilder.updateQueryParams({ label: ['master'] });
+            expect(queryBuilder.master).to.be.true;
+
+            queryBuilder.updateQueryParams({ label: [] });
+            expect(queryBuilder.master).to.be.false;
+          });
+
+          test('queryParams', () => {
+            queryBuilder.master = true;
+            expect(queryBuilder.query).to.contain('master');
+
+            queryBuilder.master = false;
+            expect(queryBuilder.query).to.not.contain('master');
           });
         });
 

--- a/webapp/components/wpt-flags.html
+++ b/webapp/components/wpt-flags.html
@@ -21,6 +21,7 @@ found in the LICENSE file.
       'diffFilter',
       'colorHomepage',
       'structuredQueries',
+      'masterRunsOnly',
     ];
 
     const _wptFlags = (superClass, readOnly) => class extends superClass {
@@ -68,6 +69,11 @@ found in the LICENSE file.
     <paper-item sub-item>
       <paper-checkbox checked="{{queryBuilderSHA}}">
         SHA input
+      </paper-checkbox>
+    </paper-item>
+    <paper-item sub-item>
+      <paper-checkbox checked="{{masterRunsOnly}}">
+        'Master only' input
       </paper-checkbox>
     </paper-item>
     <paper-item>

--- a/webapp/components/wpt-flags.html
+++ b/webapp/components/wpt-flags.html
@@ -30,6 +30,9 @@ found in the LICENSE file.
       }
 
       static get properties() {
+        if (!window.wpt) {
+          window.wpt = {};
+        }
         const props = {};
         for (const feature of WPT_FYI_FEATURES) {
           const stored = localStorage.getItem(`features.${feature}`);
@@ -41,7 +44,7 @@ found in the LICENSE file.
           }
           props[feature] = {
             type: Boolean,
-            readOnly: readOnly,
+            readOnly: readOnly && !window.wpt.MUTABLE_FLAGS,
             notify: true,
             value: value,
           };

--- a/webapp/test_results_handler.go
+++ b/webapp/test_results_handler.go
@@ -12,10 +12,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/deckarep/golang-set"
+
 	"github.com/gorilla/mux"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 	"google.golang.org/appengine"
-	"google.golang.org/appengine/datastore"
 )
 
 type testRunUIFilter struct {
@@ -89,18 +90,25 @@ func parseTestResultsUIFilter(r *http.Request) (filter testResultsUIFilter, err 
 	if err != nil {
 		return filter, err
 	}
-	var experimentalByDefault, experimentalAlignedExceptEdge shared.Flag
 	ctx := appengine.NewContext(r)
-	datastore.Get(ctx, datastore.NewKey(ctx, "Flag", "experimentalByDefault", 0, nil), &experimentalByDefault)
-	datastore.Get(ctx, datastore.NewKey(ctx, "Flag", "experimentalAlignedExceptEdge", 0, nil), &experimentalAlignedExceptEdge)
-	if experimentalByDefault.Enabled {
-		if experimentalAlignedExceptEdge.Enabled {
+
+	experimentalByDefault := shared.IsFeatureEnabled(ctx, "experimentalByDefault")
+	experimentalAlignedExceptEdge := shared.IsFeatureEnabled(ctx, "experimentalAlignedExceptEdge")
+	masterRunsOnly := shared.IsFeatureEnabled(ctx, "masterRunsOnly")
+	if experimentalByDefault {
+		if experimentalAlignedExceptEdge {
 			testRunFilter = testRunFilter.OrAlignedExperimentalRunsExceptEdge()
 		} else {
 			testRunFilter = testRunFilter.OrExperimentalRuns()
 		}
 	} else {
 		testRunFilter = testRunFilter.OrAlignedStableRuns()
+	}
+	if masterRunsOnly {
+		if testRunFilter.Labels == nil {
+			testRunFilter.Labels = mapset.NewSet()
+		}
+		testRunFilter.Labels.Add("master")
 	}
 
 	filter.testRunUIFilter = parseTestRunUIFilter(testRunFilter)


### PR DESCRIPTION
## Description
Adds a field to the query builder, and uses the `label=master` in the default query.

## Review Information
- Head to /flags, enable the feature
- Open the query builder, tick the box, reload, see `master` label is used