### PR TITLE
Migrate context creation to shared

### DIFF
--- a/api/taskcluster/webhook.go
+++ b/api/taskcluster/webhook.go
@@ -40,8 +40,7 @@ func tcWebhookHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx := appengine.NewContext(r)
-
+	ctx := shared.NewAppEngineContext(r)
 	secret, err := shared.GetSecret(ctx, "github-tc-webhook-secret")
 	if err != nil {
 		http.Error(w, "Unable to verify request: secret not found", http.StatusInternalServerError)

--- a/webapp/about_handler.go
+++ b/webapp/about_handler.go
@@ -8,11 +8,12 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/web-platform-tests/wpt.fyi/shared"
 	"google.golang.org/appengine"
 )
 
 func aboutHandler(w http.ResponseWriter, r *http.Request) {
-	ctx := appengine.NewContext(r)
+	ctx := shared.NewAppEngineContext(r)
 	version := "dev_appserver"
 	if !appengine.IsDevAppServer() {
 		version = strings.Split(appengine.VersionID(ctx), ".")[0]

--- a/webapp/dynamic_components_handler.go
+++ b/webapp/dynamic_components_handler.go
@@ -5,14 +5,18 @@ import (
 	"net/http"
 
 	"github.com/web-platform-tests/wpt.fyi/shared"
-	"google.golang.org/appengine"
 )
 
 var componentTemplates = template.Must(template.ParseGlob("dynamic-components/*.html"))
 
 func flagsComponentHandler(w http.ResponseWriter, r *http.Request) {
-	ctx := appengine.NewContext(r)
-	flags, _ := shared.GetFeatureFlags(ctx) // Errors aren't a big deal.
+	ctx := shared.NewAppEngineContext(r)
+	flags, err := shared.GetFeatureFlags(ctx)
+	if err != nil {
+		// Errors aren't a big deal; log them and ignore.
+		log := shared.GetLogger(ctx)
+		log.Debugf("Error loading flags: %s", err.Error())
+	}
 	data := struct{ Flags []shared.Flag }{flags}
 	componentTemplates.ExecuteTemplate(w, "wpt-env-flags.html", data)
 }

--- a/webapp/test_results_handler.go
+++ b/webapp/test_results_handler.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/web-platform-tests/wpt.fyi/shared"
-	"google.golang.org/appengine"
 )
 
 type testRunUIFilter struct {
@@ -89,7 +88,7 @@ func parseTestResultsUIFilter(r *http.Request) (filter testResultsUIFilter, err 
 	if err != nil {
 		return filter, err
 	}
-	ctx := appengine.NewContext(r)
+	ctx := shared.NewAppEngineContext(r)
 
 	if testRunFilter.IsDefaultQuery() {
 		experimentalByDefault := shared.IsFeatureEnabled(ctx, "experimentalByDefault")


### PR DESCRIPTION
## Description
Avoids a very peculiar bug surfaced by https://github.com/web-platform-tests/wpt.fyi/commit/d871148f0b76531b27124779525cb635059cb029

Essentially, due to the strange order of the code, `verifyAndGetPayload` was where we were attaching a logger to the nested `appengine.GetContext`. What's strange is that the context should be a copy; yet, when we later grab (another) context from appengine, the logger was still attached to it.