### PR TITLE
Login before running cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,14 +209,16 @@ dev_data: git
 	cd $(WPTD_GO_PATH)/util; go get -t ./...
 	go run $(WPTD_GO_PATH)/util/populate_dev_data.go $(FLAGS)
 
-deploy_staging: gcloud webapp_deps package_service var-BRANCH_NAME var-APP_PATH var-PROJECT $(WPTD_PATH)client-secret.json
-	gcloud config set project $(PROJECT)
+gcloud-login: gcloud
 	gcloud auth activate-service-account --key-file $(WPTD_PATH)client-secret.json
+
+deploy_staging: gcloud-login webapp_deps package_service var-BRANCH_NAME var-APP_PATH var-PROJECT $(WPTD_PATH)client-secret.json
+	gcloud config set project $(PROJECT)
 	cd $(WPTD_PATH); util/deploy.sh -q -b $(BRANCH_NAME) $(APP_PATH)
 	rm -rf $(WPTD_PATH)revisions/service/wpt.fyi
 	rm -rf $(WPTD_PATH)api/spanner/service/wpt.fyi
 
-cleanup_staging_versions: gcloud
+cleanup_staging_versions: gcloud-login
 	$(WPTD_GO_PATH)/util/cleanup-versions.sh
 
 deploy_production: gcloud webapp_deps package_service var-APP_PATH var-PROJECT

--- a/Makefile
+++ b/Makefile
@@ -209,10 +209,10 @@ dev_data: git
 	cd $(WPTD_GO_PATH)/util; go get -t ./...
 	go run $(WPTD_GO_PATH)/util/populate_dev_data.go $(FLAGS)
 
-gcloud-login: gcloud
+gcloud-login: gcloud  $(WPTD_PATH)client-secret.json
 	gcloud auth activate-service-account --key-file $(WPTD_PATH)client-secret.json
 
-deploy_staging: gcloud-login webapp_deps package_service var-BRANCH_NAME var-APP_PATH var-PROJECT $(WPTD_PATH)client-secret.json
+deploy_staging: gcloud-login webapp_deps package_service var-BRANCH_NAME var-APP_PATH var-PROJECT
 	gcloud config set project $(PROJECT)
 	cd $(WPTD_PATH); util/deploy.sh -q -b $(BRANCH_NAME) $(APP_PATH)
 	rm -rf $(WPTD_PATH)revisions/service/wpt.fyi


### PR DESCRIPTION
## Description
The cleanup script is silently failing, e.g. https://travis-ci.org/web-platform-tests/wpt.fyi/jobs/458648755
> ERROR: (gcloud.app.versions.list) You do not currently have an active account selected.
> Please run:
>   $ gcloud auth login

We've got the secret ready, but were missing the login command.