### PR TITLE
[processor] Add the raw browser_channel as a label

### DIFF
--- a/results-processor/wptreport.py
+++ b/results-processor/wptreport.py
@@ -455,12 +455,13 @@ def prepare_labels(report, labels_str, uploader):
         labels.add(label.strip())
 
     # Add the release channel label.
-    if not any([i in labels for i in set(CHANNEL_TO_LABEL.values())]):
-        if report.run_info.get('browser_channel') in CHANNEL_TO_LABEL:
+    if report.run_info.get('browser_channel'):
+        labels.add(report.run_info['browser_channel'])
+        if report.run_info['browser_channel'] in CHANNEL_TO_LABEL:
             labels.add(CHANNEL_TO_LABEL[report.run_info['browser_channel']])
-        else:
-            # Default to "stable".
-            labels.add('stable')
+    elif not any([i in labels for i in set(CHANNEL_TO_LABEL.values())]):
+        # Default to "stable".
+        labels.add('stable')
 
     # Remove any empty labels.
     if '' in labels:

--- a/results-processor/wptreport_test.py
+++ b/results-processor/wptreport_test.py
@@ -498,12 +498,12 @@ class HelpersTest(unittest.TestCase):
         }
         self.assertListEqual(
             prepare_labels(r, '', 'blade-runner'),
-            ['blade-runner', 'experimental', 'firefox']
+            ['blade-runner', 'dev', 'experimental', 'firefox']
         )
         r._report['run_info']['browser_channel'] = 'nightly'
         self.assertListEqual(
             prepare_labels(r, '', 'blade-runner'),
-            ['blade-runner', 'experimental', 'firefox']
+            ['blade-runner', 'experimental', 'firefox', 'nightly']
         )
         r._report['run_info']['browser_channel'] = 'beta'
         self.assertListEqual(


### PR DESCRIPTION
In addition to the canonical terms, also add the raw browser_channel as
a label.

Fixes #611.

## Review Information

It'd be easier to look at the changes in tests.