### PR TITLE
QueryBuilder: Handle user-entry semantic labels on submit

### DIFF
--- a/webapp/components/product-info.html
+++ b/webapp/components/product-info.html
@@ -1,5 +1,6 @@
 <dom-module id="product-info">
   <script>
+    window.wpt = window.wpt || {};
     const DISPLAY_NAMES = (() => {
       let m = new Map();
       ['chrome', 'chrome-experimental'].forEach(n => m.set(n, 'Chrome'));
@@ -32,6 +33,13 @@
     const DEFAULT_BROWSER_NAMES = ['chrome', 'edge', 'firefox', 'safari'];
     const DEFAULT_PRODUCT_SPECS = Array.from(DEFAULT_BROWSER_NAMES);
     const DEFAULT_PRODUCTS = DEFAULT_PRODUCT_SPECS.map(p => parseProductSpec(p));
+
+    Object.defineProperty(window.wpt, 'SemanticLabels', {
+      get: () => [
+        { property: '_channel', values: CHANNELS },
+        { property: '_source', values: SOURCES },
+      ],
+    });
 
     function parseProductSpec(spec) {
       // @sha (optional)

--- a/webapp/components/test-runs-query-builder.html
+++ b/webapp/components/test-runs-query-builder.html
@@ -162,9 +162,7 @@ found in the LICENSE file.
           this.handleAddProduct();
         };
         this.clearAll = this.handleClearAll.bind(this);
-        this.submit = () => {
-          this.onSubmit && this.onSubmit();
-        };
+        this.submit = this.handleSubmit.bind(this);
         this._createMethodObserver('labelsUpdated(labels, labels.*)');
         this._createMethodObserver('shasUpdated(sha, shas)');
       }
@@ -179,6 +177,22 @@ found in the LICENSE file.
 
       handleProductChanged(i, product) {
         this.set(`products.${i}`, product);
+      }
+
+      handleSubmit() {
+        // Handle the edge-case that the user typed a label for channel or source, etc.
+        const productBuilders = this.shadowRoot.querySelectorAll('product-builder');
+        for (const semantic of window.wpt.SemanticLabels) {
+          for (const label of semantic.values) {
+            if (this.labels.includes(label)) {
+              this.labels = this.labels.filter(l => l !== label);
+              for (const p of productBuilders) {
+                p[semantic.property] = label;
+              }
+            }
+          }
+        }
+        this.onSubmit && this.onSubmit();
       }
 
       // Respond to query changes by computing a new shas URL.
@@ -334,7 +348,7 @@ found in the LICENSE file.
     </paper-card>
   </template>
   <script>
-    /* global ProductInfo, CHANNELS, SOURCES, DEFAULT_BROWSER_NAMES, DEFAULT_PRODUCTS */
+    /* global ProductInfo, CHANNELS, DEFAULT_BROWSER_NAMES, DEFAULT_PRODUCTS */
     class ProductBuilder extends ProductInfo(window.Polymer.Element) {
       static get is() {
         return 'product-builder';
@@ -418,13 +432,6 @@ found in the LICENSE file.
         this._createMethodObserver('versionsUpdated(browserVersion, versions)');
       }
 
-      static get SemanticLabels() {
-        return [
-          { property: '_channel', values: CHANNELS },
-          { property: '_source', values: SOURCES },
-        ];
-      }
-
       computeProduct(browserName, browserVersion, labels) {
         const product = {
           browser_name: browserName,
@@ -442,7 +449,7 @@ found in the LICENSE file.
       labelsChanged(labels) {
         // Configure the channel from the labels.
         labels = new Set(labels || []);
-        for (const semantic of ProductBuilder.SemanticLabels) {
+        for (const semantic of window.wpt.SemanticLabels) {
           const value = Array.from(semantic.values).find(c => labels.has(c)) || 'any';
           if (this[semantic.property] !== value) {
             this[semantic.property] = value;

--- a/webapp/components/test/test-runs-query-builder.html
+++ b/webapp/components/test/test-runs-query-builder.html
@@ -132,6 +132,19 @@
               });
             });
           }
+
+          for (const channel of CHANNELS) {
+            test(channel, done => {
+              flush(() => {
+                queryBuilder.set('labels', [channel]);
+                queryBuilder.submit();
+                for (const productBuilder of queryBuilder.shadowRoot.querySelectorAll('product-builder')) {
+                  expect(productBuilder._channel).to.equal(channel);
+                }
+                done();
+              });
+            });
+          }
         });
 
         test('sha', () => {


### PR DESCRIPTION
## Description
Handles an edge-case where the user enters a semantic label (e.g. `stable`) manually as a label, rather than clicking the dropdowns 4 times.

## Review Information
As per https://github.com/web-platform-tests/wpt.fyi/pull/769#issuecomment-440844710 
- Visit /runs
- Edit the query, type a semantic label (e.g. a channel, like `stable`)
- Submit, see the expected results
- Edit the query, type a different semantic label (e.g. `experimental`)