### PR TITLE
 Search cache index: Add "results" part of index

### DIFF
--- a/api/query/cache/index/results.go
+++ b/api/query/cache/index/results.go
@@ -1,0 +1,97 @@
+// Copyright 2018 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package index
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/web-platform-tests/wpt.fyi/shared"
+)
+
+// RunID is a unique identifier for a WPT test run. These IDs are generated when
+// a run is committed to Datastore.
+type RunID int64
+
+// ResultID is a unique identifier for a WPT test result/status. RunID values
+// are documented in github.com/web-platform-tests/wpt.fyi/shared TestStatus*
+// values.
+type ResultID int64
+
+// Results is an interface for an index that stores RunID => RunResults
+// mappings.
+type Results interface {
+	// Add stores a RunID => RunResults mapping.
+	Add(RunID, RunResults) error
+	// ForRun produces a RunResults interface for a particular WPT test run, or
+	// nil if the input RunID is unknown to this index.
+	ForRun(RunID) RunResults
+
+	// TODO: Add filter binding function:
+	// ResultFilter(ru RunID, re ResultID) UnboundFilter
+}
+
+// RunResults is an interface for an index that stores a TestID => ResultID
+// mapping.
+type RunResults interface {
+	// Add stores a TestID => ResultID mapping.
+	Add(ResultID, TestID)
+	// GetResult looks up the ResultID associated with a TestID; the
+	// "status unknown" value is used if the lookup yields no ResultID.
+	GetResult(TestID) ResultID
+}
+
+type resultsMap struct {
+	byRunTest sync.Map
+}
+
+type runResultsMap struct {
+	byTest map[TestID]ResultID
+}
+
+// NewResults generates a new empty results index.
+func NewResults() Results {
+	return &resultsMap{byRunTest: sync.Map{}}
+}
+
+// NewRunResults generates a new empty run results index.
+func NewRunResults() RunResults {
+	return &runResultsMap{make(map[TestID]ResultID)}
+}
+
+func (rs *resultsMap) Add(ru RunID, rr RunResults) error {
+	_, wasLoaded := rs.byRunTest.LoadOrStore(ru, rr)
+	if wasLoaded {
+		return fmt.Errorf("Already loaded into results index: %v", ru)
+	}
+
+	return nil
+}
+
+func (rs *resultsMap) ForRun(ru RunID) RunResults {
+	v, ok := rs.byRunTest.Load(ru)
+	if !ok {
+		return nil
+	}
+	rrm := v.(*runResultsMap)
+	return rrm
+}
+
+func (rrs *runResultsMap) Add(re ResultID, t TestID) {
+	rrs.byTest[t] = re
+}
+
+func (rrs *runResultsMap) GetResult(t TestID) ResultID {
+	re, ok := rrs.byTest[t]
+	if !ok {
+		return ResultID(shared.TestStatusUnknown)
+	}
+	return re
+}
+
+// TODO: Add filter binding function:
+// func ResultFilter(ru RunID, re ResultID) UnboundFilter {
+// 	return NewResultEQFilter(ru, re)
+// }

--- a/api/query/cache/index/results_test.go
+++ b/api/query/cache/index/results_test.go
@@ -1,0 +1,47 @@
+// +build small
+
+// Copyright 2018 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package index
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/web-platform-tests/wpt.fyi/shared"
+)
+
+func TestForRun_fail(t *testing.T) {
+	rs := NewResults()
+	rrs := rs.ForRun(RunID(0))
+	assert.Nil(t, rrs)
+}
+
+func TestAdd_fail(t *testing.T) {
+	rs := NewResults()
+	rrs1 := NewRunResults()
+	rrs2 := NewRunResults()
+	err := rs.Add(RunID(0), rrs1)
+	assert.Nil(t, err)
+	err = rs.Add(RunID(0), rrs2)
+	assert.NotNil(t, err)
+}
+
+func TestAddForRunGetResult(t *testing.T) {
+	rs := NewResults()
+	rrs := NewRunResults()
+
+	ru := RunID(0)
+	re := ResultID(shared.TestStatusOK)
+	te := TestID{}
+
+	rrs.Add(re, te)
+	err := rs.Add(ru, rrs)
+	assert.Nil(t, err)
+	rrs = rs.ForRun(ru)
+	assert.NotNil(t, rrs)
+	assert.Equal(t, re, rrs.GetResult(te))
+	assert.Equal(t, ResultID(shared.TestStatusUnknown), rrs.GetResult(TestID{1, 1}))
+}

--- a/api/query/cache/index/tests.go
+++ b/api/query/cache/index/tests.go
@@ -19,8 +19,12 @@ type TestID struct {
 
 // Tests is an indexing component that provides fast test name lookup by TestID.
 type Tests interface {
-	Add(name string, subName *string) (TestID, error)
-	GetName(id TestID) (string, *string, error)
+	// Add adds a new named test/subtest to a tests index. An error is returned if
+	// there is a problem assigning a suitable TestID to the test.
+	Add(string, *string) (TestID, error)
+	// GetName retrieves the name/subtest name associated with a given TestID. If
+	// the index does not recognize the TestID, then an error is returned.
+	GetName(TestID) (string, *string, error)
 
 	// TODO: Add filter binding function:
 	// TestFilter(q string) UnboundFilter


### PR DESCRIPTION

Search cache index: Add "results" part of index  …
The search cache contains shards that service queries in parallel. Each shard contains with two main parts:

1. A maping of test IDs and test names
1. A mapping of test run IDs and test IDs and result IDs

This change implements the second of these. It is a port of [this file](https://github.com/web-platform-tests/data-migration/blob/mem/grid/mem/results.go) from the proof-of-concept implementation.

_Aside_: Also update formatting and documentation in `tests.go` for consistency with `results.go`.

CC @KyleJu 