### PR TITLE
Script + code boilerplate for /api/search/cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ notifications:
   email:
     on_success: never # default: change
     on_failure: always # default: always
-    
+
 branches:
   only:
     - master
@@ -66,11 +66,13 @@ script:
       bash util/travis-deploy-staging.sh -f results-processor;
       bash util/travis-deploy-staging.sh -f revisions/service;
       bash util/travis-deploy-staging.sh -f api/spanner/service;
+      bash util/travis-deploy-staging.sh -f api/query/cache/service;
     elif [ "${DEPLOY_PR_STAGING}" == "true" ]; then
       bash util/travis-deploy-staging.sh webapp;
       bash util/travis-deploy-staging.sh results-processor;
       bash util/travis-deploy-staging.sh revisions/service;
       bash util/travis-deploy-staging.sh api/spanner/service;
+      bash util/travis-deploy-staging.sh api/query/cache/service;
     else
       echo "Not on master or a PR. Skipping deployment.";
     fi

--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ golint_deps: git
 	fi
 
 package_service: var-APP_PATH
-	if [[ "$(APP_PATH)" == "revisions/service" || "$(APP_PATH)" == "api/spanner/service" ]]; then \
+	if [[ "$(APP_PATH)" == "revisions/service" || "$(APP_PATH)" == "api/spanner/service" || "$(APP_PATH)" == "api/query/cache/service" ]]; then \
 		export TMP_DIR=$$(mktemp -d); \
 		rm -rf $(WPTD_PATH)$(APP_PATH)/wpt.fyi; \
 		cp -r $(WPTD_PATH)* $${TMP_DIR}/; \
@@ -217,6 +217,7 @@ deploy_staging: gcloud-login webapp_deps package_service var-BRANCH_NAME var-APP
 	cd $(WPTD_PATH); util/deploy.sh -q -b $(BRANCH_NAME) $(APP_PATH)
 	rm -rf $(WPTD_PATH)revisions/service/wpt.fyi
 	rm -rf $(WPTD_PATH)api/spanner/service/wpt.fyi
+	rm -rf $(WPTD_PATH)api/query/cache/service/wpt.fyi
 
 cleanup_staging_versions: gcloud-login
 	$(WPTD_GO_PATH)/util/cleanup-versions.sh
@@ -226,6 +227,7 @@ deploy_production: gcloud webapp_deps package_service var-APP_PATH var-PROJECT
 	cd $(WPTD_PATH); util/deploy.sh -p $(APP_PATH)
 	rm -rf $(WPTD_PATH)revisions/service/wpt.fyi
 	rm -rf $(WPTD_PATH)api/spanner/service/wpt.fyi
+	rm -rf $(WPTD_PATH)api/query/cache/service/wpt.fyi
 
 bower_components: git node-bower
 	cd $(WPTD_PATH)webapp; npm run bower-components

--- a/api/query/cache/service/Dockerfile
+++ b/api/query/cache/service/Dockerfile
@@ -1,0 +1,20 @@
+# Production deployment spec for spanner write service.
+
+# Base golang 1.10 image.
+FROM gcr.io/gcp-runtimes/go1-builder:1.10 as builder
+
+RUN apt-get update
+RUN apt-get install -qy --no-install-suggests git
+WORKDIR /go/src/app
+COPY *.go .
+
+COPY wpt.fyi /root/go/src/github.com/web-platform-tests/wpt.fyi/
+RUN /usr/local/go/bin/go get -d .
+RUN /usr/local/go/bin/go build -o app .
+
+# Application image.
+FROM gcr.io/distroless/base:latest
+
+COPY --from=builder /go/src/app/app /usr/local/bin/app
+
+CMD ["/usr/local/bin/app"]

--- a/api/query/cache/service/app.yaml
+++ b/api/query/cache/service/app.yaml
@@ -4,9 +4,9 @@ service: searchcache
 
 # Should match something at https://cloud.google.com/compute/docs/machine-types.
 resources:
-  # n1-standard-64 (TODO: Would prefer n1-highmem-96 or larger ultramem)
-  cpu: 64
-  memory_gb: 240
+  # n1-standard-32 (TODO: Would prefer n1-highmem-96 or larger ultramem)
+  cpu: 32
+  memory_gb: 120
 
 manual_scaling:
   instances: 2

--- a/api/query/cache/service/app.yaml
+++ b/api/query/cache/service/app.yaml
@@ -4,9 +4,9 @@ service: searchcache
 
 # Should match something at https://cloud.google.com/compute/docs/machine-types.
 resources:
-  # n1-highmem-96
+  # n1-standard-96 (TODO: Would prefer n1-highmem-96)
   cpu: 96
-  memory_gb: 624
+  memory_gb: 360
 
 liveness_check:
   path: "/_ah/liveness_check"

--- a/api/query/cache/service/app.yaml
+++ b/api/query/cache/service/app.yaml
@@ -8,6 +8,9 @@ resources:
   cpu: 96
   memory_gb: 360
 
+manual_scaling:
+  instances: 2
+
 liveness_check:
   path: "/_ah/liveness_check"
 

--- a/api/query/cache/service/app.yaml
+++ b/api/query/cache/service/app.yaml
@@ -4,9 +4,9 @@ service: searchcache
 
 # Should match something at https://cloud.google.com/compute/docs/machine-types.
 resources:
