### PR TITLE
Give checks a neutral, but same message, outcome on regression

### DIFF
--- a/api/checks/update.go
+++ b/api/checks/update.go
@@ -108,7 +108,12 @@ func getDiffSummary(ctx context.Context, before, after map[string][]int, checkSt
 			break
 		}
 	}
-	if !regressed || !shared.IsFeatureEnabled(ctx, "failChecksOnRegression") {
+	neutral := "neutral"
+	checkState.Conclusion = &neutral
+	failsAndPasses := shared.IsFeatureEnabled(ctx, "failChecksOnRegression")
+
+	var summary summaries.Summary
+	if !regressed {
 		host := shared.NewAppEngineAPI(ctx).GetHostname()
 		data := summaries.Completed{
 			CheckState: checkState,
@@ -117,34 +122,39 @@ func getDiffSummary(ctx context.Context, before, after map[string][]int, checkSt
 			DiffURL:    getMasterDiffURL(ctx, checkState.HeadSHA, checkState.Product).String(),
 			SHAURL:     getURL(ctx, shared.TestRunFilter{SHA: checkState.HeadSHA[:10]}).String(),
 		}
-		neutral := "neutral"
-		data.CheckState.Conclusion = &neutral
-		return data
-	}
-
-	data := summaries.Regressed{
-		CheckState:  checkState,
-		Regressions: make(map[string]summaries.BeforeAndAfter),
-	}
-	failure := "failure"
-	data.CheckState.Conclusion = &failure
-	for path, d := range diff {
-		if d[1] != 0 {
-			if len(data.Regressions) <= 10 {
-				ba := summaries.BeforeAndAfter{}
-				if b, ok := before[path]; ok {
-					ba.PassingBefore = b[0]
-					ba.TotalBefore = b[1]
+		if failsAndPasses {
+			success := "success"
+			data.CheckState.Conclusion = &success
+		}
+		summary = data
+	} else {
+		data := summaries.Regressed{
+			CheckState:  checkState,
+			Regressions: make(map[string]summaries.BeforeAndAfter),
+		}
+		for path, d := range diff {
+			if d[1] != 0 {
+				if len(data.Regressions) <= 10 {
+					ba := summaries.BeforeAndAfter{}
+					if b, ok := before[path]; ok {
+						ba.PassingBefore = b[0]
+						ba.TotalBefore = b[1]
+					}
+					if a, ok := after[path]; ok {
+						ba.PassingAfter = a[0]
+						ba.TotalAfter = a[1]
+					}
+					data.Regressions[path] = ba
+				} else {
+					data.More++
 				}
-				if a, ok := after[path]; ok {
-					ba.PassingAfter = a[0]
-					ba.TotalAfter = a[1]
-				}
-				data.Regressions[path] = ba
-			} else {
-				data.More++
 			}
 		}
+		if failsAndPasses {
+			failure := "failure"
+			data.CheckState.Conclusion = &failure
+		}
+		summary = data
 	}
-	return data
+	return summary
 }


### PR DESCRIPTION
## Description
Changes the regression-detected outcome to have the same regression message, but with a non-failing status, when the fail on regression feature is disabled.