### PR TITLE
Test & implement search cache index stores all run+test+result data

### DIFF
--- a/api/query/cache/index/index.go
+++ b/api/query/cache/index/index.go
@@ -5,15 +5,27 @@
 package index
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
 	"sort"
+	"sync"
 
+	"github.com/web-platform-tests/results-analysis/metrics"
 	"github.com/web-platform-tests/wpt.fyi/shared"
+
+	log "github.com/sirupsen/logrus"
 )
 
 var (
-	errNoRuns = errors.New("No runs")
-	errNilRun = errors.New("Test run is nil")
+	errNoRuns             = errors.New("No runs")
+	errNilRun             = errors.New("Test run is nil")
+	errRunExists          = errors.New("Run already exists in index")
+	errRunLoading         = errors.New("Run currently being loaded into index")
+	errSomeShardsRequired = errors.New("Index must have at least one shard")
+	errZeroRun            = errors.New("Cannot ingest run with ID of 0")
 )
 
 // Index is an index of test run results that can ingest and evict runs.
@@ -27,25 +39,189 @@ type Index interface {
 	EvictAnyRun() error
 }
 
-type wptIndex struct {
-	runs shared.TestRuns
+type ReportLoader interface {
+	Load(shared.TestRun) (*metrics.TestResultsReport, error)
 }
 
-func (i *wptIndex) IngestRun(r shared.TestRun) error {
-	i.runs = append(i.runs, r)
-	sort.Sort(i.runs)
+type shardedWPTIndex struct {
+	runs     sync.Map
+	inFlight sync.Map
+	loader   ReportLoader
+	tests    Tests
+	shards   []*wptIndex
+}
+
+type wptIndex struct {
+	tests   Tests
+	results Results
+}
+
+type httpReportLoader struct{}
+
+func (i *shardedWPTIndex) IngestRun(r shared.TestRun) error {
+	// Error cases: ID cannot be 0, run cannot be loaded or loading-in-progress.
+	if r.ID == 0 {
+		return errZeroRun
+	}
+	id := RunID(r.ID)
+	_, wasLoaded := i.runs.Load(id)
+	if wasLoaded {
+		return errRunExists
+	}
+	// LoadOrStore will mark this run as in-flight if it is not already marked as
+	// such.
+	_, isLoading := i.inFlight.LoadOrStore(id, r)
+	defer i.inFlight.Delete(id)
+	if isLoading {
+		return errRunLoading
+	}
+
+	// Delegate loader to construct complete run report.
+	report, err := i.loader.Load(r)
+	if err != nil {
+		return err
+	}
+
+	// Results of different tests will be stored in different shards, based on the
+	// top-level test (i.e., not subtests) integral ID of each test in the report.
+	//
+	// Create RunResults for each shard's partition of this run's results.
+	numShards := uint64(len(i.shards))
+	runResults := make([]RunResults, 0, numShards)
+	for j := uint64(0); j < numShards; j++ {
+		runResults = append(runResults, NewRunResults())
+	}
+
+	for _, res := range report.Results {
+		// Add top-level test (i.e., not subtest) result to appropriate shard.
+		re := ResultID(metrics.TestStatusFromString(res.Status))
+		t, err := i.tests.Add(res.Test, nil)
+		if err != nil {
+			return err
+		}
+		runResultsForShard := runResults[int(t.testID%numShards)]
+		runResultsForShard.Add(re, t)
+
+		// Dedup subtests, warning when subtest names are duplicated.
+		subs := make(map[string]metrics.SubTest)
+		for _, sub := range res.Subtests {
+			if _, ok := subs[sub.Name]; ok {
+				log.Warningf("Duplicate subtests with the same name: %s %s", res.Test, sub.Name)
+				continue
+			}
+			subs[sub.Name] = sub
+		}
+
+		// Add each subtests' result to the appropriate shard (same shard as
+		// top-level test).
+		for _, sub := range subs {
+			re := ResultID(metrics.SubTestStatusFromString(sub.Status))
+			t, err := i.tests.Add(res.Test, &sub.Name)
+			if err != nil {
+				return err
+			}
+
+			runResultsForShard.Add(re, t)
+		}
+	}
+
+	// Add accumulated RunResults to shards.
+	for j := range runResults {
+		err := i.shards[j].results.Add(id, runResults[j])
+		if err != nil {
+			return err
+		}
+	}
+
+	// Mark run as successfully stored in index.
+	i.runs.Store(id, r)
+
 	return nil
 }
 
-func (i *wptIndex) EvictAnyRun() error {
-	if len(i.runs) == 0 {
+func (i *shardedWPTIndex) EvictAnyRun() error {
+	// Accumulate runs into sortable collection.
+	runs := make(shared.TestRuns, 0)
+	i.runs.Range(func(key, value interface{}) bool {
+		run := value.(shared.TestRun)
+		runs = append(runs, run)
+		return true
+	})
+	if len(runs) == 0 {
 		return errNoRuns
 	}
-	i.runs = i.runs[1:]
+
+	// Sort and mark and select oldest run for eviction.
+	sort.Sort(runs)
+	runIDToEvict := RunID(runs[0].ID)
+
+	// Delete run from runs-in-index collection.
+	i.runs.Delete(runIDToEvict)
+
+	// Delete run results from each shard.
+	for j, shard := range i.shards {
+		if err := shard.results.Delete(runIDToEvict); err != nil {
+			log.Warningf(`Error while evicting run from shard %d: %v`, j, err)
+		}
+	}
+
 	return nil
 }
 
-// NewWPTIndex creates a new empty Index for WPT test run results.
-func NewWPTIndex() Index {
-	return &wptIndex{make(shared.TestRuns, 0)}
+func (l httpReportLoader) Load(run shared.TestRun) (*metrics.TestResultsReport, error) {
+	// Attempt to fetch-and-unmarshal run from run.RawResultsURL.
+	resp, err := http.Get(run.RawResultsURL)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf(`Non-OK HTTP status code of %d from "%s" for run ID=%d`, resp.StatusCode, run.RawResultsURL, run.ID)
+	}
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	var report metrics.TestResultsReport
+	err = json.Unmarshal(data, &report)
+	if err != nil {
+		return nil, err
+	}
+	if len(report.Results) == 0 {
+		return nil, fmt.Errorf("Empty report from run ID=%d (%s)", run.ID, run.RawResultsURL)
+	}
+	return &report, nil
+}
+
+// NewShardedWPTIndex creates a new empty Index for WPT test run results.
+func NewShardedWPTIndex(loader ReportLoader, numShards int) (Index, error) {
+	if numShards <= 0 {
+		return nil, errSomeShardsRequired
+	}
+
+	shards := make([]*wptIndex, 0, numShards)
+	tests := NewTests()
+	for i := 0; i < numShards; i++ {
+		shards = append(shards, newWPTIndex(tests))
+	}
+	return &shardedWPTIndex{
+		runs:     sync.Map{},
+		inFlight: sync.Map{},
+		loader:   loader,
+		tests:    tests,
+		shards:   shards,
+	}, nil
+}
+
+// NewReportLoader constructs a loader that loads result reports over HTTP from
+// a shared.TestRun.RawResultsURL.
+func NewReportLoader() ReportLoader {
+	return httpReportLoader{}
+}
+
+func newWPTIndex(tests Tests) *wptIndex {
+	return &wptIndex{
+		tests:   tests,
+		results: NewResults(),
+	}
 }

--- a/api/query/cache/index/index.go
+++ b/api/query/cache/index/index.go
@@ -39,6 +39,8 @@ type Index interface {
 	EvictAnyRun() error
 }
 
+// ReportLoader handles loading a WPT test results report based on metadata in
+// a shared.TestRun.
 type ReportLoader interface {
 	Load(shared.TestRun) (*metrics.TestResultsReport, error)
 }

--- a/api/query/cache/index/index.go
+++ b/api/query/cache/index/index.go
@@ -89,9 +89,9 @@ func (i *shardedWPTIndex) IngestRun(r shared.TestRun) error {
 	//
 	// Create RunResults for each shard's partition of this run's results.
 	numShards := uint64(len(i.shards))
-	runResults := make([]RunResults, 0, numShards)
+	runResults := make([]RunResults, numShards)
 	for j := uint64(0); j < numShards; j++ {
-		runResults = append(runResults, NewRunResults())
+		runResults[j] = NewRunResults()
 	}
 
 	for _, res := range report.Results {

--- a/api/query/cache/index/index_medium_test.go
+++ b/api/query/cache/index/index_medium_test.go
@@ -1,0 +1,62 @@
+// +build medium
+
+// Copyright 2018 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package index
+
+import (
+	"runtime"
+	"strconv"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	metrics "github.com/web-platform-tests/results-analysis/metrics"
+	"github.com/web-platform-tests/wpt.fyi/shared"
+)
+
+const (
+	testEvictionNumResults = 10000
+	// Each result should require at least one byte for its name + 4 bytes for
+	// "PASS".
+	testEvictionMinBytes = testEvictionNumResults * 5
+)
+
+func TestEvictAnyRunRelievesMemoryPressure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	loader := NewMockReportLoader(ctrl)
+	i, err := NewShardedWPTIndex(loader, 1)
+	assert.Nil(t, err)
+	run := shared.TestRun{
+		ID:            1,
+		RawResultsURL: "http://example.com/results.json",
+	}
+	results := make([]*metrics.TestResults, 0, testEvictionNumResults)
+	for j := 0; j < testEvictionNumResults; j++ {
+		str := strconv.Itoa(j)
+		results = append(results, &metrics.TestResults{
+			Test:   str,
+			Status: "PASS",
+		})
+	}
+	report := &metrics.TestResultsReport{Results: results}
+	loader.EXPECT().Load(run).Return(report, nil)
+
+	assert.Nil(t, i.IngestRun(run))
+	results = nil
+	runtime.GC()
+
+	var stats runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&stats)
+	baseline := stats.HeapAlloc
+
+	assert.Nil(t, i.EvictAnyRun())
+
+	runtime.GC()
+	runtime.ReadMemStats(&stats)
+	assert.True(t, baseline-testEvictionMinBytes > stats.HeapAlloc)
+}

--- a/api/query/cache/index/index_mock.go
+++ b/api/query/cache/index/index_mock.go
@@ -6,6 +6,7 @@ package index
 
 import (
 	gomock "github.com/golang/mock/gomock"
+	metrics "github.com/web-platform-tests/results-analysis/metrics"
 	shared "github.com/web-platform-tests/wpt.fyi/shared"
 	reflect "reflect"
 )
@@ -55,4 +56,40 @@ func (m *MockIndex) EvictAnyRun() error {
 // EvictAnyRun indicates an expected call of EvictAnyRun
 func (mr *MockIndexMockRecorder) EvictAnyRun() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EvictAnyRun", reflect.TypeOf((*MockIndex)(nil).EvictAnyRun))
+}
+
+// MockReportLoader is a mock of ReportLoader interface
+type MockReportLoader struct {
+	ctrl     *gomock.Controller
+	recorder *MockReportLoaderMockRecorder
+}
+
+// MockReportLoaderMockRecorder is the mock recorder for MockReportLoader
+type MockReportLoaderMockRecorder struct {
+	mock *MockReportLoader
+}
+
+// NewMockReportLoader creates a new mock instance
+func NewMockReportLoader(ctrl *gomock.Controller) *MockReportLoader {
+	mock := &MockReportLoader{ctrl: ctrl}
+	mock.recorder = &MockReportLoaderMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockReportLoader) EXPECT() *MockReportLoaderMockRecorder {
+	return m.recorder
+}
+
+// Load mocks base method
+func (m *MockReportLoader) Load(arg0 shared.TestRun) (*metrics.TestResultsReport, error) {
+	ret := m.ctrl.Call(m, "Load", arg0)
+	ret0, _ := ret[0].(*metrics.TestResultsReport)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Load indicates an expected call of Load
+func (mr *MockReportLoaderMockRecorder) Load(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Load", reflect.TypeOf((*MockReportLoader)(nil).Load), arg0)
 }

--- a/api/query/cache/index/index_test.go
+++ b/api/query/cache/index/index_test.go
@@ -7,19 +7,143 @@
 package index
 
 import (
+	"errors"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	metrics "github.com/web-platform-tests/results-analysis/metrics"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
+func TestInvalidNumShards(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	loader := NewMockReportLoader(ctrl)
+	_, err := NewShardedWPTIndex(loader, 0)
+	assert.NotNil(t, err)
+	_, err = NewShardedWPTIndex(loader, -1)
+}
+
 func TestEvictEmpty(t *testing.T) {
-	i := NewWPTIndex()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	loader := NewMockReportLoader(ctrl)
+	i, err := NewShardedWPTIndex(loader, 1)
+	assert.Nil(t, err)
 	assert.NotNil(t, i.EvictAnyRun())
 }
 
+func TestIngestRun_zeroID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	loader := NewMockReportLoader(ctrl)
+	i, err := NewShardedWPTIndex(loader, 1)
+	assert.Nil(t, err)
+	assert.NotNil(t, i.IngestRun(shared.TestRun{ID: 0}))
+}
+
+func TestIngestRun_double(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	loader := NewMockReportLoader(ctrl)
+	i, err := NewShardedWPTIndex(loader, 1)
+	assert.Nil(t, err)
+	run := shared.TestRun{
+		ID:            1,
+		RawResultsURL: "http://example.com/results.json",
+	}
+	results := &metrics.TestResultsReport{}
+	loader.EXPECT().Load(run).Return(results, nil)
+	assert.Nil(t, i.IngestRun(run))
+	assert.NotNil(t, i.IngestRun(run))
+}
+
+func TestIngestRun_concurrent(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	loader := NewMockReportLoader(ctrl)
+	i, err := NewShardedWPTIndex(loader, 1)
+	assert.Nil(t, err)
+	run := shared.TestRun{
+		ID:            1,
+		RawResultsURL: "http://example.com/results.json",
+	}
+
+	// Wait for 2 goroutines to finish. Gate second goroutine's IngestRun()
+	// invocation with channel that receives value after first goroutine has
+	// started to ingest the run.
+	var wg sync.WaitGroup
+	startSecondIngestRun := make(chan bool)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		loader.EXPECT().Load(run).DoAndReturn(func(shared.TestRun) (*metrics.TestResultsReport, error) {
+			// Now that Load(run) has been invoked, i's implementation should have
+			// already marked run as in-flight. Trigger second attempt to ingest run,
+			// and pause a little to let it error-out.
+			startSecondIngestRun <- true
+			time.Sleep(time.Millisecond * 10)
+			return &metrics.TestResultsReport{}, nil
+		})
+		i.IngestRun(run)
+	}()
+	go func() {
+		defer wg.Done()
+		<-startSecondIngestRun
+		// Expect error during second concurrent attempt to ingest run.
+		assert.NotNil(t, i.IngestRun(run))
+	}()
+	wg.Wait()
+}
+
+func TestIngestRun_loaderError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	loader := NewMockReportLoader(ctrl)
+	i, err := NewShardedWPTIndex(loader, 1)
+	assert.Nil(t, err)
+	run := shared.TestRun{
+		ID:            1,
+		RawResultsURL: "http://example.com/results.json",
+	}
+	loaderErr := errors.New("Failed to load test results")
+	loader.EXPECT().Load(run).Return(nil, loaderErr)
+	assert.Equal(t, loaderErr, i.IngestRun(run))
+}
+
 func TestEvictNonEmpty(t *testing.T) {
-	i := NewWPTIndex()
-	i.IngestRun(shared.TestRun{})
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	loader := NewMockReportLoader(ctrl)
+	i, err := NewShardedWPTIndex(loader, 1)
+	assert.Nil(t, err)
+	run := shared.TestRun{
+		ID:            1,
+		RawResultsURL: "http://example.com/results.json",
+	}
+	results := &metrics.TestResultsReport{
+		Results: []*metrics.TestResults{
+			&metrics.TestResults{
+				Test:     "a",
+				Status:   "PASS",
+				Subtests: []metrics.SubTest{},
+			},
+			&metrics.TestResults{
+				Test:   "b",
+				Status: "OK",
+				Subtests: []metrics.SubTest{
+					metrics.SubTest{
+						Name:   "sub",
+						Status: "FAIL",
+					},
+				},
+			},
+		},
+	}
+	loader.EXPECT().Load(run).Return(results, nil)
+	assert.Nil(t, i.IngestRun(run))
 	assert.Nil(t, i.EvictAnyRun())
 }

--- a/api/query/cache/index/results.go
+++ b/api/query/cache/index/results.go
@@ -25,6 +25,8 @@ type ResultID int64
 type Results interface {
 	// Add stores a RunID => RunResults mapping.
 	Add(RunID, RunResults) error
+	// Delete deletes all result data for a particular WPT test run.
+	Delete(RunID) error
 	// ForRun produces a RunResults interface for a particular WPT test run, or
 	// nil if the input RunID is unknown to this index.
 	ForRun(RunID) RunResults
@@ -67,6 +69,16 @@ func (rs *resultsMap) Add(ru RunID, rr RunResults) error {
 		return fmt.Errorf("Already loaded into results index: %v", ru)
 	}
 
+	return nil
+}
+
+func (rs *resultsMap) Delete(ru RunID) error {
+	_, ok := rs.byRunTest.Load(ru)
+	if !ok {
+		return fmt.Errorf(`No such run in results index; run ID: %v`, ru)
+	}
+
+	rs.byRunTest.Delete(ru)
 	return nil
 }
 


### PR DESCRIPTION
- `Index` stores `Tests` and shards of `Results`
- `Index` carefully manages repeated and/or concurrent attempts to add same run
- Test new `Index` functionality + medium test for "run eviction relieves memory pressure"

CC @KyleJu