### PR TITLE
Refactor extraction of regressions from diffs for testability

### DIFF
--- a/api/checks/update.go
+++ b/api/checks/update.go
@@ -7,6 +7,7 @@ package checks
 import (
 	"fmt"
 	"net/http"
+	"sort"
 
 	"github.com/deckarep/golang-set"
 
@@ -116,13 +117,7 @@ func getDiffSummary(aeAPI shared.AppEngineAPI, diffAPI shared.DiffAPI, before, a
 		Status:     "completed",
 	}
 
-	regressed := false
-	for _, d := range diff.Differences {
-		if d[1] != 0 {
-			regressed = true
-			break
-		}
-	}
+	regressions := diff.Regressions()
 	neutral := "neutral"
 	checkState.Conclusion = &neutral
 	checksCanFailAndPass := aeAPI.IsFeatureEnabled("failChecksOnRegression")
@@ -130,7 +125,7 @@ func getDiffSummary(aeAPI shared.AppEngineAPI, diffAPI shared.DiffAPI, before, a
 	var summary summaries.Summary
 	host := aeAPI.GetHostname()
 	diffURL := diffAPI.GetMasterDiffURL(checkState.HeadSHA, checkState.Product)
-	if !regressed {
+	if regressions.Cardinality() > 0 {
 		data := summaries.Completed{
 			CheckState: checkState,
 			HostName:   host,
@@ -151,22 +146,22 @@ func getDiffSummary(aeAPI shared.AppEngineAPI, diffAPI shared.DiffAPI, before, a
 			DiffURL:     diffURL.String(),
 			Regressions: make(map[string]summaries.BeforeAndAfter),
 		}
-		for path, d := range diff.Differences {
-			if d[1] != 0 {
-				if len(data.Regressions) <= 10 {
-					ba := summaries.BeforeAndAfter{}
-					if b, ok := diff.BeforeSummary[path]; ok {
-						ba.PassingBefore = b[0]
-						ba.TotalBefore = b[1]
-					}
-					if a, ok := diff.AfterSummary[path]; ok {
-						ba.PassingAfter = a[0]
-						ba.TotalAfter = a[1]
-					}
-					data.Regressions[path] = ba
-				} else {
-					data.More++
+		tests := shared.ToStringSlice(regressions)
+		sort.Strings(tests)
+		for _, path := range tests {
+			if len(data.Regressions) <= 10 {
+				ba := summaries.BeforeAndAfter{}
+				if b, ok := diff.BeforeSummary[path]; ok {
+					ba.PassingBefore = b[0]
+					ba.TotalBefore = b[1]
 				}
+				if a, ok := diff.AfterSummary[path]; ok {
+					ba.PassingAfter = a[0]
+					ba.TotalAfter = a[1]
+				}
+				data.Regressions[path] = ba
+			} else {
+				data.More++
 			}
 		}
 		if checksCanFailAndPass {

--- a/shared/run_diff.go
+++ b/shared/run_diff.go
@@ -61,12 +61,90 @@ type RunDiff struct {
 	// Differences is a map from test-path to an array of
 	// [newly-passing, newly-failing, total-delta],
 	// where newly-pa
-	Before        TestRun           `json:"-"`
-	BeforeSummary map[string][]int  `json:"-"`
-	After         TestRun           `json:"-"`
-	AfterSummary  map[string][]int  `json:"-"`
-	Differences   map[string][]int  `json:"diff"`
-	Renames       map[string]string `json:"renames"`
+	Before        TestRun             `json:"-"`
+	BeforeSummary map[string][]int    `json:"-"`
+	After         TestRun             `json:"-"`
+	AfterSummary  map[string][]int    `json:"-"`
+	Differences   map[string]TestDiff `json:"diff"`
+	Renames       map[string]string   `json:"renames"`
+}
+
+// TestDiff is an array of differences between 2 tests.
+type TestDiff []int
+
+// NewlyPassing is the delta/increase in the number of passing tests when comparing before/after.
+func (d TestDiff) NewlyPassing() int {
+	return d[0]
+}
+
+// Regressions is the delta/increase in the number of failing tests when comparing before/after.
+func (d TestDiff) Regressions() int {
+	return d[1]
+}
+
+// TotalDelta is the delta in the number of total subtests when comparing before/after.
+func (d TestDiff) TotalDelta() int {
+	return d[2]
+}
+
+// NewTestDiff computes the differences between two test-run pass-count summaries,
+// namely an array of [passing, total] counts.
+func NewTestDiff(before, after []int, filter DiffFilterParam) TestDiff {
+	if before == nil {
+		if after == nil || !filter.Added {
+			return nil
+		}
+		return TestDiff{
+			after[0],
+			after[1] - after[0],
+			after[1],
+		}
+	}
+	if after == nil {
+		// NOTE(lukebjerring): Missing tests are only counted towards changes
+		// in the total.
+		if !filter.Deleted {
+			return nil
+		}
+		return TestDiff{0, 0, -before[1]}
+	}
+
+	delta := before[0] - after[0]
+	changed := delta != 0 || before[1] != after[1]
+	if (!changed && !filter.Unchanged) || changed && !filter.Changed {
+		return nil
+	}
+
+	improved, regressed := 0, 0
+	if d := after[0] - before[0]; d > 0 {
+		improved = d
+	}
+	failingBefore := before[1] - before[0]
+	failingAfter := after[1] - after[0]
+	if d := failingAfter - failingBefore; d > 0 {
+		regressed = d
+	}
+	// Changed tests is at most the number of different outcomes,
+	// but newly introduced tests should still be counted (e.g. 0/2 => 0/5)
+	return TestDiff{
+		improved,
+		regressed,
+		after[1] - before[1],
+	}
+}
+
+// Regressions returns the set of test paths for tests that have a regression
+// value in their diff. Regression is scored as tests that existed both before
+// and after, where the number of failing tests has increased, which will of
+// course include newly-added tests that are failing.
+func (r RunDiff) Regressions() mapset.Set {
+	regressions := mapset.NewSet()
+	for test, diff := range r.Differences {
+		if diff[1] != 0 {
+			regressions.Add(test)
+		}
+	}
+	return regressions
 }
 
 // FetchRunResultsJSONForParam fetches the results JSON blob for the given [product]@[SHA] param.
@@ -169,8 +247,8 @@ func GetResultsDiff(
 	after map[string][]int,
 	filter DiffFilterParam,
 	paths mapset.Set,
-	renames map[string]string) map[string][]int {
-	diff := make(map[string][]int)
+	renames map[string]string) map[string]TestDiff {
+	diff := make(map[string]TestDiff)
 	if filter.Deleted || filter.Changed {
 		for test, resultsBefore := range before {
 			if renames != nil {
@@ -182,40 +260,9 @@ func GetResultsDiff(
 			if !anyPathMatches(paths, test) {
 				continue
 			}
-
-			if resultsAfter, ok := after[test]; !ok {
-				// NOTE(lukebjerring): Missing tests are only counted towards changes
-				// in the total.
-				if !filter.Deleted {
-					continue
-				}
-				diff[test] = []int{0, 0, -resultsBefore[1]}
-			} else {
-				if !filter.Changed && !filter.Unchanged {
-					continue
-				}
-				delta := resultsBefore[0] - resultsAfter[0]
-				changed := delta != 0 || resultsBefore[1] != resultsAfter[1]
-				if (!changed && !filter.Unchanged) || changed && !filter.Changed {
-					continue
-				}
-
-				improved, regressed := 0, 0
-				if d := resultsAfter[0] - resultsBefore[0]; d > 0 {
-					improved = d
-				}
-				failingBefore := resultsBefore[1] - resultsBefore[0]
-				failingAfter := resultsAfter[1] - resultsAfter[0]
-				if d := failingAfter - failingBefore; d > 0 {
-					regressed = d
-				}
-				// Changed tests is at most the number of different outcomes,
-				// but newly introduced tests should still be counted (e.g. 0/2 => 0/5)
-				diff[test] = []int{
-					improved,
-					regressed,
-					resultsAfter[1] - resultsBefore[1],
-				}
+			testDiff := NewTestDiff(resultsBefore, after[test], filter)
+			if testDiff != nil {
+				diff[test] = testDiff
 			}
 		}
 	}
@@ -234,13 +281,15 @@ func GetResultsDiff(
 					continue
 				}
 			}
-			if !anyPathMatches(paths, test) {
+			// If it was in the before set, it's already been computed.
+			if _, ok := before[test]; ok {
+				continue
+			} else if !anyPathMatches(paths, test) {
 				continue
 			}
-
-			if _, ok := before[test]; !ok {
-				// Missing? Then N / N tests are 'different'
-				diff[test] = []int{resultsAfter[0], resultsAfter[1] - resultsAfter[0], resultsAfter[1]}
+			testDiff := NewTestDiff(nil, resultsAfter, filter)
+			if testDiff != nil {
+				diff[test] = testDiff
 			}
 		}
 	}

--- a/shared/run_diff.go
+++ b/shared/run_diff.go
@@ -140,7 +140,7 @@ func NewTestDiff(before, after []int, filter DiffFilterParam) TestDiff {
 func (r RunDiff) Regressions() mapset.Set {
 	regressions := mapset.NewSet()
 	for test, diff := range r.Differences {
-		if diff[1] != 0 {
+		if diff.Regressions() > 0 {
 			regressions.Add(test)
 		}
 	}


### PR DESCRIPTION
## Description
Rearranges, but does not change, the implementation of computing a diff to have a more human-friendly set of methods, which can be tested.

Only adds a basic test for now, but as things become more complicated, this will be more legible.