### PR TITLE
Append HTTP code to log for failed taskcluster fetch

### DIFF
--- a/api/taskcluster/webhook.go
+++ b/api/taskcluster/webhook.go
@@ -378,7 +378,7 @@ func createRun(
 		return err
 	}
 	if resp.StatusCode >= 300 {
-		return fmt.Errorf("API error: %s", string(respBody))
+		return fmt.Errorf("API error: HTTP %v: %s", resp.StatusCode, string(respBody))
 	}
 
 	return nil


### PR DESCRIPTION
## Description
Makes it easier to determine that it was a 404.