### PR TITLE
Add `max-count` pagination ability to /api/runs

### DIFF
--- a/api/diff.go
+++ b/api/diff.go
@@ -87,7 +87,11 @@ func handleAPIDiffGet(w http.ResponseWriter, r *http.Request) {
 		if len(beforeAndAfter) > 0 {
 			runFilter.Products = beforeAndAfter
 		}
-		runs, err = LoadTestRunsForFilters(ctx, runFilter)
+		var runsByProduct shared.TestRunsByProduct
+		runsByProduct, err = LoadTestRunsForFilters(ctx, runFilter)
+		if err != nil {
+			runs = runsByProduct.AllRuns()
+		}
 	}
 
 	if err != nil {

--- a/api/manifest.go
+++ b/api/manifest.go
@@ -33,7 +33,7 @@ func apiManifestHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
 	}
-	w.Header().Add("x-wpt-sha", sha)
+	w.Header().Add("wpt-sha", sha)
 	w.Header().Add("Content-Type", "application/json")
 	if paths != nil {
 		if manifestBytes, err = filterManifest(manifestBytes, paths); err != nil {

--- a/api/query/query.go
+++ b/api/query/query.go
@@ -23,8 +23,8 @@ type summary map[string][]int
 type sharedInterface interface {
 	ParseQueryParamInt(r *http.Request, key string) (*int, error)
 	ParseQueryFilterParams(*http.Request) (shared.QueryFilter, error)
-	LoadTestRuns([]shared.ProductSpec, mapset.Set, string, *time.Time, *time.Time, *int) ([]shared.TestRun, error)
-	LoadTestRunsByIDs(ids shared.TestRunIDs) (result []shared.TestRun, err error)
+	LoadTestRuns(shared.ProductSpecs, mapset.Set, string, *time.Time, *time.Time, *int, *int) (shared.TestRunsByProduct, error)
+	LoadTestRunsByIDs(ids shared.TestRunIDs) (result shared.TestRuns, err error)
 	LoadTestRun(int64) (*shared.TestRun, error)
 }
 
@@ -40,11 +40,11 @@ func (defaultShared) ParseQueryFilterParams(r *http.Request) (shared.QueryFilter
 	return shared.ParseQueryFilterParams(r)
 }
 
-func (sharedImpl defaultShared) LoadTestRuns(ps []shared.ProductSpec, ls mapset.Set, sha string, from *time.Time, to *time.Time, limit *int) ([]shared.TestRun, error) {
-	return shared.LoadTestRuns(sharedImpl.ctx, ps, ls, sha, from, to, limit)
+func (sharedImpl defaultShared) LoadTestRuns(ps shared.ProductSpecs, ls mapset.Set, sha string, from *time.Time, to *time.Time, limit *int, offset *int) (shared.TestRunsByProduct, error) {
+	return shared.LoadTestRuns(sharedImpl.ctx, ps, ls, sha, from, to, limit, offset)
 }
 
-func (sharedImpl defaultShared) LoadTestRunsByIDs(ids shared.TestRunIDs) (result []shared.TestRun, err error) {
+func (sharedImpl defaultShared) LoadTestRunsByIDs(ids shared.TestRunIDs) (result shared.TestRuns, err error) {
 	return ids.LoadTestRuns(sharedImpl.ctx)
 }
 
@@ -57,7 +57,7 @@ type queryHandler struct {
 	dataSource shared.CachedStore
 }
 
-func (qh queryHandler) processInput(w http.ResponseWriter, r *http.Request) (*shared.QueryFilter, []shared.TestRun, []summary, error) {
+func (qh queryHandler) processInput(w http.ResponseWriter, r *http.Request) (*shared.QueryFilter, shared.TestRuns, []summary, error) {
 	filters, err := qh.sharedImpl.ParseQueryFilterParams(r)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -79,9 +79,9 @@ func (qh queryHandler) processInput(w http.ResponseWriter, r *http.Request) (*sh
 	return &filters, testRuns, summaries, nil
 }
 
-func (qh queryHandler) getRunsAndFilters(in shared.QueryFilter) ([]shared.TestRun, shared.QueryFilter, error) {
+func (qh queryHandler) getRunsAndFilters(in shared.QueryFilter) (shared.TestRuns, shared.QueryFilter, error) {
 	filters := in
-	var testRuns []shared.TestRun
+	var testRuns shared.TestRuns
 	var err error
 
 	if filters.RunIDs == nil || len(filters.RunIDs) == 0 {
@@ -90,11 +90,12 @@ func (qh queryHandler) getRunsAndFilters(in shared.QueryFilter) ([]shared.TestRu
 		var err error
 		limit := 1
 		products := runFilters.GetProductsOrDefault()
-		testRuns, err = qh.sharedImpl.LoadTestRuns(products, runFilters.Labels, sha, runFilters.From, runFilters.To, &limit)
+		runsByProduct, err := qh.sharedImpl.LoadTestRuns(products, runFilters.Labels, sha, runFilters.From, runFilters.To, &limit, nil)
 		if err != nil {
 			return testRuns, filters, err
 		}
 
+		testRuns = runsByProduct.AllRuns()
 		filters.RunIDs = make([]int64, 0, len(testRuns))
 		for _, testRun := range testRuns {
 			filters.RunIDs = append(filters.RunIDs, testRun.ID)
@@ -109,7 +110,7 @@ func (qh queryHandler) getRunsAndFilters(in shared.QueryFilter) ([]shared.TestRu
 	return testRuns, filters, nil
 }
 
-func (qh queryHandler) loadSummaries(testRuns []shared.TestRun) ([]summary, error) {
+func (qh queryHandler) loadSummaries(testRuns shared.TestRuns) ([]summary, error) {
 	var err error
 	summaries := make([]summary, len(testRuns))
 

--- a/api/query/query_mock.go
+++ b/api/query/query_mock.go
@@ -64,22 +64,22 @@ func (mr *MocksharedInterfaceMockRecorder) ParseQueryFilterParams(arg0 interface
 }
 
 // LoadTestRuns mocks base method
-func (m *MocksharedInterface) LoadTestRuns(arg0 []shared.ProductSpec, arg1 golang_set.Set, arg2 string, arg3, arg4 *time.Time, arg5 *int) ([]shared.TestRun, error) {
-	ret := m.ctrl.Call(m, "LoadTestRuns", arg0, arg1, arg2, arg3, arg4, arg5)
-	ret0, _ := ret[0].([]shared.TestRun)
+func (m *MocksharedInterface) LoadTestRuns(arg0 shared.ProductSpecs, arg1 golang_set.Set, arg2 string, arg3, arg4 *time.Time, arg5, arg6 *int) (shared.TestRunsByProduct, error) {
+	ret := m.ctrl.Call(m, "LoadTestRuns", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	ret0, _ := ret[0].(shared.TestRunsByProduct)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // LoadTestRuns indicates an expected call of LoadTestRuns
-func (mr *MocksharedInterfaceMockRecorder) LoadTestRuns(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadTestRuns", reflect.TypeOf((*MocksharedInterface)(nil).LoadTestRuns), arg0, arg1, arg2, arg3, arg4, arg5)
+func (mr *MocksharedInterfaceMockRecorder) LoadTestRuns(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadTestRuns", reflect.TypeOf((*MocksharedInterface)(nil).LoadTestRuns), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
 // LoadTestRunsByIDs mocks base method
-func (m *MocksharedInterface) LoadTestRunsByIDs(ids shared.TestRunIDs) ([]shared.TestRun, error) {
+func (m *MocksharedInterface) LoadTestRunsByIDs(ids shared.TestRunIDs) (shared.TestRuns, error) {
 	ret := m.ctrl.Call(m, "LoadTestRunsByIDs", ids)
-	ret0, _ := ret[0].([]shared.TestRun)
+	ret0, _ := ret[0].(shared.TestRuns)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/api/query/query_test.go
+++ b/api/query/query_test.go
@@ -9,6 +9,7 @@ package query
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -133,12 +134,14 @@ func TestGetRunsAndFilters_default(t *testing.T) {
 		shared.TestRun{
 			ID:         runIDs[0],
 			ResultsURL: urls[0],
+			TimeStart:  time.Now(),
 		},
 	}
 	testRuns[edge] = shared.TestRuns{
 		shared.TestRun{
 			ID:         runIDs[1],
 			ResultsURL: urls[1],
+			TimeStart:  time.Now().AddDate(0, 0, -1),
 		},
 	}
 	filters := shared.QueryFilter{}
@@ -174,12 +177,14 @@ func TestGetRunsAndFilters_specificRunIDs(t *testing.T) {
 		shared.TestRun{
 			ID:         runIDs[0],
 			ResultsURL: urls[0],
+			TimeStart:  time.Now(),
 		},
 	}
 	testRuns[edge] = shared.TestRuns{
 		shared.TestRun{
 			ID:         runIDs[1],
 			ResultsURL: urls[1],
+			TimeStart:  time.Now().AddDate(0, 0, -1),
 		},
 	}
 	filters := shared.QueryFilter{

--- a/api/query/query_test.go
+++ b/api/query/query_test.go
@@ -126,11 +126,16 @@ func TestGetRunsAndFilters_default(t *testing.T) {
 		"https://example.com/1-summary.json.gz",
 		"https://example.com/2-summary.json.gz",
 	}
-	testRuns := []shared.TestRun{
+	chrome, _ := shared.ParseProductSpec("chrome")
+	edge, _ := shared.ParseProductSpec("edge")
+	testRuns := make(shared.TestRunsByProduct)
+	testRuns[chrome] = shared.TestRuns{
 		shared.TestRun{
 			ID:         runIDs[0],
 			ResultsURL: urls[0],
 		},
+	}
+	testRuns[edge] = shared.TestRuns{
 		shared.TestRun{
 			ID:         runIDs[1],
 			ResultsURL: urls[1],
@@ -138,11 +143,11 @@ func TestGetRunsAndFilters_default(t *testing.T) {
 	}
 	filters := shared.QueryFilter{}
 
-	si.EXPECT().LoadTestRuns(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testRuns, nil)
+	si.EXPECT().LoadTestRuns(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testRuns, nil)
 
 	trs, fs, err := sh.getRunsAndFilters(filters)
 	assert.Nil(t, err)
-	assert.Equal(t, testRuns, trs)
+	assert.Equal(t, testRuns.AllRuns(), trs)
 	assert.Equal(t, shared.QueryFilter{
 		RunIDs: runIDs,
 	}, fs)
@@ -162,11 +167,16 @@ func TestGetRunsAndFilters_specificRunIDs(t *testing.T) {
 		"https://example.com/1-summary.json.gz",
 		"https://example.com/2-summary.json.gz",
 	}
-	testRuns := []shared.TestRun{
+	chrome, _ := shared.ParseProductSpec("chrome")
+	edge, _ := shared.ParseProductSpec("edge")
+	testRuns := make(shared.TestRunsByProduct)
+	testRuns[chrome] = shared.TestRuns{
 		shared.TestRun{
 			ID:         runIDs[0],
 			ResultsURL: urls[0],
 		},
+	}
+	testRuns[edge] = shared.TestRuns{
 		shared.TestRun{
 			ID:         runIDs[1],
 			ResultsURL: urls[1],
@@ -176,10 +186,10 @@ func TestGetRunsAndFilters_specificRunIDs(t *testing.T) {
 		RunIDs: runIDs,
 	}
 
-	si.EXPECT().LoadTestRunsByIDs(shared.TestRunIDs([]int64{testRuns[0].ID, testRuns[1].ID})).Return([]shared.TestRun{testRuns[0], testRuns[1]}, nil)
+	si.EXPECT().LoadTestRunsByIDs(shared.TestRunIDs(testRuns.AllRuns().GetTestRunIDs())).Return(testRuns.AllRuns(), nil)
 
 	trs, fs, err := sh.getRunsAndFilters(filters)
 	assert.Nil(t, err)
-	assert.Equal(t, testRuns, trs)
+	assert.Equal(t, testRuns.AllRuns(), trs)
 	assert.Equal(t, filters, fs)
 }

--- a/api/results_redirect_handler.go
+++ b/api/results_redirect_handler.go
@@ -32,18 +32,19 @@ func apiResultsRedirectHandler(w http.ResponseWriter, r *http.Request) {
 
 	ctx := shared.NewAppEngineContext(r)
 	one := 1
-	testRuns, err := shared.LoadTestRuns(ctx, filters.Products, filters.Labels, filters.SHA, nil, nil, &one)
+	testRuns, err := shared.LoadTestRuns(ctx, filters.Products, filters.Labels, filters.SHA, nil, nil, &one, nil)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	if len(testRuns) == 0 {
+	allRuns := testRuns.AllRuns()
+	if len(allRuns) == 0 {
 		http.Error(w, fmt.Sprintf("404 - Test run '%s' not found", filters.SHA), http.StatusNotFound)
 		return
 	}
 
 	test := r.URL.Query().Get("test")
-	resultsURL := GetResultsURL(testRuns[0], test)
+	resultsURL := GetResultsURL(allRuns[0], test)
 
 	http.Redirect(w, r, resultsURL, http.StatusFound)
 }

--- a/api/shas.go
+++ b/api/shas.go
@@ -43,14 +43,14 @@ func (h SHAsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	} else {
-		testRuns, err := shared.LoadTestRuns(ctx, products, filters.Labels, shared.LatestSHA, filters.From, filters.To, filters.MaxCount)
+		testRuns, err := shared.LoadTestRuns(ctx, products, filters.Labels, shared.LatestSHA, filters.From, filters.To, filters.MaxCount, filters.Offset)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 
 		seen := mapset.NewSet()
-		for _, testRun := range testRuns {
+		for _, testRun := range testRuns.AllRuns() {
 			if !seen.Contains(testRun.Revision) {
 				shas = append(shas, testRun.Revision)
 				seen.Add(testRun.Revision)

--- a/api/test_run.go
+++ b/api/test_run.go
@@ -56,17 +56,18 @@ func apiTestRunHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		one := 1
-		testRuns, err := shared.LoadTestRuns(ctx, filters.Products, filters.Labels, filters.SHA, nil, nil, &one)
+		testRuns, err := shared.LoadTestRuns(ctx, filters.Products, filters.Labels, filters.SHA, nil, nil, &one, nil)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 
-		if len(testRuns) == 0 {
+		allRuns := testRuns.AllRuns()
+		if len(allRuns) == 0 {
 			http.NotFound(w, r)
 			return
 		}
-		testRun = testRuns[0]
+		testRun = allRuns[0]
 	}
 
 	testRunsBytes, err := json.Marshal(testRun)

--- a/api/test_runs.go
+++ b/api/test_runs.go
@@ -72,6 +72,7 @@ func apiTestRunsHandler(w http.ResponseWriter, r *http.Request) {
 // query to load the TestRun keys.
 func LoadTestRunKeysForFilters(ctx context.Context, filters shared.TestRunFilter) (result []*datastore.Key, err error) {
 	limit := filters.MaxCount
+	offset := filters.Offset
 	from := filters.From
 	if limit == nil && from == nil {
 		// Default to a single, latest run when from & max-count both empty.
@@ -96,7 +97,8 @@ func LoadTestRunKeysForFilters(ctx context.Context, filters shared.TestRunFilter
 		}
 		return keys, err
 	}
-	return shared.LoadTestRunKeys(ctx, products, filters.Labels, filters.SHA, from, filters.To, limit)
+	keys, err := shared.LoadTestRunKeys(ctx, products, filters.Labels, filters.SHA, from, filters.To, limit, offset)
+	return keys.AllKeys(), err
 }
 
 // LoadTestRunsForFilters deciphers the filters and executes a corresponding query to load

--- a/api/test_runs.go
+++ b/api/test_runs.go
@@ -14,7 +14,7 @@ import (
 	"google.golang.org/appengine/datastore"
 )
 
-const nextPageTokenHeaderName = "x-wpt-next-page"
+const nextPageTokenHeaderName = "wpt-next-page"
 const paginationTokenFeatureFlagName = "paginationTokens"
 
 // apiTestRunsHandler is responsible for emitting test-run JSON for all the runs at a given SHA.

--- a/shared/datastore_medium_test.go
+++ b/shared/datastore_medium_test.go
@@ -36,10 +36,11 @@ func TestLoadTestRuns(t *testing.T) {
 	key, _ = datastore.Put(ctx, key, &testRun)
 
 	chrome, _ := shared.ParseProductSpec("chrome")
-	loaded, err := shared.LoadTestRuns(ctx, []shared.ProductSpec{chrome}, nil, shared.LatestSHA, nil, nil, nil)
+	loaded, err := shared.LoadTestRuns(ctx, shared.ProductSpecs{chrome}, nil, shared.LatestSHA, nil, nil, nil, nil)
+	allRuns := loaded.AllRuns()
 	assert.Nil(t, err)
-	assert.Equal(t, 1, len(loaded))
-	assert.Equalf(t, key.IntID(), loaded[0].ID, "ID field should be populated.")
+	assert.Equal(t, 1, len(allRuns))
+	assert.Equalf(t, key.IntID(), allRuns[0].ID, "ID field should be populated.")
 }
 
 func TestLoadTestRuns_Experimental_Only(t *testing.T) {
@@ -116,11 +117,12 @@ func TestLoadTestRuns_Experimental_Only(t *testing.T) {
 	labels := mapset.NewSet()
 	labels.Add("experimental")
 	ten := 10
-	loaded, err := shared.LoadTestRuns(ctx, products, labels, shared.LatestSHA, nil, nil, &ten)
+	loaded, err := shared.LoadTestRuns(ctx, products, labels, shared.LatestSHA, nil, nil, &ten, nil)
+	allRuns := loaded.AllRuns()
 	assert.Nil(t, err)
-	assert.Equal(t, 2, len(loaded))
-	assert.Equal(t, "64.0", loaded[0].BrowserVersion)
-	assert.Equal(t, "65.0", loaded[1].BrowserVersion)
+	assert.Equal(t, 2, len(allRuns))
+	assert.Equal(t, "64.0", allRuns[0].BrowserVersion)
+	assert.Equal(t, "65.0", allRuns[1].BrowserVersion)
 }
 
 func TestLoadTestRuns_LabelinProductSpec(t *testing.T) {
@@ -153,10 +155,11 @@ func TestLoadTestRuns_LabelinProductSpec(t *testing.T) {
 	products := make([]shared.ProductSpec, 1)
 	products[0].BrowserName = "chrome"
 	products[0].Labels = mapset.NewSetWith("foo")
-	loaded, err := shared.LoadTestRuns(ctx, products, nil, shared.LatestSHA, nil, nil, nil)
+	loaded, err := shared.LoadTestRuns(ctx, products, nil, shared.LatestSHA, nil, nil, nil, nil)
+	allRuns := loaded.AllRuns()
 	assert.Nil(t, err)
-	assert.Equal(t, 1, len(loaded))
-	assert.Equal(t, "foo", loaded[0].Labels[0])
+	assert.Equal(t, 1, len(allRuns))
+	assert.Equal(t, "foo", allRuns[0].Labels[0])
 }
 
 func TestLoadTestRuns_SHAinProductSpec(t *testing.T) {
@@ -189,10 +192,11 @@ func TestLoadTestRuns_SHAinProductSpec(t *testing.T) {
 	products := make([]shared.ProductSpec, 1)
 	products[0].BrowserName = "chrome"
 	products[0].Revision = "1111111111"
-	loaded, err := shared.LoadTestRuns(ctx, products, nil, shared.LatestSHA, nil, nil, nil)
+	loaded, err := shared.LoadTestRuns(ctx, products, nil, shared.LatestSHA, nil, nil, nil, nil)
 	assert.Nil(t, err)
-	assert.Equal(t, 1, len(loaded))
-	assert.Equal(t, "1111111111", loaded[0].Revision)
+	allRuns := loaded.AllRuns()
+	assert.Equal(t, 1, len(allRuns))
+	assert.Equal(t, "1111111111", allRuns[0].Revision)
 }
 
 func TestLoadTestRuns_Ordering(t *testing.T) {
@@ -229,12 +233,13 @@ func TestLoadTestRuns_Ordering(t *testing.T) {
 	}
 
 	chrome, _ := shared.ParseProductSpec("chrome")
-	loaded, err := shared.LoadTestRuns(ctx, []shared.ProductSpec{chrome}, nil, shared.LatestSHA, nil, nil, nil)
+	loaded, err := shared.LoadTestRuns(ctx, []shared.ProductSpec{chrome}, nil, shared.LatestSHA, nil, nil, nil, nil)
 	assert.Nil(t, err)
-	assert.Equal(t, 2, len(loaded))
+	allRuns := loaded.AllRuns()
+	assert.Equal(t, 2, len(allRuns))
 	// Runs should be ordered descendingly by TimeStart.
-	assert.Equal(t, "0987654321", loaded[0].Revision)
-	assert.Equal(t, "1234567890", loaded[1].Revision)
+	assert.Equal(t, "0987654321", allRuns[0].Revision)
+	assert.Equal(t, "1234567890", allRuns[1].Revision)
 }
 
 func TestLoadTestRuns_From(t *testing.T) {
@@ -272,10 +277,11 @@ func TestLoadTestRuns_From(t *testing.T) {
 	}
 
 	chrome, _ := shared.ParseProductSpec("chrome")
-	loaded, err := shared.LoadTestRuns(ctx, []shared.ProductSpec{chrome}, nil, shared.LatestSHA, &yesterday, nil, nil)
+	loaded, err := shared.LoadTestRuns(ctx, []shared.ProductSpec{chrome}, nil, shared.LatestSHA, &yesterday, nil, nil, nil)
 	assert.Nil(t, err)
-	assert.Equal(t, 1, len(loaded))
-	assert.Equal(t, "1234567890", loaded[0].Revision)
+	allRuns := loaded.AllRuns()
+	assert.Equal(t, 1, len(allRuns))
+	assert.Equal(t, "1234567890", allRuns[0].Revision)
 }
 
 func TestLoadTestRuns_To(t *testing.T) {
@@ -312,10 +318,11 @@ func TestLoadTestRuns_To(t *testing.T) {
 	}
 
 	chrome, _ := shared.ParseProductSpec("chrome")
-	loaded, err := shared.LoadTestRuns(ctx, shared.ProductSpecs{chrome}, nil, shared.LatestSHA, nil, &now, nil)
+	loaded, err := shared.LoadTestRuns(ctx, shared.ProductSpecs{chrome}, nil, shared.LatestSHA, nil, &now, nil, nil)
 	assert.Nil(t, err)
-	assert.Equal(t, 1, len(loaded))
-	assert.Equal(t, "0987654321", loaded[0].Revision)
+	allRuns := loaded.AllRuns()
+	assert.Equal(t, 1, len(allRuns))
+	assert.Equal(t, "0987654321", allRuns[0].Revision)
 }
 
 func TestGetAlignedRunSHAs(t *testing.T) {

--- a/shared/models.go
+++ b/shared/models.go
@@ -165,21 +165,21 @@ func (t TestRuns) Less(i, j int) bool { return t[i].TimeStart.Before(t[j].TimeSt
 func (t TestRuns) Swap(i, j int)      { t[i], t[j] = t[j], t[i] }
 
 // GetTestRunIDs gets an array of the IDs for the TestRun entities in the array.
-func (runs TestRuns) GetTestRunIDs() TestRunIDs {
-	ids := make([]int64, len(runs))
-	for i, run := range runs {
+func (t TestRuns) GetTestRunIDs() TestRunIDs {
+	ids := make([]int64, len(t))
+	for i, run := range t {
 		ids[i] = run.ID
 	}
 	return ids
 }
 
 // OldestRunTimeStart returns the TimeStart of the oldest run in the set.
-func (runs TestRuns) OldestRunTimeStart() time.Time {
-	if len(runs) < 1 {
+func (t TestRuns) OldestRunTimeStart() time.Time {
+	if len(t) < 1 {
 		return time.Time{}
 	}
 	oldest := time.Now()
-	for _, run := range runs {
+	for _, run := range t {
 		if run.TimeStart.Before(oldest) {
 			oldest = run.TimeStart
 		}

--- a/shared/params.go
+++ b/shared/params.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"regexp"
 	"sort"
 	"strconv"
@@ -23,102 +22,6 @@ import (
 type QueryFilter struct {
 	RunIDs []int64
 	Q      string
-}
-
-// TestRunFilter represents the ways TestRun entities can be filtered in
-// the webapp and api.
-type TestRunFilter struct {
-	SHA      string
-	Labels   mapset.Set
-	Aligned  *bool
-	From     *time.Time
-	To       *time.Time
-	MaxCount *int
-	Products ProductSpecs
-}
-
-// IsDefaultQuery returns whether the params are just an empty query (or,
-// the equivalent defaults of an empty query).
-func (filter TestRunFilter) IsDefaultQuery() bool {
-	return IsLatest(filter.SHA) &&
-		(filter.Labels == nil || filter.Labels.Cardinality() < 1) &&
-		(filter.Aligned == nil) &&
-		(filter.From == nil) &&
-		(filter.MaxCount == nil || *filter.MaxCount == 1) &&
-		(len(filter.Products) < 1)
-}
-
-// OrDefault returns the current filter, or, if it is a default query, returns
-// the query used by default in wpt.fyi.
-func (filter TestRunFilter) OrDefault() TestRunFilter {
-	return filter.OrAlignedStableRuns()
-}
-
-// OrAlignedStableRuns returns the current filter, or, if it is a default query, returns
-// a query for stable runs, with an aligned SHA.
-func (filter TestRunFilter) OrAlignedStableRuns() TestRunFilter {
-	if !filter.IsDefaultQuery() {
-		return filter
-	}
-	aligned := true
-	filter.Aligned = &aligned
-	filter.Labels = mapset.NewSetWith(StableLabel)
-	return filter
-}
-
-// OrExperimentalRuns returns the current filter, or, if it is a default query, returns
-// a query for the latest experimental runs.
-func (filter TestRunFilter) OrExperimentalRuns() TestRunFilter {
-	if !filter.IsDefaultQuery() {
-		return filter
-	}
-	filter.Labels = mapset.NewSetWith(ExperimentalLabel)
-	return filter
-}
-
-// OrAlignedExperimentalRunsExceptEdge returns the current filter, or, if it is a default
-// query, returns a query for the latest experimental runs.
-func (filter TestRunFilter) OrAlignedExperimentalRunsExceptEdge() TestRunFilter {
-	if !filter.IsDefaultQuery() {
-		return filter
-	}
-	aligned := true
-	filter.Aligned = &aligned
-	filter.Products = GetDefaultProducts()
-	for i := range filter.Products {
-		if filter.Products[i].BrowserName != "edge" {
-			filter.Products[i].Labels = mapset.NewSetWith("experimental")
-		}
-	}
-	return filter
-}
-
-// MasterOnly returns the current filter, ensuring it has with the master-only
-// restriction (a label of "master").
-func (filter TestRunFilter) MasterOnly() TestRunFilter {
-	if filter.Labels == nil {
-		filter.Labels = mapset.NewSet()
-	}
-	filter.Labels.Add(MasterLabel)
-	return filter
-}
-
-// IsDefaultProducts returns whether the params products are empty, or the
-// equivalent of the default product set.
-func (filter TestRunFilter) IsDefaultProducts() bool {
-	if len(filter.Products) == 0 {
-		return true
-	}
-	def := GetDefaultProducts()
-	if len(filter.Products) != len(def) {
-		return false
-	}
-	for i := range def {
-		if def[i] != filter.Products[i] {
-			return false
-		}
-	}
-	return true
 }
 
 // ProductSpec is a struct representing a parsed product spec string.
@@ -216,38 +119,6 @@ func (p ProductSpec) String() string {
 func (p ProductSpecs) Len() int           { return len(p) }
 func (p ProductSpecs) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 func (p ProductSpecs) Less(i, j int) bool { return p[i].String() < p[j].String() }
-
-// ToQuery converts the filter set to a url.Values (set of query params).
-func (filter TestRunFilter) ToQuery() (q url.Values) {
-	u := url.URL{}
-	q = u.Query()
-	if !IsLatest(filter.SHA) {
-		q.Set("sha", filter.SHA)
-	}
-	if filter.Labels != nil && filter.Labels.Cardinality() > 0 {
-		for label := range filter.Labels.Iter() {
-			q.Add("label", label.(string))
-		}
-	}
-	if len(filter.Products) > 0 {
-		for _, p := range filter.Products {
-			q.Add("product", p.String())
-		}
-	}
-	if filter.Aligned != nil {
-		q.Set("aligned", strconv.FormatBool(*filter.Aligned))
-	}
-	if filter.MaxCount != nil {
-		q.Set("max-count", fmt.Sprintf("%v", *filter.MaxCount))
-	}
-	if filter.From != nil {
-		q.Set("from", filter.From.Format(time.RFC3339))
-	}
-	if filter.To != nil {
-		q.Set("to", filter.From.Format(time.RFC3339))
-	}
-	return q
-}
 
 // MaxCountMaxValue is the maximum allowed value for the max-count param.
 const MaxCountMaxValue = 500
@@ -516,12 +387,6 @@ func ParseProductOrBrowserParams(r *http.Request) (products ProductSpecs, err er
 		products = append(products, spec)
 	}
 	return products, nil
-}
-
-// GetProductsOrDefault parses the 'products' (and legacy 'browsers') params, returning
-// the ordered list of products to include, or a default list.
-func (filter TestRunFilter) GetProductsOrDefault() (products ProductSpecs) {
-	return filter.Products.OrDefault()
 }
 
 // ParseMaxCountParam parses the 'max-count' parameter as an integer

--- a/shared/params_test.go
+++ b/shared/params_test.go
@@ -635,6 +635,8 @@ func TestParsePageToken(t *testing.T) {
 	assert.Nil(t, err)
 	if parsed == nil {
 		assert.FailNow(t, "Parsed page token was nil")
+	} else if parsed.To == nil {
+		assert.FailNow(t, "Parsed page token has no 'to' param")
 	}
-	assert.EqualValues(t, filter, *parsed)
+	assert.True(t, filter.To.Equal(*parsed.To))
 }

--- a/shared/params_test.go
+++ b/shared/params_test.go
@@ -624,7 +624,7 @@ func TestProductSpecMatches_Revision(t *testing.T) {
 
 func TestParsePageToken(t *testing.T) {
 	filter := TestRunFilter{}
-	now := time.Now().Truncate(time.Microsecond)
+	now := time.Now().Truncate(time.Second)
 	filter.To = &now
 
 	token, err := filter.Token()
@@ -636,5 +636,5 @@ func TestParsePageToken(t *testing.T) {
 	if parsed == nil {
 		assert.FailNow(t, "Parsed page token was nil")
 	}
-	assert.Equal(t, filter, *parsed)
+	assert.EqualValues(t, filter, *parsed)
 }

--- a/shared/params_test.go
+++ b/shared/params_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -619,4 +620,21 @@ func TestProductSpecMatches_Revision(t *testing.T) {
 	assert.False(t, chrome.Matches(chromeRun)) // Still wrong version
 	chromeRun.BrowserVersion = version
 	assert.True(t, chrome.Matches(chromeRun))
+}
+
+func TestParsePageToken(t *testing.T) {
+	filter := TestRunFilter{}
+	now := time.Now().Truncate(time.Microsecond)
+	filter.To = &now
+
+	token, err := filter.Token()
+	assert.Nil(t, err)
+	r := httptest.NewRequest("GET", "/?page="+token, nil)
+
+	parsed, err := ParsePageToken(r)
+	assert.Nil(t, err)
+	if parsed == nil {
+		assert.FailNow(t, "Parsed page token was nil")
+	}
+	assert.Equal(t, filter, *parsed)
 }

--- a/shared/run_diff.go
+++ b/shared/run_diff.go
@@ -50,14 +50,18 @@ func FetchRunResultsJSONForSpec(
 // FetchRunForSpec loads the wpt.fyi TestRun metadata for the given spec.
 func FetchRunForSpec(ctx context.Context, spec ProductSpec) (*TestRun, error) {
 	one := 1
-	testRuns, err := LoadTestRuns(ctx, []ProductSpec{spec}, nil, spec.Revision, nil, nil, &one)
+	testRuns, err := LoadTestRuns(ctx, []ProductSpec{spec}, nil, spec.Revision, nil, nil, &one, nil)
 	if err != nil {
 		return nil, err
 	}
-	if len(testRuns) < 1 {
-		return nil, nil
+	if len(testRuns) == 1 {
+		for _, v := range testRuns {
+			if len(v) == 1 {
+				return &v[0], nil
+			}
+		}
 	}
-	return &testRuns[0], nil
+	return nil, nil
 }
 
 // FetchRunResultsJSON fetches the results JSON summary for the given test run, but does not include subtests (since

--- a/shared/test_run_filter.go
+++ b/shared/test_run_filter.go
@@ -1,0 +1,172 @@
+package shared
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"time"
+
+	mapset "github.com/deckarep/golang-set"
+)
+
+// TestRunFilter represents the ways TestRun entities can be filtered in
+// the webapp and api.
+type TestRunFilter struct {
+	SHA      string
+	Labels   mapset.Set
+	Aligned  *bool
+	From     *time.Time
+	To       *time.Time
+	MaxCount *int
+	Offset   *int // Used for paginating with MaxCount.
+	Products ProductSpecs
+}
+
+// IsDefaultQuery returns whether the params are just an empty query (or,
+// the equivalent defaults of an empty query).
+func (filter TestRunFilter) IsDefaultQuery() bool {
+	return IsLatest(filter.SHA) &&
+		(filter.Labels == nil || filter.Labels.Cardinality() < 1) &&
+		(filter.Aligned == nil) &&
+		(filter.From == nil) &&
+		(filter.MaxCount == nil || *filter.MaxCount == 1) &&
+		(len(filter.Products) < 1)
+}
+
+// OrDefault returns the current filter, or, if it is a default query, returns
+// the query used by default in wpt.fyi.
+func (filter TestRunFilter) OrDefault() TestRunFilter {
+	return filter.OrAlignedStableRuns()
+}
+
+// OrAlignedStableRuns returns the current filter, or, if it is a default query, returns
+// a query for stable runs, with an aligned SHA.
+func (filter TestRunFilter) OrAlignedStableRuns() TestRunFilter {
+	if !filter.IsDefaultQuery() {
+		return filter
+	}
+	aligned := true
+	filter.Aligned = &aligned
+	filter.Labels = mapset.NewSetWith(StableLabel)
+	return filter
+}
+
+// OrExperimentalRuns returns the current filter, or, if it is a default query, returns
+// a query for the latest experimental runs.
+func (filter TestRunFilter) OrExperimentalRuns() TestRunFilter {
+	if !filter.IsDefaultQuery() {
+		return filter
+	}
+	filter.Labels = mapset.NewSetWith(ExperimentalLabel)
+	return filter
+}
+
+// OrAlignedExperimentalRunsExceptEdge returns the current filter, or, if it is a default
+// query, returns a query for the latest experimental runs.
+func (filter TestRunFilter) OrAlignedExperimentalRunsExceptEdge() TestRunFilter {
+	if !filter.IsDefaultQuery() {
+		return filter
+	}
+	aligned := true
+	filter.Aligned = &aligned
+	filter.Products = GetDefaultProducts()
+	for i := range filter.Products {
+		if filter.Products[i].BrowserName != "edge" {
+			filter.Products[i].Labels = mapset.NewSetWith("experimental")
+		}
+	}
+	return filter
+}
+
+// MasterOnly returns the current filter, ensuring it has with the master-only
+// restriction (a label of "master").
+func (filter TestRunFilter) MasterOnly() TestRunFilter {
+	if filter.Labels == nil {
+		filter.Labels = mapset.NewSet()
+	}
+	filter.Labels.Add(MasterLabel)
+	return filter
+}
+
+// IsDefaultProducts returns whether the params products are empty, or the
+// equivalent of the default product set.
+func (filter TestRunFilter) IsDefaultProducts() bool {
+	if len(filter.Products) == 0 {
+		return true
+	}
+	def := GetDefaultProducts()
+	if len(filter.Products) != len(def) {
+		return false
+	}
+	for i := range def {
+		if def[i] != filter.Products[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// GetProductsOrDefault parses the 'products' (and legacy 'browsers') params, returning
+// the ordered list of products to include, or a default list.
+func (filter TestRunFilter) GetProductsOrDefault() (products ProductSpecs) {
+	return filter.Products.OrDefault()
+}
+
+// ToQuery converts the filter set to a url.Values (set of query params).
+func (filter TestRunFilter) ToQuery() (q url.Values) {
+	u := url.URL{}
+	q = u.Query()
+	if !IsLatest(filter.SHA) {
+		q.Set("sha", filter.SHA)
+	}
+	if filter.Labels != nil && filter.Labels.Cardinality() > 0 {
+		for label := range filter.Labels.Iter() {
+			q.Add("label", label.(string))
+		}
+	}
+	if len(filter.Products) > 0 {
+		for _, p := range filter.Products {
+			q.Add("product", p.String())
+		}
+	}
+	if filter.Aligned != nil {
+		q.Set("aligned", strconv.FormatBool(*filter.Aligned))
+	}
+	if filter.MaxCount != nil {
+		q.Set("max-count", fmt.Sprintf("%v", *filter.MaxCount))
+	}
+	if filter.From != nil {
+		q.Set("from", filter.From.Format(time.RFC3339))
+	}
+	if filter.To != nil {
+		q.Set("to", filter.From.Format(time.RFC3339))
+	}
+	return q
+}
+
+// NextPage returns a filter for the next page of results that
+// would match the current filter, based on the given results that were
+// loaded.
+func (filter TestRunFilter) NextPage(loadedRuns TestRuns) *TestRunFilter {
+	// TODO: Handle to/from ranges.
+	if filter.MaxCount != nil {
+		offset := *filter.MaxCount
+		if filter.Offset != nil {
+			offset += *filter.Offset
+		}
+		filter.Offset = &offset
+		return &filter
+	}
+	return nil
+}
+
+// Token returns a base64 encoded copy of the filter.
+func (filter TestRunFilter) Token() (string, error) {
+	if bytes, err := json.Marshal(filter); err != nil {
+		return "", err
+	} else {
+		return base64.URLEncoding.EncodeToString(bytes), nil
+	}
+}

--- a/shared/test_run_filter.go
+++ b/shared/test_run_filter.go
@@ -149,15 +149,24 @@ func (filter TestRunFilter) ToQuery() (q url.Values) {
 // NextPage returns a filter for the next page of results that
 // would match the current filter, based on the given results that were
 // loaded.
-func (filter TestRunFilter) NextPage(loadedRuns TestRuns) *TestRunFilter {
+func (filter TestRunFilter) NextPage(loadedRuns TestRunsByProduct) *TestRunFilter {
 	// TODO: Handle to/from ranges.
 	if filter.MaxCount != nil {
-		offset := *filter.MaxCount
-		if filter.Offset != nil {
-			offset += *filter.Offset
+		// We only have another page if N results were returned for a max of N.
+		anyMaxedOut := false
+		for _, v := range loadedRuns {
+			if len(v) >= *filter.MaxCount {
+				anyMaxedOut = true
+			}
 		}
-		filter.Offset = &offset
-		return &filter
+		if anyMaxedOut {
+			offset := *filter.MaxCount
+			if filter.Offset != nil {
+				offset += *filter.Offset
+			}
+			filter.Offset = &offset
+			return &filter
+		}
 	}
 	return nil
 }

--- a/shared/test_run_filter.go
+++ b/shared/test_run_filter.go
@@ -14,14 +14,14 @@ import (
 // TestRunFilter represents the ways TestRun entities can be filtered in
 // the webapp and api.
 type TestRunFilter struct {
-	SHA      string
-	Labels   mapset.Set
-	Aligned  *bool
-	From     *time.Time
-	To       *time.Time
-	MaxCount *int
-	Offset   *int // Used for paginating with MaxCount.
-	Products ProductSpecs
+	SHA      string       `json:"sha,omitempty"`
+	Labels   mapset.Set   `json:"labels,omitempty"`
+	Aligned  *bool        `json:"aligned,omitempty"`
+	From     *time.Time   `json:"from,omitempty"`
+	To       *time.Time   `json:"to,omitempty"`
+	MaxCount *int         `json:"maxcount,omitempty"`
+	Offset   *int         `json:"offset,omitempty"` // Used for paginating with MaxCount.
+	Products ProductSpecs `json:"products,omitempty"`
 }
 
 // IsDefaultQuery returns whether the params are just an empty query (or,

--- a/shared/test_run_filter.go
+++ b/shared/test_run_filter.go
@@ -164,9 +164,9 @@ func (filter TestRunFilter) NextPage(loadedRuns TestRuns) *TestRunFilter {
 
 // Token returns a base64 encoded copy of the filter.
 func (filter TestRunFilter) Token() (string, error) {
-	if bytes, err := json.Marshal(filter); err != nil {
+	bytes, err := json.Marshal(filter)
+	if err != nil {
 		return "", err
-	} else {
-		return base64.URLEncoding.EncodeToString(bytes), nil
 	}
+	return base64.URLEncoding.EncodeToString(bytes), nil
 }

--- a/util/populate_dev_data.go
+++ b/util/populate_dev_data.go
@@ -252,16 +252,18 @@ func copyProdRuns(ctx context.Context, filters shared.TestRunFilter) {
 		var localRunCopies shared.TestRuns
 		if aligned {
 			var shas []string
-			var keys map[string][]*datastore.Key
+			var keys map[string]shared.KeysByProduct
 			if shas, keys, err = shared.GetAlignedRunSHAs(ctx, shared.GetDefaultProducts(), filters.Labels, nil, nil, &one); err != nil {
 				log.Printf("Failed to load a aligned run SHA: %s", err.Error())
 				continue
 			}
 			if len(shas) > 0 {
 				sha = shas[0]
-				if localRunCopies, err = shared.LoadTestRunsByKeys(ctx, keys[sha]); err != nil {
+				if loaded, err := shared.LoadTestRunsByKeys(ctx, keys[sha]); err != nil {
 					log.Printf("Failed to load test runs by keys: %s", err.Error())
 					continue
+				} else {
+					localRunCopies = loaded.AllRuns()
 				}
 			}
 		}

--- a/webapp/components/wpt-flags.html
+++ b/webapp/components/wpt-flags.html
@@ -113,6 +113,7 @@ found in the LICENSE file.
       'experimentalByDefault',
       'experimentalAlignedExceptEdge',
       'taskclusterAllBranches',
+      'paginationTokens',
     ];
 
     /* global _wptFlags, WPT_FYI_FEATURES */
@@ -189,6 +190,11 @@ found in the LICENSE file.
     <paper-item>
       <paper-checkbox checked="{{taskclusterAllBranches}}">
         Process all taskcluster results (not just master)
+      </paper-checkbox>
+    </paper-item>
+    <paper-item>
+      <paper-checkbox checked="{{paginationTokens}}">
+        Return "x-wpt-next-page" pagination token HTTP header in /api/runs
       </paper-checkbox>
     </paper-item>
   </template>

--- a/webapp/components/wpt-flags.html
+++ b/webapp/components/wpt-flags.html
@@ -194,7 +194,7 @@ found in the LICENSE file.
     </paper-item>
     <paper-item>
       <paper-checkbox checked="{{paginationTokens}}">
-        Return "x-wpt-next-page" pagination token HTTP header in /api/runs
+        Return "wpt-next-page" pagination token HTTP header in /api/runs
       </paper-checkbox>
     </paper-item>
   </template>


### PR DESCRIPTION
## Description
Fixes https://github.com/web-platform-tests/wpt.fyi/issues/588

Hides the token behind a feature, but supports base64 encoded tokens of a TestRunFilter.

Currently, the next page only works for `MaxCount` (using an offset). Will follow up with some time-range based behaviour. 

## Review Information
- Head to /admin/flags, turn on the feature
- Visit /api/runs?max-count=1, observe the `x-wpt-next-page` header in the response headers
- Fetch /api/runs?page=[the token], see that you get the next runs (1 per product).

As for code review, I recommend you eyeball and overlook the first commit (a refactor that'll be needed later when combining pagination of time + max-count), and scrutinize the 2nd commit.