### PR TITLE
Correct the order of the diff used in regressions

### DIFF
--- a/api/checks/summaries/compile.go
+++ b/api/checks/summaries/compile.go
@@ -95,11 +95,14 @@ type BeforeAndAfter struct {
 type Regressed struct {
 	CheckState
 
-	HostName    string
-	HostURL     string
-	DiffURL     string
-	Regressions map[string]BeforeAndAfter
-	More        int
+	MasterRun     shared.TestRun
+	PRRun         shared.TestRun
+	HostName      string
+	HostURL       string
+	DiffURL       string
+	MasterDiffURL string
+	Regressions   map[string]BeforeAndAfter
+	More          int
 }
 
 // GetCheckState returns the info needed to update a check.

--- a/api/checks/summaries/compile_test.go
+++ b/api/checks/summaries/compile_test.go
@@ -7,9 +7,11 @@
 package summaries
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
 func TestGetSummary_Completed(t *testing.T) {
@@ -36,4 +38,40 @@ func TestGetSummary_Pending(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Contains(t, s, foo.HostName)
 	assert.Contains(t, s, foo.RunsURL)
+}
+
+func TestGetSummary_Regressed(t *testing.T) {
+	master := shared.TestRun{}
+	master.Revision = "abcdef0123"
+	master.FullRevisionHash = strings.Repeat(master.Revision, 4)
+	pr := shared.TestRun{}
+	pr.Revision = "0123456789"
+	pr.FullRevisionHash = strings.Repeat(master.Revision, 4)
+	foo := Regressed{
+		MasterRun:     master,
+		PRRun:         pr,
+		HostName:      "foo.com",
+		HostURL:       "https://foo.com/",
+		DiffURL:       "https://foo.com/?products=chrome@0000000000,chrome@0123456789&diff",
+		MasterDiffURL: "https://foo.com/?products=chrome[master],chrome@0123456789&diff",
+		Regressions: map[string]BeforeAndAfter{
+			"/foo.html": BeforeAndAfter{
+				PassingBefore: 1,
+				TotalBefore:   1,
+				PassingAfter:  0,
+				TotalAfter:    1,
+			},
+		},
+		More: 1,
+	}
+	s, err := foo.GetSummary()
+	assert.Nil(t, err)
+	assert.Contains(t, s, foo.HostName)
+	assert.Contains(t, s, foo.HostURL)
+	assert.Contains(t, s, foo.DiffURL)
+	assert.Contains(t, s, master.String())
+	assert.Contains(t, s, pr.String())
+	assert.Contains(t, s, "0 / 1")
+	assert.Contains(t, s, "1 / 1")
+	assert.Contains(t, s, "And 1 others...")
 }

--- a/api/checks/summaries/regressed.md
+++ b/api/checks/summaries/regressed.md
@@ -4,7 +4,8 @@ Uh-oh - it looks like there are some newly-failing results when we compared the 
 to the latest run against the `master` branch.
 
 Run | Spec
-`master` | [{{ .MasterRun.String }}]
+--- | ---
+`master` | {{ .MasterRun.String }}
 `{{ printf "%.7s" .PRRun.FullRevisionHash }}` | {{ .PRRun.String }}
 
 ### Regressions

--- a/api/checks/summaries/regressed.md
+++ b/api/checks/summaries/regressed.md
@@ -1,8 +1,15 @@
 Results have successfully been scraped and added to [{{ .HostName }}]({{ .HostURL }}).
 
-Uh-oh - it looks like there are some newly-failing results.
+Uh-oh - it looks like there are some newly-failing results when we compared the affected tests
+to the latest run against the `master` branch.
 
-Test | `master` | `{{ printf "%.7s" .HeadSHA }}`
+Run | Spec
+`master` | [{{ .MasterRun.String }}]
+`{{ printf "%.7s" .PRRun.FullRevisionHash }}` | {{ .PRRun.String }}
+
+### Regressions
+
+Test | `master` | `{{ printf "%.7s" .PRRun.FullRevisionHash }}`
 --- | --- | ---
 {{ range $test, $results := .Regressions -}}
 {{ $test }} | {{ $results.PassingBefore }} / {{ $results.TotalBefore }} | {{ $results.PassingAfter }} / {{ $results.TotalAfter }}
@@ -10,5 +17,10 @@ Test | `master` | `{{ printf "%.7s" .HeadSHA }}`
 {{ if gt .More 0 -}}
 And {{ .More }} others...
 {{ end }}
-A visual comparison of the results against `master` run:
-[This PR vs master]({{ .DiffURL }})
+
+You can view a visual comparison of all the results [here]]({{ .DiffURL }}).
+
+Other views that might be useful:
+- [`{{ printf "%.7s" .PRRun.FullRevisionHash }}` vs `master`@`{{ printf "%.7s" .MasterRun.FullRevisionHash }}`]({{ .DiffURL }})
+- [`{{ printf "%.7s" .PRRun.FullRevisionHash }}` vs latest master]({{ .MasterDiffURL }})
+- [Latest results for `{{ printf "%.7s" .PRRun.FullRevisionHash }}`]({{.HostURL}}?sha={{.PRRun.Revision}})

--- a/api/checks/summaries/regressed.md
+++ b/api/checks/summaries/regressed.md
@@ -18,7 +18,7 @@ Test | `master` | `{{ printf "%.7s" .PRRun.FullRevisionHash }}`
 And {{ .More }} others...
 {{ end }}
 
-You can view a visual comparison of all the results [here]]({{ .DiffURL }}).
+[Visual comparison of the results]({{ .DiffURL }})
 
 Other views that might be useful:
 - [`{{ printf "%.7s" .PRRun.FullRevisionHash }}` vs `master`@`{{ printf "%.7s" .MasterRun.FullRevisionHash }}`]({{ .DiffURL }})

