### PR TITLE
Use the max page size by default for listing PR commits

### DIFF
--- a/api/test_runs.go
+++ b/api/test_runs.go
@@ -152,7 +152,10 @@ func getPRCommits(ctx context.Context, pr int) []string {
 		AccessToken: secret,
 	}))
 	githubClient := github.NewClient(oauthClient)
-	commits, _, err := githubClient.PullRequests.ListCommits(ctx, "web-platform-tests", "wpt", pr, nil)
+	opts := github.ListOptions{
+		PerPage: 100,
+	}
+	commits, _, err := githubClient.PullRequests.ListCommits(ctx, "web-platform-tests", "wpt", pr, &opts)
 	if err != nil || commits == nil {
 		log.Errorf("Failed to fetch PR #%v: %s", pr, err.Error())
 		return nil


### PR DESCRIPTION
## Description
Lists a larger number of commits by default.