### PR TITLE
Ignore other check_suite apps

### DIFF
--- a/api/checks/webhook.go
+++ b/api/checks/webhook.go
@@ -9,7 +9,6 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -138,13 +137,17 @@ func handleCheckRunEvent(ctx context.Context, payload []byte) (bool, error) {
 		return false, err
 	}
 
-	if checkRun.Action == nil {
-		return false, errors.New("No action present on the check_run event")
+	appID := checkRun.GetCheckRun().GetApp().GetID()
+	if appID != wptfyiCheckAppID {
+		log.Infof("Ignoring check_suite App ID %v", appID)
+		return false, nil
 	}
-	if (*checkRun.Action == "created" && *checkRun.CheckRun.Status != "completed") ||
-		*checkRun.Action == "rerequested" {
+
+	action := checkRun.GetAction()
+	status := checkRun.GetCheckRun().GetStatus()
+	if (action == "created" && status != "completed") || action == "rerequested" {
 		name, sha := *checkRun.CheckRun.Name, *checkRun.CheckRun.HeadSHA
-		log.Debugf("Check run %s @ %s %s", name, sha, *checkRun.Action)
+		log.Debugf("Check run %s @ %s %s", name, sha, action)
 		spec, err := shared.ParseProductSpec(*checkRun.CheckRun.Name)
 		if err != nil {
 			log.Errorf("Failed to parse \"%s\" as product spec", *checkRun.CheckRun.Name)

--- a/api/checks/webhook.go
+++ b/api/checks/webhook.go
@@ -15,6 +15,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strconv"
 	"time"
 
 	jwt "github.com/dgrijalva/jwt-go"
@@ -25,6 +26,9 @@ import (
 	"golang.org/x/oauth2"
 	"google.golang.org/appengine/datastore"
 )
+
+// NOTE(lukebjerring): This is https://github.com/apps/staging-wpt-fyi-status-check
+const wptfyiCheckAppID = 19965
 
 // checkWebhookHandler listens for check_suite and check_run events,
 // responding to requested and rerequested events.
@@ -84,6 +88,12 @@ func handleCheckSuiteEvent(ctx context.Context, payload []byte) (bool, error) {
 		return false, err
 	}
 
+	appID := checkSuite.GetCheckSuite().GetApp().GetID()
+	if appID != wptfyiCheckAppID {
+		log.Infof("Ignoring check_suite App ID %v", appID)
+		return false, nil
+	}
+
 	if !shared.IsFeatureEnabled(ctx, "checksAllUsers") {
 		whitelist := []string{
 			"lukebjerring",
@@ -94,7 +104,7 @@ func handleCheckSuiteEvent(ctx context.Context, payload []byte) (bool, error) {
 			sender = *checkSuite.Sender.Login
 		}
 		if !shared.StringSliceContains(whitelist, sender) {
-			log.Infof("Sender %s not whitelisted for wpt.fyi checks")
+			log.Infof("Sender %s not whitelisted for wpt.fyi checks", sender)
 			return false, nil
 		}
 	}
@@ -258,8 +268,7 @@ func getSignedJWT(ctx context.Context) (string, error) {
 	claims := &jwt.StandardClaims{
 		IssuedAt:  now.Unix(),
 		ExpiresAt: now.Add(time.Minute * 10).Unix(),
-		// NOTE(lukebjerring): This is https://github.com/apps/wpt-fyi-status-check
-		Issuer: "19965",
+		Issuer:    strconv.Itoa(wptfyiCheckAppID),
 	}
 
 	jwtToken := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)


### PR DESCRIPTION
## Description
Currently we're trying to parse all check_run names as a product and erroring out, when we should be ignoring other App IDs.