### PR TITLE
Fixup: fix typo in c8088f655

### DIFF
--- a/results-processor/processor.py
+++ b/results-processor/processor.py
@@ -194,8 +194,8 @@ def process_report(params):
     secret = _get_uploader_password('_processor')
     test_run_id = wptreport.create_test_run(
         report, labels, uploader, secret,
-        raw_results_url,
-        gsutil.gs_to_public_url(raw_results_gs_url))
+        gsutil.gs_to_public_url(results_gs_url),
+        raw_results_url)
     assert test_run_id
 
     success = _after_new_run(report, test_run_id)


### PR DESCRIPTION
There was a typo in c8088f65585043268d6a28bd29d53e45618d554b.

The  wrong parameter was passed to create_test_run.

I'll follow up with some tests: with the business logic factored out into a separate module, it's now much easier to write tests for this.