### PR TITLE
Refactor: Add DiffAPI for testability

### DIFF
--- a/api/checks/suites.go
+++ b/api/checks/suites.go
@@ -60,7 +60,7 @@ func pendingCheckRun(ctx context.Context, sha string, product shared.ProductSpec
 			Product:    product,
 			HeadSHA:    sha,
 			Title:      getCheckTitle(product),
-			DetailsURL: getMasterDiffURL(ctx, sha, product),
+			DetailsURL: shared.NewDiffAPI(ctx).GetMasterDiffURL(sha, product),
 			Status:     "in_progress",
 		},
 		HostName: host,
@@ -70,21 +70,25 @@ func pendingCheckRun(ctx context.Context, sha string, product shared.ProductSpec
 }
 
 func completeCheckRun(ctx context.Context, sha string, product shared.ProductSpec) (bool, error) {
-	host := shared.NewAppEngineAPI(ctx).GetHostname()
+	aeAPI := shared.NewAppEngineAPI(ctx)
+	host := aeAPI.GetHostname()
+	runsURL := aeAPI.GetRunsURL(shared.TestRunFilter{SHA: sha[:10]})
+	diffAPI := shared.NewDiffAPI(ctx)
+	diffURL := diffAPI.GetMasterDiffURL(sha, product)
 	success := "success"
 	completed := summaries.Completed{
 		CheckState: summaries.CheckState{
 			Product:    product,
 			HeadSHA:    sha,
 			Title:      fmt.Sprintf("wpt.fyi - %s results", product.DisplayName()),
-			DetailsURL: getMasterDiffURL(ctx, sha, product),
+			DetailsURL: diffURL,
 			Status:     "completed",
 			Conclusion: &success,
 		},
 		HostName: host,
 		HostURL:  fmt.Sprintf("https://%s/", host),
-		SHAURL:   getURL(ctx, shared.TestRunFilter{SHA: sha[:10]}).String(),
-		DiffURL:  getMasterDiffURL(ctx, sha, product).String(),
+		SHAURL:   runsURL.String(),
+		DiffURL:  diffURL.String(),
 	}
 	return updateCheckRun(ctx, completed)
 }

--- a/api/checks/update.go
+++ b/api/checks/update.go
@@ -113,7 +113,7 @@ func getDiffSummary(aeAPI shared.AppEngineAPI, diffAPI shared.DiffAPI, before, a
 		HeadSHA:    before.FullRevisionHash,
 		Title:      getCheckTitle(product),
 		DetailsURL: diffAPI.GetMasterDiffURL(before.FullRevisionHash, product),
-		Status:     "in_progress",
+		Status:     "completed",
 	}
 
 	regressed := false

--- a/api/checks/update.go
+++ b/api/checks/update.go
@@ -5,7 +5,6 @@
 package checks
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 
@@ -62,7 +61,7 @@ func updateCheckHandler(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	} else if len(allRuns) > 1 {
-		log.Errorf("Failed to load test runs: %s", err.Error())
+		log.Errorf("Found more that one test run")
 		http.Error(w, fmt.Sprintf("Expected exactly 1 run, but found %v", len(runs)), http.StatusBadRequest)
 		return
 	}
@@ -74,37 +73,23 @@ func updateCheckHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	labels.Add("master")
 	masterRuns, err := shared.LoadTestRuns(ctx, filter.Products, labels, "", nil, nil, &one, nil)
-	allMasterRuns := masterRuns.AllRuns()
+	masterRun := masterRuns.First()
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
-	} else if len(allMasterRuns) < 1 {
+	} else if masterRun == nil {
 		log.Debugf("No masters runs found for %s @ %s", filter.Products[0].String(), sha[:7])
 		http.Error(w, "No master run found to compare differences", http.StatusNotFound)
 		return
 	}
 
