### PR TITLE
Complete any check_suites when a run arrives

### DIFF
--- a/api/receiver/create_run.go
+++ b/api/receiver/create_run.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/web-platform-tests/wpt.fyi/api/checks"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
@@ -18,7 +19,7 @@ import (
 const InternalUsername = "_processor"
 
 // HandleResultsCreate handles the POST requests for creating test runs.
-func HandleResultsCreate(a AppEngineAPI, w http.ResponseWriter, r *http.Request) {
+func HandleResultsCreate(a AppEngineAPI, s checks.SuitesAPI, w http.ResponseWriter, r *http.Request) {
 	username, password, ok := r.BasicAuth()
 	if !ok || username != InternalUsername || !a.authenticateUploader(username, password) {
 		http.Error(w, "Authentication error", http.StatusUnauthorized)
@@ -50,6 +51,8 @@ func HandleResultsCreate(a AppEngineAPI, w http.ResponseWriter, r *http.Request)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+
+	s.CompleteCheckRun(testRun.FullRevisionHash, testRun.BrowserName)
 
 	// Copy int64 representation of key into TestRun.ID so that clients can
 	// inspect/use key value.

--- a/api/receiver/create_run_test.go
+++ b/api/receiver/create_run_test.go
@@ -37,8 +37,6 @@ func TestHandleResultsCreate(t *testing.T) {
 		"labels":             []string{"foo", "bar"},
 		"time_start":         "2018-06-21T18:39:54.218000+00:00",
 		"time_end":           "2018-06-21T20:03:49Z",
-		// Intentionally missing full_revision_hash; no error should be raised.
-		// Unknown parameters should be ignored.
 		"_random_extra_key_": "some_value",
 	}
 	body, err := json.Marshal(payload)

--- a/api/results_receive_handler.go
+++ b/api/results_receive_handler.go
@@ -7,6 +7,7 @@ package api
 import (
 	"net/http"
 
+	"github.com/web-platform-tests/wpt.fyi/api/checks"
 	"github.com/web-platform-tests/wpt.fyi/api/receiver"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
@@ -30,5 +31,6 @@ func apiResultsCreateHandler(w http.ResponseWriter, r *http.Request) {
 
 	ctx := shared.NewAppEngineContext(r)
 	a := receiver.NewAppEngineAPI(ctx)
-	receiver.HandleResultsCreate(a, w, r)
+	s := checks.NewSuitesAPI(ctx)
+	receiver.HandleResultsCreate(a, s, w, r)
 }


### PR DESCRIPTION
## Description
Leverages the `checks` package's API to trigger a `completed` status for any `CheckSuite` for the SHA of the newly-uploaded run.

Currently, not doing this, we end up with infinitely `in_progress` check_runs.