### PR TITLE
Add admin-only endpoint for toggling features environment-wide

### DIFF
--- a/shared/datastore.go
+++ b/shared/datastore.go
@@ -280,6 +280,13 @@ func IsFeatureEnabled(ctx context.Context, flagName string) bool {
 	return flag.Enabled
 }
 
+// SetFeature puts a feature with the given flag name and enabled state.
+func SetFeature(ctx context.Context, flag Flag) error {
+	key := datastore.NewKey(ctx, "Flag", flag.Name, 0, nil)
+	_, err := datastore.Put(ctx, key, &flag)
+	return err
+}
+
 // GetSecret is a helper wrapper for loading a token's secret from the datastore
 // by name.
 func GetSecret(ctx context.Context, tokenName string) (string, error) {

--- a/webapp/admin_handler.go
+++ b/webapp/admin_handler.go
@@ -5,6 +5,9 @@
 package webapp
 
 import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
 	"net/http"
 
 	"github.com/web-platform-tests/wpt.fyi/api/receiver"
@@ -18,8 +21,51 @@ func adminUploadHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func showAdminUploadForm(a receiver.AppEngineAPI, w http.ResponseWriter, r *http.Request) {
+	assertLoginAndRenderTemplate(a, w, r, "/admin/results/upload", "admin_upload.html", nil)
+}
+
+func adminFlagsHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := shared.NewAppEngineContext(r)
+	a := receiver.NewAppEngineAPI(ctx)
+	showAdminFlags(a, w, r)
+}
+
+func showAdminFlags(a receiver.AppEngineAPI, w http.ResponseWriter, r *http.Request) {
+	data := struct {
+		Host string
+	}{
+		Host: shared.GetHostname(a.Context()),
+	}
+	if r.Method == "GET" {
+		assertLoginAndRenderTemplate(a, w, r, "/admin/results/upload", "admin_flags.html", data)
+	} else if r.Method == "POST" {
+		if !a.IsAdmin() {
+			http.Error(w, "Admin only", http.StatusUnauthorized)
+			return
+		}
+		var flag shared.Flag
+		if bytes, err := ioutil.ReadAll(r.Body); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		} else if err = json.Unmarshal(bytes, &flag); err != nil {
+			http.Error(w, fmt.Sprintf("Failed to unmarshal flag: %s", err.Error()), http.StatusBadRequest)
+			return
+		} else if err = shared.SetFeature(a.Context(), flag); err != nil {
+			http.Error(w, fmt.Sprintf("Failed to save feature %s: %s", flag.Name, err.Error()), http.StatusInternalServerError)
+			return
+		}
+	}
+}
+
+func assertLoginAndRenderTemplate(
+	a receiver.AppEngineAPI,
+	w http.ResponseWriter,
+	r *http.Request,
+	redirectPath,
+	template string,
+	data interface{}) {
 	if !a.IsLoggedIn() {
-		loginURL, err := a.LoginURL("/admin/results/upload")
+		loginURL, err := a.LoginURL(redirectPath)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
@@ -32,7 +78,7 @@ func showAdminUploadForm(a receiver.AppEngineAPI, w http.ResponseWriter, r *http
 		return
 	}
 
-	if err := templates.ExecuteTemplate(w, "admin_upload.html", nil); err != nil {
+	if err := templates.ExecuteTemplate(w, template, data); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/webapp/components/wpt-flags.html
+++ b/webapp/components/wpt-flags.html
@@ -30,30 +30,32 @@ found in the LICENSE file.
       }
 
       static get properties() {
-        if (!window.wpt) {
-          window.wpt = {};
-        }
-        const props = {};
-        for (const feature of WPT_FYI_FEATURES) {
-          let value = null;
-          if (useLocalStorage) {
-            const stored = localStorage.getItem(`features.${feature}`);
-            value = stored && JSON.parse(stored);
-          }
-          // Fall back to env default.
-          if (value === null) {
-            value = window.WPTEnvironmentFlags
-              && window.WPTEnvironmentFlags[feature];
-          }
-          props[feature] = {
-            type: Boolean,
-            readOnly: readOnly && !window.wpt.MUTABLE_FLAGS,
-            notify: true,
-            value: value,
-          };
-        }
-        return props;
+        return window.wpt.makeFeatureProperties(WPT_FYI_FEATURES, readOnly, useLocalStorage);
       }
+    };
+
+    window.wpt = window.wpt || {};
+    window.wpt.makeFeatureProperties = function(features, readOnly, useLocalStorage) {
+      const props = {};
+      for (const feature of features) {
+        let value = null;
+        if (useLocalStorage) {
+          const stored = localStorage.getItem(`features.${feature}`);
+          value = stored && JSON.parse(stored);
+        }
+        // Fall back to env default.
+        if (value === null) {
+          value = window.WPTEnvironmentFlags
+            && window.WPTEnvironmentFlags[feature];
+        }
+        props[feature] = {
+          type: Boolean,
+          readOnly: readOnly && !window.wpt.MUTABLE_FLAGS,
+          notify: true,
+          value: value,
+        };
+      }
+      return props;
     };
     // eslint-disable-next-line no-unused-vars
     const WPTFlags = (superClass) => _wptFlags(superClass, /*readOnly*/ true, /*useLocalStorage*/ true);
@@ -106,19 +108,34 @@ found in the LICENSE file.
   </template>
 
   <script>
+    const WPT_FYI_SERVER_SIDE_FEATURES = [
+      'diffRenames',
+      'experimentalByDefault',
+      'experimentalAlignedExceptEdge',
+      'taskclusterAllBranches',
+    ];
+
     /* global _wptFlags, WPT_FYI_FEATURES */
     const _wptFlagsEditor = (environmentFlags) =>
       class extends _wptFlags(window.Polymer.Element, /*readOnly*/ false, /*useLocalStorage*/ !environmentFlags) {
         ready() {
           super.ready();
-          for (const feature of WPT_FYI_FEATURES) {
+          const features = WPT_FYI_FEATURES.concat(WPT_FYI_SERVER_SIDE_FEATURES);
+          for (const feature of features) {
             this._createMethodObserver(`valueChanged(${feature}, '${feature}')`);
           }
         }
 
+        static get properties() {
+          const useLocalStorage = !environmentFlags;
+          const readOnly = false;
+          return window.wpt.makeFeatureProperties(
+            WPT_FYI_SERVER_SIDE_FEATURES, readOnly, useLocalStorage);
+        }
+
         valueChanged(value, feature) {
           if (environmentFlags) {
-            fetch(`/admin/flags`, {
+            fetch('/admin/flags', {
               method: 'POST',
               body: JSON.stringify({
                 Name: feature,
@@ -146,10 +163,47 @@ found in the LICENSE file.
 </dom-module>
 
 <dom-module id="wpt-environment-flags-editor">
+  <template>
+    <!-- WPTFlags template prepended in code, below. -->
+    <h4>Server-side only features</h4>
+    <paper-item>
+      <paper-checkbox checked="{{diffRenames}}">
+        Compute renames in diffs with the GitHub API
+      </paper-checkbox>
+    </paper-item>
+    <paper-item>
+      <paper-checkbox checked="{{experimentalByDefault}}">
+        Fetch experimental runs as the default (homepage) query
+      </paper-checkbox>
+    </paper-item>
+    <paper-item sub-item>
+      <paper-checkbox checked="{{experimentalAlignedExceptEdge}}">
+        All experimental, except edge, and aligned
+      </paper-checkbox>
+    </paper-item>
+    <paper-item sub-item>
+      <paper-checkbox checked="{{masterRunsOnly}}">
+        Master runs only
+      </paper-checkbox>
+    </paper-item>
+    <paper-item>
+      <paper-checkbox checked="{{taskclusterAllBranches}}">
+        Process all taskcluster results (not just master)
+      </paper-checkbox>
+    </paper-item>
+  </template>
   <script>
+    /* global _wptFlagsEditor, WPTFlagsEditor, WPT_FYI_SERVER_SIDE_FEATURES */
     class WPTEnvironmentFlagsEditor extends _wptFlagsEditor(/*environmentFlags*/ true) {
       static get is() {
         return 'wpt-environment-flags-editor';
+      }
+
+      ready() {
+        super.ready();
+        for (const feature of WPT_FYI_SERVER_SIDE_FEATURES) {
+          this._createMethodObserver(`valueChanged(${feature}, '${feature}')`);
+        }
       }
     }
 
@@ -159,7 +213,9 @@ found in the LICENSE file.
       Object.defineProperty(WPTEnvironmentFlagsEditor, 'template', {
         get: function() {
           if (!this[template]) {
+            const envTemplate = window.Polymer.DomModule.import(WPTEnvironmentFlagsEditor.is, 'template');
             this[template] = window.Polymer.DomModule.import(WPTFlagsEditor.is, 'template');
+            this[template].content.appendChild(envTemplate.content);
           }
           return this[template];
         }

--- a/webapp/components/wpt-flags.html
+++ b/webapp/components/wpt-flags.html
@@ -24,7 +24,7 @@ found in the LICENSE file.
       'masterRunsOnly',
     ];
 
-    const _wptFlags = (superClass, readOnly) => class extends superClass {
+    const _wptFlags = (superClass, readOnly, useLocalStorage) => class extends superClass {
       static get is() {
         return 'wpt-flags';
       }
@@ -35,8 +35,11 @@ found in the LICENSE file.
         }
         const props = {};
         for (const feature of WPT_FYI_FEATURES) {
-          const stored = localStorage.getItem(`features.${feature}`);
-          let value = stored && JSON.parse(stored);
+          let value = null;
+          if (useLocalStorage) {
+            const stored = localStorage.getItem(`features.${feature}`);
+            value = stored && JSON.parse(stored);
+          }
           // Fall back to env default.
           if (value === null) {
             value = window.WPTEnvironmentFlags
@@ -53,7 +56,7 @@ found in the LICENSE file.
       }
     };
     // eslint-disable-next-line no-unused-vars
-    const WPTFlags = (superClass) => _wptFlags(superClass, /*readOnly*/ true);
+    const WPTFlags = (superClass) => _wptFlags(superClass, /*readOnly*/ true, /*useLocalStorage*/ true);
   </script>
 </dom-module>
 
@@ -104,25 +107,65 @@ found in the LICENSE file.
 
   <script>
     /* global _wptFlags, WPT_FYI_FEATURES */
-    class WPTFlagsEditor extends _wptFlags(window.Polymer.Element, /*readOnly*/ false) {
+    const _wptFlagsEditor = (environmentFlags) =>
+      class extends _wptFlags(window.Polymer.Element, /*readOnly*/ false, /*useLocalStorage*/ !environmentFlags) {
+        ready() {
+          super.ready();
+          for (const feature of WPT_FYI_FEATURES) {
+            this._createMethodObserver(`valueChanged(${feature}, '${feature}')`);
+          }
+        }
+
+        valueChanged(value, feature) {
+          if (environmentFlags) {
+            fetch(`/admin/flags`, {
+              method: 'POST',
+              body: JSON.stringify({
+                Name: feature,
+                Enabled: value,
+              }),
+              credentials: 'include',
+            }).catch(e => {
+              alert(`Failed to save feature ${feature}.\n\n${e}`);
+            });
+          } else {
+            return localStorage.setItem(
+              `features.${feature}`,
+              JSON.stringify(value));
+          }
+        }
+      };
+
+    class WPTFlagsEditor extends _wptFlagsEditor(/*environmentFlags*/ false) {
       static get is() {
         return 'wpt-flags-editor';
       }
+    }
+    window.customElements.define(WPTFlagsEditor.is, WPTFlagsEditor);
+  </script>
+</dom-module>
 
-      ready() {
-        super.ready();
-        for (const feature of WPT_FYI_FEATURES) {
-          this._createMethodObserver(`valueChanged(${feature}, '${feature}')`);
-        }
-      }
-
-      valueChanged(value, feature) {
-        return localStorage.setItem(
-          `features.${feature}`,
-          JSON.stringify(value));
+<dom-module id="wpt-environment-flags-editor">
+  <script>
+    class WPTEnvironmentFlagsEditor extends _wptFlagsEditor(/*environmentFlags*/ true) {
+      static get is() {
+        return 'wpt-environment-flags-editor';
       }
     }
 
-    window.customElements.define(WPTFlagsEditor.is, WPTFlagsEditor);
+    // Copy the WPTFlags template.
+    (() => {
+      const template = Symbol();
+      Object.defineProperty(WPTEnvironmentFlagsEditor, 'template', {
+        get: function() {
+          if (!this[template]) {
+            this[template] = window.Polymer.DomModule.import(WPTFlagsEditor.is, 'template');
+          }
+          return this[template];
+        }
+      });
+    })();
+
+    window.customElements.define(WPTEnvironmentFlagsEditor.is, WPTEnvironmentFlagsEditor);
   </script>
 </dom-module>

--- a/webapp/routes.go
+++ b/webapp/routes.go
@@ -48,6 +48,9 @@ func RegisterRoutes() {
 	// Admin-only manual results upload.
 	shared.AddRoute("/admin/results/upload", "admin-results-upload", adminUploadHandler)
 
+	// Admin-only environment flag management
+	shared.AddRoute("/admin/flags", "admin-flags", adminFlagsHandler)
+
 	// Test run results, viewed by browser (default view)
 	// For run results diff view, 'before' and 'after' params can be given.
 	shared.AddRoute("/results/", "results", testResultsHandler)

--- a/webapp/templates/admin_flags.html
+++ b/webapp/templates/admin_flags.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<head>
+  <meta charset="utf-8">
+  <title>wpt.fyi - Feature flags</title>
+
+  <link rel="import" href="/components/wpt-flags.html">
+</head>
+<body>
+  <h3>
+    Environment-wide {{ .Host }} feature flags
+  </h3>
+  <wpt-environment-flags-editor />
+</body>
+


### PR DESCRIPTION
## Description
This simplifies the current need to head to appengine and manually create an entity, into a simple "tick the box" (same style as /flags, but posts to the /admin/flags endpoint and affects datastore, not local storage.).

## Review Information
Head to /admin/flags, toggle a feature.

NOTE: This affects the whole staging environment, so revert your changes :)