-	beforeJSON, err := shared.FetchRunResultsJSON(ctx, r, allRuns[0])
+	aeAPI := shared.NewAppEngineAPI(ctx)
+	diffAPI := shared.NewDiffAPI(ctx)
+	summaryData, err := getDiffSummary(aeAPI, diffAPI, allRuns[0], *masterRun)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("Failed to fetch 'before' results: %s", err.Error()), http.StatusInternalServerError)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	afterJSON, err := shared.FetchRunResultsJSON(ctx, r, allMasterRuns[0])
-	if err != nil {
-		http.Error(w, fmt.Sprintf("Failed to fetch 'after' results: %s", err.Error()), http.StatusInternalServerError)
-		return
-	}
-
-	product, _ := shared.ParseProductSpec(runs[0].Product.String())
-	checkState := summaries.CheckState{
-		Product:    product,
-		HeadSHA:    sha,
-		Title:      getCheckTitle(product),
-		DetailsURL: getMasterDiffURL(ctx, sha, product),
-		Status:     "in_progress",
-	}
-	summaryData := getDiffSummary(ctx, beforeJSON, afterJSON, checkState)
-
 	updated, err := updateCheckRun(ctx, summaryData)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -115,12 +100,24 @@ func updateCheckHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func getDiffSummary(ctx context.Context, before, after map[string][]int, checkState summaries.CheckState) summaries.Summary {
+func getDiffSummary(aeAPI shared.AppEngineAPI, diffAPI shared.DiffAPI, before, after shared.TestRun) (summaries.Summary, error) {
 	diffFilter := shared.DiffFilterParam{Added: true, Changed: true, Unchanged: true}
-	diff := shared.GetResultsDiff(before, after, diffFilter, nil, nil)
+	diff, err := diffAPI.GetRunsDiff(before, after, diffFilter, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	product, _ := shared.ParseProductSpec(before.Product.String())
+	checkState := summaries.CheckState{
+		Product:    product,
+		HeadSHA:    before.FullRevisionHash,
+		Title:      getCheckTitle(product),
+		DetailsURL: diffAPI.GetMasterDiffURL(before.FullRevisionHash, product),
+		Status:     "in_progress",
+	}
 
 	regressed := false
-	for _, d := range diff {
+	for _, d := range diff.Differences {
 		if d[1] != 0 {
 			regressed = true
 			break
@@ -128,17 +125,17 @@ func getDiffSummary(ctx context.Context, before, after map[string][]int, checkSt
 	}
 	neutral := "neutral"
 	checkState.Conclusion = &neutral
-	checksCanFailAndPass := shared.IsFeatureEnabled(ctx, "failChecksOnRegression")
+	checksCanFailAndPass := aeAPI.IsFeatureEnabled("failChecksOnRegression")
 
 	var summary summaries.Summary
 	if !regressed {
-		host := shared.NewAppEngineAPI(ctx).GetHostname()
+		host := aeAPI.GetHostname()
 		data := summaries.Completed{
 			CheckState: checkState,
 			HostName:   host,
 			HostURL:    fmt.Sprintf("https://%s/", host),
-			DiffURL:    getMasterDiffURL(ctx, checkState.HeadSHA, checkState.Product).String(),
-			SHAURL:     getURL(ctx, shared.TestRunFilter{SHA: checkState.HeadSHA[:10]}).String(),
+			DiffURL:    diffAPI.GetMasterDiffURL(checkState.HeadSHA, checkState.Product).String(),
+			SHAURL:     aeAPI.GetRunsURL(shared.TestRunFilter{SHA: checkState.HeadSHA[:10]}).String(),
 		}
 		if checksCanFailAndPass {
 			success := "success"
@@ -150,15 +147,15 @@ func getDiffSummary(ctx context.Context, before, after map[string][]int, checkSt
 			CheckState:  checkState,
 			Regressions: make(map[string]summaries.BeforeAndAfter),
 		}
-		for path, d := range diff {
+		for path, d := range diff.Differences {
 			if d[1] != 0 {
 				if len(data.Regressions) <= 10 {
 					ba := summaries.BeforeAndAfter{}
-					if b, ok := before[path]; ok {
+					if b, ok := diff.BeforeSummary[path]; ok {
 						ba.PassingBefore = b[0]
 						ba.TotalBefore = b[1]
 					}
-					if a, ok := after[path]; ok {
+					if a, ok := diff.AfterSummary[path]; ok {
 						ba.PassingAfter = a[0]
 						ba.TotalAfter = a[1]
 					}
@@ -174,5 +171,5 @@ func getDiffSummary(ctx context.Context, before, after map[string][]int, checkSt
 		}
 		summary = data
 	}
-	return summary
+	return summary, nil
 }

--- a/api/checks/webhook.go
+++ b/api/checks/webhook.go
@@ -13,13 +13,11 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"net/url"
 	"strconv"
 	"time"
 
 	jwt "github.com/dgrijalva/jwt-go"
 
-	"github.com/deckarep/golang-set"
 	"github.com/google/go-github/github"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 	"golang.org/x/oauth2"
@@ -357,31 +355,6 @@ func getSignedJWT(ctx context.Context) (string, error) {
 	return jwtToken.SignedString(key)
 }
 
-// Diff for the given product at master vs the given sha.
-func getMasterDiffURL(ctx context.Context, sha string, product shared.ProductSpec) *url.URL {
-	filter := shared.TestRunFilter{}
-	filter.Products = shared.ProductSpecs{product, product}
-	filter.Products[0].Labels = mapset.NewSet("master")
-	filter.Products[1].Revision = sha
-	detailsURL := getURL(ctx, filter)
-	query := detailsURL.Query()
-	query.Set("diff", "")
-	query.Set("filter", shared.DiffFilterParam{
-		Added:     true,
-		Changed:   true,
-		Unchanged: true,
-	}.String())
-	detailsURL.RawQuery = query.Encode()
-	return detailsURL
-}
-
 func getCheckTitle(product shared.ProductSpec) string {
 	return fmt.Sprintf("wpt.fyi - %s results", product.DisplayName())
-}
-
-func getURL(ctx context.Context, filter shared.TestRunFilter) *url.URL {
-	hostname := shared.NewAppEngineAPI(ctx).GetHostname()
-	detailsURL, _ := url.Parse(fmt.Sprintf("https://%s/results/", hostname))
-	detailsURL.RawQuery = filter.ToQuery().Encode()
-	return detailsURL
 }

--- a/api/diff.go
+++ b/api/diff.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -9,10 +8,8 @@ import (
 	"net/url"
 
 	mapset "github.com/deckarep/golang-set"
-	"github.com/google/go-github/github"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 
-	"golang.org/x/oauth2"
 	"google.golang.org/appengine"
 	"google.golang.org/appengine/datastore"
 )
@@ -103,25 +100,12 @@ func handleAPIDiffGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	beforeJSON, err := shared.FetchRunResultsJSON(ctx, r, runs[0])
+	diffAPI := shared.NewDiffAPI(ctx)
+	diff, err := diffAPI.GetRunsDiff(runs[0], runs[1], diffFilter, paths)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("Failed to fetch 'before' results: %s", err.Error()), http.StatusInternalServerError)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	afterJSON, err := shared.FetchRunResultsJSON(ctx, r, runs[1])
-	if err != nil {
-		http.Error(w, fmt.Sprintf("Failed to fetch 'after' results: %s", err.Error()), http.StatusInternalServerError)
-		return
-	}
-
-	var renames map[string]string
-	if shared.IsFeatureEnabled(ctx, "diffRenames") {
-		renames = getDiffRenames(ctx, runs[0].FullRevisionHash, runs[1].FullRevisionHash)
-	}
-	diff := diffResult{
-		Diff: shared.GetResultsDiff(beforeJSON, afterJSON, diffFilter, paths, renames),
-	}
-	diff.Renames = renames
 
 	var bytes []byte
 	if bytes, err = json.Marshal(diff); err != nil {
@@ -183,37 +167,4 @@ func handleAPIDiffPost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Write(bytes)
-}
-
-func getDiffRenames(ctx context.Context, shaBefore, shaAfter string) map[string]string {
-	if shaBefore == shaAfter {
-		return nil
-	}
-	log := shared.GetLogger(ctx)
-	secret, err := shared.GetSecret(ctx, "github-api-token")
-	if err != nil {
-		log.Debugf("Failed to load github-api-token: %s", err.Error())
-		return nil
-	}
-	oauthClient := oauth2.NewClient(ctx, oauth2.StaticTokenSource(&oauth2.Token{
-		AccessToken: secret,
-	}))
-	githubClient := github.NewClient(oauthClient)
-	comparison, _, err := githubClient.Repositories.CompareCommits(ctx, "web-platform-tests", "wpt", shaBefore, shaAfter)
-	if err != nil || comparison == nil {
-		log.Errorf("Failed to fetch diff for %s...%s: %s", shaBefore[:7], shaAfter[:7], err.Error())
-		return nil
-	}
-
-	renames := make(map[string]string)
-	for _, file := range comparison.Files {
-		if file.GetStatus() == "renamed" {
-			is, was := file.GetFilename(), file.GetPreviousFilename()
-			renames["/"+was] = "/" + is
-		}
-	}
-	if len(renames) < 1 {
-		log.Debugf("No renames for %s...%s", shaBefore[:7], shaAfter[:7])
-	}
-	return renames
 }

--- a/api/receiver/appengine_mock.go
+++ b/api/receiver/appengine_mock.go
@@ -7,6 +7,7 @@ package receiver
 import (
 	context "context"
 	io "io"
+	url "net/url"
 	reflect "reflect"
 	time "time"
 
@@ -62,6 +63,30 @@ func (mr *MockAppEngineAPIMockRecorder) GetHostname() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHostname", reflect.TypeOf((*MockAppEngineAPI)(nil).GetHostname))
 }
 
+// GetResultsURL mocks base method
+func (m *MockAppEngineAPI) GetResultsURL(arg0 shared.TestRunFilter) *url.URL {
+	ret := m.ctrl.Call(m, "GetResultsURL", arg0)
+	ret0, _ := ret[0].(*url.URL)
+	return ret0
+}
+
+// GetResultsURL indicates an expected call of GetResultsURL
+func (mr *MockAppEngineAPIMockRecorder) GetResultsURL(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResultsURL", reflect.TypeOf((*MockAppEngineAPI)(nil).GetResultsURL), arg0)
+}
+
+// GetRunsURL mocks base method
+func (m *MockAppEngineAPI) GetRunsURL(arg0 shared.TestRunFilter) *url.URL {
+	ret := m.ctrl.Call(m, "GetRunsURL", arg0)
+	ret0, _ := ret[0].(*url.URL)
+	return ret0
+}
+
+// GetRunsURL indicates an expected call of GetRunsURL
+func (mr *MockAppEngineAPIMockRecorder) GetRunsURL(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRunsURL", reflect.TypeOf((*MockAppEngineAPI)(nil).GetRunsURL), arg0)
+}
+
 // IsAdmin mocks base method
 func (m *MockAppEngineAPI) IsAdmin() bool {
 	ret := m.ctrl.Call(m, "IsAdmin")
@@ -72,6 +97,18 @@ func (m *MockAppEngineAPI) IsAdmin() bool {
 // IsAdmin indicates an expected call of IsAdmin
 func (mr *MockAppEngineAPIMockRecorder) IsAdmin() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsAdmin", reflect.TypeOf((*MockAppEngineAPI)(nil).IsAdmin))
+}
+
+// IsFeatureEnabled mocks base method
+func (m *MockAppEngineAPI) IsFeatureEnabled(arg0 string) bool {
+	ret := m.ctrl.Call(m, "IsFeatureEnabled", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsFeatureEnabled indicates an expected call of IsFeatureEnabled
+func (mr *MockAppEngineAPIMockRecorder) IsFeatureEnabled(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsFeatureEnabled", reflect.TypeOf((*MockAppEngineAPI)(nil).IsFeatureEnabled), arg0)
 }
 
 // IsLoggedIn mocks base method

--- a/shared/appengine.go
+++ b/shared/appengine.go
@@ -3,6 +3,7 @@ package shared
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strings"
 
 	"google.golang.org/appengine"
@@ -17,8 +18,12 @@ type AppEngineAPI interface {
 	IsAdmin() bool
 	LoginURL(redirect string) (string, error)
 
+	IsFeatureEnabled(featureName string) bool
+
 	// GetHostname returns a cleaned-up hostname for the current environment.
 	GetHostname() string
+	GetResultsURL(filter TestRunFilter) *url.URL
+	GetRunsURL(filter TestRunFilter) *url.URL
 }
 
 // NewAppEngineAPI returns an AppEngineAPI for the given context.
@@ -54,6 +59,13 @@ func (a AppEngineAPIImpl) IsAdmin() bool {
 	return user.IsAdmin(a.ctx)
 }
 
+// IsFeatureEnabled returns true if the given feature name is stored as a Flag
+// and its Enabled property is true.
+func (a AppEngineAPIImpl) IsFeatureEnabled(featureName string) bool {
+	// TODO(lukebjerring): Migrate other callers of this signature to AppEngineAPI
+	return IsFeatureEnabled(a.ctx, featureName)
+}
+
 // GetHostname returns a cleaned-up hostname for the current environment.
 func (a AppEngineAPIImpl) GetHostname() string {
 	hostname := appengine.DefaultVersionHostname(a.ctx)
@@ -65,4 +77,24 @@ func (a AppEngineAPIImpl) GetHostname() string {
 		return "staging.wpt.fyi"
 	}
 	return fmt.Sprintf("%s-dot-%s", version, hostname)
+}
+
+// GetResultsURL returns a url for the wpt.fyi results page for the test runs
+// loaded for the given filter.
+func (a AppEngineAPIImpl) GetResultsURL(filter TestRunFilter) *url.URL {
+	return getURL(a.GetHostname(), "/results/", filter)
+}
+
+// GetRunsURL returns a url for the wpt.fyi results page for the test runs
+// loaded for the given filter.
+func (a AppEngineAPIImpl) GetRunsURL(filter TestRunFilter) *url.URL {
+	return getURL(a.GetHostname(), "/runs", filter)
+}
+
+// GetResultsURL returns a url for the wpt.fyi results page for the test runs
+// loaded for the given filter.
+func getURL(host, path string, filter TestRunFilter) *url.URL {
+	detailsURL, _ := url.Parse(fmt.Sprintf("https://%s%s", host, path))
+	detailsURL.RawQuery = filter.ToQuery().Encode()
+	return detailsURL
 }

--- a/shared/models.go
+++ b/shared/models.go
@@ -212,6 +212,15 @@ func (t TestRunsByProduct) AllRuns() TestRuns {
 	return runs
 }
 
+// First returns the first TestRun
+func (t TestRunsByProduct) First() *TestRun {
+	if len(t) > 0 {
+		first := t.AllRuns()[0]
+		return &first
+	}
+	return nil
+}
+
 // ProductTestRunKeys is a tuple of a product and test run keys loaded for it.
 type ProductTestRunKeys struct {
 	Product ProductSpec

--- a/shared/sharedtest/appengine_mock.go
+++ b/shared/sharedtest/appengine_mock.go
@@ -6,8 +6,11 @@ package sharedtest
 
 import (
 	context "context"
-	gomock "github.com/golang/mock/gomock"
+	url "net/url"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
+	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
 // MockAppEngineAPI is a mock of AppEngineAPI interface
@@ -82,6 +85,18 @@ func (mr *MockAppEngineAPIMockRecorder) LoginURL(redirect interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoginURL", reflect.TypeOf((*MockAppEngineAPI)(nil).LoginURL), redirect)
 }
 
+// IsFeatureEnabled mocks base method
+func (m *MockAppEngineAPI) IsFeatureEnabled(featureName string) bool {
+	ret := m.ctrl.Call(m, "IsFeatureEnabled", featureName)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsFeatureEnabled indicates an expected call of IsFeatureEnabled
+func (mr *MockAppEngineAPIMockRecorder) IsFeatureEnabled(featureName interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsFeatureEnabled", reflect.TypeOf((*MockAppEngineAPI)(nil).IsFeatureEnabled), featureName)
+}
+
 // GetHostname mocks base method
 func (m *MockAppEngineAPI) GetHostname() string {
 	ret := m.ctrl.Call(m, "GetHostname")
@@ -92,4 +107,28 @@ func (m *MockAppEngineAPI) GetHostname() string {
 // GetHostname indicates an expected call of GetHostname
 func (mr *MockAppEngineAPIMockRecorder) GetHostname() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHostname", reflect.TypeOf((*MockAppEngineAPI)(nil).GetHostname))
+}
+
+// GetResultsURL mocks base method
+func (m *MockAppEngineAPI) GetResultsURL(filter shared.TestRunFilter) *url.URL {
+	ret := m.ctrl.Call(m, "GetResultsURL", filter)
+	ret0, _ := ret[0].(*url.URL)
+	return ret0
+}
+
+// GetResultsURL indicates an expected call of GetResultsURL
+func (mr *MockAppEngineAPIMockRecorder) GetResultsURL(filter interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResultsURL", reflect.TypeOf((*MockAppEngineAPI)(nil).GetResultsURL), filter)
+}
+
+// GetRunsURL mocks base method
+func (m *MockAppEngineAPI) GetRunsURL(filter shared.TestRunFilter) *url.URL {
+	ret := m.ctrl.Call(m, "GetRunsURL", filter)
+	ret0, _ := ret[0].(*url.URL)
+	return ret0
+}
+
+// GetRunsURL indicates an expected call of GetRunsURL
+func (mr *MockAppEngineAPIMockRecorder) GetRunsURL(filter interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRunsURL", reflect.TypeOf((*MockAppEngineAPI)(nil).GetRunsURL), filter)
 }


### PR DESCRIPTION
## Description
No-op refactor that introduces a `DiffAPI` abstraction to supporting adding a range of tests to various currently-untested areas of the Golang codebase.

## Review Information
For the most-part, just verifying that the diff views are still working should suffice for smoke-testing.