### PR TITLE
Count subtest deletion as a regression

### DIFF
--- a/api/checks/update.go
+++ b/api/checks/update.go
@@ -129,7 +129,7 @@ func getDiffSummary(aeAPI shared.AppEngineAPI, diffAPI shared.DiffAPI, masterRun
 
 	regressed := false
 	for _, d := range diff.Differences {
-		if d[1] != 0 {
+		if d[1] != 0 || d[2] < 0 {
 			regressed = true
 			break
 		}
@@ -165,7 +165,7 @@ func getDiffSummary(aeAPI shared.AppEngineAPI, diffAPI shared.DiffAPI, masterRun
 			Regressions:   make(map[string]summaries.BeforeAndAfter),
 		}
 		for path, d := range diff.Differences {
-			if d[1] != 0 {
+			if d[1] != 0 || d[2] < 0 {
 				if len(data.Regressions) <= 10 {
 					ba := summaries.BeforeAndAfter{}
 					if b, ok := diff.BeforeSummary[path]; ok {


### PR DESCRIPTION
## Description
While we need to ignore file-level deletes to compare full master runs to PR runs, it's probably a safe bet that we need to highlight a reduction in the number of _subtests_.

[Here's an example.](https://staging.wpt.fyi/results/accelerometer?product=firefox-65.0a1-linux-18.04%4002621fd7b6&product=firefox-65.0a1-linux-18.04%409c669769fa&diff&q=idlharness)