### PR TITLE
Add plumbing for pr param in UI

### DIFF
--- a/shared/datastore.go
+++ b/shared/datastore.go
@@ -32,10 +32,11 @@ func LoadTestRunsBySHAs(ctx context.Context, shas ...string) (runs TestRuns, err
 			sha = sha[:10]
 		}
 		var shaRuns TestRuns
-		_, err = datastore.NewQuery("TestRun").Filter("Revision =", sha).GetAll(ctx, &shaRuns)
+		keys, err := datastore.NewQuery("TestRun").Filter("Revision =", sha).GetAll(ctx, &shaRuns)
 		if err != nil {
 			return runs, err
 		}
+		shaRuns.SetTestRunIDs(keys)
 		runs = append(runs, shaRuns...)
 	}
 	return runs, err
@@ -165,9 +166,7 @@ func LoadTestRunsByKeys(ctx context.Context, keysByProduct KeysByProduct) (resul
 	}
 	// Append the keys as ID
 	for i, kbp := range keysByProduct {
-		for j, key := range kbp.Keys {
-			result[i].TestRuns[j].ID = key.IntID()
-		}
+		result[i].TestRuns.SetTestRunIDs(kbp.Keys)
 	}
 	return result, err
 }

--- a/shared/datastore.go
+++ b/shared/datastore.go
@@ -25,6 +25,22 @@ func LoadTestRun(ctx context.Context, id int64) (*TestRun, error) {
 	return &testRun, nil
 }
 
+// LoadTestRunsBySHAs loads all test runs that belong to any of the given revisions (SHAs).
+func LoadTestRunsBySHAs(ctx context.Context, shas ...string) (runs TestRuns, err error) {
+	for _, sha := range shas {
+		if len(sha) > 10 {
+			sha = sha[:10]
+		}
+		var shaRuns TestRuns
+		_, err = datastore.NewQuery("TestRun").Filter("Revision =", sha).GetAll(ctx, &shaRuns)
+		if err != nil {
+			return runs, err
+		}
+		runs = append(runs, shaRuns...)
+	}
+	return runs, err
+}
+
 // LoadTestRunKeys loads the keys for the TestRun entities for the given parameters.
 // It is encapsulated because we cannot run single queries with multiple inequality
 // filters, so must load the keys and merge the results.

--- a/shared/datastore_medium_test.go
+++ b/shared/datastore_medium_test.go
@@ -67,6 +67,9 @@ func TestLoadTestRunsBySHAs(t *testing.T) {
 	runs, err := shared.LoadTestRunsBySHAs(ctx, "1111111111", "3333333333")
 	assert.Nil(t, err)
 	assert.Len(t, runs, 2)
+	for _, run := range runs {
+		assert.True(t, run.ID > 0, "ID field should be populated.")
+	}
 	assert.Equal(t, runs[0].Revision, "1111111111")
 	assert.Equal(t, runs[1].Revision, "3333333333")
 }
@@ -149,6 +152,9 @@ func TestLoadTestRuns_Experimental_Only(t *testing.T) {
 	allRuns := loaded.AllRuns()
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(allRuns))
+	for _, run := range allRuns {
+		assert.True(t, run.ID > 0, "ID field should be populated.")
+	}
 	assert.Equal(t, "64.0", allRuns[0].BrowserVersion)
 	assert.Equal(t, "65.0", allRuns[1].BrowserVersion)
 }

