### PR TITLE
Add load more button

### DIFF
--- a/webapp/components/test-runs.html
+++ b/webapp/components/test-runs.html
@@ -35,6 +35,7 @@ found in the LICENSE file.
               type: Boolean,
               computed: 'computePathIsATestFile(path)'
             },
+            nextPageToken: String,
           };
         }
 
@@ -65,8 +66,13 @@ found in the LICENSE file.
           }
           // Fetch by products.
           if (this.productSpecs && this.productSpecs.length) {
-            runs.push(fetch(`/api/runs${this.query}`)
-              .then(r => r.ok && r.json()));
+            runs.push(
+              fetch(`/api/runs${this.query}`)
+                .then(r => r.ok && r.json().then(runs => {
+                  this.nextPageToken = r.headers.get('wpt-next-page');
+                  return runs;
+                }))
+            );
           }
           const fetches = await Promise.all(runs);
 
@@ -77,6 +83,22 @@ found in the LICENSE file.
           }, []);
           this.testRuns = flattened;
           return flattened;
+        }
+
+        /**
+         * Fetch the next page of runs, using nextPageToken, if applicable.
+         */
+        loadMoreRuns() {
+          if (!this.nextPageToken) {
+            return;
+          }
+          const url = new URL('/api/runs', window.location);
+          url.searchParams.set('page', this.nextPageToken);
+          this.nextPageToken = null;
+          return fetch(url).then(r => r.ok && r.json().then(runs => {
+            this.splice('testRuns', this.testRuns.length - 1, 0, ...runs);
+            this.nextPageToken = r.headers.get('wpt-next-page');
+          }));
         }
 
         splitPathIntoLinkedParts(inputPath) {

--- a/webapp/components/wpt-runs.html
+++ b/webapp/components/wpt-runs.html
@@ -54,6 +54,11 @@ found in the LICENSE file.
       .runs.present {
         background-color: var(--paper-blue-100);
       }
+      .load-more {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+      }
       paper-spinner-lite {
         display: block;
         margin: auto;
@@ -72,8 +77,6 @@ found in the LICENSE file.
         }
       }
     </style>
-
-    <paper-spinner-lite active="[[isLoading]]" class="blue"></paper-spinner-lite>
 
     <template is="dom-if" if="[[loadingFailed]]">
       <info-banner type="error">
@@ -115,7 +118,7 @@ found in the LICENSE file.
         </thead>
         <tbody>
 
-        <template is="dom-repeat" items="{{ testRuns }}" as="results">
+        <template is="dom-repeat" items="{{ testRunsBySHA }}" as="results">
           <tr>
             <td>
               <a href="/?sha={{ results.sha }}">{{ results.sha }}</a>
@@ -142,7 +145,17 @@ found in the LICENSE file.
 
         </tbody>
       </table>
+
     </template>
+
+    <div class="load-more">
+      <template is="dom-if" if="[[nextPageToken]]">
+        <paper-button id="load-more" onclick="[[loadNextPage]]">
+          Load more
+        </paper-button>
+      </template>
+      <paper-spinner-lite active="[[isLoading]]" class="blue"></paper-spinner-lite>
+    </div>
 
   </template>
 
