### PR TITLE
Accept Taskcluster groups with failing tasks

### DIFF
--- a/api/taskcluster/webhook.go
+++ b/api/taskcluster/webhook.go
@@ -21,6 +21,7 @@ import (
 	"google.golang.org/appengine/datastore"
 	"google.golang.org/appengine/urlfetch"
 
+	mapset "github.com/deckarep/golang-set"
 	"github.com/lukebjerring/go-github/github"
 	"github.com/web-platform-tests/wpt.fyi/api/checks"
 	"github.com/web-platform-tests/wpt.fyi/shared"
@@ -77,8 +78,8 @@ type statusEventPayload struct {
 	github.StatusEvent
 }
 
-func (s statusEventPayload) IsSuccess() bool {
-	return s.GetState() == "success"
+func (s statusEventPayload) IsCompleted() bool {
+	return s.GetState() == "success" || s.GetState() == "failure"
 }
 
 func (s statusEventPayload) IsTaskcluster() bool {
@@ -141,7 +142,7 @@ func handleStatusEvent(ctx context.Context, payload []byte) (bool, error) {
 		return false, err
 	}
 
-	urlsByBrowser, err := extractResultURLs(taskGroup)
+	urlsByBrowser, err := extractResultURLs(log, taskGroup)
 	if err != nil {
 		return false, err
 	}
@@ -181,8 +182,8 @@ func handleStatusEvent(ctx context.Context, payload []byte) (bool, error) {
 }
 
 func shouldProcessStatus(log shared.Logger, processAllBranches bool, status *statusEventPayload) bool {
-	if !status.IsSuccess() {
-		log.Debugf("Ignoring non-success status: %s", status.GetState())
+	if !status.IsCompleted() {
+		log.Debugf("Ignoring status: %s", status.GetState())
 		return false
 	} else if !status.IsTaskcluster() {
 		log.Debugf("Ignoring non-Taskcluster context: %s", status.GetContext())
@@ -239,28 +240,38 @@ func getTaskGroupInfo(client *http.Client, groupID string) (*taskGroupInfo, erro
 	return &group, nil
 }
 
-func extractResultURLs(group *taskGroupInfo) (map[string][]string, error) {
+func extractResultURLs(log shared.Logger, group *taskGroupInfo) (map[string][]string, error) {
+	failures := mapset.NewSet()
 	resultURLs := make(map[string][]string)
 	for _, task := range group.Tasks {
 		taskID := task.Status.TaskID
 		if taskID == "" {
 			return nil, fmt.Errorf("task group %s has a task without taskId", group.TaskGroupID)
 		}
-		if task.Status.State != "completed" {
-			return nil, fmt.Errorf("task group %s has an unfinished task: %s", group.TaskGroupID, taskID)
-		}
 
 		matches := taskNameRegex.FindStringSubmatch(task.Task.Metadata.Name)
 		if len(matches) != 4 { // full match, browser, channel, test type
+			log.Debugf("Ignoring unrecognized task: %s", task.Task.Metadata.Name)
 			continue
 		}
 		browser := fmt.Sprintf("%s-%s", matches[1], matches[2])
+
+		if task.Status.State != "completed" {
+			log.Errorf("Task group %s has an unfinished task: %s; %s will be ignored in this group.",
+				group.TaskGroupID, taskID, browser)
+			failures.Add(browser)
+			continue
+		}
 
 		resultURLs[browser] = append(resultURLs[browser],
 			// https://docs.taskcluster.net/docs/reference/platform/taskcluster-queue/references/api#get-artifact-from-latest-run
 			fmt.Sprintf(
 				"https://queue.taskcluster.net/v1/task/%s/artifacts/public/results/wpt_report.json.gz", taskID,
 			))
+	}
+
+	for failure := range failures.Iter() {
+		delete(resultURLs, failure.(string))
 	}
 
 	if len(resultURLs) == 0 {


### PR DESCRIPTION
It is OK to have some failing tasks in a Taskcluster group, in which
case we will just drop the corresponding browser in that group to
prevent incomplete results but still keep the other browsers with
complete results.

Fixes #835 .