-  # n1-highmem-32 (TODO: Would prefer n1-highmem-96 or larger ultramem)
+  # n1-standard-32 (TODO: Would prefer n1-highmem-96 or larger ultramem)
   cpu: 32
-  memory_gb: 208
+  memory_gb: 120
 
 manual_scaling:
   instances: 2

--- a/api/query/cache/service/app.yaml
+++ b/api/query/cache/service/app.yaml
@@ -4,9 +4,9 @@ service: searchcache
 
 # Should match something at https://cloud.google.com/compute/docs/machine-types.
 resources:
-  # n1-standard-96 (TODO: Would prefer n1-highmem-96)
-  cpu: 96
-  memory_gb: 360
+  # n1-standard-64 (TODO: Would prefer n1-highmem-96 or larger ultramem)
+  cpu: 64
+  memory_gb: 240
 
 manual_scaling:
   instances: 2

--- a/api/query/cache/service/app.yaml
+++ b/api/query/cache/service/app.yaml
@@ -1,0 +1,15 @@
+runtime: custom
+env: flex
+service: searchcache
+
+# Should match something at https://cloud.google.com/compute/docs/machine-types.
+resources:
+  # n1-highmem-96
+  cpu: 96
+  memory_gb: 624
+
+liveness_check:
+  path: "/_ah/liveness_check"
+
+readiness_check:
+  path: "/_ah/readiness_check"

--- a/api/query/cache/service/app.yaml
+++ b/api/query/cache/service/app.yaml
@@ -4,9 +4,9 @@ service: searchcache
 
 # Should match something at https://cloud.google.com/compute/docs/machine-types.
 resources:
-  # n1-standard-32 (TODO: Would prefer n1-highmem-96 or larger ultramem)
+  # n1-highmem-32 (TODO: Would prefer n1-highmem-96 or larger ultramem)
   cpu: 32
-  memory_gb: 120
+  memory_gb: 208
 
 manual_scaling:
   instances: 2

--- a/api/query/cache/service/main.go
+++ b/api/query/cache/service/main.go
@@ -1,0 +1,60 @@
+// Copyright 2018 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+
+	"net/http"
+
+	"cloud.google.com/go/compute/metadata"
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	port               = flag.Int("port", 8080, "Port to listen on")
+	projectID          = flag.String("project_id", "", "Google Cloud Platform project ID, if different from ID detected from metadata service")
+	gcpCredentialsFile = flag.String("gcp_credentials_file", "", "Path to Google Cloud Platform credentials file, if necessary")
+)
+
+func livenessCheckHandler(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte("Alive"))
+}
+
+func readinessCheckHandler(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte("Ready"))
+}
+
+func searchHandler(w http.ResponseWriter, r *http.Request) {
+	// TODO: Implement search against in-memory cache.
+	http.Error(w, "Not implemented", http.StatusNotImplemented)
+}
+
+func init() {
+	flag.Parse()
+}
+
+func main() {
+	autoProjectID, err := metadata.ProjectID()
+	if err != nil {
+		log.Warningf("Failed to get project ID from metadata service")
+	} else {
+		if *projectID == "" {
+			log.Infof(`Using project ID from metadata service: "%s"`, *projectID)
+			*projectID = autoProjectID
+		} else if *projectID != autoProjectID {
+			log.Warningf(`Using project ID from flag: "%s" even though metadata service reports project ID of "%s"`, *projectID, autoProjectID)
+		} else {
+			log.Infof(`Using project ID: "%s"`, *projectID)
+		}
+	}
+
+	http.HandleFunc("/_ah/liveness_check", livenessCheckHandler)
+	http.HandleFunc("/_ah/readiness_check", readinessCheckHandler)
+	http.HandleFunc("/api/search/cache", searchHandler)
+	log.Infof("Listening on port %d", *port)
+	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", *port), nil))
+}

--- a/util/deploy.sh
+++ b/util/deploy.sh
@@ -28,7 +28,7 @@ while getopts ':b:phq:g:' flag; do
 done
 
 if [[ "${APP_PATH}" == ""  ]]; then fatal "app path not specified."; fi
-if [[ "${APP_PATH}" != "webapp" && "${APP_PATH}" != "results-processor" && "${APP_PATH}" != "revisions/service" && "${APP_PATH}" != "api/spanner/service" ]];
+if [[ "${APP_PATH}" != "webapp" && "${APP_PATH}" != "results-processor" && "${APP_PATH}" != "revisions/service" && "${APP_PATH}" != "api/spanner/service" && "${APP_PATH}" != "api/query/cache/service" ]];
 then
   fatal "Unrecognized app path \"${APP_PATH}\"."
 fi

--- a/webapp/dispatch.yaml
+++ b/webapp/dispatch.yaml
@@ -3,3 +3,7 @@ dispatch:
     service: announcer
   - url: "*.appspot.com/api/revisions/*"
     service: announcer
+  - url: "*wpt.fyi/api/search/cache"
+    service: searchcache
+  - url: "*.appspot.com/api/search/cache"
+    service: searchcache


### PR DESCRIPTION
This change adds boilerplate for a new service for handling structured test result queries. For now, the new handler simply returns `Not implemented`.

This API is intended for internal use, as a delegate to the public `/api/search` API.