### PR TITLE
Fix product order preservation

### DIFF
--- a/api/checks/webhook.go
+++ b/api/checks/webhook.go
@@ -219,9 +219,9 @@ func completeChecksForExistingRuns(ctx context.Context, sha string, products ...
 		return false, fmt.Errorf("Failed to load test runs: %s", err.Error())
 	}
 	createdSome := false
-	for p, runs := range runsByProduct {
-		if len(runs) > 0 {
-			created, err := completeCheckRun(ctx, sha, p)
+	for _, rbp := range runsByProduct {
+		if len(rbp.TestRuns) > 0 {
+			created, err := completeCheckRun(ctx, sha, rbp.Product)
 			createdSome = createdSome || created
 			if err != nil {
 				return createdSome, err

--- a/api/interop.go
+++ b/api/interop.go
@@ -145,10 +145,8 @@ func checkKeysAreAligned(shaKeys map[string]shared.KeysByProduct) func(shared.Te
 	keySets := make(map[string]mapset.Set)
 	for sha, keys := range shaKeys {
 		keySet := mapset.NewSet()
-		for _, kbp := range keys {
-			for _, key := range kbp {
-				keySet.Add(key.IntID())
-			}
+		for _, key := range keys.AllKeys() {
+			keySet.Add(key.IntID())
 		}
 		keySets[sha] = keySet
 	}
@@ -171,10 +169,8 @@ func checkKeysAreAligned(shaKeys map[string]shared.KeysByProduct) func(shared.Te
 
 func checkKeysMatchQuery(keys shared.KeysByProduct) func(shared.TestRunIDs) bool {
 	keysFilter := mapset.NewSet()
-	for _, kbp := range keys {
-		for _, key := range kbp {
-			keysFilter.Add(key.IntID())
-		}
+	for _, key := range keys.AllKeys() {
+		keysFilter.Add(key.IntID())
 	}
 	return func(ids shared.TestRunIDs) bool {
 		all := true

--- a/api/query/query_test.go
+++ b/api/query/query_test.go
@@ -129,19 +129,26 @@ func TestGetRunsAndFilters_default(t *testing.T) {
 	}
 	chrome, _ := shared.ParseProductSpec("chrome")
 	edge, _ := shared.ParseProductSpec("edge")
-	testRuns := make(shared.TestRunsByProduct)
-	testRuns[chrome] = shared.TestRuns{
-		shared.TestRun{
-			ID:         runIDs[0],
-			ResultsURL: urls[0],
-			TimeStart:  time.Now(),
+	testRuns := shared.TestRunsByProduct{
+		shared.ProductTestRuns{
+			Product: chrome,
+			TestRuns: shared.TestRuns{
+				shared.TestRun{
+					ID:         runIDs[0],
+					ResultsURL: urls[0],
+					TimeStart:  time.Now(),
+				},
+			},
 		},
-	}
-	testRuns[edge] = shared.TestRuns{
-		shared.TestRun{
-			ID:         runIDs[1],
-			ResultsURL: urls[1],
-			TimeStart:  time.Now().AddDate(0, 0, -1),
+		shared.ProductTestRuns{
+			Product: edge,
+			TestRuns: shared.TestRuns{
+				shared.TestRun{
+					ID:         runIDs[1],
+					ResultsURL: urls[1],
+					TimeStart:  time.Now().AddDate(0, 0, -1),
+				},
+			},
 		},
 	}
 	filters := shared.QueryFilter{}
@@ -172,19 +179,26 @@ func TestGetRunsAndFilters_specificRunIDs(t *testing.T) {
 	}
 	chrome, _ := shared.ParseProductSpec("chrome")
 	edge, _ := shared.ParseProductSpec("edge")
-	testRuns := make(shared.TestRunsByProduct)
-	testRuns[chrome] = shared.TestRuns{
-		shared.TestRun{
-			ID:         runIDs[0],
-			ResultsURL: urls[0],
-			TimeStart:  time.Now(),
+	testRuns := shared.TestRunsByProduct{
+		shared.ProductTestRuns{
+			Product: chrome,
+			TestRuns: shared.TestRuns{
+				shared.TestRun{
+					ID:         runIDs[0],
+					ResultsURL: urls[0],
+					TimeStart:  time.Now(),
+				},
+			},
 		},
-	}
-	testRuns[edge] = shared.TestRuns{
-		shared.TestRun{
-			ID:         runIDs[1],
-			ResultsURL: urls[1],
-			TimeStart:  time.Now().AddDate(0, 0, -1),
+		shared.ProductTestRuns{
+			Product: edge,
+			TestRuns: shared.TestRuns{
+				shared.TestRun{
+					ID:         runIDs[1],
+					ResultsURL: urls[1],
+					TimeStart:  time.Now().AddDate(0, 0, -1),
+				},
+			},
 		},
 	}
 	filters := shared.QueryFilter{

--- a/api/test_runs.go
+++ b/api/test_runs.go
@@ -110,10 +110,10 @@ func LoadTestRunKeysForFilters(ctx context.Context, filters shared.TestRunFilter
 			// Bail out early - can't find any complete runs.
 			return result, nil
 		}
-		keys := make(shared.KeysByProduct)
+		keys := make(shared.KeysByProduct, len(products))
 		for _, sha := range shas {
-			for p := range shaKeys[sha] {
-				keys[p] = append(keys[p], shaKeys[sha][p]...)
+			for i := range shaKeys[sha] {
+				keys[i].Keys = append(keys[i].Keys, shaKeys[sha][i].Keys...)
 			}
 		}
 		return keys, err

--- a/shared/datastore.go
+++ b/shared/datastore.go
@@ -37,7 +37,7 @@ func LoadTestRunKeys(
 	to *time.Time,
 	limit *int,
 	offset *int) (result KeysByProduct, err error) {
-	result = make(KeysByProduct)
+	result = make(KeysByProduct, len(products))
 	baseQuery := datastore.NewQuery("TestRun")
 	if !IsLatest(sha) {
 		baseQuery = baseQuery.Filter("Revision =", sha)
@@ -91,7 +91,10 @@ func LoadTestRunKeys(
 			}
 			keys = append(keys, key)
 		}
-		result[product] = append(result[product], keys...)
+		result = append(result, ProductTestRunKeys{
+			Product: product,
+			Keys:    keys,
+		})
 	}
 	return result, nil
 }
@@ -118,22 +121,26 @@ func LoadTestRuns(
 // LoadTestRunsByKeys loads the given test runs (by key), but also appends the
 // ID to the TestRun entity.
 func LoadTestRunsByKeys(ctx context.Context, keysByProduct KeysByProduct) (result TestRunsByProduct, err error) {
-	result = make(TestRunsByProduct)
+	result = TestRunsByProduct{}
 	cs := NewObjectCachedStore(ctx, NewJSONObjectCache(ctx, NewMemcacheReadWritable(ctx, 48*time.Hour)), NewDatastoreObjectStore(ctx, "TestRun"))
 	var wg sync.WaitGroup
-	for product, keys := range keysByProduct {
-		result[product] = make(TestRuns, len(keys))
-		for i := range keys {
+	for _, kbp := range keysByProduct {
+		runs := make(TestRuns, len(kbp.Keys))
+		for i := range kbp.Keys {
 			wg.Add(1)
 			go func(i int) {
 				defer wg.Done()
 
-				localErr := cs.Get(getTestRunMemcacheKey(keys[i].IntID()), keys[i].IntID(), &result[product][i])
+				localErr := cs.Get(getTestRunMemcacheKey(kbp.Keys[i].IntID()), kbp.Keys[i].IntID(), &runs[i])
 				if localErr != nil {
 					err = localErr
 				}
 			}(i)
 		}
+		result = append(result, ProductTestRuns{
+			Product:  kbp.Product,
+			TestRuns: runs,
+		})
 		wg.Wait()
 	}
 
@@ -141,9 +148,9 @@ func LoadTestRunsByKeys(ctx context.Context, keysByProduct KeysByProduct) (resul
 		return nil, err
 	}
 	// Append the keys as ID
-	for product, keys := range keysByProduct {
-		for i, key := range keys {
-			result[product][i].ID = key.IntID()
+	for i, kbp := range keysByProduct {
+		for j, key := range kbp.Keys {
+			result[i].TestRuns[j].ID = key.IntID()
 		}
 	}
 	return result, err
@@ -228,7 +235,7 @@ func GetAlignedRunSHAs(
 	for {
 		var testRun TestRun
 		var key *datastore.Key
-		var matchingProduct *ProductSpec
+		matchingProduct := -1
 		key, err := it.Next(&testRun)
 		if err == datastore.Done {
 			break
@@ -237,24 +244,24 @@ func GetAlignedRunSHAs(
 		} else {
 			for i := range products {
 				if products[i].Matches(testRun) {
-					matchingProduct = &products[i]
+					matchingProduct = i
 					break
 				}
 			}
 		}
-		if matchingProduct == nil {
+		if matchingProduct < 0 {
 			continue
 		}
 		if _, ok := productsBySHA[testRun.Revision]; !ok {
 			productsBySHA[testRun.Revision] = mapset.NewSet()
-			keyCollector[testRun.Revision] = make(KeysByProduct)
+			keyCollector[testRun.Revision] = make(KeysByProduct, len(products))
 		}
 		set := productsBySHA[testRun.Revision]
 		if set.Contains(matchingProduct) {
 			continue
 		}
 		set.Add(matchingProduct)
-		keyCollector[testRun.Revision][*matchingProduct] = []*datastore.Key{key}
+		keyCollector[testRun.Revision][matchingProduct].Keys = []*datastore.Key{key}
 		if set.Cardinality() == len(products) && !done.Contains(testRun.Revision) {
 			done.Add(testRun.Revision)
 			shas = append(shas, testRun.Revision)

--- a/shared/models.go
+++ b/shared/models.go
@@ -7,7 +7,6 @@ package shared
 import (
 	"encoding/json"
 	"fmt"
-	"sort"
 	"strings"
 	"time"
 
@@ -187,29 +186,40 @@ func (t TestRuns) OldestRunTimeStart() time.Time {
 	return oldest
 }
 
+// ProductTestRuns is a tuple of a product and test runs loaded for it.
+type ProductTestRuns struct {
+	Product  ProductSpec
+	TestRuns TestRuns
+}
+
 // TestRunsByProduct is a map of product to matching runs, returned
 // when a TestRun query is executed.
-type TestRunsByProduct map[ProductSpec]TestRuns
+type TestRunsByProduct []ProductTestRuns
 
 // AllRuns returns an array of all the loaded runs.
 func (t TestRunsByProduct) AllRuns() TestRuns {
 	var runs TestRuns
-	for _, v := range t {
-		runs = append(runs, v...)
+	for _, p := range t {
+		runs = append(runs, p.TestRuns...)
 	}
-	sort.Sort(sort.Reverse(runs))
 	return runs
+}
+
+// ProductTestRunKeys is a tuple of a product and test run keys loaded for it.
+type ProductTestRunKeys struct {
+	Product ProductSpec
+	Keys    []*datastore.Key
 }
 
 // KeysByProduct is a map of product to matching keys, returned
 // when a TestRun key query is executed.
-type KeysByProduct map[ProductSpec][]*datastore.Key
+type KeysByProduct []ProductTestRunKeys
 
 // AllKeys returns an array of all the loaded keys.
 func (t KeysByProduct) AllKeys() []*datastore.Key {
 	var keys []*datastore.Key
 	for _, v := range t {
-		keys = append(keys, v...)
+		keys = append(keys, v.Keys...)
 	}
 	return keys
 }

--- a/shared/run_diff.go
+++ b/shared/run_diff.go
@@ -54,12 +54,9 @@ func FetchRunForSpec(ctx context.Context, spec ProductSpec) (*TestRun, error) {
 	if err != nil {
 		return nil, err
 	}
-	if len(testRuns) == 1 {
-		for _, v := range testRuns {
-			if len(v) == 1 {
-				return &v[0], nil
-			}
-		}
+	allRuns := testRuns.AllRuns()
+	if len(allRuns) == 1 {
+		return &allRuns[0], nil
 	}
 	return nil, nil
 }

--- a/shared/test_run_filter.go
+++ b/shared/test_run_filter.go
@@ -155,7 +155,7 @@ func (filter TestRunFilter) NextPage(loadedRuns TestRunsByProduct) *TestRunFilte
 		// We only have another page if N results were returned for a max of N.
 		anyMaxedOut := false
 		for _, v := range loadedRuns {
-			if len(v) >= *filter.MaxCount {
+			if len(v.TestRuns) >= *filter.MaxCount {
 				anyMaxedOut = true
 			}
 		}

--- a/webdriver/product_test.go
+++ b/webdriver/product_test.go
@@ -14,6 +14,13 @@ import (
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
+func TestProductParam_Order(t *testing.T) {
+	testProductParamSets(
+		t,
+		[]string{"chrome", "firefox"},
+		[]string{"firefox", "chrome"},
+}
+
 func TestProductParam_Labels(t *testing.T) {
 	testProductParamSets(
 		t,

--- a/webdriver/product_test.go
+++ b/webdriver/product_test.go
@@ -18,7 +18,7 @@ func TestProductParam_Order(t *testing.T) {
 	testProductParamSets(
 		t,
 		[]string{"chrome", "firefox"},
-		[]string{"firefox", "chrome"},
+		[]string{"firefox", "chrome"})
 }
 
 func TestProductParam_Labels(t *testing.T) {


### PR DESCRIPTION
## Description
Tests are flaky from the non-deterministic ranging over a map, mistakenly done in #772 

Luckily, most callers were using `AllRuns` already, so this isn't too bad of a follow-up fix.