### PR TITLE
Support fetching runs by their IDs

### DIFF
--- a/api/diff.go
+++ b/api/diff.go
@@ -65,19 +65,16 @@ func handleAPIDiffGet(w http.ResponseWriter, r *http.Request) {
 	} else {
 		// NOTE: We use the same params as /results, but also support
 		// 'before' and 'after' and 'filter'.
-		runFilter, err := shared.ParseTestRunFilterParams(r)
-		if err != nil {
+		runFilter, parseErr := shared.ParseTestRunFilterParams(r)
+		if parseErr != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-
-		var beforeAndAfter shared.ProductSpecs
-		beforeAndAfter, err = shared.ParseBeforeAndAfterParams(r)
-		if err != nil {
+		beforeAndAfter, parseErr := shared.ParseBeforeAndAfterParams(r)
+		if parseErr != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-
 		if len(beforeAndAfter) > 0 {
 			runFilter.Products = beforeAndAfter
 		}

--- a/shared/params.go
+++ b/shared/params.go
@@ -703,7 +703,7 @@ func ParseBooleanParam(r *http.Request, name string) (result *bool, err error) {
 
 // ParseRunIDsParam parses the "run_ids" parameter. If the ID is not a valid
 // int64, an error will be returned.
-func ParseRunIDsParam(r *http.Request) (ids []int64, err error) {
+func ParseRunIDsParam(r *http.Request) (ids TestRunIDs, err error) {
 	return ParseRepeatedInt64Param(r, "run_id", "run_ids")
 }
 

--- a/shared/params_test.go
+++ b/shared/params_test.go
@@ -484,12 +484,17 @@ func TestParseRunIDsParam_nil(t *testing.T) {
 func TestParseRunIDsParam_ok(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/api/search?run_ids=1,2,3", nil)
 	runIDs, err := ParseRunIDsParam(r)
-	assert.Equal(t, []int64{1, 2, 3}, runIDs)
+	assert.Equal(t, []int64{1, 2, 3}, []int64(runIDs))
 	assert.Nil(t, err)
 
 	r = httptest.NewRequest("GET", "http://wpt.fyi/api/search?run_id=1&run_id=2&run_id=3", nil)
 	runIDs, err = ParseRunIDsParam(r)
-	assert.Equal(t, []int64{1, 2, 3}, runIDs)
+	assert.Equal(t, []int64{1, 2, 3}, []int64(runIDs))
+	assert.Nil(t, err)
+
+	r = httptest.NewRequest("GET", "http://wpt.fyi/api/search?run_id=1&run_id=2&run_id=3", nil)
+	runIDs, err = ParseRunIDsParam(r)
+	assert.Equal(t, []int64{1, 2, 3}, []int64(runIDs))
 	assert.Nil(t, err)
 }
 

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -343,7 +343,7 @@ found in the LICENSE file.
           },
           diffURL: {
             type: String,
-            computed: 'computeDiffURL(testRuns, query)',
+            computed: 'computeDiffURL(testRuns)',
           },
           diffFilter: {
             type: String,
@@ -440,20 +440,15 @@ found in the LICENSE file.
         return url;
       }
 
-      computeDiffURL(productSpecs, query) {
-        if (!productSpecs || productSpecs.length !== 2) {
+      computeDiffURL(testRuns) {
+        if (!testRuns || testRuns.length !== 2) {
           return;
         }
         let url = new URL('/api/diff', window.location);
-        url.search = query;
-        const productParams = url.searchParams.getAll('product');
-        if (productParams && productParams.length === 2) {
-          url.searchParams.delete('product');
-          url.searchParams.set('before', productParams[0]);
-          url.searchParams.set('after', productParams[1]);
+        for (const run of testRuns) {
+          url.searchParams.append('run_id', run.id);
         }
-        url.searchParams.delete('diff');
-        url.searchParams.set('filter', this.diffFilter);
+        url.searchParams.set('filter', this.filter);
         return url;
       }
 

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -427,7 +427,7 @@ found in the LICENSE file.
         for (const run of testRuns) {
           url.searchParams.append('run_id', run.id);
         }
-        url.searchParams.set('filter', this.filter);
+        url.searchParams.set('filter', this.diffFilter);
         return url;
       }
 


### PR DESCRIPTION
## Description
Follow-up from https://github.com/web-platform-tests/wpt.fyi/pull/617 

On `/api/diff`, this prevents the (unlikely) race-condition, and any potential discrepancies, between executing the same query on 2 different api endpoints.