### PR TITLE
Handle fetch errors a little better

### DIFF
--- a/api/query/query.go
+++ b/api/query/query.go
@@ -7,6 +7,7 @@ package query
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
 	"sync"
@@ -124,7 +125,7 @@ func (qh queryHandler) loadSummaries(testRuns []shared.TestRun) ([]summary, erro
 			s := make(summary)
 			data, loadErr := qh.loadSummary(testRun)
 			if err == nil && loadErr != nil {
-				err = loadErr
+				err = fmt.Errorf("Failed to load test run %v: %s", testRun.ID, loadErr.Error())
 				return
 			}
 			marshalErr := json.Unmarshal(data, &s)

--- a/api/query/query_test.go
+++ b/api/query/query_test.go
@@ -109,7 +109,7 @@ func TestLoadSummaries_fail(t *testing.T) {
 	cachedStore.EXPECT().Get(keys[1], urls[1], gomock.Any()).Return(storeMiss)
 
 	_, err := sh.loadSummaries(testRuns)
-	assert.Equal(t, storeMiss, err)
+	assert.Contains(t, err.Error(), storeMiss.Error())
 }
 
 func TestGetRunsAndFilters_default(t *testing.T) {

--- a/webapp/components/loading-state.html
+++ b/webapp/components/loading-state.html
@@ -37,10 +37,14 @@ still being loaded (generally, fetched).
         }
       }
 
-      async load(promise) {
+      async load(promise, opt_errHandler) {
         this.loadingCount++;
         try {
           return await promise;
+        } catch (e) {
+          if (opt_errHandler) {
+            opt_errHandler(e);
+          }
         } finally {
           this.loadingCount--;
         }

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -500,7 +500,7 @@ found in the LICENSE file.
               this.fetchDiff();
             }
           }),
-          e => {
+          () => {
             this.resultsLoadFailed = true;
           }
         );
@@ -540,7 +540,7 @@ found in the LICENSE file.
             this.searchResults = json.results;
             this.refreshDisplayedNodes();
           }),
-          e => {
+          () => {
             this.resultsLoadFailed = true;
           }
         );

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -436,7 +436,6 @@ found in the LICENSE file.
         this.onSearchCommit = this.handleSearchCommit.bind(this);
         this.onSearchAutocomplete = this.handleSearchAutocomplete.bind(this);
         this.onLoadingComplete = () => {
-          this.resultsLoadFailed = !(this.testRuns && this.testRuns.length);
           this.noResults = !this.resultsLoadFailed
             && !(this.searchResults && this.searchResults.length);
         };
@@ -484,6 +483,7 @@ found in the LICENSE file.
       }
 
       loadData() {
+        this.resultsLoadFailed = false;
         this.load(
           this.loadRuns().then(async runs => {
             // Pass current (un)structured query is passed to fetchResults().
@@ -499,7 +499,10 @@ found in the LICENSE file.
               };
               this.fetchDiff();
             }
-          })
+          }),
+          e => {
+            this.resultsLoadFailed = true;
+          }
         );
       }
 
@@ -527,15 +530,20 @@ found in the LICENSE file.
           }
         }
 
-        this.load(window.fetch(url, fetchOpts).then(r => {
-          if (!r.ok || r.status !== 200) {
-            return Promise.reject('Failed to fetch results data.');
+        this.load(
+          window.fetch(url, fetchOpts).then(r => {
+            if (!r.ok || r.status !== 200) {
+              return Promise.reject('Failed to fetch results data.');
+            }
+            return r.json();
+          }).then(json => {
+            this.searchResults = json.results;
+            this.refreshDisplayedNodes();
+          }),
+          e => {
+            this.resultsLoadFailed = true;
           }
-          return r.json();
-        }).then(json => {
-          this.searchResults = json.results;
-          this.refreshDisplayedNodes();
-        }));
+        );
       }
 
       fetchDiff() {


### PR DESCRIPTION
## Description
Makes sure that we handle results fetching (from /api/search) failures in the UI.
Also tweaks the error message to include which run is being a problem.