### PR TITLE
Add time-based pagination

### DIFF
--- a/shared/test_run_filter.go
+++ b/shared/test_run_filter.go
@@ -1,3 +1,7 @@
+// Copyright 2018 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package shared
 
 import (
@@ -167,6 +171,20 @@ func (filter TestRunFilter) NextPage(loadedRuns TestRunsByProduct) *TestRunFilte
 			filter.Offset = &offset
 			return &filter
 		}
+	} else if filter.From != nil {
+		from := *filter.From
+		var to time.Time
+		if filter.To != nil {
+			to = *filter.To
+		} else {
+			to = time.Now()
+		}
+		span := to.Sub(from)
+		newFrom := from.Add(-span)
+		newTo := from.Add(-time.Millisecond)
+		filter.To = &newTo
+		filter.From = &newFrom
+		return &filter
 	}
 	return nil
 }

--- a/shared/test_run_filter_test.go
+++ b/shared/test_run_filter_test.go
@@ -1,0 +1,54 @@
+// +build small
+
+// Copyright 2018 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package shared
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTestRunFilter_NextPage_MaxCount(t *testing.T) {
+	ten := 10
+	filter := TestRunFilter{
+		MaxCount: &ten,
+	}
+	chrome, _ := ParseProductSpec("chrome")
+	loadedRuns := TestRunsByProduct{
+		ProductTestRuns{
+			Product:  chrome,
+			TestRuns: make(TestRuns, 10),
+		},
+	}
+	assert.Equal(t, &TestRunFilter{
+		MaxCount: &ten,
+		Offset:   &ten,
+	}, filter.NextPage(loadedRuns))
+}
+
+func TestTestRunFilter_NextPage_From(t *testing.T) {
+	now := time.Now()
+	aWeekAgo := now.AddDate(0, 0, -7)
+	filter := TestRunFilter{
+		From: &aWeekAgo,
+		To:   &now,
+	}
+	chrome, _ := ParseProductSpec("chrome")
+	loadedRuns := TestRunsByProduct{
+		ProductTestRuns{
+			Product:  chrome,
+			TestRuns: make(TestRuns, 1),
+		},
+	}
+	twoWeeksAgo := aWeekAgo.AddDate(0, 0, -7)
+	aWeekAgoMinusAMilli := aWeekAgo.Add(-time.Millisecond)
+	assert.Equal(t, &TestRunFilter{
+		From: &twoWeeksAgo,
+		To:   &aWeekAgoMinusAMilli,
+	}, filter.NextPage(loadedRuns))
+}


### PR DESCRIPTION
## Description
Recognizes the `from` param as pageable, and thus returns a `wpt-next-page` header on /api/runs?from=[RFC3339]`

Part of https://github.com/web-platform-tests/wpt.fyi/issues/636

## Review Information
- Visit /runs with the devtools open
- See that the request to /api/runs has a `wpt-next-page` header (token)
- Load /api/runs?page=[token]