@@ -156,7 +169,7 @@ found in the LICENSE file.
       static get properties() {
         return {
           // Array({ sha, Array({ platform, run, sum }))
-          testRuns: {
+          testRunsBySHA: {
             type: Array
           },
           browsers: {
@@ -179,12 +192,13 @@ found in the LICENSE file.
       constructor() {
         super();
         this.onLoadingComplete = () => {
-          this.loadingFailed = !this.testRuns;
+          this.loadingFailed = !this.testRunsBySHA;
         };
         this.toggleBuilder = () => {
           this.editingQuery = !this.editingQuery;
         };
         this.submitQuery = this.handleSubmitQuery.bind(this);
+        this.loadNextPage = this.handleLoadNextPage.bind(this);
       }
 
       computeDateDisplay(results) {
@@ -218,58 +232,61 @@ found in the LICENSE file.
       async ready() {
         super.ready();
         this.loadData();
+        this._createMethodObserver('testRunsLoaded(testRuns, testRuns.*)');
       }
 
       async loadData() {
-        return this.load(this.loadRuns().then(testRuns => {
-          let browsers = new Set();
-          // Group the runs by their revision/SHA
-          let testRunsBySha = testRuns.reduce((accum, results) => {
-            browsers.add(results.browser_name);
-            if (!accum[results.revision]) {
-              accum[results.revision] = {};
-            }
-            if (!accum[results.revision][results.browser_name]) {
-              accum[results.revision][results.browser_name] = [];
-            }
-            accum[results.revision][results.browser_name].push(results);
-            return accum;
-          }, {});
+        return this.load(this.loadRuns());
+      }
 
-          // We flatten into an array of objects so Polymer can deal with them.
-          const firstRunDate = runs => {
-            return Object.values(runs)
-              .reduce((oldest, runs) => {
-                for (const time of runs.map(r => new Date(r.time_start))) {
-                  if (time < oldest) {
-                    oldest = time;
-                  }
-                }
-                return oldest;
-              }, new Date()); // Existing runs should be historical...
-          };
-          const flattened = Object.entries(testRunsBySha)
-            .map(([sha, runs]) => ({ sha, runs, firstRunDate: firstRunDate(runs) }))
-            .sort((a, b) => b.firstRunDate.getTime() - a.firstRunDate.getTime());
-
-          // Append time (day) metadata.
-          if (flattened.length > 1) {
-            let previous = new Date(8640000000000000); // Max date.
-            for (let i = 0; i < flattened.length; i++) {
-              let current = flattened[i].firstRunDate;
-              flattened[i].date = current;
-              if (previous.getDate() !== current.getDate()) {
-                flattened[i].day_boundary = true;
-              }
-              if (previous.getYear() !== current.getYear()) {
-                flattened[i].year_boundary = true;
-              }
-              previous = current;
-            }
+      testRunsLoaded(testRuns) {
+        let browsers = new Set();
+        // Group the runs by their revision/SHA
+        let testRunsBySha = testRuns.reduce((accum, results) => {
+          browsers.add(results.browser_name);
+          if (!accum[results.revision]) {
+            accum[results.revision] = {};
           }
-          this.testRuns = flattened;
-          this.browsers = Array.from(browsers).sort();
-        }));
+          if (!accum[results.revision][results.browser_name]) {
+            accum[results.revision][results.browser_name] = [];
+          }
+          accum[results.revision][results.browser_name].push(results);
+          return accum;
+        }, {});
+
+        // We flatten into an array of objects so Polymer can deal with them.
+        const firstRunDate = runs => {
+          return Object.values(runs)
+            .reduce((oldest, runs) => {
+              for (const time of runs.map(r => new Date(r.time_start))) {
+                if (time < oldest) {
+                  oldest = time;
+                }
+              }
+              return oldest;
+            }, new Date()); // Existing runs should be historical...
+        };
+        const flattened = Object.entries(testRunsBySha)
+          .map(([sha, runs]) => ({ sha, runs, firstRunDate: firstRunDate(runs) }))
+          .sort((a, b) => b.firstRunDate.getTime() - a.firstRunDate.getTime());
+
+        // Append time (day) metadata.
+        if (flattened.length > 1) {
+          let previous = new Date(8640000000000000); // Max date.
+          for (let i = 0; i < flattened.length; i++) {
+            let current = flattened[i].firstRunDate;
+            flattened[i].date = current;
+            if (previous.getDate() !== current.getDate()) {
+              flattened[i].day_boundary = true;
+            }
+            if (previous.getYear() !== current.getYear()) {
+              flattened[i].year_boundary = true;
+            }
+            previous = current;
+          }
+        }
+        this.testRunsBySHA = flattened;
+        this.browsers = Array.from(browsers).sort();
       }
 
       runClass(testRuns, browser) {
@@ -312,6 +329,10 @@ found in the LICENSE file.
           testRuns: [],
         });
         this.loadData();
+      }
+
+      handleLoadNextPage() {
+        this.load(this.loadMoreRuns());
       }
     }
 

--- a/webapp/components/wpt-runs.html
+++ b/webapp/components/wpt-runs.html
@@ -231,18 +231,14 @@ found in the LICENSE file.
 
       async ready() {
         super.ready();
-        this.loadData();
+        this.load(this.loadRuns());
         this._createMethodObserver('testRunsLoaded(testRuns, testRuns.*)');
-      }
-
-      async loadData() {
-        return this.load(this.loadRuns());
       }
 
       testRunsLoaded(testRuns) {
         let browsers = new Set();
         // Group the runs by their revision/SHA
-        let testRunsBySha = testRuns.reduce((accum, results) => {
+        let shaToRunsMap = testRuns.reduce((accum, results) => {
           browsers.add(results.browser_name);
           if (!accum[results.revision]) {
             accum[results.revision] = {};
@@ -266,7 +262,7 @@ found in the LICENSE file.
               return oldest;
             }, new Date()); // Existing runs should be historical...
         };
-        const flattened = Object.entries(testRunsBySha)
+        const flattened = Object.entries(shaToRunsMap)
           .map(([sha, runs]) => ({ sha, runs, firstRunDate: firstRunDate(runs) }))
           .sort((a, b) => b.firstRunDate.getTime() - a.firstRunDate.getTime());
 
@@ -328,7 +324,7 @@ found in the LICENSE file.
           browsers: [],
           testRuns: [],
         });
-        this.loadData();
+        this.load(this.loadRuns());
       }
 
       handleLoadNextPage() {


### PR DESCRIPTION
## Description
Adds a "load more" button to the bottom of the /runs list when a `wpt-next-page` header is returned from the /api/runs fetch.

## Review Information
- Visit https://more-dot-wptdashboard-staging.appspot.com/runs?max-count=10
- Click "Load more"
- See another 10 runs per-product

NOTE: The UI currently merges `max-count` with the default `from` param of 1 week, so it won't load more than one week's worth of runs.