### PR TITLE
Fixup: cannot take len() of iterators directly

### DIFF
--- a/results-processor/processor.py
+++ b/results-processor/processor.py
@@ -41,7 +41,7 @@ def _find_run_by_raw_results(raw_results_url):
     q = _datastore.query(kind='TestRun')
     q.add_filter('RawResultsURL', '=', raw_results_url)
     q.keys_only()
-    run = q.fetch(limit=1)
+    run = list(q.fetch(limit=1))
     return len(run) > 0
 
 


### PR DESCRIPTION
@lukebjerring oops, sorry... Unlike AppEngine Standard, there is no standalone local emulator for Datastore for AppEngine Flex, so it's hard to test the API integration.