### PR TITLE
Add feature for listing runs for a PR

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -52,6 +52,10 @@ __`to`__ : RFC3339 timestamp, for which to include runs that occured before the 
 
 __`max-count`__ : Maximum number of runs to get (for each browser). Maximum of 500.
 
+#### staging.wpt.fyi only (Beta params)
+
+__`pr`__ (Beta): GitHub PR number. Shows runs for commits that belong to the PR.
+
 #### Examples
 
 - https://wpt.fyi/api/runs?product=chrome&product=safari
@@ -379,7 +383,7 @@ version, Sauce Labs, or custom runners), they can be overridden with the followi
 parameters in the POST payload (this is __NOT__ recommended; please include metadata in the reports
 whenever possible):
 
-* __`revision`__ (note this should be the full revision hash, not a 10-char truncation) 
+* __`revision`__ (note this should be the full revision hash, not a 10-char truncation)
 * __`browser_name`__ (note that it is not called `product` here)
 * __`browser_version`__
 * __`os_name`__ (note that it is not called `os` here)

--- a/shared/datastore.go
+++ b/shared/datastore.go
@@ -32,10 +32,11 @@ func LoadTestRunsBySHAs(ctx context.Context, shas ...string) (runs TestRuns, err
 			sha = sha[:10]
 		}
 		var shaRuns TestRuns
-		_, err = datastore.NewQuery("TestRun").Filter("Revision =", sha).GetAll(ctx, &shaRuns)
+		keys, err := datastore.NewQuery("TestRun").Filter("Revision =", sha).GetAll(ctx, &shaRuns)
 		if err != nil {
 			return runs, err
 		}
+		shaRuns.SetTestRunIDs(keys)
 		runs = append(runs, shaRuns...)
 	}
 	return runs, err
@@ -165,9 +166,7 @@ func LoadTestRunsByKeys(ctx context.Context, keysByProduct KeysByProduct) (resul
 	}
 	// Append the keys as ID
 	for i, kbp := range keysByProduct {
-		for j, key := range kbp.Keys {
-			result[i].TestRuns[j].ID = key.IntID()
-		}
+		result[i].TestRuns.SetTestRunIDs(kbp.Keys)
 	}
 	return result, err
 }

--- a/shared/datastore.go
+++ b/shared/datastore.go
@@ -25,6 +25,22 @@ func LoadTestRun(ctx context.Context, id int64) (*TestRun, error) {
 	return &testRun, nil
 }
 
+// LoadTestRunsBySHAs loads all test runs that belong to any of the given revisions (SHAs).
+func LoadTestRunsBySHAs(ctx context.Context, shas ...string) (runs TestRuns, err error) {
+	for _, sha := range shas {
+		if len(sha) > 10 {
+			sha = sha[:10]
+		}
+		var shaRuns TestRuns
+		_, err = datastore.NewQuery("TestRun").Filter("Revision =", sha).GetAll(ctx, &shaRuns)
+		if err != nil {
+			return runs, err
+		}
+		runs = append(runs, shaRuns...)
+	}
+	return runs, err
+}
+
 // LoadTestRunKeys loads the keys for the TestRun entities for the given parameters.
 // It is encapsulated because we cannot run single queries with multiple inequality
 // filters, so must load the keys and merge the results.

--- a/shared/datastore_medium_test.go
+++ b/shared/datastore_medium_test.go
@@ -67,6 +67,9 @@ func TestLoadTestRunsBySHAs(t *testing.T) {
 	runs, err := shared.LoadTestRunsBySHAs(ctx, "1111111111", "3333333333")
 	assert.Nil(t, err)
 	assert.Len(t, runs, 2)
+	for _, run := range runs {
+		assert.True(t, run.ID > 0, "ID field should be populated.")
+	}
 	assert.Equal(t, runs[0].Revision, "1111111111")
 	assert.Equal(t, runs[1].Revision, "3333333333")
 }
@@ -149,6 +152,9 @@ func TestLoadTestRuns_Experimental_Only(t *testing.T) {
 	allRuns := loaded.AllRuns()
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(allRuns))
+	for _, run := range allRuns {
+		assert.True(t, run.ID > 0, "ID field should be populated.")
+	}
 	assert.Equal(t, "64.0", allRuns[0].BrowserVersion)
 	assert.Equal(t, "65.0", allRuns[1].BrowserVersion)
 }

