### PR TITLE
Consolidate Completed/Regressed summaries

### DIFF
--- a/api/checks/summaries/_pr_and_master_specs.md
+++ b/api/checks/summaries/_pr_and_master_specs.md
@@ -1,0 +1,4 @@
+Run | Spec
+--- | ---
+`master` | {{ .MasterRun.String }}
+`{{ printf "%.7s" .PRRun.FullRevisionHash }}` | {{ .PRRun.String }}

--- a/api/checks/summaries/_successfully_scraped.md
+++ b/api/checks/summaries/_successfully_scraped.md
@@ -1,0 +1,1 @@
+Results have successfully been scraped and added to [{{ .HostName }}]({{ .HostURL }}).

--- a/api/checks/summaries/compile.go
+++ b/api/checks/summaries/compile.go
@@ -1,3 +1,7 @@
+// Copyright 2018 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package summaries
 
 import (
@@ -37,80 +41,10 @@ type CheckState struct {
 	Conclusion *string // Can be one of "success", "failure", "neutral", "cancelled", "timed_out", or "action_required". (Optional. Required if you provide a status of "completed".)
 }
 
-// Completed is the struct for completed.md
-type Completed struct {
-	CheckState
-
-	DiffURL  string // URL for the diff-view of the results
-	HostName string // Host environment name, e.g. "wpt.fyi"
-	HostURL  string // Host environment URL, e.g. "https://wpt.fyi"
-	SHAURL   string // URL for the latest results for the same SHA
-}
-
-// GetCheckState returns the info needed to update a check.
-func (c Completed) GetCheckState() CheckState {
-	return c.CheckState
-}
-
-// GetSummary executes the template for the data.
-func (c Completed) GetSummary() (string, error) {
-	return compile(&c, "completed.md")
-}
-
-// Pending is the struct for pending.md
-type Pending struct {
-	CheckState
-
-	HostName string // Host environment name
-	RunsURL  string // URL for the list of test runs
-}
-
-// GetCheckState returns the info needed to update a check.
-func (c Pending) GetCheckState() CheckState {
-	return c.CheckState
-}
-
-// GetSummary executes the template for the data.
-func (c Pending) GetSummary() (string, error) {
-	return compile(&c, "pending.md")
-}
-
 func compile(i interface{}, t string) (string, error) {
 	var dest bytes.Buffer
 	if err := templates.ExecuteTemplate(&dest, t, i); err != nil {
 		return "", err
 	}
 	return dest.String(), nil
-}
-
-// BeforeAndAfter is a struct summarizing pass rates before and after in a diff.
-type BeforeAndAfter struct {
-	PassingBefore int
-	PassingAfter  int
-	TotalBefore   int
-	TotalAfter    int
-}
-
-// Regressed is the struct for regressed.md
-type Regressed struct {
-	CheckState
-
-	MasterRun     shared.TestRun
-	PRRun         shared.TestRun
-	HostName      string
-	HostURL       string
-	DiffURL       string
-	MasterDiffURL string
-	Regressions   map[string]BeforeAndAfter
-	More          int
-}
-
-// GetCheckState returns the info needed to update a check.
-func (r Regressed) GetCheckState() CheckState {
-	return r.CheckState
-}
-
-// GetSummary executes the template for the data.
-func (r Regressed) GetSummary() (string, error) {
-	return compile(&r, "regressed.md")
 }

--- a/api/checks/summaries/compile_test.go
+++ b/api/checks/summaries/compile_test.go
@@ -32,9 +32,9 @@ func TestGetSummary_Completed(t *testing.T) {
 	foo := Completed{}
 	foo.MasterRun = master
 	foo.PRRun = pr
-	foo.DiffURL = "foo.com/diff?before=chrome[master]&after=chrome@0123456789"
+	foo.DiffURL = "https://foo.com/diff?before=chrome[master]&after=chrome@0123456789"
 	foo.HostName = "foo.com"
-	foo.HostURL = "foo.com/results/"
+	foo.HostURL = "https://foo.com/"
 	foo.Results = map[string][]int{
 		"/foo.html": []int{2, 3},
 	}
@@ -54,8 +54,8 @@ func TestGetSummary_Completed(t *testing.T) {
 
 func TestGetSummary_Pending(t *testing.T) {
 	foo := Pending{
-		HostName: "foo.com",
-		RunsURL:  "foo.com/runs?products=chrome&sha=0123456789",
+		HostName: "https://foo.com",
+		RunsURL:  "https://foo.com/runs?products=chrome&sha=0123456789",
 	}
 	s, err := foo.GetSummary()
 	printOutput(s)

--- a/api/checks/summaries/completed.go
+++ b/api/checks/summaries/completed.go
@@ -1,0 +1,37 @@
+// Copyright 2018 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package summaries
+
+import "github.com/web-platform-tests/wpt.fyi/shared"
+
+// ResultsComparison is all the fields shared across summaries that
+// involve a result comparison.
+type ResultsComparison struct {
+	MasterRun     shared.TestRun
+	PRRun         shared.TestRun
+	MasterDiffURL string
+	DiffURL       string // URL for the diff-view of the results
+	HostName      string // Host environment name, e.g. "wpt.fyi"
+	HostURL       string // Host environment URL, e.g. "https://wpt.fyi"
+}
+
+// Completed is the struct for completed.md
+type Completed struct {
+	CheckState
+	ResultsComparison
+
+	Results map[string][]int
+	More    int
+}
+
+// GetCheckState returns the info needed to update a check.
+func (c Completed) GetCheckState() CheckState {
+	return c.CheckState
+}
+
+// GetSummary executes the template for the data.
+func (c Completed) GetSummary() (string, error) {
+	return compile(&c, "completed.md")
+}

--- a/api/checks/summaries/completed.go
+++ b/api/checks/summaries/completed.go
@@ -17,7 +17,7 @@ type ResultsComparison struct {
 	HostURL       string // Host environment URL, e.g. "https://wpt.fyi"
 }
 
-// Completed is the struct for completed.md
+// Completed is the struct for completed.md.
 type Completed struct {
 	CheckState
 	ResultsComparison

--- a/api/checks/summaries/completed.md
+++ b/api/checks/summaries/completed.md
@@ -1,7 +1,23 @@
-Results have successfully been scraped and added to [{{ .HostName }}]({{ .HostURL }}).
+{{ template "_successfully_scraped.md" . }}
 
-They can be compared to the latest `master` run here:
-{{ .DiffURL }}
+There were no regressions detected in the results.
 
-Or, to view _all_ the latest runs for the same revision:
-{{ .SHAURL }}
+{{ template "_pr_and_master_specs.md" . }}
+
+### Results
+
+Test | `{{ printf "%.7s" .PRRun.FullRevisionHash }}`
+--- | ---
+{{ range $test, $results := .Results -}}
+{{ $test }} | {{ index $results 0 }} / {{ index $results 1 }}
+{{end}}
+{{ if gt .More 0 -}}
+And {{ .More }} others...
+{{ end }}
+
+[Visual comparison of the results]({{ .DiffURL }})
+
+Other views that might be useful:
+- [`{{ printf "%.7s" .PRRun.FullRevisionHash }}` vs `master`@`{{ printf "%.7s" .MasterRun.FullRevisionHash }}`]({{ .DiffURL }})
+- [`{{ printf "%.7s" .PRRun.FullRevisionHash }}` vs latest master]({{ .MasterDiffURL }})
+- [Latest results for `{{ printf "%.7s" .PRRun.FullRevisionHash }}`]({{.HostURL}}?sha={{.PRRun.Revision}})

--- a/api/checks/summaries/pending.go
+++ b/api/checks/summaries/pending.go
@@ -1,0 +1,23 @@
+// Copyright 2018 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package summaries
+
+// Pending is the struct for pending.md
+type Pending struct {
+	CheckState
+
+	HostName string // Host environment name
+	RunsURL  string // URL for the list of test runs
+}
+
+// GetCheckState returns the info needed to update a check.
+func (c Pending) GetCheckState() CheckState {
+	return c.CheckState
+}
+
+// GetSummary executes the template for the data.
+func (c Pending) GetSummary() (string, error) {
+	return compile(&c, "pending.md")
+}

--- a/api/checks/summaries/pending.go
+++ b/api/checks/summaries/pending.go
@@ -4,7 +4,7 @@
 
 package summaries
 
-// Pending is the struct for pending.md
+// Pending is the struct for pending.md.
 type Pending struct {
 	CheckState
 

--- a/api/checks/summaries/regressed.go
+++ b/api/checks/summaries/regressed.go
@@ -1,0 +1,32 @@
+// Copyright 2018 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package summaries
+
+// BeforeAndAfter is a struct summarizing pass rates before and after in a diff.
+type BeforeAndAfter struct {
+	PassingBefore int
+	PassingAfter  int
+	TotalBefore   int
+	TotalAfter    int
+}
+
+// Regressed is the struct for regressed.md
+type Regressed struct {
+	CheckState
+	ResultsComparison
+
+	Regressions map[string]BeforeAndAfter
+	More        int
+}
+
+// GetCheckState returns the info needed to update a check.
+func (r Regressed) GetCheckState() CheckState {
+	return r.CheckState
+}
+
+// GetSummary executes the template for the data.
+func (r Regressed) GetSummary() (string, error) {
+	return compile(&r, "regressed.md")
+}

--- a/api/checks/summaries/regressed.md
+++ b/api/checks/summaries/regressed.md
@@ -1,12 +1,9 @@
-Results have successfully been scraped and added to [{{ .HostName }}]({{ .HostURL }}).
+{{ template "_successfully_scraped.md" . }}
 
 Uh-oh - it looks like there are some newly-failing results when we compared the affected tests
 to the latest run against the `master` branch.
 
-Run | Spec
---- | ---
-`master` | {{ .MasterRun.String }}
-`{{ printf "%.7s" .PRRun.FullRevisionHash }}` | {{ .PRRun.String }}
+{{ template "_pr_and_master_specs.md" . }}
 
 ### Regressions
 

--- a/shared/util.go
+++ b/shared/util.go
@@ -7,6 +7,7 @@ package shared
 import (
 	"context"
 	"net/http"
+	"reflect"
 
 	mapset "github.com/deckarep/golang-set"
 	log "github.com/sirupsen/logrus"
@@ -213,4 +214,14 @@ func StringSliceContains(ss []string, s string) bool {
 		}
 	}
 	return false
+}
+
+// MapStringKeys returns the keys in the given string-keyed map.
+func MapStringKeys(m interface{}) []string {
+	keys := reflect.ValueOf(m).MapKeys()
+	strKeys := make([]string, len(keys))
+	for i, key := range keys {
+		strKeys[i] = key.Interface().(string)
+	}
+	return strKeys
 }

--- a/shared/util_test.go
+++ b/shared/util_test.go
@@ -1,0 +1,43 @@
+// +build small
+
+// Copyright 2018 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package shared
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMapStringKeys(t *testing.T) {
+	m := map[string]int{"foo": 1}
+	keys, err := MapStringKeys(m)
+	if err != nil {
+		assert.FailNow(t, "Error getting map string keys")
+	}
+	assert.Equal(t, []string{"foo"}, keys)
+
+	m2 := map[string]interface{}{"bar": "baz"}
+	keys, err = MapStringKeys(m2)
+	if err != nil {
+		assert.FailNow(t, "Error getting map string keys")
+	}
+	assert.Equal(t, []string{"bar"}, keys)
+}
+
+func TestMapStringKeys_NotAMap(t *testing.T) {
+	one := 1
+	keys, err := MapStringKeys(one)
+	assert.Nil(t, keys)
+	assert.NotNil(t, err)
+}
+
+func TestMapStringKeys_NotAStringKeyedMap(t *testing.T) {
+	m := map[int]int{1: 1}
+	keys, err := MapStringKeys(m)
+	assert.Nil(t, keys)
+	assert.NotNil(t, err)
+}


### PR DESCRIPTION
## Description
They should be roughly similar, except for the "stuff regressed" and "stuff is fine" messages.
This PR refactors stuff out of `Regressed` and adds a results table to the `Completed` summary.