### PR TITLE
Use ACU filter for master-pr diffs

### DIFF
--- a/api/checks/webhook.go
+++ b/api/checks/webhook.go
@@ -363,6 +363,11 @@ func getMasterDiffURL(ctx context.Context, sha string, product shared.ProductSpe
 	detailsURL := getURL(ctx, filter)
 	query := detailsURL.Query()
 	query.Set("diff", "")
+	query.Set("filter", shared.DiffFilterParam{
+		Added:     true,
+		Changed:   true,
+		Unchanged: true,
+	}.String())
 	detailsURL.RawQuery = query.Encode()
 	return detailsURL
 }


### PR DESCRIPTION
## Description
Changes the details link for the wpt.fyi checks to filter out deleted tests, since the affected tests is always a subset of the last master run.

For example, if you follow the link here:
https://github.com/web-platform-tests/wpt/pull/14070/checks?check_run_id=32143663
You see a bunch of delete changes. But if you set `&filter=ACU` in the url, it's more informative.