--- a/shared/datastore_medium_test.go
+++ b/shared/datastore_medium_test.go
@@ -3,6 +3,8 @@
 package shared_test
 
 import (
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -41,6 +43,32 @@ func TestLoadTestRuns(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(allRuns))
 	assert.Equalf(t, key.IntID(), allRuns[0].ID, "ID field should be populated.")
+}
+
+func TestLoadTestRunsBySHAs(t *testing.T) {
+	testRun := shared.TestRun{}
+	testRun.BrowserName = "chrome"
+	testRun.BrowserVersion = "63.0"
+	testRun.OSName = "linux"
+	testRun.Revision = "0000000000"
+	testRun.CreatedAt = time.Now()
+
+	ctx, done, err := sharedtest.NewAEContext(true)
+	assert.Nil(t, err)
+	defer done()
+
+	for i := 0; i < 5; i++ {
+		testRun.Revision = strings.Repeat(strconv.Itoa(i), 10)
+		testRun.CreatedAt = time.Now().AddDate(0, 0, -i)
+		key := datastore.NewIncompleteKey(ctx, "TestRun", nil)
+		datastore.Put(ctx, key, &testRun)
+	}
+
+	runs, err := shared.LoadTestRunsBySHAs(ctx, "1111111111", "3333333333")
+	assert.Nil(t, err)
+	assert.Len(t, runs, 2)
+	assert.Equal(t, runs[0].Revision, "1111111111")
+	assert.Equal(t, runs[1].Revision, "3333333333")
 }
 
 func TestLoadTestRuns_Experimental_Only(t *testing.T) {

--- a/shared/models.go
+++ b/shared/models.go
@@ -163,6 +163,13 @@ func (t TestRuns) Len() int           { return len(t) }
 func (t TestRuns) Less(i, j int) bool { return t[i].TimeStart.Before(t[j].TimeStart) }
 func (t TestRuns) Swap(i, j int)      { t[i], t[j] = t[j], t[i] }
 
+// SetTestRunIDs sets the ID field for each run, from the given keys.
+func (t TestRuns) SetTestRunIDs(keys []*datastore.Key) {
+	for i := 0; i < len(keys) && i < len(t); i++ {
+		t[i].ID = keys[i].IntID()
+	}
+}
+
 // GetTestRunIDs gets an array of the IDs for the TestRun entities in the array.
 func (t TestRuns) GetTestRunIDs() TestRunIDs {
 	ids := make([]int64, len(t))

--- a/shared/params.go
+++ b/shared/params.go
@@ -541,6 +541,19 @@ func parseRepeatedParamValues(repeatedParam []string, pluralParam string) (param
 	return params
 }
 
+// ParseIntParam parses the result of ParseParam as int64.
+func ParseIntParam(r *http.Request, param string) (*int, error) {
+	strVal := r.URL.Query().Get(param)
+	if strVal == "" {
+		return nil, nil
+	}
+	parsed, err := strconv.Atoi(strVal)
+	if err != nil {
+		return nil, err
+	}
+	return &parsed, nil
+}
+
 // ParseRepeatedInt64Param parses the result of ParseRepeatedParam as int64.
 func ParseRepeatedInt64Param(r *http.Request, singular, plural string) (params []int64, err error) {
 	strs := ParseRepeatedParam(r, singular, plural)
@@ -549,11 +562,10 @@ func ParseRepeatedInt64Param(r *http.Request, singular, plural string) (params [
 	}
 	ints := make([]int64, len(strs))
 	for i, idStr := range strs {
-		id, err := strconv.ParseInt(idStr, 10, 64)
+		ints[i], err = strconv.ParseInt(idStr, 10, 64)
 		if err != nil {
 			return nil, err
 		}
-		ints[i] = id
 	}
 	return ints, err
 }
@@ -601,6 +613,12 @@ func ParseBooleanParam(r *http.Request, name string) (result *bool, err error) {
 // int64, an error will be returned.
 func ParseRunIDsParam(r *http.Request) (ids TestRunIDs, err error) {
 	return ParseRepeatedInt64Param(r, "run_id", "run_ids")
+}
+
+// ParsePRParam parses the "pr" parameter. If it's not a valid int64, an error
+// will be returned.
+func ParsePRParam(r *http.Request) (*int, error) {
+	return ParseIntParam(r, "pr")
 }
 
 // ParseQueryFilterParams parses shared params for the search and autocomplete

--- a/webapp/components/wpt-flags.html
+++ b/webapp/components/wpt-flags.html
@@ -114,6 +114,7 @@ found in the LICENSE file.
       'experimentalAlignedExceptEdge',
       'taskclusterAllBranches',
       'paginationTokens',
+      'runsByPRNumber',
     ];
 
     /* global _wptFlags, WPT_FYI_FEATURES */

--- a/webapp/components/wpt-flags.html
+++ b/webapp/components/wpt-flags.html
@@ -197,6 +197,11 @@ found in the LICENSE file.
         Return "wpt-next-page" pagination token HTTP header in /api/runs
       </paper-checkbox>
     </paper-item>
+    <paper-item>
+      <paper-checkbox checked="{{runsByPRNumber}}">
+        Allow /api/runs?pr=[GitHub PR number]
+      </paper-checkbox>
+    </paper-item>
   </template>
   <script>
     /* global _wptFlagsEditor, WPTFlagsEditor, WPT_FYI_SERVER_SIDE_FEATURES */


### PR DESCRIPTION
## Description
First steps towards https://github.com/web-platform-tests/wpt.fyi/issues/784

Adds `runsByPRNumber` feature, which will run a GitHub API fetch for commits for the PR number and list all runs pertaining to all SHAs in the PR.

## Review Information
NOTE - won't work on the UI as a result of this PR, needs a follow-up.

- Head to /admin/flags, ensure feature is enabled
- Load /api/runs?pr=[PR number]
  - Needs to be a whitelisted user, e.g. `autofoolip`
  - e.g. [/api/runs?pr=14143](https://prs-dot-wptdashboard-staging.appspot.com/api/runs?pr=14143)