### PR TITLE
Remove custom go-github branch

### DIFF
--- a/api/checks/api.go
+++ b/api/checks/api.go
@@ -10,7 +10,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/lukebjerring/go-github/github"
+	"github.com/google/go-github/github"
 	"github.com/web-platform-tests/wpt.fyi/api/checks/summaries"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 	"google.golang.org/appengine/datastore"

--- a/api/checks/api_mock.go
+++ b/api/checks/api_mock.go
@@ -6,10 +6,11 @@ package checks
 
 import (
 	context "context"
-	gomock "github.com/golang/mock/gomock"
-	github "github.com/lukebjerring/go-github/github"
-	shared "github.com/web-platform-tests/wpt.fyi/shared"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
+	github "github.com/google/go-github/github"
+	shared "github.com/web-platform-tests/wpt.fyi/shared"
 )
 
 // MockAPI is a mock of API interface

--- a/api/checks/jwt.go
+++ b/api/checks/jwt.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	jwt "github.com/dgrijalva/jwt-go"
-	"github.com/lukebjerring/go-github/github"
+	"github.com/google/go-github/github"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 	"golang.org/x/oauth2"
 )

--- a/api/checks/runs.go
+++ b/api/checks/runs.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/lukebjerring/go-github/github"
+	"github.com/google/go-github/github"
 	"github.com/web-platform-tests/wpt.fyi/api/checks/summaries"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )

--- a/api/checks/summaries/compile.go
+++ b/api/checks/summaries/compile.go
@@ -11,7 +11,7 @@ import (
 	"runtime"
 	"text/template"
 
-	"github.com/lukebjerring/go-github/github"
+	"github.com/google/go-github/github"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 

--- a/api/checks/summaries/completed.go
+++ b/api/checks/summaries/completed.go
@@ -5,7 +5,7 @@
 package summaries
 
 import (
-	"github.com/lukebjerring/go-github/github"
+	"github.com/google/go-github/github"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 

--- a/api/checks/summaries/pending.go
+++ b/api/checks/summaries/pending.go
@@ -4,7 +4,7 @@
 
 package summaries
 
-import "github.com/lukebjerring/go-github/github"
+import "github.com/google/go-github/github"
 
 // Pending is the struct for pending.md.
 type Pending struct {

--- a/api/checks/summaries/regressed.go
+++ b/api/checks/summaries/regressed.go
@@ -4,7 +4,7 @@
 
 package summaries
 
-import "github.com/lukebjerring/go-github/github"
+import "github.com/google/go-github/github"
 
 // BeforeAndAfter is a struct summarizing pass rates before and after in a diff.
 type BeforeAndAfter struct {

--- a/api/checks/webhook.go
+++ b/api/checks/webhook.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/lukebjerring/go-github/github"
+	"github.com/google/go-github/github"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 

--- a/api/checks/webhook_test.go
+++ b/api/checks/webhook_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/lukebjerring/go-github/github"
+	"github.com/google/go-github/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
 )

--- a/api/taskcluster/webhook.go
+++ b/api/taskcluster/webhook.go
@@ -22,7 +22,7 @@ import (
 	"google.golang.org/appengine/urlfetch"
 
 	mapset "github.com/deckarep/golang-set"
-	"github.com/lukebjerring/go-github/github"
+	"github.com/google/go-github/github"
 	"github.com/web-platform-tests/wpt.fyi/api/checks"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )

--- a/api/taskcluster/webhook_test.go
+++ b/api/taskcluster/webhook_test.go
@@ -15,7 +15,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/lukebjerring/go-github/github"
+	"github.com/google/go-github/github"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/web-platform-tests/wpt.fyi/api/checks"

--- a/api/test_runs.go
+++ b/api/test_runs.go
@@ -9,7 +9,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/lukebjerring/go-github/github"
+	"github.com/google/go-github/github"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 	"golang.org/x/oauth2"
 	"google.golang.org/appengine"

--- a/shared/run_diff.go
+++ b/shared/run_diff.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 
 	mapset "github.com/deckarep/golang-set"
-	"github.com/lukebjerring/go-github/github"
+	"github.com/google/go-github/github"
 	"golang.org/x/oauth2"
 	"google.golang.org/appengine/urlfetch"
 )


### PR DESCRIPTION
## Description
No longer needed now that https://github.com/google/go-github/pull/1063 has landed.