--- a/shared/datastore_medium_test.go
+++ b/shared/datastore_medium_test.go
@@ -3,6 +3,8 @@
 package shared_test
 
 import (
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -41,6 +43,32 @@ func TestLoadTestRuns(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(allRuns))
 	assert.Equalf(t, key.IntID(), allRuns[0].ID, "ID field should be populated.")
+}
+
+func TestLoadTestRunsBySHAs(t *testing.T) {
+	testRun := shared.TestRun{}
+	testRun.BrowserName = "chrome"
+	testRun.BrowserVersion = "63.0"
+	testRun.OSName = "linux"
+	testRun.Revision = "0000000000"
+	testRun.CreatedAt = time.Now()
+
+	ctx, done, err := sharedtest.NewAEContext(true)
+	assert.Nil(t, err)
+	defer done()
+
+	for i := 0; i < 5; i++ {
+		testRun.Revision = strings.Repeat(strconv.Itoa(i), 10)
+		testRun.CreatedAt = time.Now().AddDate(0, 0, -i)
+		key := datastore.NewIncompleteKey(ctx, "TestRun", nil)
+		datastore.Put(ctx, key, &testRun)
+	}
+
+	runs, err := shared.LoadTestRunsBySHAs(ctx, "1111111111", "3333333333")
+	assert.Nil(t, err)
+	assert.Len(t, runs, 2)
+	assert.Equal(t, runs[0].Revision, "1111111111")
+	assert.Equal(t, runs[1].Revision, "3333333333")
 }
 
 func TestLoadTestRuns_Experimental_Only(t *testing.T) {

--- a/shared/models.go
+++ b/shared/models.go
@@ -163,6 +163,13 @@ func (t TestRuns) Len() int           { return len(t) }
 func (t TestRuns) Less(i, j int) bool { return t[i].TimeStart.Before(t[j].TimeStart) }
 func (t TestRuns) Swap(i, j int)      { t[i], t[j] = t[j], t[i] }
 
+// SetTestRunIDs sets the ID field for each run, from the given keys.
+func (t TestRuns) SetTestRunIDs(keys []*datastore.Key) {
+	for i := 0; i < len(keys) && i < len(t); i++ {
+		t[i].ID = keys[i].IntID()
+	}
+}
+
 // GetTestRunIDs gets an array of the IDs for the TestRun entities in the array.
 func (t TestRuns) GetTestRunIDs() TestRunIDs {
 	ids := make([]int64, len(t))

--- a/shared/params.go
+++ b/shared/params.go
@@ -541,6 +541,19 @@ func parseRepeatedParamValues(repeatedParam []string, pluralParam string) (param
 	return params
 }
 
+// ParseIntParam parses the result of ParseParam as int64.
+func ParseIntParam(r *http.Request, param string) (*int, error) {
+	strVal := r.URL.Query().Get(param)
+	if strVal == "" {
+		return nil, nil
+	}
+	parsed, err := strconv.Atoi(strVal)
+	if err != nil {
+		return nil, err
+	}
+	return &parsed, nil
+}
+
 // ParseRepeatedInt64Param parses the result of ParseRepeatedParam as int64.
 func ParseRepeatedInt64Param(r *http.Request, singular, plural string) (params []int64, err error) {
 	strs := ParseRepeatedParam(r, singular, plural)
@@ -549,11 +562,10 @@ func ParseRepeatedInt64Param(r *http.Request, singular, plural string) (params [
 	}
 	ints := make([]int64, len(strs))
 	for i, idStr := range strs {
-		id, err := strconv.ParseInt(idStr, 10, 64)
+		ints[i], err = strconv.ParseInt(idStr, 10, 64)
 		if err != nil {
 			return nil, err
 		}
-		ints[i] = id
 	}
 	return ints, err
 }
@@ -601,6 +613,12 @@ func ParseBooleanParam(r *http.Request, name string) (result *bool, err error) {
 // int64, an error will be returned.
 func ParseRunIDsParam(r *http.Request) (ids TestRunIDs, err error) {
 	return ParseRepeatedInt64Param(r, "run_id", "run_ids")
+}
+
+// ParsePRParam parses the "pr" parameter. If it's not a valid int64, an error
+// will be returned.
+func ParsePRParam(r *http.Request) (*int, error) {
+	return ParseIntParam(r, "pr")
 }
 
 // ParseQueryFilterParams parses shared params for the search and autocomplete

--- a/webapp/components/test-runs-query.html
+++ b/webapp/components/test-runs-query.html
@@ -221,7 +221,7 @@ found in the LICENSE file.
     (() => {
       // TODO(lukebjerring): Support to & from in the builder.
       const testRunsUIQueryComputer =
-        'computeTestRunUIQueryParams(sha, aligned, master, labels, productSpecs, maxCount, diff, search)';
+        'computeTestRunUIQueryParams(pr, sha, aligned, master, labels, productSpecs, maxCount, diff, search)';
       /* global TestRunsQuery */
       window.TestRunsUIQuery = (superClass, opt_queryCompute) => class extends TestRunsQuery(
         superClass,
@@ -239,10 +239,14 @@ found in the LICENSE file.
               value: false,
               notify: true,
             },
+            pr: {
+              type: Number,
+              notify: true,
+            },
           };
         }
 
-        computeTestRunUIQueryParams(sha, aligned, master, labels, productSpecs, maxCount, diff, search) {
+        computeTestRunUIQueryParams(pr, sha, aligned, master, labels, productSpecs, maxCount, diff, search) {
           const params = this.computeTestRunQueryParams(sha, aligned, master, labels, productSpecs, maxCount);
           if (diff || this.diff) {
             params.diff = true;
@@ -250,11 +254,15 @@ found in the LICENSE file.
           if (search) {
             params.q = search;
           }
+          if (pr) {
+            params.pr = pr;
+          }
           return params;
         }
 
         updateQueryParams(params) {
           super.updateQueryParams(params);
+          this.pr = params.pr;
           this.search = params.q;
           this.diff = params.diff;
         }

--- a/webapp/components/wpt-flags.html
+++ b/webapp/components/wpt-flags.html
@@ -114,6 +114,7 @@ found in the LICENSE file.
       'experimentalAlignedExceptEdge',
       'taskclusterAllBranches',
       'paginationTokens',
+      'runsByPRNumber',
     ];
 
     /* global _wptFlags, WPT_FYI_FEATURES */

--- a/webapp/components/wpt-flags.html
+++ b/webapp/components/wpt-flags.html
@@ -197,6 +197,11 @@ found in the LICENSE file.
         Return "wpt-next-page" pagination token HTTP header in /api/runs
       </paper-checkbox>
     </paper-item>
+    <paper-item>
+      <paper-checkbox checked="{{runsByPRNumber}}">
+        Allow /api/runs?pr=[GitHub PR number]
+      </paper-checkbox>
+    </paper-item>
   </template>
   <script>
     /* global _wptFlagsEditor, WPTFlagsEditor, WPT_FYI_SERVER_SIDE_FEATURES */

--- a/webapp/interop_handler.go
+++ b/webapp/interop_handler.go
@@ -20,7 +20,7 @@ func interopHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	testRunFilter = testRunFilter.OrDefault()
 
-	uiFilters := parseTestRunUIFilter(testRunFilter)
+	uiFilters := convertTestRunUIFilter(testRunFilter)
 
 	data := struct {
 		Metadata string

--- a/webapp/templates/results.html
+++ b/webapp/templates/results.html
@@ -6,12 +6,11 @@
   {{ template "_header.html" }}
   <div>
     <wpt-results
-        {{ template "_test_run_query_params.html" .Filter }}
-        {{- with .Filter}}
-          {{- if .Diff}} diff{{end}}
-          {{- if .DiffFilter}} diff-filter="{{.DiffFilter}}"{{end}}
-        {{- end}}
-        {{- if .Query }} search="{{.Query}}"{{end}}></wpt-results>
+        {{- template "_test_run_query_params.html" . }}
+        {{- if .Diff}} diff{{end}}
+        {{- if .DiffFilter}} diff-filter="{{.DiffFilter}}"{{end}}
+        {{- if .PR }} pr="{{.PR}}"{{end}}
+        {{- if .Search }} search="{{.Search}}"{{end}}></wpt-results>
   </div>
 </div>
 {{ template "_ga.html" }}

--- a/webapp/test_results_handler.go
+++ b/webapp/test_results_handler.go
@@ -17,6 +17,7 @@ import (
 )
 
 type testRunUIFilter struct {
+	PR       *int // GitHub PR to fetch the results for.
 	Products string
 	Labels   string
 	SHA      string
@@ -24,6 +25,7 @@ type testRunUIFilter struct {
 	MaxCount *int
 	From     string
 	To       string
+	Search   string
 	// JSON blob of extra (arbitrary) test runs
 	TestRuns string
 }
@@ -65,17 +67,7 @@ func testResultsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	data := struct {
-		// TestRuns are inlined marshalled JSON for arbitrary test runs (e.g. when
-		// diffing), for runs which aren't fetchable via a URL or the api.
-		Filter testResultsUIFilter
-		Query  string
-	}{
-		Filter: filter,
-		Query:  r.URL.Query().Get("q"),
-	}
-
-	if err := templates.ExecuteTemplate(w, "results.html", data); err != nil {
+	if err := templates.ExecuteTemplate(w, "results.html", filter); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -90,36 +82,46 @@ func parseTestResultsUIFilter(r *http.Request) (filter testResultsUIFilter, err 
 	}
 	ctx := shared.NewAppEngineContext(r)
 
-	if testRunFilter.IsDefaultQuery() {
-		experimentalByDefault := shared.IsFeatureEnabled(ctx, "experimentalByDefault")
-		experimentalAlignedExceptEdge := shared.IsFeatureEnabled(ctx, "experimentalAlignedExceptEdge")
-		masterRunsOnly := shared.IsFeatureEnabled(ctx, "masterRunsOnly")
-		if experimentalByDefault {
-			if experimentalAlignedExceptEdge {
-				testRunFilter = testRunFilter.OrAlignedExperimentalRunsExceptEdge()
+	filter.PR, err = shared.ParsePRParam(r)
+	if err != nil {
+		return filter, err
+	} else if filter.PR != nil {
+		one := 1
+		filter.MaxCount = &one
+	} else {
+		if testRunFilter.IsDefaultQuery() {
+			experimentalByDefault := shared.IsFeatureEnabled(ctx, "experimentalByDefault")
+			experimentalAlignedExceptEdge := shared.IsFeatureEnabled(ctx, "experimentalAlignedExceptEdge")
+			masterRunsOnly := shared.IsFeatureEnabled(ctx, "masterRunsOnly")
+			if experimentalByDefault {
+				if experimentalAlignedExceptEdge {
+					testRunFilter = testRunFilter.OrAlignedExperimentalRunsExceptEdge()
+				} else {
+					testRunFilter = testRunFilter.OrExperimentalRuns()
+				}
 			} else {
-				testRunFilter = testRunFilter.OrExperimentalRuns()
+				testRunFilter = testRunFilter.OrAlignedStableRuns()
 			}
-		} else {
-			testRunFilter = testRunFilter.OrAlignedStableRuns()
+			if masterRunsOnly {
+				testRunFilter = testRunFilter.MasterOnly()
+			}
 		}
-		if masterRunsOnly {
-			testRunFilter = testRunFilter.MasterOnly()
-		}
-	}
 
-	filter.testRunUIFilter = parseTestRunUIFilter(testRunFilter)
+		filter.testRunUIFilter = convertTestRunUIFilter(testRunFilter)
+	}
 
 	diff, err := shared.ParseBooleanParam(r, "diff")
 	if err != nil {
 		return filter, err
 	}
 	filter.Diff = diff != nil && *diff
-	diffFilter, _, err := shared.ParseDiffFilterParams(r)
-	if err != nil {
-		return filter, err
+	if filter.Diff {
+		diffFilter, _, err := shared.ParseDiffFilterParams(r)
+		if err != nil {
+			return filter, err
+		}
+		filter.DiffFilter = diffFilter.String()
 	}
-	filter.DiffFilter = diffFilter.String()
 
 	var beforeAndAfter shared.ProductSpecs
 	if beforeAndAfter, err = shared.ParseBeforeAndAfterParams(r); err != nil {
@@ -132,10 +134,13 @@ func parseTestResultsUIFilter(r *http.Request) (filter testResultsUIFilter, err 
 		filter.Products = string(bytes)
 		filter.Diff = true
 	}
+
+	filter.Search = r.URL.Query().Get("q")
+
 	return filter, nil
 }
 
-func parseTestRunUIFilter(testRunFilter shared.TestRunFilter) (filter testRunUIFilter) {
+func convertTestRunUIFilter(testRunFilter shared.TestRunFilter) (filter testRunUIFilter) {
 	if testRunFilter.Labels != nil {
 		data, _ := json.Marshal(testRunFilter.Labels.ToSlice())
 		filter.Labels = string(data)

--- a/webapp/test_runs_handler.go
+++ b/webapp/test_runs_handler.go
@@ -33,7 +33,7 @@ func testRunsHandler(w http.ResponseWriter, r *http.Request) {
 		testRunFilter.MaxCount = &oneHundred
 	}
 
-	filter := parseTestRunUIFilter(testRunFilter)
+	filter := convertTestRunUIFilter(testRunFilter)
 
 	data := struct {
 		Filter testRunUIFilter


### PR DESCRIPTION
## Description
Extension of #785 that includes the UI plumbing needed.

## Review Information
Only need to review the last 2 commits.

Find a PR that has loaded results into wpt.fyi, and load ?pr=[PR number]
e.g. [/results/?pr=14143](https://prs-ui-dot-wptdashboard-staging.appspot.com/results/?pr=14143)