### PR TITLE
Whitelist chromium-wpt-export-bot for wpt.fyi checks

### DIFF
--- a/api/checks/webhook.go
+++ b/api/checks/webhook.go
@@ -111,6 +111,7 @@ func handleCheckSuiteEvent(ctx context.Context, payload []byte) (bool, error) {
 		whitelist := []string{
 			"lukebjerring",
 			"autofoolip",
+			"chromium-wpt-export-bot",
 		}
 		sender := ""
 		if checkSuite.Sender != nil && checkSuite.Sender.Login != nil {


### PR DESCRIPTION
## Description
The bot produces a bunch of exports from some CLs that worked in Chromium™ and are a good candidate for regression checks.