### PR TITLE
Use only browser name in check name

### DIFF
--- a/api/checks/update.go
+++ b/api/checks/update.go
@@ -116,7 +116,7 @@ func getDiffSummary(aeAPI shared.AppEngineAPI, diffAPI shared.DiffAPI, before, a
 		return nil, err
 	}
 
-	product, _ := shared.ParseProductSpec(before.Product.String())
+	product, _ := shared.ParseProductSpec(before.Product.BrowserName)
 	checkState := summaries.CheckState{
 		Product:    product,
 		HeadSHA:    before.FullRevisionHash,


### PR DESCRIPTION
## Description
We name the pending check after the browser name, but the completed check is being named after the full product spec for the TestRun, which leaves the differently-named pending runs hanging.
