### PR TITLE
Search API: Test & implement query interpretation

### DIFF
--- a/api/query/atoms.go
+++ b/api/query/atoms.go
@@ -29,10 +29,13 @@ type RunQuery struct {
 	AbstractQuery
 }
 
+// TestNamePattern is a query atom that matches test names to a pattern string.
 type TestNamePattern struct {
 	Pattern string
 }
 
+// BindToRuns for TestNamePattern is a no-op: TestNamePattern implements both
+// AbstractQuery and ConcreteQuery because it is independent of test runs.
 func (tnp TestNamePattern) BindToRuns(runs []shared.TestRun) ConcreteQuery {
 	return tnp
 }
@@ -149,6 +152,8 @@ func (rq *RunQuery) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// UnmarshalJSON for TestNamePattern attempts to interpret a query atom as as
+// {"pattern":<test name pattern string>}.
 func (tnp *TestNamePattern) UnmarshalJSON(b []byte) error {
 	var data struct {
 		Pattern string `json:"pattern"`

--- a/api/query/atoms.go
+++ b/api/query/atoms.go
@@ -15,25 +15,26 @@ import (
 
 var browsers = shared.GetDefaultBrowserNames()
 
-type query interface {
-	toPlan(runIDs []int64) plan
+// AbstractQuery is an intermetidate representation of a test results query that
+//  has not been bound to specific shared.TestRun specs for processing.
+type AbstractQuery interface {
+	BindToRuns(runs []shared.TestRun) ConcreteQuery
 }
 
-type runQuery struct {
+// RunQuery is the internal representation of a query recieved from an HTTP
+// client, including the IDs of the test runs to query, and the structured query
+// to run.
+type RunQuery struct {
 	runIDs []int64
-	query
+	AbstractQuery
 }
 
-func (rq runQuery) toPlan() plan {
-	return rq.query.toPlan(rq.runIDs)
+type TestNamePattern struct {
+	Pattern string
 }
 
-type testNamePattern struct {
-	pattern string
-}
-
-func (tnp testNamePattern) toPlan(runIDs []int64) plan {
-	return nil
+func (tnp TestNamePattern) BindToRuns(runs []shared.TestRun) ConcreteQuery {
+	return tnp
 }
 
 type testStatusConstraint struct {
@@ -41,35 +42,88 @@ type testStatusConstraint struct {
 	status      int64
 }
 
-func (tsc testStatusConstraint) toPlan(runIDs []int64) plan {
-	return nil
+func (tsc testStatusConstraint) BindToRuns(runs []shared.TestRun) ConcreteQuery {
+	ids := make([]int64, 0, len(runs))
+	for _, run := range runs {
+		if run.BrowserName == tsc.browserName {
+			ids = append(ids, run.ID)
+		}
+	}
+	if len(ids) == 0 {
+		return True{}
+	}
+	if len(ids) == 1 {
+		return RunTestStatusConstraint{ids[0], tsc.status}
+	}
+
+	q := Or{make([]ConcreteQuery, len(ids))}
+	for i := range ids {
+		q.Args[i] = RunTestStatusConstraint{ids[i], tsc.status}
+	}
+	return q
 }
 
 type not struct {
-	not query
+	not AbstractQuery
 }
 
-func (n not) toPlan(runIDs []int64) plan {
-	return nil
+func (n not) BindToRuns(runs []shared.TestRun) ConcreteQuery {
+	return Not{n.not.BindToRuns(runs)}
 }
 
 type or struct {
-	or []query
+	or []AbstractQuery
 }
 
-func (o or) toPlan(runIDs []int64) plan {
-	return nil
+func (o or) BindToRuns(runs []shared.TestRun) ConcreteQuery {
+	q := Or{make([]ConcreteQuery, 0, len(o.or))}
+	for i := range o.or {
+		sub := o.or[i].BindToRuns(runs)
+		if _, ok := sub.(True); ok {
+			return True{}
+		}
+		if _, ok := sub.(False); ok {
+			continue
+		}
+		q.Args = append(q.Args, sub)
+	}
+	if len(q.Args) == 0 {
+		return True{}
+	}
+	if len(q.Args) == 1 {
+		return q.Args[0]
+	}
+	return q
 }
 
 type and struct {
-	and []query
+	and []AbstractQuery
 }
 
-func (a and) toPlan(runIDs []int64) plan {
-	return nil
+func (a and) BindToRuns(runs []shared.TestRun) ConcreteQuery {
+	q := And{make([]ConcreteQuery, 0, len(a.and))}
+	for i := range a.and {
+		sub := a.and[i].BindToRuns(runs)
+		if _, ok := sub.(False); ok {
+			return False{}
+		}
+		if _, ok := sub.(True); ok {
+			continue
+		}
+		q.Args = append(q.Args, sub)
+	}
+	if len(q.Args) == 0 {
+		return True{}
+	}
+	if len(q.Args) == 1 {
+		return q.Args[0]
+	}
+	return q
 }
 
-func (rq *runQuery) UnmarshalJSON(b []byte) error {
+// UnmarshalJSON interprets the JSON representation of a RunQuery, instantiating
+// (an) appropriate Query implementation(s) according to the JSON structure.
+func (rq *RunQuery) UnmarshalJSON(b []byte) error {
 	var data struct {
 		RunIDs []int64         `json:"run_ids"`
 		Query  json.RawMessage `json:"query"`
@@ -91,11 +145,11 @@ func (rq *runQuery) UnmarshalJSON(b []byte) error {
 	}
 
 	rq.runIDs = data.RunIDs
-	rq.query = q
+	rq.AbstractQuery = q
 	return nil
 }
 
-func (tnp *testNamePattern) UnmarshalJSON(b []byte) error {
+func (tnp *TestNamePattern) UnmarshalJSON(b []byte) error {
 	var data struct {
 		Pattern string `json:"pattern"`
 	}
@@ -107,7 +161,7 @@ func (tnp *testNamePattern) UnmarshalJSON(b []byte) error {
 		return errors.New(`Missing testn mae pattern property: "pattern"`)
 	}
 
-	tnp.pattern = data.Pattern
+	tnp.Pattern = data.Pattern
 	return nil
 }
 
@@ -177,7 +231,7 @@ func (o *or) UnmarshalJSON(b []byte) error {
 		return errors.New(`Missing disjunction property: "or"`)
 	}
 
-	qs := make([]query, 0, len(data.Or))
+	qs := make([]AbstractQuery, 0, len(data.Or))
 	for _, msg := range data.Or {
 		q, err := unmarshalQ(msg)
 		if err != nil {
@@ -201,7 +255,7 @@ func (a *and) UnmarshalJSON(b []byte) error {
 		return errors.New(`Missing conjunction property: "and"`)
 	}
 
-	qs := make([]query, 0, len(data.And))
+	qs := make([]AbstractQuery, 0, len(data.And))
 	for _, msg := range data.And {
 		q, err := unmarshalQ(msg)
 		if err != nil {
@@ -213,8 +267,8 @@ func (a *and) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-func unmarshalQ(b []byte) (query, error) {
-	var tnp testNamePattern
+func unmarshalQ(b []byte) (AbstractQuery, error) {
+	var tnp TestNamePattern
 	err := json.Unmarshal(b, &tnp)
 	if err == nil {
 		return tnp, nil

--- a/api/query/atoms.go
+++ b/api/query/atoms.go
@@ -79,7 +79,7 @@ type or struct {
 }
 
 func (o or) BindToRuns(runs []shared.TestRun) ConcreteQuery {
-	q := Or{make([]ConcreteQuery, 0, len(o.or))}
+	args := make([]ConcreteQuery, 0, len(o.or))
 	for i := range o.or {
 		sub := o.or[i].BindToRuns(runs)
 		if _, ok := sub.(True); ok {
@@ -88,15 +88,17 @@ func (o or) BindToRuns(runs []shared.TestRun) ConcreteQuery {
 		if _, ok := sub.(False); ok {
 			continue
 		}
-		q.Args = append(q.Args, sub)
+		args = append(args, sub)
 	}
-	if len(q.Args) == 0 {
+	if len(args) == 0 {
 		return True{}
 	}
-	if len(q.Args) == 1 {
-		return q.Args[0]
+	if len(args) == 1 {
+		return args[0]
 	}
-	return q
+	return Or{
+		Args: args,
+	}
 }
 
 type and struct {
@@ -104,7 +106,7 @@ type and struct {
 }
 
 func (a and) BindToRuns(runs []shared.TestRun) ConcreteQuery {
-	q := And{make([]ConcreteQuery, 0, len(a.and))}
+	args := make([]ConcreteQuery, 0, len(a.and))
 	for i := range a.and {
 		sub := a.and[i].BindToRuns(runs)
 		if _, ok := sub.(False); ok {
@@ -113,15 +115,17 @@ func (a and) BindToRuns(runs []shared.TestRun) ConcreteQuery {
 		if _, ok := sub.(True); ok {
 			continue
 		}
-		q.Args = append(q.Args, sub)
+		args = append(args, sub)
 	}
-	if len(q.Args) == 0 {
+	if len(args) == 0 {
 		return True{}
 	}
-	if len(q.Args) == 1 {
-		return q.Args[0]
+	if len(args) == 1 {
+		return args[0]
 	}
-	return q
+	return And{
+		Args: args,
+	}
 }
 
 // UnmarshalJSON interprets the JSON representation of a RunQuery, instantiating

--- a/api/query/atoms_test.go
+++ b/api/query/atoms_test.go
@@ -15,13 +15,13 @@ import (
 )
 
 func TestStructuredQuery_empty(t *testing.T) {
-	var rq runQuery
+	var rq RunQuery
 	err := json.Unmarshal([]byte(`{}`), &rq)
 	assert.NotNil(t, err)
 }
 
 func TestStructuredQuery_missingRunIDs(t *testing.T) {
-	var rq runQuery
+	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
 		"query": {
 			"pattern": "/2dcontext/"
@@ -31,7 +31,7 @@ func TestStructuredQuery_missingRunIDs(t *testing.T) {
 }
 
 func TestStructuredQuery_missingQuery(t *testing.T) {
-	var rq runQuery
+	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
 		"run_ids": [0, 1, 2]
 	}`), &rq)
@@ -39,7 +39,7 @@ func TestStructuredQuery_missingQuery(t *testing.T) {
 }
 
 func TestStructuredQuery_emptyRunIDs(t *testing.T) {
-	var rq runQuery
+	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
 		"run_ids": [],
 		"query": {
@@ -50,7 +50,7 @@ func TestStructuredQuery_emptyRunIDs(t *testing.T) {
 }
 
 func TestStructuredQuery_emptyBrowserName(t *testing.T) {
-	var rq runQuery
+	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
 		"run_ids": [0, 1, 2],
 		"query": {
@@ -62,7 +62,7 @@ func TestStructuredQuery_emptyBrowserName(t *testing.T) {
 }
 
 func TestStructuredQuery_missingStatus(t *testing.T) {
-	var rq runQuery
+	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
 		"run_ids": [0, 1, 2],
 		"query": {
@@ -73,7 +73,7 @@ func TestStructuredQuery_missingStatus(t *testing.T) {
 }
 
 func TestStructuredQuery_badStatus(t *testing.T) {
-	var rq runQuery
+	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
 		"run_ids": [0, 1, 2],
 		"query": {
@@ -84,7 +84,7 @@ func TestStructuredQuery_badStatus(t *testing.T) {
 	assert.NotNil(t, err)
 }
 func TestStructuredQuery_unknownStatus(t *testing.T) {
-	var rq runQuery
+	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
 		"run_ids": [0, 1, 2],
 		"query": {
@@ -93,11 +93,11 @@ func TestStructuredQuery_unknownStatus(t *testing.T) {
 		}
 	}`), &rq)
 	assert.Nil(t, err)
-	assert.Equal(t, runQuery{runIDs: []int64{0, 1, 2}, query: testStatusConstraint{"chrome", shared.TestStatusValueFromString("UNKNOWN")}}, rq)
+	assert.Equal(t, RunQuery{runIDs: []int64{0, 1, 2}, AbstractQuery: testStatusConstraint{"chrome", shared.TestStatusValueFromString("UNKNOWN")}}, rq)
 }
 
 func TestStructuredQuery_pattern(t *testing.T) {
-	var rq runQuery
+	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
 		"run_ids": [0, 1, 2],
 		"query": {
@@ -105,11 +105,11 @@ func TestStructuredQuery_pattern(t *testing.T) {
 		}
 	}`), &rq)
 	assert.Nil(t, err)
-	assert.Equal(t, runQuery{runIDs: []int64{0, 1, 2}, query: testNamePattern{"/2dcontext/"}}, rq)
+	assert.Equal(t, RunQuery{runIDs: []int64{0, 1, 2}, AbstractQuery: TestNamePattern{"/2dcontext/"}}, rq)
 }
 
 func TestStructuredQuery_status(t *testing.T) {
-	var rq runQuery
+	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
 		"run_ids": [0, 1, 2],
 		"query": {
@@ -118,11 +118,11 @@ func TestStructuredQuery_status(t *testing.T) {
 		}
 	}`), &rq)
 	assert.Nil(t, err)
-	assert.Equal(t, runQuery{runIDs: []int64{0, 1, 2}, query: testStatusConstraint{"firefox", shared.TestStatusValueFromString("PASS")}}, rq)
+	assert.Equal(t, RunQuery{runIDs: []int64{0, 1, 2}, AbstractQuery: testStatusConstraint{"firefox", shared.TestStatusValueFromString("PASS")}}, rq)
 }
 
 func TestStructuredQuery_not(t *testing.T) {
-	var rq runQuery
+	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
 		"run_ids": [0, 1, 2],
 		"query": {
@@ -132,11 +132,11 @@ func TestStructuredQuery_not(t *testing.T) {
 		}
 	}`), &rq)
 	assert.Nil(t, err)
-	assert.Equal(t, runQuery{runIDs: []int64{0, 1, 2}, query: not{testNamePattern{"cssom"}}}, rq)
+	assert.Equal(t, RunQuery{runIDs: []int64{0, 1, 2}, AbstractQuery: not{TestNamePattern{"cssom"}}}, rq)
 }
 
 func TestStructuredQuery_or(t *testing.T) {
-	var rq runQuery
+	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
 		"run_ids": [0, 1, 2],
 		"query": {
@@ -147,11 +147,11 @@ func TestStructuredQuery_or(t *testing.T) {
 		}
 	}`), &rq)
 	assert.Nil(t, err)
-	assert.Equal(t, runQuery{runIDs: []int64{0, 1, 2}, query: or{[]query{testNamePattern{"cssom"}, testNamePattern{"html"}}}}, rq)
+	assert.Equal(t, RunQuery{runIDs: []int64{0, 1, 2}, AbstractQuery: or{[]AbstractQuery{TestNamePattern{"cssom"}, TestNamePattern{"html"}}}}, rq)
 }
 
 func TestStructuredQuery_and(t *testing.T) {
-	var rq runQuery
+	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
 		"run_ids": [0, 1, 2],
 		"query": {
@@ -162,11 +162,11 @@ func TestStructuredQuery_and(t *testing.T) {
 		}
 	}`), &rq)
 	assert.Nil(t, err)
-	assert.Equal(t, runQuery{runIDs: []int64{0, 1, 2}, query: and{[]query{testNamePattern{"cssom"}, testNamePattern{"html"}}}}, rq)
+	assert.Equal(t, RunQuery{runIDs: []int64{0, 1, 2}, AbstractQuery: and{[]AbstractQuery{TestNamePattern{"cssom"}, TestNamePattern{"html"}}}}, rq)
 }
 
 func TestStructuredQuery_nested(t *testing.T) {
-	var rq runQuery
+	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
 		"run_ids": [0, 1, 2],
 		"query": {
@@ -185,18 +185,343 @@ func TestStructuredQuery_nested(t *testing.T) {
 		}
 	}`), &rq)
 	assert.Nil(t, err)
-	assert.Equal(t, runQuery{
+	assert.Equal(t, RunQuery{
 		runIDs: []int64{0, 1, 2},
-		query: or{
-			or: []query{
+		AbstractQuery: or{
+			or: []AbstractQuery{
 				and{
-					and: []query{
-						not{testNamePattern{"cssom"}},
-						testNamePattern{"html"},
+					and: []AbstractQuery{
+						not{TestNamePattern{"cssom"}},
+						TestNamePattern{"html"},
 					},
 				},
 				testStatusConstraint{"edge", shared.TestStatusValueFromString("TIMEOUT")},
 			},
 		},
 	}, rq)
+}
+
+func TestStructuredQuery_bindPattern(t *testing.T) {
+	tnp := TestNamePattern{
+		Pattern: "/",
+	}
+	q := tnp.BindToRuns([]shared.TestRun{})
+	assert.Equal(t, tnp, q)
+}
+
+func TestStructuredQuery_bindStatusNoRuns(t *testing.T) {
+	assert.Equal(t, True{}, testStatusConstraint{
+		browserName: "Chrome",
+		status:      1,
+	}.BindToRuns([]shared.TestRun{}))
+}
+
+func TestStructuredQuery_bindStatusSingleRun(t *testing.T) {
+	assert.Equal(t, RunTestStatusConstraint{
+		Run:    1,
+		Status: 1,
+	}, testStatusConstraint{
+		browserName: "Firefox",
+		status:      1,
+	}.BindToRuns([]shared.TestRun{
+		shared.TestRun{
+			ID: 1,
+			ProductAtRevision: shared.ProductAtRevision{
+				Product: shared.Product{
+					BrowserName: "Firefox",
+				},
+			},
+		},
+		shared.TestRun{
+			ID: 2,
+			ProductAtRevision: shared.ProductAtRevision{
+				Product: shared.Product{
+					BrowserName: "Chrome",
+				},
+			},
+		},
+	}))
+}
+
+func TestStructuredQuery_bindStatusSomeRuns(t *testing.T) {
+	assert.Equal(t, Or{
+		Args: []ConcreteQuery{
+			RunTestStatusConstraint{
+				Run:    1,
+				Status: 1,
+			},
+			RunTestStatusConstraint{
+				Run:    3,
+				Status: 1,
+			},
+		},
+	}, testStatusConstraint{
+		browserName: "Firefox",
+		status:      1,
+	}.BindToRuns([]shared.TestRun{
+		shared.TestRun{
+			ID: 1,
+			ProductAtRevision: shared.ProductAtRevision{
+				Product: shared.Product{
+					BrowserName: "Firefox",
+				},
+			},
+		},
+		shared.TestRun{
+			ID: 2,
+			ProductAtRevision: shared.ProductAtRevision{
+				Product: shared.Product{
+					BrowserName: "Chrome",
+				},
+			},
+		},
+		shared.TestRun{
+			ID: 3,
+			ProductAtRevision: shared.ProductAtRevision{
+				Product: shared.Product{
+					BrowserName: "Firefox",
+				},
+			},
+		},
+	}))
+}
+
+func TestStructuredQuery_bindAnd(t *testing.T) {
+	assert.Equal(t, And{
+		Args: []ConcreteQuery{
+			TestNamePattern{
+				Pattern: "/",
+			},
+			RunTestStatusConstraint{
+				Run:    1,
+				Status: 1,
+			},
+		},
+	}, and{
+		and: []AbstractQuery{
+			TestNamePattern{
+				Pattern: "/",
+			},
+			testStatusConstraint{
+				browserName: "Edge",
+				status:      1,
+			},
+		},
+	}.BindToRuns([]shared.TestRun{
+		shared.TestRun{
+			ID: 1,
+			ProductAtRevision: shared.ProductAtRevision{
+				Product: shared.Product{
+					BrowserName: "Edge",
+				},
+			},
+		},
+	}))
+}
+
+func TestStructuredQuery_bindOr(t *testing.T) {
+	assert.Equal(t, Or{
+		Args: []ConcreteQuery{
+			TestNamePattern{
+				Pattern: "/",
+			},
+			RunTestStatusConstraint{
+				Run:    1,
+				Status: 1,
+			},
+		},
+	}, or{
+		or: []AbstractQuery{
+			TestNamePattern{
+				Pattern: "/",
+			},
+			testStatusConstraint{
+				browserName: "Edge",
+				status:      1,
+			},
+		},
+	}.BindToRuns([]shared.TestRun{
+		shared.TestRun{
+			ID: 1,
+			ProductAtRevision: shared.ProductAtRevision{
+				Product: shared.Product{
+					BrowserName: "Edge",
+				},
+			},
+		},
+	}))
+}
+
+func TestStructuredQuery_bindNot(t *testing.T) {
+	assert.Equal(t, Not{
+		Arg: RunTestStatusConstraint{
+			Run:    1,
+			Status: 1,
+		},
+	}, not{
+		not: testStatusConstraint{
+			browserName: "Edge",
+			status:      1,
+		},
+	}.BindToRuns([]shared.TestRun{
+		shared.TestRun{
+			ID: 1,
+			ProductAtRevision: shared.ProductAtRevision{
+				Product: shared.Product{
+					BrowserName: "Edge",
+				},
+			},
+		},
+	}))
+}
+
+func TestStructuredQuery_bindAndReduce(t *testing.T) {
+	assert.Equal(t, TestNamePattern{
+		Pattern: "/",
+	}, and{
+		and: []AbstractQuery{
+			TestNamePattern{
+				Pattern: "/",
+			},
+			testStatusConstraint{
+				browserName: "Safari",
+				status:      1,
+			},
+		},
+	}.BindToRuns([]shared.TestRun{
+		shared.TestRun{
+			ID: 1,
+			ProductAtRevision: shared.ProductAtRevision{
+				Product: shared.Product{
+					BrowserName: "Edge",
+				},
+			},
+		},
+	}))
+}
+
+func TestStructuredQuery_bindAndReduceToTrue(t *testing.T) {
+	assert.Equal(t, True{}, and{
+		and: []AbstractQuery{
+			testStatusConstraint{
+				browserName: "Chrome",
+				status:      1,
+			},
+			testStatusConstraint{
+				browserName: "Safari",
+				status:      1,
+			},
+		},
+	}.BindToRuns([]shared.TestRun{
+		shared.TestRun{
+			ID: 1,
+			ProductAtRevision: shared.ProductAtRevision{
+				Product: shared.Product{
+					BrowserName: "Edge",
+				},
+			},
+		},
+	}))
+}
+
+func TestStructuredQuery_bindOrReduce(t *testing.T) {
+	assert.Equal(t, True{}, or{
+		or: []AbstractQuery{
+			TestNamePattern{
+				Pattern: "/",
+			},
+			testStatusConstraint{
+				browserName: "Safari",
+				status:      1,
+			},
+		},
+	}.BindToRuns([]shared.TestRun{
+		shared.TestRun{
+			ID: 1,
+			ProductAtRevision: shared.ProductAtRevision{
+				Product: shared.Product{
+					BrowserName: "Edge",
+				},
+			},
+		},
+	}))
+}
+
+func TestStructuredQuery_bindComplex(t *testing.T) {
+	assert.Equal(t, Or{
+		Args: []ConcreteQuery{
+			TestNamePattern{
+				Pattern: "cssom",
+			},
+			And{
+				Args: []ConcreteQuery{
+					Not{
+						Arg: TestNamePattern{
+							Pattern: "css",
+						},
+					},
+					Or{
+						Args: []ConcreteQuery{
+							RunTestStatusConstraint{
+								Run:    1,
+								Status: 1,
+							},
+							RunTestStatusConstraint{
+								Run:    3,
+								Status: 1,
+							},
+						},
+					},
+				},
+			},
+		},
+	}, or{
+		or: []AbstractQuery{
+			TestNamePattern{
+				Pattern: "cssom",
+			},
+			and{
+				and: []AbstractQuery{
+					not{
+						not: TestNamePattern{
+							Pattern: "css",
+						},
+					},
+					testStatusConstraint{
+						browserName: "Safari",
+						status:      1,
+					},
+					testStatusConstraint{
+						browserName: "Chrome",
+						status:      1,
+					},
+				},
+			},
+		},
+	}.BindToRuns([]shared.TestRun{
+		shared.TestRun{
+			ID: 1,
+			ProductAtRevision: shared.ProductAtRevision{
+				Product: shared.Product{
+					BrowserName: "Chrome",
+				},
+			},
+		},
+		shared.TestRun{
+			ID: 2,
+			ProductAtRevision: shared.ProductAtRevision{
+				Product: shared.Product{
+					BrowserName: "Edge",
+				},
+			},
+		},
+		shared.TestRun{
+			ID: 3,
+			ProductAtRevision: shared.ProductAtRevision{
+				Product: shared.Product{
+					BrowserName: "Chrome",
+				},
+			},
+		},
+	}))
 }

--- a/api/query/concrete_query.go
+++ b/api/query/concrete_query.go
@@ -1,0 +1,70 @@
+// Copyright 2018 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package query
+
+// ConcreteQuery is an AbstractQuery that has been bound to specific test runs.
+type ConcreteQuery interface {
+	Size() int
+}
+
+// RunTestStatusConstraint is constrains search results to include only test
+// results from a particular run that have a particular test status value. Run
+// IDs are those values automatically assigned to shared.TestRun instances by
+// Datastore. Status IDs are those codified in shared.TestStatus* symbols.
+type RunTestStatusConstraint struct {
+	Run    int64
+	Status int64
+}
+
+// Or is a logical disjunction of ConcreteQuery instances.
+type Or struct {
+	Args []ConcreteQuery
+}
+
+// And is a logical conjunction of ConcreteQuery instances.
+type And struct {
+	Args []ConcreteQuery
+}
+
+// Not is a logical negation of ConcreteQuery instances.
+type Not struct {
+	Arg ConcreteQuery
+}
+
+// True is a true-valued ConcreteQuery.
+type True struct{}
+
+// False is a false-valued ConcreteQuery.
+type False struct{}
+
+func (TestNamePattern) Size() int { return 1 }
+
+// Size of RunTestStatusConstraint is 1: servicing such a query requires a
+// single lookup in a test run result mapping.
+func (RunTestStatusConstraint) Size() int { return 1 }
+
+// Size of Or is the sum of the sizes of its constituent ConcretQuery instances.
+func (o Or) Size() int { return size(o.Args) }
+
+// Size of And is the sum of the sizes of its constituent ConcretQuery
+// instances.
+func (a And) Size() int { return size(a.Args) }
+
+// Size of Not is one unit greater than the size of its ConcreteQuery argument.
+func (n Not) Size() int { return 1 + n.Arg.Size() }
+
+// Size of True is 0: It should be optimized out of queries in practice.
+func (True) Size() int { return 0 }
+
+// Size of False is 0: It should be optimized out of queries in practice.
+func (False) Size() int { return 0 }
+
+func size(qs []ConcreteQuery) int {
+	s := 0
+	for _, q := range qs {
+		s += q.Size()
+	}
+	return s
+}

--- a/api/query/concrete_query.go
+++ b/api/query/concrete_query.go
@@ -39,10 +39,12 @@ type True struct{}
 // False is a false-valued ConcreteQuery.
 type False struct{}
 
+// Size of TestNamePattern has a size of 1: servicing such a query requires a
+// substring match per test.
 func (TestNamePattern) Size() int { return 1 }
 
 // Size of RunTestStatusConstraint is 1: servicing such a query requires a
-// single lookup in a test run result mapping.
+// single lookup in a test run result mapping per test.
 func (RunTestStatusConstraint) Size() int { return 1 }
 
 // Size of Or is the sum of the sizes of its constituent ConcretQuery instances.

--- a/api/query/plan.go
+++ b/api/query/plan.go
@@ -1,8 +1,0 @@
-// Copyright 2018 The WPT Dashboard Project. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
-package query
-
-// TODO: Establish query execution plans over internal data schema.
-type plan interface{}

--- a/api/query/search.go
+++ b/api/query/search.go
@@ -100,14 +100,14 @@ func (sh structuredSearchHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 		http.Error(w, "Failed to finish reading request body", http.StatusInternalServerError)
 	}
 
-	var rq runQuery
+	var rq RunQuery
 	err = json.Unmarshal(data, &rq)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	simpleQ, ok := rq.query.(testNamePattern)
+	simpleQ, ok := rq.AbstractQuery.(TestNamePattern)
 	if !ok {
 		// TODO: Implement serving complex queries.
 		http.Error(w, "Query pattern is valid, but processing of this query configuration is not yet implemented", http.StatusServiceUnavailable)
@@ -126,7 +126,7 @@ func (sh structuredSearchHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 		runIDStrs = append(runIDStrs, strconv.FormatInt(id, 10))
 	}
 	runIDsStr := strings.Join(runIDStrs, ",")
-	r2.URL.RawQuery = fmt.Sprintf("run_ids=%s&q=%s", url.QueryEscape(runIDsStr), url.QueryEscape(simpleQ.pattern))
+	r2.URL.RawQuery = fmt.Sprintf("run_ids=%s&q=%s", url.QueryEscape(runIDsStr), url.QueryEscape(simpleQ.Pattern))
 	unstructuredSearchHandler{queryHandler: sh.queryHandler}.ServeHTTP(w, &r2)
 }
 


### PR DESCRIPTION
- Interpret `query.AbstractQuery` (formerly `query.query) as `query.ConcreteQuery`
  - This constitutes binding an unmarshaled query to a set of runs
- Export `ConcreteQuery` implementations so that query service strategies can reason about their constituent parts

This work is towards the search cache, but multiple cache search indexing strategies (in different packages) may be implemented to service instances of `ConcreteQuery`. Hence the code lives in `query`, not `cache`, and must be exported.