--- a/api/checks/update.go
+++ b/api/checks/update.go
@@ -65,6 +65,7 @@ func updateCheckHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("Expected exactly 1 run, but found %v", len(runs)), http.StatusBadRequest)
 		return
 	}
+	prRun := allRuns[0]
 
 	// Get the most recent master run to compare.
 	labels := filter.Labels
@@ -85,7 +86,7 @@ func updateCheckHandler(w http.ResponseWriter, r *http.Request) {
 
 	aeAPI := shared.NewAppEngineAPI(ctx)
 	diffAPI := shared.NewDiffAPI(ctx)
-	summaryData, err := getDiffSummary(aeAPI, diffAPI, allRuns[0], *masterRun)
+	summaryData, err := getDiffSummary(aeAPI, diffAPI, *masterRun, prRun)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -109,19 +110,20 @@ func updateCheckHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func getDiffSummary(aeAPI shared.AppEngineAPI, diffAPI shared.DiffAPI, before, after shared.TestRun) (summaries.Summary, error) {
+func getDiffSummary(aeAPI shared.AppEngineAPI, diffAPI shared.DiffAPI, masterRun, prRun shared.TestRun) (summaries.Summary, error) {
 	diffFilter := shared.DiffFilterParam{Added: true, Changed: true, Unchanged: true}
-	diff, err := diffAPI.GetRunsDiff(before, after, diffFilter, nil)
+	diff, err := diffAPI.GetRunsDiff(masterRun, prRun, diffFilter, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	product, _ := shared.ParseProductSpec(before.Product.String())
+	product, _ := shared.ParseProductSpec(prRun.Product.String())
+	diffURL := diffAPI.GetDiffURL(masterRun, prRun, &diffFilter)
 	checkState := summaries.CheckState{
 		Product:    product,
-		HeadSHA:    before.FullRevisionHash,
+		HeadSHA:    prRun.FullRevisionHash,
 		Title:      getCheckTitle(product),
-		DetailsURL: diffAPI.GetMasterDiffURL(before.FullRevisionHash, product),
+		DetailsURL: diffURL,
 		Status:     "completed",
 	}
 
@@ -138,7 +140,6 @@ func getDiffSummary(aeAPI shared.AppEngineAPI, diffAPI shared.DiffAPI, before, a
 
 	var summary summaries.Summary
 	host := aeAPI.GetHostname()
-	diffURL := diffAPI.GetMasterDiffURL(checkState.HeadSHA, checkState.Product)
 	if !regressed {
 		data := summaries.Completed{
 			CheckState: checkState,
@@ -154,11 +155,14 @@ func getDiffSummary(aeAPI shared.AppEngineAPI, diffAPI shared.DiffAPI, before, a
 		summary = data
 	} else {
 		data := summaries.Regressed{
-			CheckState:  checkState,
-			HostName:    host,
-			HostURL:     fmt.Sprintf("https://%s/", host),
-			DiffURL:     diffURL.String(),
-			Regressions: make(map[string]summaries.BeforeAndAfter),
+			MasterRun:     masterRun,
+			PRRun:         prRun,
+			CheckState:    checkState,
+			HostName:      host,
+			HostURL:       fmt.Sprintf("https://%s/", host),
+			DiffURL:       diffURL.String(),
+			MasterDiffURL: diffAPI.GetMasterDiffURL(checkState.HeadSHA, checkState.Product).String(),
+			Regressions:   make(map[string]summaries.BeforeAndAfter),
 		}
 		for path, d := range diff.Differences {
 			if d[1] != 0 {


### PR DESCRIPTION
## Description
We were comparing the PR as the 'before' state, which fails to ignore tests which aren't present in the affected tests for the PR execution (and thus shows all failing tests on master as regressions).