### PR TITLE
When a check suite is created, detect PRs across forks

### DIFF
--- a/api/checks/webhook.go
+++ b/api/checks/webhook.go
@@ -194,7 +194,11 @@ func handlePullRequestEvent(ctx context.Context, payload []byte) (bool, error) {
 		return false, err
 	}
 
-	if pullRequest.GetAction() != "opened" {
+	switch pullRequest.GetAction() {
+	case "opened":
+	case "synchronize":
+		break
+	default:
 		return false, nil
 	}
 

--- a/api/checks/webhook.go
+++ b/api/checks/webhook.go
@@ -124,7 +124,9 @@ func handleCheckSuiteEvent(ctx context.Context, payload []byte) (bool, error) {
 
 	action := checkSuite.GetAction()
 	if action == "requested" || action == "rerequested" {
-		log.Debugf("Check suite %s: %s", *(checkSuite.Action), *(checkSuite.CheckSuite.HeadBranch))
+		repo := checkSuite.GetRepo().GetName()
+		branch := checkSuite.GetCheckSuite().GetHeadBranch()
+		log.Debugf("Check suite %s: %s:%s", action, repo, branch)
 
 		sha := checkSuite.GetCheckSuite().GetHeadSHA()
 
@@ -144,7 +146,6 @@ func handleCheckSuiteEvent(ctx context.Context, payload []byte) (bool, error) {
 		}
 
 		owner := checkSuite.GetRepo().GetOwner().GetLogin()
-		repo := checkSuite.GetRepo().GetName()
 		installation := *checkSuite.Installation.ID
 		suite, err := getOrCreateCheckSuite(ctx, sha, owner, repo, installation)
 		if err != nil || suite == nil {

--- a/api/checks/webhook.go
+++ b/api/checks/webhook.go
@@ -126,7 +126,10 @@ func handleCheckSuiteEvent(ctx context.Context, payload []byte) (bool, error) {
 		destRepoID := p.GetBase().GetRepo().GetID()
 		if destRepoID == wptRepoID && p.GetHead().GetRepo().GetID() != destRepoID {
 			// Pull is across forks; request a check suite on the main fork too.
-			createWPTCheckSuite(ctx, sha)
+			_, err := createWPTCheckSuite(ctx, sha)
+			if err != nil {
+				log.Errorf("Failed to create wpt check_suite: %s", err.Error())
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description
Detects when a check_suite event occurs for a SHA that's part of a PR that originates from another fork (but is created on the web-platform-tests/wpt repo), and requests a check-suite for the wpt repo too.

The one (other) case that we need to be wary of is the initial creation of the PR. A check_suite is created by GitHub when a new commit is pushed. This, of course, occurs on the forked repository, and there is also initially no associated PR at the time. Thus, when a PR is opened, we should ensure a check_suite on wpt for the PR's HeadSHA.  

## Review Information
Example check that used this code:
https://github.com/web-platform-tests/wpt/pull/14037/checks?sha=2ececcbafaa0b19cb5fac4e912c8709a7e295642