### PR TITLE
Don't create a pending check unless create succeeds

### DIFF
--- a/api/taskcluster/webhook.go
+++ b/api/taskcluster/webhook.go
@@ -298,11 +298,12 @@ func createAllRuns(
 			err := createRun(log, client, aeAPI, sha, uploadURL, username, password, urls, labels)
 			if err != nil {
 				errors <- err
-			}
-			spec := shared.ProductSpec{}
-			spec.BrowserName = strings.Split(browser, "-")[0] // chrome-dev => chrome
-			for _, suite := range suites {
-				suitesAPI.PendingCheckRun(suite, spec)
+			} else {
+				spec := shared.ProductSpec{}
+				spec.BrowserName = strings.Split(browser, "-")[0] // chrome-dev => chrome
+				for _, suite := range suites {
+					suitesAPI.PendingCheckRun(suite, spec)
+				}
 			}
 		}(browser, urls)
 	}

--- a/api/taskcluster/webhook_test.go
+++ b/api/taskcluster/webhook_test.go
@@ -176,7 +176,7 @@ func TestCreateAllRuns_one_error(t *testing.T) {
 	suitesAPI := checks.NewMockSuitesAPI(mockC)
 	suite := shared.CheckSuite{SHA: sha}
 	suitesAPI.EXPECT().GetSuitesForSHA(sha).Return([]shared.CheckSuite{suite}, nil)
-	suitesAPI.EXPECT().PendingCheckRun(suite, sharedtest.SameProductSpec("firefox"))
+	suitesAPI.EXPECT().PendingCheckRun(suite, gomock.Any())
 	aeAPI := sharedtest.NewMockAppEngineAPI(mockC)
 	aeAPI.EXPECT().GetHostname().MinTimes(1).Return("localhost:8080")
 

--- a/api/taskcluster/webhook_test.go
+++ b/api/taskcluster/webhook_test.go
@@ -176,7 +176,6 @@ func TestCreateAllRuns_one_error(t *testing.T) {
 	suitesAPI := checks.NewMockSuitesAPI(mockC)
 	suite := shared.CheckSuite{SHA: sha}
 	suitesAPI.EXPECT().GetSuitesForSHA(sha).Return([]shared.CheckSuite{suite}, nil)
-	suitesAPI.EXPECT().PendingCheckRun(suite, sharedtest.SameProductSpec("chrome"))
 	suitesAPI.EXPECT().PendingCheckRun(suite, sharedtest.SameProductSpec("firefox"))
 	aeAPI := sharedtest.NewMockAppEngineAPI(mockC)
 	aeAPI.EXPECT().GetHostname().MinTimes(1).Return("localhost:8080")
@@ -212,8 +211,6 @@ func TestCreateAllRuns_all_errors(t *testing.T) {
 	suitesAPI := checks.NewMockSuitesAPI(mockC)
 	suite := shared.CheckSuite{SHA: sha}
 	suitesAPI.EXPECT().GetSuitesForSHA(sha).Return([]shared.CheckSuite{suite}, nil)
-	suitesAPI.EXPECT().PendingCheckRun(suite, sharedtest.SameProductSpec("chrome"))
-	suitesAPI.EXPECT().PendingCheckRun(suite, sharedtest.SameProductSpec("firefox"))
 	aeAPI := sharedtest.NewMockAppEngineAPI(mockC)
 	aeAPI.EXPECT().GetHostname().MinTimes(1).Return("localhost:8080")
 


### PR DESCRIPTION
## Description
Prevents checks hanging in a pending status, when they were never going to succeed.
e.g. https://github.com/web-platform-tests/wpt/pull/14309