### PR TITLE
Avoid HTML escaping in md template properly

### DIFF
--- a/api/checks/summaries/compile.go
+++ b/api/checks/summaries/compile.go
@@ -2,9 +2,9 @@ package summaries
 
 import (
 	"bytes"
-	"html/template"
 	"path/filepath"
 	"runtime"
+	"text/template"
 )
 
 var templates *template.Template
@@ -17,9 +17,9 @@ func init() {
 
 // Completed is the struct for completed.md
 type Completed struct {
+	DiffURL  string // URL for the diff-view of the results
 	HostName string // Host environment name, e.g. "wpt.fyi"
 	HostURL  string // Host environment URL, e.g. "https://wpt.fyi"
-	DiffURL  string // URL for the diff-view of the results
 	SHAURL   string // URL for the latest results for the same SHA
 }
 

--- a/api/checks/summaries/compile.go
+++ b/api/checks/summaries/compile.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"html/template"
 	"path/filepath"
-	"reflect"
 	"runtime"
 )
 
@@ -41,20 +40,8 @@ func (c Pending) Compile() (string, error) {
 }
 
 func compile(i interface{}, t string) (string, error) {
-	// Copy all the fields as template.HTML to avoid HTML escaping.
-	values := make(map[string]template.HTML)
-	v := reflect.Indirect(reflect.ValueOf(i))
-	for i := 0; i < v.NumField(); i++ {
-		field := v.Field(i)
-		if field.CanInterface() {
-			if s, ok := field.Interface().(string); ok {
-				values[v.Type().Field(i).Name] = template.HTML(s)
-			}
-		}
-	}
-
 	var dest bytes.Buffer
-	if err := templates.ExecuteTemplate(&dest, t, values); err != nil {
+	if err := templates.ExecuteTemplate(&dest, t, i); err != nil {
 		return "", err
 	}
 	return dest.String(), nil

--- a/api/checks/summaries/compile_test.go
+++ b/api/checks/summaries/compile_test.go
@@ -14,9 +14,9 @@ import (
 
 func TestCompile_Completed(t *testing.T) {
 	foo := Completed{
+		DiffURL:  "foo.com/diff?before=chrome[master]&after=chrome@0123456789",
 		HostName: "foo.com",
 		HostURL:  "foo.com/results/",
-		DiffURL:  "foo.com/diff/",
 		SHAURL:   "foo.com/sha/",
 	}
 	s, err := foo.Compile()
@@ -30,7 +30,7 @@ func TestCompile_Completed(t *testing.T) {
 func TestCompile_Pending(t *testing.T) {
 	foo := Pending{
 		HostName: "foo.com",
-		RunsURL:  "foo.com/runs",
+		RunsURL:  "foo.com/runs?products=chrome&sha=0123456789",
 	}
 	s, err := foo.Compile()
 	assert.Nil(t, err)

--- a/api/checks/summaries/compile_test.go
+++ b/api/checks/summaries/compile_test.go
@@ -14,9 +14,9 @@ import (
 
 func TestCompile_Completed(t *testing.T) {
 	foo := Completed{
-		DiffURL:  "foo.com/diff?before=chrome[master]&after=chrome@0123456789",
 		HostName: "foo.com",
 		HostURL:  "foo.com/results/",
+		DiffURL:  "foo.com/diff/",
 		SHAURL:   "foo.com/sha/",
 	}
 	s, err := foo.Compile()
@@ -30,7 +30,7 @@ func TestCompile_Completed(t *testing.T) {
 func TestCompile_Pending(t *testing.T) {
 	foo := Pending{
 		HostName: "foo.com",
-		RunsURL:  "foo.com/runs?products=chrome&sha=0123456789",
+		RunsURL:  "foo.com/runs",
 	}
 	s, err := foo.Compile()
 	assert.Nil(t, err)


### PR DESCRIPTION
Reverts web-platform-tests/wpt.fyi#774