### PR TITLE
Fix check run naming

### DIFF
--- a/api/checks/api.go
+++ b/api/checks/api.go
@@ -68,7 +68,6 @@ func (s checksAPIImpl) PendingCheckRun(suite shared.CheckSuite, product shared.P
 		CheckState: summaries.CheckState{
 			Product:    product,
 			HeadSHA:    suite.SHA,
-			Title:      getCheckTitle(product),
 			DetailsURL: shared.NewDiffAPI(s.ctx).GetMasterDiffURL(suite.SHA, product),
 			Status:     "in_progress",
 		},
@@ -114,8 +113,4 @@ func (s checksAPIImpl) IgnoreFailure(sender, owner, repo string, run *github.Che
 	}
 	_, _, err = client.Checks.UpdateCheckRun(s.ctx, owner, repo, run.GetID(), opts)
 	return err
-}
-
-func getCheckTitle(product shared.ProductSpec) string {
-	return fmt.Sprintf("wpt.fyi - %s results", product.DisplayName())
 }

--- a/api/checks/runs.go
+++ b/api/checks/runs.go
@@ -25,14 +25,15 @@ func updateCheckRun(ctx context.Context, summary summaries.Summary, suites ...sh
 	}
 
 	detailsURLStr := state.DetailsURL.String()
+	title := state.Title()
 	opts := github.CreateCheckRunOptions{
-		Name:       state.Product.String(),
+		Name:       state.Name(),
 		HeadSHA:    state.HeadSHA,
 		DetailsURL: &detailsURLStr,
 		Status:     &state.Status,
 		Conclusion: state.Conclusion,
 		Output: &github.CheckRunOutput{
-			Title:   &state.Title,
+			Title:   &title,
 			Summary: &summaryStr,
 		},
 		Actions: actions,

--- a/api/checks/summaries/compile.go
+++ b/api/checks/summaries/compile.go
@@ -6,10 +6,13 @@ package summaries
 
 import (
 	"bytes"
+	"fmt"
 	"net/url"
 	"path/filepath"
 	"runtime"
 	"text/template"
+
+	"github.com/deckarep/golang-set"
 
 	"github.com/lukebjerring/go-github/github"
 	"github.com/web-platform-tests/wpt.fyi/shared"
@@ -40,10 +43,24 @@ type CheckState struct {
 	Product    shared.ProductSpec
 	HeadSHA    string
 	DetailsURL *url.URL
-	Title      string
 	Status     string  // The current status. Can be one of "queued", "in_progress", or "completed". Default: "queued". (Optional.)
 	Conclusion *string // Can be one of "success", "failure", "neutral", "cancelled", "timed_out", or "action_required". (Optional. Required if you provide a status of "completed".)
 	Actions    []github.CheckRunAction
+}
+
+// Name returns the check run's name, based on the product.
+func (c CheckState) Name() string {
+	spec := shared.ProductSpec{}
+	spec.BrowserName = c.Product.BrowserName
+	if c.Product.IsExperimental() {
+		spec.Labels = mapset.NewSetWith(shared.ExperimentalLabel)
+	}
+	return spec.String()
+}
+
+// Title returns the check run's title, based on the product.
+func (c CheckState) Title() string {
+	return fmt.Sprintf("wpt.fyi - %s results", c.Product.DisplayName())
 }
 
 // GetCheckState returns the info in the CheckState struct.

--- a/api/checks/update.go
+++ b/api/checks/update.go
@@ -123,12 +123,10 @@ func getDiffSummary(aeAPI shared.AppEngineAPI, diffAPI shared.DiffAPI, masterRun
 		return nil, err
 	}
 
-	product, _ := shared.ParseProductSpec(prRun.Product.BrowserName)
 	diffURL := diffAPI.GetDiffURL(masterRun, prRun, &diffFilter)
 	checkState := summaries.CheckState{
-		Product:    product,
+		Product:    shared.ProductSpec{ProductAtRevision: prRun.ProductAtRevision},
 		HeadSHA:    prRun.FullRevisionHash,
-		Title:      getCheckTitle(product),
 		DetailsURL: diffURL,
 		Status:     "completed",
 	}

--- a/shared/params.go
+++ b/shared/params.go
@@ -59,6 +59,12 @@ func (p ProductSpec) Matches(run TestRun) bool {
 	return true
 }
 
+// IsExperimental returns true if the product spec is restricted to experimental
+// runs (i.e. has the label "experimental").
+func (p ProductSpec) IsExperimental() bool {
+	return p.Labels != nil && p.Labels.Contains(ExperimentalLabel)
+}
+
 // DisplayName returns a capitalized version of the product's name.
 func (p ProductSpec) DisplayName() string {
 	switch p.BrowserName {


### PR DESCRIPTION
## Description
Allows a more complete product spec to be named as a more simple one, so that we're not computing the check name separately.