### PR TITLE
Search cache: Make Indexes implement Binder

### DIFF
--- a/api/query/cache/backfill/backfill.go
+++ b/api/query/cache/backfill/backfill.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/api/option"
 
 	"cloud.google.com/go/datastore"
+	"github.com/web-platform-tests/wpt.fyi/api/query"
 	"github.com/web-platform-tests/wpt.fyi/api/query/cache/index"
 	"github.com/web-platform-tests/wpt.fyi/api/query/cache/monitor"
 	"github.com/web-platform-tests/wpt.fyi/shared"
@@ -91,6 +92,10 @@ func (i *backfillIndex) EvictAnyRun() error {
 func (m *backfillMonitor) Stop() error {
 	m.idx.backfilling = false
 	return m.ProxyMonitor.Stop()
+}
+
+func (*backfillIndex) Bind([]shared.TestRun, query.AbstractQuery) (query.Plan, error) {
+	return nil, nil
 }
 
 // FillIndex starts backfilling an index given a series of configuration

--- a/api/query/cache/backfill/backfill_medium_test.go
+++ b/api/query/cache/backfill/backfill_medium_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"github.com/web-platform-tests/wpt.fyi/api/query"
 	"github.com/web-platform-tests/wpt.fyi/api/query/cache/index"
 	"github.com/web-platform-tests/wpt.fyi/api/query/cache/monitor"
 	shared "github.com/web-platform-tests/wpt.fyi/shared"
@@ -41,6 +42,10 @@ func (i *countingIndex) EvictAnyRun() error {
 
 	i.count--
 	return nil
+}
+
+func (*countingIndex) Bind([]shared.TestRun, query.AbstractQuery) (query.Plan, error) {
+	return nil, nil
 }
 
 func TestStopImmediately(t *testing.T) {

--- a/api/query/cache/index/index.go
+++ b/api/query/cache/index/index.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 
 	"github.com/web-platform-tests/results-analysis/metrics"
+	"github.com/web-platform-tests/wpt.fyi/api/query"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 
 	log "github.com/sirupsen/logrus"
@@ -29,8 +30,9 @@ var (
 )
 
 // Index is an index of test run results that can ingest and evict runs.
-// FUTURE: Index will also be able to service queries.
 type Index interface {
+	query.Binder
+
 	// IngestRun loads the test run results associated with the input test run
 	// into the index.
 	IngestRun(shared.TestRun) error
@@ -192,6 +194,35 @@ func (i *shardedWPTIndex) EvictAnyRun() error {
 	}
 
 	return nil
+}
+
+func (i *shardedWPTIndex) Bind(runs []shared.TestRun, aq query.AbstractQuery) (query.Plan, error) {
+	if len(runs) == 0 {
+		return nil, errNoRuns
+	}
+	if aq == nil {
+		return nil, errNoQuery
+	}
+
+	ids := make([]RunID, len(runs))
+	for j, run := range runs {
+		ids[j] = RunID(run.ID)
+	}
+	idxs, err := i.syncExtractRuns(ids)
+	if err != nil {
+		return nil, err
+	}
+
+	q := aq.BindToRuns(runs)
+	fs := make(ShardedFilter, len(idxs))
+	for j, idx := range idxs {
+		f, err := newFilter(idx, q)
+		if err != nil {
+			return nil, err
+		}
+		fs[j] = f
+	}
+	return fs, nil
 }
 
 func (l httpReportLoader) Load(run shared.TestRun) (*metrics.TestResultsReport, error) {

--- a/api/query/cache/index/index_mock.go
+++ b/api/query/cache/index/index_mock.go
@@ -5,10 +5,12 @@
 package index
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	metrics "github.com/web-platform-tests/results-analysis/metrics"
+	query "github.com/web-platform-tests/wpt.fyi/api/query"
 	shared "github.com/web-platform-tests/wpt.fyi/shared"
-	reflect "reflect"
 )
 
 // MockIndex is a mock of Index interface
@@ -32,6 +34,19 @@ func NewMockIndex(ctrl *gomock.Controller) *MockIndex {
 // EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockIndex) EXPECT() *MockIndexMockRecorder {
 	return m.recorder
+}
+
+// Bind mocks base method
+func (m *MockIndex) Bind(arg0 []shared.TestRun, arg1 query.AbstractQuery) (query.Plan, error) {
+	ret := m.ctrl.Call(m, "Bind", arg0, arg1)
+	ret0, _ := ret[0].(query.Plan)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Bind indicates an expected call of Bind
+func (mr *MockIndexMockRecorder) Bind(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bind", reflect.TypeOf((*MockIndex)(nil).Bind), arg0, arg1)
 }
 
 // IngestRun mocks base method


### PR DESCRIPTION
This (along with existing open PRs) completes the Bind+Execute implementation a sharded index, allowing for landing integration tests labeled as `TODO` in previous PRs.