### PR TITLE
Only force the master label for default queries

### DIFF
--- a/shared/params.go
+++ b/shared/params.go
@@ -93,6 +93,16 @@ func (filter TestRunFilter) OrAlignedExperimentalRunsExceptEdge() TestRunFilter 
 	return filter
 }
 
+// MasterOnly returns the current filter, ensuring it has with the master-only
+// restriction (a label of "master").
+func (filter TestRunFilter) MasterOnly() TestRunFilter {
+	if filter.Labels == nil {
+		filter.Labels = mapset.NewSet()
+	}
+	filter.Labels.Add(MasterLabel)
+	return filter
+}
+
 // IsDefaultProducts returns whether the params products are empty, or the
 // equivalent of the default product set.
 func (filter TestRunFilter) IsDefaultProducts() bool {

--- a/shared/util.go
+++ b/shared/util.go
@@ -25,6 +25,10 @@ const LatestSHA = "latest"
 // StableLabel is the implicit label present for runs marked 'stable'.
 const StableLabel = "stable"
 
+// MasterLabel is the implicit label present for runs marked 'master',
+// i.e. run from the master branch.
+const MasterLabel = "master"
+
 // GetDefaultProducts returns the default set of products to show on wpt.fyi
 func GetDefaultProducts() ProductSpecs {
 	browserNames := GetDefaultBrowserNames()

--- a/webapp/test_results_handler_medium_test.go
+++ b/webapp/test_results_handler_medium_test.go
@@ -10,7 +10,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/web-platform-tests/wpt.fyi/shared"
 	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
+	"google.golang.org/appengine"
+	"google.golang.org/appengine/datastore"
 )
 
 func TestParseTestResultsUIFilter(t *testing.T) {
@@ -41,4 +44,17 @@ func TestParseTestResultsUIFilter(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "[\"edge\",\"chrome\"]", f.Products)
 	assert.Equal(t, true, f.Diff)
+
+	// MasterOnly default query.
+	ctx := appengine.NewContext(r)
+	datastore.Put(ctx, datastore.NewKey(ctx, "Flag", "masterRunsOnly", 0, nil), &shared.Flag{Enabled: true})
+	r, _ = i.NewRequest("GET", "/results/", nil)
+	f, err = parseTestResultsUIFilter(r)
+	assert.Nil(t, err)
+	assert.Contains(t, f.Labels, shared.MasterLabel)
+
+	r, _ = i.NewRequest("GET", "/results/?sha=0123456789", nil)
+	f, err = parseTestResultsUIFilter(r)
+	assert.Nil(t, err)
+	assert.NotContains(t, f.Labels, shared.MasterLabel)
 }


### PR DESCRIPTION
## Description
With the master-only feature enabled, we end up unable to run a query like `sha=...` for non-master runs.