### PR TITLE
TBR: Use get to avoid ValueError

### DIFF
--- a/results-processor/processor.py
+++ b/results-processor/processor.py
@@ -109,7 +109,7 @@ def process_report(params):
     gcs_paths = params.getlist('gcs')
     result_type = params['type']
     # Optional fields:
-    callback_url = params['callback_url']
+    callback_url = params.get('callback_url')
     labels = params.get('labels', '')
 
     assert (


### PR DESCRIPTION
> From Werkzeug 0.3 onwards, the KeyError raised by this class is also a subclass of the BadRequest HTTP exception and will render a page for a 400 BAD REQUEST if caught in a catch-all for HTTP exceptions.

For the callers to the processor that aren't providing the value, this is causing 400s.