### PR TITLE
Speed up results processor by using cp instead of rsync

### DIFF
--- a/results-processor/app.yaml
+++ b/results-processor/app.yaml
@@ -5,7 +5,7 @@ env: flex
 manual_scaling:
   instances: 2
 resources:
-  cpu: 1
+  cpu: 2
   memory_gb: 4
   disk_size_gb: 10
 

--- a/results-processor/main.py
+++ b/results-processor/main.py
@@ -27,7 +27,9 @@ TIMESTAMP_FILE = '/tmp/results-processor.last'
 # smaller than the 60-minute timeout of AppEngine to give a safe margin.
 TIMEOUT = 3500
 
-
+# Hack to work around the bad logging setup of google.cloud.*:
+# https://github.com/googleapis/google-cloud-python/issues/6742
+logging.getLogger().handlers = []
 logging.basicConfig(level=logging.INFO)
 # Suppress the lock acquire/release logs from filelock.
 logging.getLogger('filelock').setLevel(logging.WARNING)
@@ -86,7 +88,7 @@ def liveness_check():
             assert time.time() - last_locked <= TIMEOUT
         # Respectively: file not found, invalid content, old timestamp.
         except (IOError, ValueError, AssertionError):
-            app.logger.warn('Liveness check failed.')
+            app.logger.warning('Liveness check failed.')
             return ('The current task has taken too long.',
                     HTTPStatus.INTERNAL_SERVER_ERROR)
     return 'Service alive'

--- a/results-processor/requirements.txt
+++ b/results-processor/requirements.txt
@@ -2,7 +2,7 @@ cachetools==2.1.0
 certifi==2018.10.15
 chardet==3.0.4
 Click==7.0
-filelock==3.0.9
+filelock==3.0.10
 flake8==3.6.0
 Flask==1.0.2
 google-api-core==1.5.1
@@ -25,7 +25,7 @@ pyasn1-modules==0.2.2
 pycodestyle==2.4.0
 pyflakes==2.0.0
 pytz==2018.7
-requests==2.20.0
+requests==2.20.1
 rsa==4.0
 six==1.11.0
 urllib3==1.24


### PR DESCRIPTION
## Description

We don't really need to synchronize the directories. `rsync` used to save us time when the results already exist, but such scenario is becoming less likely following #746. Therefore, we can switch to `cp` which uses less CPU in general, and is easier to parallelize.

Based on monitoring, we only use ~1MB/s network bandwidth during the recursive upload, which is far less than the available bandwidth between GCE & GCS, while on the other hand we use almost 100% CPU. In other words, we are CPU-bound because of the sheer amount of small files. With this PR, we are able to bring down the average upload time (for a full run) from ~30min to ~5min.

Additional drive-by changes:
1. Fix the logging setup that's broken by google.cloud imports.
2. Use logging.warning instead of the deprecated logging.warn.

## Review

This change has been tested online in staging with careful monitoring.