### PR TITLE
Add AppID field

### DIFF
--- a/shared/models.go
+++ b/shared/models.go
@@ -141,6 +141,8 @@ type PendingTestRun struct {
 type CheckSuite struct {
 	// SHA of the revision that requested a check suite.
 	SHA string `json:"sha"`
+	// The GitHub app ID for the custom wpt.fyi check.
+	AppID int64 `json:"app_id"`
 	// The GitHub app installation ID for custom wpt.fyi check
 	InstallationID int64  `json:"installation"`
 	Owner          string `json:"owner"` // Owner username


### PR DESCRIPTION
## Description
We will need to extract the AppID instead of fixing it to the staging.wpt.fyi App once we deploy to prod, but also needed for a testing copy of the App used in #829.