### PR TITLE
TBR: Parse /api/checks/{commit} body as Form

### DIFF
--- a/api/checks/suites.go
+++ b/api/checks/suites.go
@@ -103,12 +103,13 @@ func updateCheckRun(ctx context.Context, summary summaries.Summary) (bool, error
 
 	summaryStr, err := summary.GetSummary()
 	if err != nil {
+		log.Warningf("Failed to generate summary for %s: %s", state.HeadSHA, err.Error())
 		return false, err
 	}
 
 	detailsURLStr := state.DetailsURL.String()
 	opts := github.CreateCheckRunOptions{
-		Name:       state.Product.BrowserName,
+		Name:       state.Product.String(),
 		HeadSHA:    state.HeadSHA,
 		DetailsURL: &detailsURLStr,
 		Status:     &state.Status,
@@ -127,6 +128,7 @@ func updateCheckRun(ctx context.Context, summary summaries.Summary) (bool, error
 		if !created || err != nil {
 			return false, err
 		}
+		log.Debugf("Check for %s/%s @ %s (%s) updated", suite.Owner, suite.Repo, suite.SHA[:7], state.Product.String())
 	}
 	return true, nil
 }

--- a/api/checks/update.go
+++ b/api/checks/update.go
@@ -16,12 +16,11 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/web-platform-tests/wpt.fyi/api/checks/summaries"
 	"github.com/web-platform-tests/wpt.fyi/shared"
-	"google.golang.org/appengine"
 )
 
 // updateCheckHandler handles /api/checks/[commit] POST requests.
 func updateCheckHandler(w http.ResponseWriter, r *http.Request) {
-	ctx := appengine.NewContext(r)
+	ctx := shared.NewAppEngineContext(r)
 	log := shared.GetLogger(ctx)
 
 	vars := mux.Vars(r)

--- a/api/checks/update.go
+++ b/api/checks/update.go
@@ -6,9 +6,7 @@ package checks
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/deckarep/golang-set"
@@ -32,27 +30,17 @@ func updateCheckHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Pull the params from either the query params or the post body.
-	payload, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		log.Errorf("Failed to read request body: %s", err.Error())
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	filter, err := shared.ParseTestRunFilterParams(r)
-	if err != nil {
-		log.Warningf("Failed to parse params: %s", err.Error())
+	if err := r.ParseForm(); err != nil {
+		log.Warningf("Failed to parse form: %s", err.Error())
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	if len(payload) > 0 {
-		if err := json.Unmarshal(payload, &filter); err != nil {
-			log.Warningf("Failed to unmarshal body: %s", err.Error())
-			http.Error(w, "Invalid post body", http.StatusBadRequest)
-			return
-		}
+	filter, err := shared.ParseTestRunFilterParams(r.Form)
+	if err != nil {
+		log.Warningf("Failed to parse params: %s", err.Error())
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
 	}
 
 	if len(filter.Products) < 1 {

--- a/api/diff.go
+++ b/api/diff.go
@@ -41,7 +41,8 @@ type diffResult struct {
 func handleAPIDiffGet(w http.ResponseWriter, r *http.Request) {
 	ctx := shared.NewAppEngineContext(r)
 
-	runIDs, err := shared.ParseRunIDsParam(r)
+	q := r.URL.Query()
+	runIDs, err := shared.ParseRunIDsParam(q)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -49,7 +50,7 @@ func handleAPIDiffGet(w http.ResponseWriter, r *http.Request) {
 
 	var diffFilter shared.DiffFilterParam
 	var paths mapset.Set
-	if diffFilter, paths, err = shared.ParseDiffFilterParams(r); err != nil {
+	if diffFilter, paths, err = shared.ParseDiffFilterParams(q); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -74,12 +75,12 @@ func handleAPIDiffGet(w http.ResponseWriter, r *http.Request) {
 	} else {
 		// NOTE: We use the same params as /results, but also support
 		// 'before' and 'after' and 'filter'.
-		runFilter, parseErr := shared.ParseTestRunFilterParams(r)
+		runFilter, parseErr := shared.ParseTestRunFilterParams(q)
 		if parseErr != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		beforeAndAfter, parseErr := shared.ParseBeforeAndAfterParams(r)
+		beforeAndAfter, parseErr := shared.ParseBeforeAndAfterParams(q)
 		if parseErr != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
@@ -170,7 +171,7 @@ func handleAPIDiffPost(w http.ResponseWriter, r *http.Request) {
 
 	var filter shared.DiffFilterParam
 	var paths mapset.Set
-	if filter, paths, err = shared.ParseDiffFilterParams(r); err != nil {
+	if filter, paths, err = shared.ParseDiffFilterParams(params); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}

--- a/api/interop.go
+++ b/api/interop.go
@@ -21,7 +21,7 @@ import (
 func apiInteropHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := shared.NewAppEngineContext(r)
 
-	filters, err := shared.ParseTestRunFilterParams(r)
+	filters, err := shared.ParseTestRunFilterParams(r.URL.Query())
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return

--- a/api/manifest.go
+++ b/api/manifest.go
@@ -21,12 +21,13 @@ import (
 )
 
 func apiManifestHandler(w http.ResponseWriter, r *http.Request) {
-	sha, err := shared.ParseSHAParamFull(r)
+	q := r.URL.Query()
+	sha, err := shared.ParseSHAParamFull(q)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	paths := shared.ParsePathsParam(r)
+	paths := shared.ParsePathsParam(q)
 	ctx := shared.NewAppEngineContext(r)
 	sha, manifestBytes, err := getManifestForSHA(ctx, sha)
 	if err != nil {

--- a/api/query/query.go
+++ b/api/query/query.go
@@ -34,11 +34,11 @@ type defaultShared struct {
 }
 
 func (defaultShared) ParseQueryParamInt(r *http.Request, key string) (*int, error) {
-	return shared.ParseQueryParamInt(r, key)
+	return shared.ParseQueryParamInt(r.URL.Query(), key)
 }
 
 func (defaultShared) ParseQueryFilterParams(r *http.Request) (shared.QueryFilter, error) {
-	return shared.ParseQueryFilterParams(r)
+	return shared.ParseQueryFilterParams(r.URL.Query())
 }
 
 func (sharedImpl defaultShared) LoadTestRuns(ps shared.ProductSpecs, ls mapset.Set, sha string, from *time.Time, to *time.Time, limit *int, offset *int) (shared.TestRunsByProduct, error) {
@@ -155,6 +155,6 @@ func getMemcacheKey(testRun shared.TestRun) string {
 }
 
 func isRequestCacheable(r *http.Request) bool {
-	ids, err := shared.ParseRunIDsParam(r)
+	ids, err := shared.ParseRunIDsParam(r.URL.Query())
 	return err == nil && len(ids) > 0
 }

--- a/api/results_redirect_handler.go
+++ b/api/results_redirect_handler.go
@@ -24,7 +24,7 @@ import (
 //   (optional) run: SHA[0:10] of the test run, or "latest" (latest is the default)
 //   (optional) test: Path of the test, e.g. "/css/css-images-3/gradient-button.html"
 func apiResultsRedirectHandler(w http.ResponseWriter, r *http.Request) {
-	filters, err := shared.ParseTestRunFilterParams(r)
+	filters, err := shared.ParseTestRunFilterParams(r.URL.Query())
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return

--- a/api/shas.go
+++ b/api/shas.go
@@ -27,7 +27,7 @@ func apiSHAsHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h SHAsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	filters, err := shared.ParseTestRunFilterParams(r)
+	filters, err := shared.ParseTestRunFilterParams(r.URL.Query())
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return

--- a/api/test_run.go
+++ b/api/test_run.go
@@ -44,7 +44,7 @@ func apiTestRunHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		testRun = *run
 	} else {
-		filters, err := shared.ParseTestRunFilterParams(r)
+		filters, err := shared.ParseTestRunFilterParams(r.URL.Query())
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return

--- a/api/test_runs.go
+++ b/api/test_runs.go
@@ -25,13 +25,14 @@ const paginationTokenFeatureFlagName = "paginationTokens"
 //     sha: SHA[0:10] of the repo when the tests were executed (or 'latest')
 func apiTestRunsHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := shared.NewAppEngineContext(r)
-	ids, err := shared.ParseRunIDsParam(r)
+	q := r.URL.Query()
+	ids, err := shared.ParseRunIDsParam(q)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	pr, err := shared.ParsePRParam(r)
+	pr, err := shared.ParsePRParam(q)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 	}
@@ -57,7 +58,7 @@ func apiTestRunsHandler(w http.ResponseWriter, r *http.Request) {
 		testRuns, err = shared.LoadTestRunsBySHAs(ctx, commits...)
 	} else {
 		var filters shared.TestRunFilter
-		filters, err = shared.ParseTestRunFilterParams(r)
+		filters, err = shared.ParseTestRunFilterParams(r.URL.Query())
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return

--- a/api/versions.go
+++ b/api/versions.go
@@ -30,7 +30,7 @@ func apiVersionsHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h VersionsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	product, err := shared.ParseProductParam(r)
+	product, err := shared.ParseProductParam(r.URL.Query())
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return

--- a/revisions/api/handlers/list.go
+++ b/revisions/api/handlers/list.go
@@ -32,7 +32,7 @@ func ListHandler(a api.API, w http.ResponseWriter, r *http.Request) {
 
 	q := r.URL.Query()
 
-	numRevisions, err := shared.ParseQueryParamInt(r, "num_revisions")
+	numRevisions, err := shared.ParseQueryParamInt(r.URL.Query(), "num_revisions")
 	if numRevisions == nil {
 		one := 1
 		numRevisions = &one

--- a/shared/params.go
+++ b/shared/params.go
@@ -9,7 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
+	"net/url"
 	"regexp"
 	"sort"
 	"strconv"
@@ -133,8 +133,8 @@ var SHARegex = regexp.MustCompile("[0-9a-fA-F]{10,40}")
 
 // ParseSHAParam parses and validates the 'sha' param for the request,
 // cropping it to 10 chars. It returns "latest" by default. (and in error cases).
-func ParseSHAParam(r *http.Request) (runSHA string, err error) {
-	sha, err := ParseSHAParamFull(r)
+func ParseSHAParam(v url.Values) (runSHA string, err error) {
+	sha, err := ParseSHAParamFull(v)
 	if err != nil || !SHARegex.MatchString(sha) {
 		return sha, err
 	}
@@ -153,9 +153,9 @@ func ParseSHA(sha string) (runSHA string, err error) {
 
 // ParseSHAParamFull parses and validates the 'sha' param for the request.
 // It returns "latest" by default (and in error cases).
-func ParseSHAParamFull(r *http.Request) (runSHA string, err error) {
+func ParseSHAParamFull(v url.Values) (runSHA string, err error) {
 	// Get the SHA for the run being loaded (the first part of the path.)
-	return ParseSHAFull(r.URL.Query().Get("sha"))
+	return ParseSHAFull(v.Get("sha"))
 }
 
 // ParseSHAFull parses and validates the given 'sha'.
@@ -306,8 +306,8 @@ func ParseVersion(version string) (result *Version, err error) {
 
 // ParseBrowserParam parses and validates the 'browser' param for the request.
 // It returns "" by default (and in error cases).
-func ParseBrowserParam(r *http.Request) (product *Product, err error) {
-	browser := r.URL.Query().Get("browser")
+func ParseBrowserParam(v url.Values) (product *Product, err error) {
+	browser := v.Get("browser")
 	if "" == browser {
 		return nil, nil
 	}
@@ -322,8 +322,8 @@ func ParseBrowserParam(r *http.Request) (product *Product, err error) {
 // ParseBrowsersParam returns a list of browser params for the request.
 // It parses the 'browsers' parameter, split on commas, and also checks for the (repeatable)
 // 'browser' params.
-func ParseBrowsersParam(r *http.Request) (browsers []string, err error) {
-	browserParams := ParseRepeatedParam(r, "browser", "browsers")
+func ParseBrowsersParam(v url.Values) (browsers []string, err error) {
+	browserParams := ParseRepeatedParam(v, "browser", "browsers")
 	if browserParams == nil {
 		return nil, nil
 	}
@@ -337,8 +337,8 @@ func ParseBrowsersParam(r *http.Request) (browsers []string, err error) {
 }
 
 // ParseProductParam parses and validates the 'product' param for the request.
-func ParseProductParam(r *http.Request) (product *ProductSpec, err error) {
-	productParam := r.URL.Query().Get("product")
+func ParseProductParam(v url.Values) (product *ProductSpec, err error) {
+	productParam := v.Get("product")
 	if "" == productParam {
 		return nil, nil
 	}
@@ -352,9 +352,9 @@ func ParseProductParam(r *http.Request) (product *ProductSpec, err error) {
 // ParseProductsParam returns a list of product params for the request.
 // It parses the 'products' parameter, split on commas, and also checks for the (repeatable)
 // 'product' params.
-func ParseProductsParam(r *http.Request) (ProductSpecs, error) {
-	repeatedParam := r.URL.Query()["product"]
-	pluralParam := r.URL.Query().Get("products")
+func ParseProductsParam(v url.Values) (ProductSpecs, error) {
+	repeatedParam := v["product"]
+	pluralParam := v.Get("products")
 	// Replace nested ',' in the label part with a placeholder
 	nestedCommas := regexp.MustCompile(`(\[[^\]]*),`)
 	const comma = `%COMMA%`
@@ -374,12 +374,12 @@ func ParseProductsParam(r *http.Request) (ProductSpecs, error) {
 
 // ParseProductOrBrowserParams parses the product (or, browser) params present in the given
 // request.
-func ParseProductOrBrowserParams(r *http.Request) (products ProductSpecs, err error) {
-	if products, err = ParseProductsParam(r); err != nil {
+func ParseProductOrBrowserParams(v url.Values) (products ProductSpecs, err error) {
+	if products, err = ParseProductsParam(v); err != nil {
 		return nil, err
 	}
 	// Handle legacy browser param.
-	browserParams, err := ParseBrowsersParam(r)
+	browserParams, err := ParseBrowsersParam(v)
 	if err != nil {
 		return nil, err
 	}
@@ -392,8 +392,8 @@ func ParseProductOrBrowserParams(r *http.Request) (products ProductSpecs, err er
 }
 
 // ParseMaxCountParam parses the 'max-count' parameter as an integer
-func ParseMaxCountParam(r *http.Request) (*int, error) {
-	if maxCountParam := r.URL.Query().Get("max-count"); maxCountParam != "" {
+func ParseMaxCountParam(v url.Values) (*int, error) {
+	if maxCountParam := v.Get("max-count"); maxCountParam != "" {
 		count, err := strconv.Atoi(maxCountParam)
 		if err != nil {
 			return nil, err
@@ -411,8 +411,8 @@ func ParseMaxCountParam(r *http.Request) (*int, error) {
 
 // ParseMaxCountParamWithDefault parses the 'max-count' parameter as an integer, or returns the
 // default when no param is present, or on error.
-func ParseMaxCountParamWithDefault(r *http.Request, defaultValue int) (count int, err error) {
-	if maxCountParam, err := ParseMaxCountParam(r); maxCountParam != nil {
+func ParseMaxCountParamWithDefault(v url.Values, defaultValue int) (count int, err error) {
+	if maxCountParam, err := ParseMaxCountParam(v); maxCountParam != nil {
 		return *maxCountParam, err
 	} else if err != nil {
 		return defaultValue, err
@@ -421,8 +421,8 @@ func ParseMaxCountParamWithDefault(r *http.Request, defaultValue int) (count int
 }
 
 // ParseDateTimeParam parses the date/time param named "name" as a timestamp.
-func ParseDateTimeParam(r *http.Request, name string) (*time.Time, error) {
-	if fromParam := r.URL.Query().Get(name); fromParam != "" {
+func ParseDateTimeParam(v url.Values, name string) (*time.Time, error) {
+	if fromParam := v.Get(name); fromParam != "" {
 		parsed, err := time.Parse(time.RFC3339, fromParam)
 		if err != nil {
 			return nil, err
@@ -471,13 +471,13 @@ func (d DiffFilterParam) String() string {
 // ParseDiffFilterParams collects the diff filtering params for the given request.
 // It splits the filter param into the differences to include. The filter param is inspired by Git's --diff-filter flag.
 // It also adds the set of test paths to include; see ParsePathsParam below.
-func ParseDiffFilterParams(r *http.Request) (param DiffFilterParam, paths mapset.Set, err error) {
+func ParseDiffFilterParams(v url.Values) (param DiffFilterParam, paths mapset.Set, err error) {
 	param = DiffFilterParam{
 		Added:   true,
 		Deleted: true,
 		Changed: true,
 	}
-	if filter := r.URL.Query().Get("filter"); filter != "" {
+	if filter := v.Get("filter"); filter != "" {
 		param = DiffFilterParam{}
 		for _, char := range filter {
 			switch char {
@@ -494,28 +494,28 @@ func ParseDiffFilterParams(r *http.Request) (param DiffFilterParam, paths mapset
 			}
 		}
 	}
-	return param, NewSetFromStringSlice(ParsePathsParam(r)), nil
+	return param, NewSetFromStringSlice(ParsePathsParam(v)), nil
 }
 
 // ParsePathsParam returns a set list of test paths to include, or nil if no
 // filter is provided (and all tests should be included). It parses the 'paths'
 // parameter, split on commas, and also checks for the (repeatable) 'path' params
-func ParsePathsParam(r *http.Request) []string {
-	return ParseRepeatedParam(r, "path", "paths")
+func ParsePathsParam(v url.Values) []string {
+	return ParseRepeatedParam(v, "path", "paths")
 }
 
 // ParseLabelsParam returns a set list of test-run labels to include, or nil if
 // no labels are provided.
-func ParseLabelsParam(r *http.Request) []string {
-	return ParseRepeatedParam(r, "label", "labels")
+func ParseLabelsParam(v url.Values) []string {
+	return ParseRepeatedParam(v, "label", "labels")
 }
 
 // ParseRepeatedParam parses a param that may be a plural name, with all values
 // comma-separated, or a repeated singular param.
 // e.g. ?label=foo&label=bar vs ?labels=foo,bar
-func ParseRepeatedParam(r *http.Request, singular string, plural string) (params []string) {
-	repeatedParam := r.URL.Query()[singular]
-	pluralParam := r.URL.Query().Get(plural)
+func ParseRepeatedParam(v url.Values, singular string, plural string) (params []string) {
+	repeatedParam := v[singular]
+	pluralParam := v.Get(plural)
 	return parseRepeatedParamValues(repeatedParam, pluralParam)
 }
 
@@ -542,8 +542,8 @@ func parseRepeatedParamValues(repeatedParam []string, pluralParam string) (param
 }
 
 // ParseIntParam parses the result of ParseParam as int64.
-func ParseIntParam(r *http.Request, param string) (*int, error) {
-	strVal := r.URL.Query().Get(param)
+func ParseIntParam(v url.Values, param string) (*int, error) {
+	strVal := v.Get(param)
 	if strVal == "" {
 		return nil, nil
 	}
@@ -555,8 +555,8 @@ func ParseIntParam(r *http.Request, param string) (*int, error) {
 }
 
 // ParseRepeatedInt64Param parses the result of ParseRepeatedParam as int64.
-func ParseRepeatedInt64Param(r *http.Request, singular, plural string) (params []int64, err error) {
-	strs := ParseRepeatedParam(r, singular, plural)
+func ParseRepeatedInt64Param(v url.Values, singular, plural string) (params []int64, err error) {
+	strs := ParseRepeatedParam(v, singular, plural)
 	if len(strs) < 1 {
 		return nil, nil
 	}
@@ -572,8 +572,8 @@ func ParseRepeatedInt64Param(r *http.Request, singular, plural string) (params [
 
 // ParseQueryParamInt parses the URL query parameter at key. If the parameter is
 // empty or missing, nil is returned.
-func ParseQueryParamInt(r *http.Request, key string) (*int, error) {
-	value := r.URL.Query().Get(key)
+func ParseQueryParamInt(v url.Values, key string) (*int, error) {
+	value := v.Get(key)
 	if value == "" {
 		return nil, nil
 	}
@@ -585,19 +585,19 @@ func ParseQueryParamInt(r *http.Request, key string) (*int, error) {
 }
 
 // ParseAlignedParam parses the "aligned" param. See ParseBooleanParam.
-func ParseAlignedParam(r *http.Request) (aligned *bool, err error) {
-	if aligned, err := ParseBooleanParam(r, "aligned"); aligned != nil || err != nil {
+func ParseAlignedParam(v url.Values) (aligned *bool, err error) {
+	if aligned, err := ParseBooleanParam(v, "aligned"); aligned != nil || err != nil {
 		return aligned, err
 	}
 	// Legacy param name: complete
-	return ParseBooleanParam(r, "complete")
+	return ParseBooleanParam(v, "complete")
 }
 
 // ParseBooleanParam parses the given param name as a bool.
 // Return nil if the param is missing, true if if it's present with no value,
 // otherwise the parsed boolean value of the param's value.
-func ParseBooleanParam(r *http.Request, name string) (result *bool, err error) {
-	q := r.URL.Query()
+func ParseBooleanParam(v url.Values, name string) (result *bool, err error) {
+	q := v
 	b := false
 	if _, ok := q[name]; !ok {
 		return nil, nil
@@ -611,55 +611,55 @@ func ParseBooleanParam(r *http.Request, name string) (result *bool, err error) {
 
 // ParseRunIDsParam parses the "run_ids" parameter. If the ID is not a valid
 // int64, an error will be returned.
-func ParseRunIDsParam(r *http.Request) (ids TestRunIDs, err error) {
-	return ParseRepeatedInt64Param(r, "run_id", "run_ids")
+func ParseRunIDsParam(v url.Values) (ids TestRunIDs, err error) {
+	return ParseRepeatedInt64Param(v, "run_id", "run_ids")
 }
 
 // ParsePRParam parses the "pr" parameter. If it's not a valid int64, an error
 // will be returned.
-func ParsePRParam(r *http.Request) (*int, error) {
-	return ParseIntParam(r, "pr")
+func ParsePRParam(v url.Values) (*int, error) {
+	return ParseIntParam(v, "pr")
 }
 
 // ParseQueryFilterParams parses shared params for the search and autocomplete
 // APIs.
-func ParseQueryFilterParams(r *http.Request) (filter QueryFilter, err error) {
-	keys, err := ParseRunIDsParam(r)
+func ParseQueryFilterParams(v url.Values) (filter QueryFilter, err error) {
+	keys, err := ParseRunIDsParam(v)
 	if err != nil {
 		return filter, err
 	}
 	filter.RunIDs = keys
 
-	filter.Q = r.URL.Query().Get("q")
+	filter.Q = v.Get("q")
 
 	return filter, nil
 }
 
 // ParseTestRunFilterParams parses all of the filter params for a TestRun query.
-func ParseTestRunFilterParams(r *http.Request) (filter TestRunFilter, err error) {
-	if page, err := ParsePageToken(r); page != nil || err != nil {
+func ParseTestRunFilterParams(v url.Values) (filter TestRunFilter, err error) {
+	if page, err := ParsePageToken(v); page != nil || err != nil {
 		return *page, err
 	}
 
-	runSHA, err := ParseSHAParam(r)
+	runSHA, err := ParseSHAParam(v)
 	if err != nil {
 		return filter, err
 	}
 	filter.SHA = runSHA
-	filter.Labels = NewSetFromStringSlice(ParseLabelsParam(r))
-	if filter.Aligned, err = ParseAlignedParam(r); err != nil {
+	filter.Labels = NewSetFromStringSlice(ParseLabelsParam(v))
+	if filter.Aligned, err = ParseAlignedParam(v); err != nil {
 		return filter, err
 	}
-	if filter.Products, err = ParseProductOrBrowserParams(r); err != nil {
+	if filter.Products, err = ParseProductOrBrowserParams(v); err != nil {
 		return filter, err
 	}
-	if filter.MaxCount, err = ParseMaxCountParam(r); err != nil {
+	if filter.MaxCount, err = ParseMaxCountParam(v); err != nil {
 		return filter, err
 	}
-	if filter.From, err = ParseDateTimeParam(r, "from"); err != nil {
+	if filter.From, err = ParseDateTimeParam(v, "from"); err != nil {
 		return filter, err
 	}
-	if filter.To, err = ParseDateTimeParam(r, "to"); err != nil {
+	if filter.To, err = ParseDateTimeParam(v, "to"); err != nil {
 		return filter, err
 	}
 	return filter, nil
@@ -668,9 +668,9 @@ func ParseTestRunFilterParams(r *http.Request) (filter TestRunFilter, err error)
 // ParseBeforeAndAfterParams parses the before and after params used when
 // intending to diff two test runs. Either both or neither of the params
 // must be present.
-func ParseBeforeAndAfterParams(r *http.Request) (ProductSpecs, error) {
-	before := r.URL.Query().Get("before")
-	after := r.URL.Query().Get("after")
+func ParseBeforeAndAfterParams(v url.Values) (ProductSpecs, error) {
+	before := v.Get("before")
+	after := v.Get("after")
 	if before == "" && after == "" {
 		return nil, nil
 	}
@@ -696,8 +696,8 @@ func ParseBeforeAndAfterParams(r *http.Request) (ProductSpecs, error) {
 }
 
 // ParsePageToken decodes a base64 encoding of a TestRunFilter struct.
-func ParsePageToken(r *http.Request) (*TestRunFilter, error) {
-	token := r.URL.Query().Get("page")
+func ParsePageToken(v url.Values) (*TestRunFilter, error) {
+	token := v.Get("page")
 	if token == "" {
 		return nil, nil
 	}

--- a/shared/params_test.go
+++ b/shared/params_test.go
@@ -17,14 +17,14 @@ import (
 
 func TestParseSHAParam(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/", nil)
-	runSHA, err := ParseSHAParam(r)
+	runSHA, err := ParseSHAParam(r.URL.Query())
 	assert.Nil(t, err)
 	assert.Equal(t, "latest", runSHA)
 }
 
 func TestParseSHAParam_Latest(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?sha=latest", nil)
-	runSHA, err := ParseSHAParam(r)
+	runSHA, err := ParseSHAParam(r.URL.Query())
 	assert.Nil(t, err)
 	assert.Equal(t, "latest", runSHA)
 }
@@ -32,7 +32,7 @@ func TestParseSHAParam_Latest(t *testing.T) {
 func TestParseSHAParam_ShortSHA(t *testing.T) {
 	sha := "0123456789"
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?sha="+sha, nil)
-	runSHA, err := ParseSHAParam(r)
+	runSHA, err := ParseSHAParam(r.URL.Query())
 	assert.Nil(t, err)
 	assert.Equal(t, sha, runSHA)
 }
@@ -40,33 +40,33 @@ func TestParseSHAParam_ShortSHA(t *testing.T) {
 func TestParseSHAParam_FullSHA(t *testing.T) {
 	sha := "0123456789aaaaabbbbbcccccdddddeeeeefffff"
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?sha="+sha, nil)
-	runSHA, err := ParseSHAParam(r)
+	runSHA, err := ParseSHAParam(r.URL.Query())
 	assert.Nil(t, err)
 	assert.Equal(t, sha[:10], runSHA)
 }
 
 func TestParseSHAParam_NonSHA(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?sha=123", nil)
-	_, err := ParseSHAParam(r)
+	_, err := ParseSHAParam(r.URL.Query())
 	assert.NotNil(t, err)
 }
 
 func TestParseSHAParam_NonSHA_2(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?sha=zapper0123", nil)
-	_, err := ParseSHAParam(r)
+	_, err := ParseSHAParam(r.URL.Query())
 	assert.NotNil(t, err)
 }
 
 func TestParseBrowserParam(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/", nil)
-	browser, err := ParseBrowserParam(r)
+	browser, err := ParseBrowserParam(r.URL.Query())
 	assert.Nil(t, err)
 	assert.Nil(t, browser)
 }
 
 func TestParseBrowserParam_Chrome(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?browser=chrome", nil)
-	browser, err := ParseBrowserParam(r)
+	browser, err := ParseBrowserParam(r.URL.Query())
 	assert.Nil(t, err)
 	assert.NotNil(t, browser)
 	assert.Equal(t, "chrome", browser.BrowserName)
@@ -74,14 +74,14 @@ func TestParseBrowserParam_Chrome(t *testing.T) {
 
 func TestParseBrowserParam_Invalid(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?browser=invalid", nil)
-	browser, err := ParseBrowserParam(r)
+	browser, err := ParseBrowserParam(r.URL.Query())
 	assert.NotNil(t, err)
 	assert.Nil(t, browser)
 }
 
 func TestGetProductsOrDefault_Default(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/", nil)
-	filters, err := ParseTestRunFilterParams(r)
+	filters, err := ParseTestRunFilterParams(r.URL.Query())
 	products := filters.GetProductsOrDefault()
 	assert.Nil(t, err)
 	defaultBrowsers := GetDefaultBrowserNames()
@@ -93,7 +93,7 @@ func TestGetProductsOrDefault_Default(t *testing.T) {
 
 func TestGetProductsOrDefault_BrowserParam_ChromeSafari(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?browsers=chrome,safari", nil)
-	filter, err := ParseTestRunFilterParams(r)
+	filter, err := ParseTestRunFilterParams(r.URL.Query())
 	browsers := filter.GetProductsOrDefault()
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(browsers))
@@ -103,13 +103,13 @@ func TestGetProductsOrDefault_BrowserParam_ChromeSafari(t *testing.T) {
 
 func TestGetProductsOrDefault_BrowserParam_ChromeInvalid(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?browsers=chrome,invalid", nil)
-	_, err := ParseTestRunFilterParams(r)
+	_, err := ParseTestRunFilterParams(r.URL.Query())
 	assert.NotNil(t, err)
 }
 
 func TestGetProductsOrDefault_BrowserParam_EmptyCommas(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?browsers=,edge,,,,chrome,,", nil)
-	filters, err := ParseTestRunFilterParams(r)
+	filters, err := ParseTestRunFilterParams(r.URL.Query())
 	products := filters.GetProductsOrDefault()
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(products))
@@ -119,7 +119,7 @@ func TestGetProductsOrDefault_BrowserParam_EmptyCommas(t *testing.T) {
 
 func TestGetProductsOrDefault_BrowserParam_SafariChrome(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?browsers=safari,chrome", nil)
-	filters, err := ParseTestRunFilterParams(r)
+	filters, err := ParseTestRunFilterParams(r.URL.Query())
 	products := filters.GetProductsOrDefault()
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(products))
@@ -129,7 +129,7 @@ func TestGetProductsOrDefault_BrowserParam_SafariChrome(t *testing.T) {
 
 func TestGetProductsOrDefault_BrowserParam_MultiBrowserParam_SafariChrome(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?browser=safari&browser=chrome", nil)
-	filters, err := ParseTestRunFilterParams(r)
+	filters, err := ParseTestRunFilterParams(r.URL.Query())
 	products := filters.GetProductsOrDefault()
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(products))
@@ -139,13 +139,13 @@ func TestGetProductsOrDefault_BrowserParam_MultiBrowserParam_SafariChrome(t *tes
 
 func TestGetProductsOrDefault_BrowserParam_MultiBrowserParam_SafariInvalid(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?browser=safari&browser=invalid", nil)
-	_, err := ParseTestRunFilterParams(r)
+	_, err := ParseTestRunFilterParams(r.URL.Query())
 	assert.NotNil(t, err)
 }
 
 func TestGetProductsOrDefault_BrowserAndProductParam(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?product=edge-16&browser=chrome", nil)
-	filters, err := ParseTestRunFilterParams(r)
+	filters, err := ParseTestRunFilterParams(r.URL.Query())
 	products := filters.GetProductsOrDefault()
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(products))
@@ -156,7 +156,7 @@ func TestGetProductsOrDefault_BrowserAndProductParam(t *testing.T) {
 
 func TestGetProductsOrDefault_BrowsersAndProductsParam(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?products=edge-16,safari&browsers=chrome,firefox", nil)
-	filters, err := ParseTestRunFilterParams(r)
+	filters, err := ParseTestRunFilterParams(r.URL.Query())
 	products := filters.GetProductsOrDefault()
 	assert.Nil(t, err)
 	assert.Equal(t, 4, len(products))
@@ -169,161 +169,161 @@ func TestGetProductsOrDefault_BrowsersAndProductsParam(t *testing.T) {
 
 func TestParseMaxCountParam_Missing(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/", nil)
-	count, err := ParseMaxCountParam(r)
+	count, err := ParseMaxCountParam(r.URL.Query())
 	assert.Nil(t, err)
 	assert.Nil(t, count)
 
-	d, err := ParseMaxCountParamWithDefault(r, 5)
+	d, err := ParseMaxCountParamWithDefault(r.URL.Query(), 5)
 	assert.Nil(t, err)
 	assert.Equal(t, 5, d)
 }
 
 func TestParseMaxCountParam_TooSmall(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?max-count=0", nil)
-	count, err := ParseMaxCountParam(r)
+	count, err := ParseMaxCountParam(r.URL.Query())
 	assert.Nil(t, err)
 	assert.Equal(t, MaxCountMinValue, *count)
 
 	r = httptest.NewRequest("GET", "http://wpt.fyi/?max-count=-1", nil)
-	count, err = ParseMaxCountParam(r)
+	count, err = ParseMaxCountParam(r.URL.Query())
 	assert.Nil(t, err)
 	assert.Equal(t, MaxCountMinValue, *count)
 }
 
 func TestParseMaxCountParam_TooLarge(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?max-count=123456789", nil)
-	count, err := ParseMaxCountParam(r)
+	count, err := ParseMaxCountParam(r.URL.Query())
 	assert.Nil(t, err)
 	assert.Equal(t, MaxCountMaxValue, *count)
 
 	r = httptest.NewRequest("GET", "http://wpt.fyi/?max-count=100000000", nil)
-	count, err = ParseMaxCountParam(r)
+	count, err = ParseMaxCountParam(r.URL.Query())
 	assert.Nil(t, err)
 	assert.Equal(t, MaxCountMaxValue, *count)
 }
 
 func TestParseMaxCountParam(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?max-count=2", nil)
-	count, err := ParseMaxCountParam(r)
+	count, err := ParseMaxCountParam(r.URL.Query())
 	assert.Nil(t, err)
 	assert.Equal(t, 2, *count)
 }
 
 func TestParsePathsParam_Missing(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/api/diff", nil)
-	paths := ParsePathsParam(r)
+	paths := ParsePathsParam(r.URL.Query())
 	assert.Nil(t, paths)
 }
 
 func TestParsePathsParam_Empty(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/api/diff?path=", nil)
-	paths := ParsePathsParam(r)
+	paths := ParsePathsParam(r.URL.Query())
 	assert.Nil(t, paths)
 
 	r = httptest.NewRequest("GET", "http://wpt.fyi/api/diff?paths=", nil)
-	paths = ParsePathsParam(r)
+	paths = ParsePathsParam(r.URL.Query())
 	assert.Nil(t, paths)
 }
 
 func TestParsePathsParam_Path_Duplicate(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/api/diff?path=/css&path=/css", nil)
-	paths := ParsePathsParam(r)
+	paths := ParsePathsParam(r.URL.Query())
 	assert.Len(t, paths, 1)
 }
 
 func TestParsePathsParam_Paths_Duplicate(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/api/diff?paths=/css,/css", nil)
-	paths := ParsePathsParam(r)
+	paths := ParsePathsParam(r.URL.Query())
 	assert.Len(t, paths, 1)
 }
 
 func TestParsePathsParam_PathsAndPath_Duplicate(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/api/diff?paths=/css&path=/css", nil)
-	paths := ParsePathsParam(r)
+	paths := ParsePathsParam(r.URL.Query())
 	assert.Len(t, paths, 1)
 }
 
 func TestParsePathsParam_Paths_DiffFilter(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/api/diff?paths=/css&path=/css", nil)
-	_, paths, err := ParseDiffFilterParams(r)
+	_, paths, err := ParseDiffFilterParams(r.URL.Query())
 	assert.Nil(t, err)
 	assert.Equal(t, 1, paths.Cardinality())
 }
 
 func TestParseDiffFilterParam(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/api/diff?filter=A", nil)
-	filter, _, _ := ParseDiffFilterParams(r)
+	filter, _, _ := ParseDiffFilterParams(r.URL.Query())
 	assert.Equal(t, DiffFilterParam{Added: true, Deleted: false, Changed: false}, filter)
 
 	r = httptest.NewRequest("GET", "http://wpt.fyi/api/diff?filter=D", nil)
-	filter, _, _ = ParseDiffFilterParams(r)
+	filter, _, _ = ParseDiffFilterParams(r.URL.Query())
 	assert.Equal(t, DiffFilterParam{Added: false, Deleted: true, Changed: false}, filter)
 
 	r = httptest.NewRequest("GET", "http://wpt.fyi/api/diff?filter=C", nil)
-	filter, _, _ = ParseDiffFilterParams(r)
+	filter, _, _ = ParseDiffFilterParams(r.URL.Query())
 	assert.Equal(t, DiffFilterParam{Added: false, Deleted: false, Changed: true}, filter)
 
 	r = httptest.NewRequest("GET", "http://wpt.fyi/api/diff?filter=CAD", nil)
-	filter, _, _ = ParseDiffFilterParams(r)
+	filter, _, _ = ParseDiffFilterParams(r.URL.Query())
 	assert.Equal(t, DiffFilterParam{Added: true, Deleted: true, Changed: true}, filter)
 
 	r = httptest.NewRequest("GET", "http://wpt.fyi/api/diff?filter=CD", nil)
-	filter, _, _ = ParseDiffFilterParams(r)
+	filter, _, _ = ParseDiffFilterParams(r.URL.Query())
 	assert.Equal(t, DiffFilterParam{Added: false, Deleted: true, Changed: true}, filter)
 
 	r = httptest.NewRequest("GET", "http://wpt.fyi/api/diff?filter=CACA", nil)
-	filter, _, _ = ParseDiffFilterParams(r)
+	filter, _, _ = ParseDiffFilterParams(r.URL.Query())
 	assert.Equal(t, DiffFilterParam{Added: true, Deleted: false, Changed: true}, filter)
 
 	r = httptest.NewRequest("GET", "http://wpt.fyi/api/diff?filter=U", nil)
-	filter, _, _ = ParseDiffFilterParams(r)
+	filter, _, _ = ParseDiffFilterParams(r.URL.Query())
 	assert.Equal(t, DiffFilterParam{Unchanged: true}, filter)
 }
 
 func TestParseDiffFilterParam_Empty(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/api/diff", nil)
-	filter, _, err := ParseDiffFilterParams(r)
+	filter, _, err := ParseDiffFilterParams(r.URL.Query())
 	assert.Nil(t, err)
 	assert.Equal(t, DiffFilterParam{Added: true, Deleted: true, Changed: true, Unchanged: false}, filter)
 }
 
 func TestParseDiffFilterParam_Invalid(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/api/diff?filter=Z", nil)
-	_, _, err := ParseDiffFilterParams(r)
+	_, _, err := ParseDiffFilterParams(r.URL.Query())
 	assert.NotNil(t, err)
 }
 
 func TestParseLabelsParam_Missing(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/api/runs", nil)
-	labels := ParseLabelsParam(r)
+	labels := ParseLabelsParam(r.URL.Query())
 	assert.Nil(t, labels)
 }
 
 func TestParseLabelsParam_Empty(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/api/runs?label=", nil)
-	labels := ParseLabelsParam(r)
+	labels := ParseLabelsParam(r.URL.Query())
 	assert.Nil(t, labels)
 
 	r = httptest.NewRequest("GET", "http://wpt.fyi/api/runs?labels=", nil)
-	labels = ParseLabelsParam(r)
+	labels = ParseLabelsParam(r.URL.Query())
 	assert.Nil(t, labels)
 }
 
 func TestParseLabelsParam_Label_Duplicate(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/api/runs?label=experimental&label=experimental", nil)
-	labels := ParseLabelsParam(r)
+	labels := ParseLabelsParam(r.URL.Query())
 	assert.Len(t, labels, 1)
 }
 
 func TestParseLabelsParam_Labels_Duplicate(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/api/runs?labels=experimental,experimental", nil)
-	labels := ParseLabelsParam(r)
+	labels := ParseLabelsParam(r.URL.Query())
 	assert.Len(t, labels, 1)
 }
 
 func TestParseLabelsParam_LabelsAndLabel_Duplicate(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/api/runs?labels=experimental&label=experimental", nil)
-	labels := ParseLabelsParam(r)
+	labels := ParseLabelsParam(r.URL.Query())
 	assert.Len(t, labels, 1)
 }
 
@@ -369,7 +369,7 @@ func TestParseProductSpec(t *testing.T) {
 func TestParseProductSpec_FullSHA(t *testing.T) {
 	sha := "0123456789aaaaabbbbbcccccdddddeeeeefffff"
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?product=chrome@"+sha, nil)
-	filters, err := ParseTestRunFilterParams(r)
+	filters, err := ParseTestRunFilterParams(r.URL.Query())
 	assert.Nil(t, err)
 	products := filters.GetProductsOrDefault()
 	assert.Len(t, products, 1)
@@ -443,14 +443,14 @@ func TestParseProductSpec_String(t *testing.T) {
 
 func TestParseProductSpec_Plural(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/api/runs?products=chrome[stable],chrome[experimental]", nil)
-	products, err := ParseProductsParam(r)
+	products, err := ParseProductsParam(r.URL.Query())
 	assert.Nil(t, err)
 	assert.Len(t, products, 2)
 	assert.Equal(t, "chrome[stable]", products[0].String())
 	assert.Equal(t, "chrome[experimental]", products[1].String())
 
 	r = httptest.NewRequest("GET", "http://wpt.fyi/api/runs?products=chrome[foo,bar,baz],chrome[qux]", nil)
-	products, err = ParseProductsParam(r)
+	products, err = ParseProductsParam(r.URL.Query())
 	assert.Nil(t, err)
 	assert.Len(t, products, 2)
 	assert.Equal(t, "chrome[bar,baz,foo]", products[0].String()) // Labels alphabeticized.
@@ -459,68 +459,68 @@ func TestParseProductSpec_Plural(t *testing.T) {
 
 func TestParseAligned(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/api/runs", nil)
-	aligned, _ := ParseAlignedParam(r)
+	aligned, _ := ParseAlignedParam(r.URL.Query())
 	assert.Nil(t, aligned)
 
 	r = httptest.NewRequest("GET", "http://wpt.fyi/api/runs?aligned", nil)
-	aligned, _ = ParseAlignedParam(r)
+	aligned, _ = ParseAlignedParam(r.URL.Query())
 	assert.True(t, *aligned)
 
 	r = httptest.NewRequest("GET", "http://wpt.fyi/api/runs?aligned=true", nil)
-	aligned, _ = ParseAlignedParam(r)
+	aligned, _ = ParseAlignedParam(r.URL.Query())
 	assert.True(t, *aligned)
 
 	r = httptest.NewRequest("GET", "http://wpt.fyi/api/runs?aligned=false", nil)
-	aligned, _ = ParseAlignedParam(r)
+	aligned, _ = ParseAlignedParam(r.URL.Query())
 	assert.False(t, *aligned)
 }
 
 func TestParseRunIDsParam_nil(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/api/search", nil)
-	runIDs, err := ParseRunIDsParam(r)
+	runIDs, err := ParseRunIDsParam(r.URL.Query())
 	assert.Nil(t, runIDs)
 	assert.Nil(t, err)
 }
 
 func TestParseRunIDsParam_ok(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/api/search?run_ids=1,2,3", nil)
-	runIDs, err := ParseRunIDsParam(r)
+	runIDs, err := ParseRunIDsParam(r.URL.Query())
 	assert.Equal(t, []int64{1, 2, 3}, []int64(runIDs))
 	assert.Nil(t, err)
 
 	r = httptest.NewRequest("GET", "http://wpt.fyi/api/search?run_id=1&run_id=2&run_id=3", nil)
-	runIDs, err = ParseRunIDsParam(r)
+	runIDs, err = ParseRunIDsParam(r.URL.Query())
 	assert.Equal(t, []int64{1, 2, 3}, []int64(runIDs))
 	assert.Nil(t, err)
 
 	r = httptest.NewRequest("GET", "http://wpt.fyi/api/search?run_id=1&run_id=2&run_id=3", nil)
-	runIDs, err = ParseRunIDsParam(r)
+	runIDs, err = ParseRunIDsParam(r.URL.Query())
 	assert.Equal(t, []int64{1, 2, 3}, []int64(runIDs))
 	assert.Nil(t, err)
 }
 
 func TestParseRunIDsParam_err(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/api/search?run_ids=1,notanumber,3", nil)
-	runIDs, err := ParseRunIDsParam(r)
+	runIDs, err := ParseRunIDsParam(r.URL.Query())
 	assert.Nil(t, runIDs)
 	assert.NotNil(t, err)
 
 	r = httptest.NewRequest("GET", "http://wpt.fyi/api/search?run_id=1&run_id=notanumber&run_id=3", nil)
-	runIDs, err = ParseRunIDsParam(r)
+	runIDs, err = ParseRunIDsParam(r.URL.Query())
 	assert.Nil(t, runIDs)
 	assert.NotNil(t, err)
 }
 
 func TestParseQueryFilterParams_nil(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/api/search", nil)
-	filter, err := ParseQueryFilterParams(r)
+	filter, err := ParseQueryFilterParams(r.URL.Query())
 	assert.Equal(t, QueryFilter{}, filter)
 	assert.Nil(t, err)
 }
 
 func TestParseQueryFilterParams_runIDs(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/api/search?run_ids=1,2,3", nil)
-	filter, err := ParseQueryFilterParams(r)
+	filter, err := ParseQueryFilterParams(r.URL.Query())
 	assert.Equal(t, QueryFilter{
 		RunIDs: []int64{1, 2, 3},
 	}, filter)
@@ -529,7 +529,7 @@ func TestParseQueryFilterParams_runIDs(t *testing.T) {
 
 func TestParseQueryFilterParams_q(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/api/search?q=abcd", nil)
-	filter, err := ParseQueryFilterParams(r)
+	filter, err := ParseQueryFilterParams(r.URL.Query())
 	assert.Equal(t, QueryFilter{
 		Q: "abcd",
 	}, filter)
@@ -538,7 +538,7 @@ func TestParseQueryFilterParams_q(t *testing.T) {
 
 func TestParseQueryFilterParams_aligned(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/api/search?run_ids=1,2,3&q=abcd", nil)
-	filter, err := ParseQueryFilterParams(r)
+	filter, err := ParseQueryFilterParams(r.URL.Query())
 	assert.Equal(t, QueryFilter{
 		RunIDs: []int64{1, 2, 3},
 		Q:      "abcd",
@@ -548,30 +548,30 @@ func TestParseQueryFilterParams_aligned(t *testing.T) {
 
 func TestParseQueryFilterParams_err(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/api/search?run_ids=1,notanumber,3&q=abcd", nil)
-	_, err := ParseQueryFilterParams(r)
+	_, err := ParseQueryFilterParams(r.URL.Query())
 	assert.NotNil(t, err)
 }
 
 func TestParseTestRunFilterParams(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/", nil)
-	filter, _ := ParseTestRunFilterParams(r)
+	filter, _ := ParseTestRunFilterParams(r.URL.Query())
 	assert.Nil(t, filter.Aligned)
 	assert.Equal(t, "aligned=true&label=stable", filter.OrDefault().ToQuery().Encode())
 	assert.Equal(t, "", filter.ToQuery().Encode())
 
 	r = httptest.NewRequest("GET", "http://wpt.fyi/?label=stable", nil)
-	filter, _ = ParseTestRunFilterParams(r)
+	filter, _ = ParseTestRunFilterParams(r.URL.Query())
 	assert.Equal(t, "label=stable", filter.OrDefault().ToQuery().Encode())
 	assert.Equal(t, "label=stable", filter.ToQuery().Encode())
 
 	r = httptest.NewRequest("GET", "http://wpt.fyi/?from=2018-01-01T00%3A00%3A00Z", nil)
-	filter, _ = ParseTestRunFilterParams(r)
+	filter, _ = ParseTestRunFilterParams(r.URL.Query())
 	assert.Equal(t, "from=2018-01-01T00%3A00%3A00Z", filter.ToQuery().Encode())
 }
 
 func TestParseTestRunFilterParams_Invalid(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?product=chrome%5B", nil)
-	_, err := ParseTestRunFilterParams(r)
+	_, err := ParseTestRunFilterParams(r.URL.Query())
 	assert.NotNil(t, err)
 }
 
@@ -631,7 +631,7 @@ func TestParsePageToken(t *testing.T) {
 	assert.Nil(t, err)
 	r := httptest.NewRequest("GET", "/?page="+token, nil)
 
-	parsed, err := ParsePageToken(r)
+	parsed, err := ParsePageToken(r.URL.Query())
 	assert.Nil(t, err)
 	if parsed == nil {
 		assert.FailNow(t, "Parsed page token was nil")

--- a/shared/test_run_filter.go
+++ b/shared/test_run_filter.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"net/url"
 	"strconv"
 	"time"
@@ -23,25 +22,6 @@ type TestRunFilter struct {
 	MaxCount *int         `json:"maxcount,omitempty"`
 	Offset   *int         `json:"offset,omitempty"` // Used for paginating with MaxCount.
 	Products ProductSpecs `json:"products,omitempty"`
-}
-
-// UnmarshalJSON treats the data a URL param map, and parses the same
-// way the request params do.
-func (filter *TestRunFilter) UnmarshalJSON(data []byte) (err error) {
-	var params map[string]interface{}
-	if err = json.Unmarshal(data, &params); err != nil {
-		return err
-	}
-	r, _ := http.NewRequest("GET", "/", nil)
-	q := r.URL.Query()
-	for k, v := range params {
-		if s, ok := v.(string); ok {
-			q.Set(k, s)
-		}
-	}
-	r.URL.RawQuery = q.Encode()
-	*filter, err = ParseTestRunFilterParams(r)
-	return err
 }
 
 // IsDefaultQuery returns whether the params are just an empty query (or,

--- a/shared/test_run_filter.go
+++ b/shared/test_run_filter.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strconv"
 	"time"
@@ -22,6 +23,25 @@ type TestRunFilter struct {
 	MaxCount *int         `json:"maxcount,omitempty"`
 	Offset   *int         `json:"offset,omitempty"` // Used for paginating with MaxCount.
 	Products ProductSpecs `json:"products,omitempty"`
+}
+
+// UnmarshalJSON treats the data a URL param map, and parses the same
+// way the request params do.
+func (filter *TestRunFilter) UnmarshalJSON(data []byte) (err error) {
+	var params map[string]interface{}
+	if err = json.Unmarshal(data, &params); err != nil {
+		return err
+	}
+	r, _ := http.NewRequest("GET", "/", nil)
+	q := r.URL.Query()
+	for k, v := range params {
+		if s, ok := v.(string); ok {
+			q.Set(k, s)
+		}
+	}
+	r.URL.RawQuery = q.Encode()
+	*filter, err = ParseTestRunFilterParams(r)
+	return err
 }
 
 // IsDefaultQuery returns whether the params are just an empty query (or,

--- a/webapp/anomaly_handler.go
+++ b/webapp/anomaly_handler.go
@@ -22,7 +22,7 @@ type AnomalyData struct {
 // anomalyHandler handles the view of test results showing which tests pass in
 // some, but not all, browsers.
 func anomalyHandler(w http.ResponseWriter, r *http.Request) {
-	product, err := shared.ParseBrowserParam(r)
+	product, err := shared.ParseBrowserParam(r.URL.Query())
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return

--- a/webapp/interop_handler.go
+++ b/webapp/interop_handler.go
@@ -13,7 +13,7 @@ import (
 // interopHandler handles the view of test results broken down by the
 // number of browsers for which the test passes.
 func interopHandler(w http.ResponseWriter, r *http.Request) {
-	testRunFilter, err := shared.ParseTestRunFilterParams(r)
+	testRunFilter, err := shared.ParseTestRunFilterParams(r.URL.Query())
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return

--- a/webapp/queue.yaml
+++ b/webapp/queue.yaml
@@ -6,5 +6,6 @@ queue:
 - name: check-processing
   rate: 1/s
   retry_parameters:
-    task_retry_limit: 3
-    min_backoff_seconds: 5
+    task_age_limit: 5m
+    min_backoff_seconds: 15
+    max_doublings: 2 # longest timeout will be 1m

--- a/webapp/test_results_handler.go
+++ b/webapp/test_results_handler.go
@@ -76,13 +76,14 @@ func testResultsHandler(w http.ResponseWriter, r *http.Request) {
 // parseTestResultsUIFilter parses the standard TestRunFilter, as well as the extra
 // diff params (diff, before, after).
 func parseTestResultsUIFilter(r *http.Request) (filter testResultsUIFilter, err error) {
-	testRunFilter, err := shared.ParseTestRunFilterParams(r)
+	q := r.URL.Query()
+	testRunFilter, err := shared.ParseTestRunFilterParams(q)
 	if err != nil {
 		return filter, err
 	}
 	ctx := shared.NewAppEngineContext(r)
 
-	filter.PR, err = shared.ParsePRParam(r)
+	filter.PR, err = shared.ParsePRParam(q)
 	if err != nil {
 		return filter, err
 	} else if filter.PR != nil {
@@ -110,13 +111,13 @@ func parseTestResultsUIFilter(r *http.Request) (filter testResultsUIFilter, err 
 		filter.testRunUIFilter = convertTestRunUIFilter(testRunFilter)
 	}
 
-	diff, err := shared.ParseBooleanParam(r, "diff")
+	diff, err := shared.ParseBooleanParam(q, "diff")
 	if err != nil {
 		return filter, err
 	}
 	filter.Diff = diff != nil && *diff
 	if filter.Diff {
-		diffFilter, _, err := shared.ParseDiffFilterParams(r)
+		diffFilter, _, err := shared.ParseDiffFilterParams(q)
 		if err != nil {
 			return filter, err
 		}
@@ -124,7 +125,7 @@ func parseTestResultsUIFilter(r *http.Request) (filter testResultsUIFilter, err 
 	}
 
 	var beforeAndAfter shared.ProductSpecs
-	if beforeAndAfter, err = shared.ParseBeforeAndAfterParams(r); err != nil {
+	if beforeAndAfter, err = shared.ParseBeforeAndAfterParams(q); err != nil {
 		return filter, err
 	} else if len(beforeAndAfter) > 0 {
 		var bytes []byte

--- a/webapp/test_runs_handler.go
+++ b/webapp/test_runs_handler.go
@@ -18,7 +18,7 @@ func testRunsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	testRunFilter, err := shared.ParseTestRunFilterParams(r)
+	testRunFilter, err := shared.ParseTestRunFilterParams(r.URL.Query())
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return


### PR DESCRIPTION
## Description
The more simple API for a TaskQueue POST dumps given params in the payload; we were trying to parse them from the query params.

This PR refactors the `Parse*Param` helpers to take the `url.Values` objects directly, instead of the `*http.Request`. It also uses `ParseForm()` and passes that for /api/checks/{commit}, so that non-empty POST body as url params in the same manner.