### PR TITLE
Add "Tests" part of search cache index

### DIFF
--- a/api/query/cache/index/tests.go
+++ b/api/query/cache/index/tests.go
@@ -1,0 +1,77 @@
+// Copyright 2018 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package index
+
+import (
+	"fmt"
+	"sync"
+
+	farm "github.com/dgryski/go-farm"
+)
+
+// TestID is a unique identifier for a WPT test or sub-test.
+type TestID struct {
+	testID uint64
+	subID  uint64
+}
+
+// Tests is an indexing component that provides fast test name lookup by TestID.
+type Tests interface {
+	Add(name string, subName *string) (TestID, error)
+	GetName(id TestID) (string, *string, error)
+
+	// TODO: Add filter binding function:
+	// TestFilter(q string) UnboundFilter
+}
+
+// Tests is an indexing component that provides fast test name lookup by TestID.
+type testsMap struct {
+	tests sync.Map
+}
+
+type testName struct {
+	name    string
+	subName *string
+}
+
+// NewTests constructs an empty Tests instance.
+func NewTests() Tests {
+	return &testsMap{tests: sync.Map{}}
+}
+
+func (ts *testsMap) Add(name string, subName *string) (TestID, error) {
+	id, err := computeID(name, subName)
+	if err != nil {
+		return id, err
+	}
+	ts.tests.Store(id, testName{name, subName})
+	return id, nil
+}
+
+func (ts *testsMap) GetName(id TestID) (string, *string, error) {
+	v, ok := ts.tests.Load(id)
+	if !ok {
+		return "", nil, fmt.Errorf(`Test not found; ID: %v`, id)
+	}
+	name := v.(testName)
+	return name.name, name.subName, nil
+}
+
+// TODO: Add filter binding function:
+// func TestFilter(q string) UnboundFilter {
+// 	return NewTestNameFilter(q)
+// }
+
+func computeID(name string, subPtr *string) (TestID, error) {
+	var s uint64
+	t := farm.Fingerprint64([]byte(name))
+	if subPtr != nil && *subPtr != "" {
+		s = farm.Fingerprint64([]byte(*subPtr))
+		if s == 0 {
+			return TestID{}, fmt.Errorf(`Subtest ID for string "%s" is 0`, *subPtr)
+		}
+	}
+	return TestID{t, s}, nil
+}

--- a/api/query/cache/index/tests_test.go
+++ b/api/query/cache/index/tests_test.go
@@ -21,16 +21,15 @@ func TestGetName_fail(t *testing.T) {
 func TestAddGetName(t *testing.T) {
 	ts := NewTests()
 	name := "/a/b/c"
-	var subName *string
-	id, err := ts.Add(name, subName)
+	id, err := ts.Add(name, nil)
 	assert.Nil(t, err)
 	actualName, actualSubName, err := ts.GetName(id)
 	assert.Nil(t, err)
 	assert.Equal(t, name, actualName)
-	assert.Equal(t, subName, actualSubName)
+	assert.Nil(t, actualSubName)
 
 	subNameValue := "some sub name"
-	subName = &subNameValue
+	subName := &subNameValue
 	id, err = ts.Add(name, subName)
 	assert.Nil(t, err)
 	actualName, actualSubName, err = ts.GetName(id)

--- a/api/query/cache/index/tests_test.go
+++ b/api/query/cache/index/tests_test.go
@@ -1,0 +1,40 @@
+// +build small
+
+// Copyright 2018 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package index
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetName_fail(t *testing.T) {
+	ts := NewTests()
+	_, _, err := ts.GetName(TestID{})
+	assert.NotNil(t, err)
+}
+
+func TestAddGetName(t *testing.T) {
+	ts := NewTests()
+	name := "/a/b/c"
+	var subName *string
+	id, err := ts.Add(name, subName)
+	assert.Nil(t, err)
+	actualName, actualSubName, err := ts.GetName(id)
+	assert.Nil(t, err)
+	assert.Equal(t, name, actualName)
+	assert.Equal(t, subName, actualSubName)
+
+	subNameValue := "some sub name"
+	subName = &subNameValue
+	id, err = ts.Add(name, subName)
+	assert.Nil(t, err)
+	actualName, actualSubName, err = ts.GetName(id)
+	assert.Nil(t, err)
+	assert.Equal(t, name, actualName)
+	assert.Equal(t, *subName, *actualSubName)
+}


### PR DESCRIPTION
The search cache contains shards that service queries in parallel. Each shard contains with two main parts:

1. A maping of test IDs and test names
1. A mapping of test run IDs and test IDs and result IDs

This change implements the first of these. It is a port of [this file](https://github.com/web-platform-tests/data-migration/blob/mem/grid/mem/tests.go) from the proof-of-concept implementation.

CC @KyleJu, who may end up working on a directory tree-based implementation of this and other components.