### PR TITLE
Fix cache index synchronization

### DIFF
--- a/api/query/cache/index/filter.go
+++ b/api/query/cache/index/filter.go
@@ -1,0 +1,14 @@
+// Copyright 2018 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package index
+
+// FUTURE: This file will contain code for composing filter functions from
+// queries. These functions will be bound to a subset of Index data stored in
+// an instance of index.
+
+type index struct {
+	tests      Tests
+	runResults map[RunID]RunResults
+}

--- a/api/query/cache/index/index.go
+++ b/api/query/cache/index/index.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"sync"
 
+	mapset "github.com/deckarep/golang-set"
 	"github.com/web-platform-tests/results-analysis/metrics"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 
@@ -20,8 +21,9 @@ import (
 )
 
 var (
-	errNoRuns             = errors.New("No runs")
 	errNilRun             = errors.New("Test run is nil")
+	errNoQuery            = errors.New("No query provided")
+	errNoRuns             = errors.New("No runs")
 	errRunExists          = errors.New("Run already exists in index")
 	errRunLoading         = errors.New("Run currently being loaded into index")
 	errSomeShardsRequired = errors.New("Index must have at least one shard")
@@ -69,17 +71,28 @@ type ReportLoader interface {
 	Load(shared.TestRun) (*metrics.TestResultsReport, error)
 }
 
+// shardedWPTIndex is an Index that manages test and result data across mutually
+// exclusive shards.
 type shardedWPTIndex struct {
-	runs     sync.Map
-	inFlight sync.Map
+	runs     map[RunID]shared.TestRun
+	inFlight mapset.Set
 	loader   ReportLoader
-	tests    Tests
 	shards   []*wptIndex
+	m        *sync.Mutex
 }
 
+// wptIndex is an index of tests and results. Multicore machines should use
+// shardedWPTIndex, which embed a slice of wptIndex containing mutually
+// exclusive subsets of test and result data.
 type wptIndex struct {
 	tests   Tests
 	results Results
+}
+
+// testData is a wrapper for a single unit of test+result data from a test run.
+type testData struct {
+	testName
+	ResultID
 }
 
 type httpReportLoader struct{}
@@ -89,18 +102,10 @@ func (i *shardedWPTIndex) IngestRun(r shared.TestRun) error {
 	if r.ID == 0 {
 		return errZeroRun
 	}
-	id := RunID(r.ID)
-	_, wasLoaded := i.runs.Load(id)
-	if wasLoaded {
-		return errRunExists
+	if err := i.syncMarkInProgress(r); err != nil {
+		return err
 	}
-	// LoadOrStore will mark this run as in-flight if it is not already marked as
-	// such.
-	_, isLoading := i.inFlight.LoadOrStore(id, r)
-	defer i.inFlight.Delete(id)
-	if isLoading {
-		return errRunLoading
-	}
+	defer i.syncClearInProgress(r)
 
 	// Delegate loader to construct complete run report.
 	report, err := i.loader.Load(r)
@@ -112,21 +117,30 @@ func (i *shardedWPTIndex) IngestRun(r shared.TestRun) error {
 	// top-level test (i.e., not subtests) integral ID of each test in the report.
 	//
 	// Create RunResults for each shard's partition of this run's results.
-	numShards := uint64(len(i.shards))
-	runResults := make([]RunResults, numShards)
-	for j := uint64(0); j < numShards; j++ {
-		runResults[j] = NewRunResults()
+	numShards := len(i.shards)
+	numShardsU64 := uint64(numShards)
+	shardData := make([]map[TestID]testData, numShards)
+	for j := 0; j < numShards; j++ {
+		shardData[j] = make(map[TestID]testData)
 	}
 
 	for _, res := range report.Results {
 		// Add top-level test (i.e., not subtest) result to appropriate shard.
-		re := ResultID(metrics.TestStatusFromString(res.Status))
-		t, err := i.tests.Add(res.Test, nil)
+		t, err := computeID(res.Test, nil)
 		if err != nil {
 			return err
 		}
-		runResultsForShard := runResults[int(t.testID%numShards)]
-		runResultsForShard.Add(re, t)
+
+		shardIdx := int(t.testID % numShardsU64)
+		dataForShard := shardData[shardIdx]
+		re := ResultID(shared.TestStatusValueFromString(res.Status))
+		dataForShard[t] = testData{
+			testName: testName{
+				name:    res.Test,
+				subName: nil,
+			},
+			ResultID: re,
+		}
 
 		// Dedup subtests, warning when subtest names are duplicated.
 		subs := make(map[string]metrics.SubTest)
@@ -141,57 +155,29 @@ func (i *shardedWPTIndex) IngestRun(r shared.TestRun) error {
 		// Add each subtests' result to the appropriate shard (same shard as
 		// top-level test).
 		for _, sub := range subs {
-			re := ResultID(metrics.SubTestStatusFromString(sub.Status))
-			t, err := i.tests.Add(res.Test, &sub.Name)
+			t, err := computeID(res.Test, &sub.Name)
 			if err != nil {
 				return err
 			}
 
-			runResultsForShard.Add(re, t)
+			re := ResultID(shared.TestStatusValueFromString(sub.Status))
+			dataForShard[t] = testData{
+				testName: testName{
+					name:    res.Test,
+					subName: &sub.Name,
+				},
+				ResultID: re,
+			}
 		}
 	}
 
-	// Add accumulated RunResults to shards.
-	for j := range runResults {
-		err := i.shards[j].results.Add(id, runResults[j])
-		if err != nil {
-			return err
-		}
-	}
-
-	// Mark run as successfully stored in index.
-	i.runs.Store(id, r)
+	i.syncStoreRun(r, shardData)
 
 	return nil
 }
 
 func (i *shardedWPTIndex) EvictAnyRun() error {
-	// Accumulate runs into sortable collection.
-	runs := make(shared.TestRuns, 0)
-	i.runs.Range(func(key, value interface{}) bool {
-		run := value.(shared.TestRun)
-		runs = append(runs, run)
-		return true
-	})
-	if len(runs) == 0 {
-		return errNoRuns
-	}
-
-	// Sort and mark and select oldest run for eviction.
-	sort.Sort(runs)
-	runIDToEvict := RunID(runs[0].ID)
-
-	// Delete run from runs-in-index collection.
-	i.runs.Delete(runIDToEvict)
-
-	// Delete run results from each shard.
-	for j, shard := range i.shards {
-		if err := shard.results.Delete(runIDToEvict); err != nil {
-			log.Warningf(`Error while evicting run from shard %d: %v`, j, err)
-		}
-	}
-
-	return nil
+	return i.syncEvictRun()
 }
 
 func (l httpReportLoader) Load(run shared.TestRun) (*metrics.TestResultsReport, error) {
@@ -226,16 +212,17 @@ func NewShardedWPTIndex(loader ReportLoader, numShards int) (Index, error) {
 	}
 
 	shards := make([]*wptIndex, 0, numShards)
-	tests := NewTests()
 	for i := 0; i < numShards; i++ {
+		tests := NewTests()
 		shards = append(shards, newWPTIndex(tests))
 	}
+
 	return &shardedWPTIndex{
-		runs:     sync.Map{},
-		inFlight: sync.Map{},
+		runs:     make(map[RunID]shared.TestRun),
+		inFlight: mapset.NewSet(),
 		loader:   loader,
-		tests:    tests,
 		shards:   shards,
+		m:        &sync.Mutex{},
 	}, nil
 }
 
@@ -243,6 +230,113 @@ func NewShardedWPTIndex(loader ReportLoader, numShards int) (Index, error) {
 // a shared.TestRun.RawResultsURL.
 func NewReportLoader() ReportLoader {
 	return httpReportLoader{}
+}
+
+func (i *shardedWPTIndex) syncMarkInProgress(run shared.TestRun) error {
+	i.m.Lock()
+	defer i.m.Unlock()
+
+	id := RunID(run.ID)
+	_, loaded := i.runs[id]
+	if loaded {
+		return errRunExists
+	}
+	if i.inFlight.Contains(id) {
+		return errRunLoading
+	}
+
+	i.inFlight.Add(id)
+
+	return nil
+}
+
+func (i *shardedWPTIndex) syncClearInProgress(run shared.TestRun) error {
+	i.m.Lock()
+	defer i.m.Unlock()
+
+	id := RunID(run.ID)
+	if !i.inFlight.Contains(id) {
+		return errNilRun
+	}
+
+	i.inFlight.Remove(id)
+
+	return nil
+}
+
+func (i *shardedWPTIndex) syncStoreRun(run shared.TestRun, data []map[TestID]testData) error {
+	i.m.Lock()
+	defer i.m.Unlock()
+
+	id := RunID(run.ID)
+	for j, shardData := range data {
+		runResults := NewRunResults()
+		for t, data := range shardData {
+			i.shards[j].tests.Add(t, data.testName.name, data.testName.subName)
+			runResults.Add(data.ResultID, t)
+		}
+		err := i.shards[j].results.Add(id, runResults)
+		if err != nil {
+			return err
+		}
+	}
+	i.runs[id] = run
+
+	return nil
+}
+
+func (i *shardedWPTIndex) syncEvictRun() error {
+	i.m.Lock()
+	defer i.m.Unlock()
+
+	if len(i.runs) == 0 {
+		return errNoRuns
+	}
+
+	// Accumulate runs into sortable collection.
+	runs := make(shared.TestRuns, 0, len(i.runs))
+	for _, run := range i.runs {
+		runs = append(runs, run)
+	}
+
+	// Sort and mark oldest run for eviction.
+	sort.Sort(runs)
+	id := RunID(runs[0].ID)
+
+	// Delete data from shards, and from runs collection.
+	for _, shard := range i.shards {
+		err := shard.results.Delete(id)
+		if err != nil {
+			return err
+		}
+	}
+	delete(i.runs, id)
+
+	return nil
+}
+
+func (i *shardedWPTIndex) syncExtractRuns(ids []RunID) ([]index, error) {
+	i.m.Lock()
+	defer i.m.Unlock()
+
+	idxs := make([]index, len(i.shards))
+	for j, shard := range i.shards {
+		tests := shard.tests
+		runResults := make(map[RunID]RunResults)
+		for _, id := range ids {
+			rrs := shard.results.ForRun(id)
+			if rrs == nil {
+				return nil, fmt.Errorf("Run is unknown to shard: RunID=%v", id)
+			}
+			runResults[id] = shard.results.ForRun(id)
+		}
+		idxs[j] = index{
+			tests:      tests,
+			runResults: runResults,
+		}
+	}
+
+	return idxs, nil
 }
 
 func newWPTIndex(tests Tests) *wptIndex {

--- a/api/query/cache/index/index.go
+++ b/api/query/cache/index/index.go
@@ -78,7 +78,7 @@ type shardedWPTIndex struct {
 	inFlight mapset.Set
 	loader   ReportLoader
 	shards   []*wptIndex
-	m        *sync.Mutex
+	m        *sync.RWMutex
 }
 
 // wptIndex is an index of tests and results. Multicore machines should use
@@ -222,7 +222,7 @@ func NewShardedWPTIndex(loader ReportLoader, numShards int) (Index, error) {
 		inFlight: mapset.NewSet(),
 		loader:   loader,
 		shards:   shards,
-		m:        &sync.Mutex{},
+		m:        &sync.RWMutex{},
 	}, nil
 }
 
@@ -316,8 +316,8 @@ func (i *shardedWPTIndex) syncEvictRun() error {
 }
 
 func (i *shardedWPTIndex) syncExtractRuns(ids []RunID) ([]index, error) {
-	i.m.Lock()
-	defer i.m.Unlock()
+	i.m.RLock()
+	defer i.m.RUnlock()
 
 	idxs := make([]index, len(i.shards))
 	for j, shard := range i.shards {

--- a/api/query/cache/index/index_test.go
+++ b/api/query/cache/index/index_test.go
@@ -147,3 +147,6 @@ func TestEvictNonEmpty(t *testing.T) {
 	assert.Nil(t, i.IngestRun(run))
 	assert.Nil(t, i.EvictAnyRun())
 }
+
+// TODO: Add synchronization test to check for race conditions once Bind+Execute
+// are fully implemented over indexes and filters.

--- a/api/query/cache/index/tests_test.go
+++ b/api/query/cache/index/tests_test.go
@@ -21,8 +21,9 @@ func TestGetName_fail(t *testing.T) {
 func TestAddGetName(t *testing.T) {
 	ts := NewTests()
 	name := "/a/b/c"
-	id, err := ts.Add(name, nil)
+	id, err := computeID(name, nil)
 	assert.Nil(t, err)
+	ts.Add(id, name, nil)
 	actualName, actualSubName, err := ts.GetName(id)
 	assert.Nil(t, err)
 	assert.Equal(t, name, actualName)
@@ -30,8 +31,9 @@ func TestAddGetName(t *testing.T) {
 
 	subNameValue := "some sub name"
 	subName := &subNameValue
-	id, err = ts.Add(name, subName)
+	id, err = computeID(name, subName)
 	assert.Nil(t, err)
+	ts.Add(id, name, subName)
 	actualName, actualSubName, err = ts.GetName(id)
 	assert.Nil(t, err)
 	assert.Equal(t, name, actualName)


### PR DESCRIPTION
Drop use of sync.Map in favour of critical sections that ensure a stable state when reading from and writing to index.