### PR TITLE
Where applicable, update existing check-runs

### DIFF
--- a/api/checks/api.go
+++ b/api/checks/api.go
@@ -68,6 +68,7 @@ func (s checksAPIImpl) PendingCheckRun(suite shared.CheckSuite, product shared.P
 	host := shared.NewAppEngineAPI(s.ctx).GetHostname()
 	pending := summaries.Pending{
 		CheckState: summaries.CheckState{
+			TestRun:    nil, // It's pending, no run exists yet.
 			Product:    product,
 			HeadSHA:    suite.SHA,
 			DetailsURL: shared.NewDiffAPI(s.ctx).GetMasterDiffURL(suite.SHA, product),
@@ -76,7 +77,7 @@ func (s checksAPIImpl) PendingCheckRun(suite shared.CheckSuite, product shared.P
 		HostName: host,
 		RunsURL:  fmt.Sprintf("https://%s/runs", host),
 	}
-	return updateCheckRun(s.ctx, pending, suite)
+	return updateCheckRunSummary(s.ctx, pending, suite)
 }
 
 // GetSuitesForSHA gets all existing check suites for the given Head SHA

--- a/api/checks/runs.go
+++ b/api/checks/runs.go
@@ -26,6 +26,7 @@ func updateCheckRunSummary(ctx context.Context, summary summaries.Summary, suite
 			for _, run := range runs {
 				if spec, _ := shared.ParseProductSpec(run.GetName()); spec.Matches(*testRun) {
 					existing = run
+					break
 				}
 			}
 		}

--- a/api/checks/runs.go
+++ b/api/checks/runs.go
@@ -13,8 +13,79 @@ import (
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
-func updateCheckRun(ctx context.Context, summary summaries.Summary, suites ...shared.CheckSuite) (bool, error) {
+func updateCheckRunSummary(ctx context.Context, summary summaries.Summary, suites ...shared.CheckSuite) (bool, error) {
 	log := shared.GetLogger(ctx)
+	product := summary.GetCheckState().Product
+
+	testRun := summary.GetCheckState().TestRun
+	for _, suite := range suites {
+		// Update, not create, if a run name matches this completed TestRun.
+		var existing *github.CheckRun
+		if testRun != nil {
+			runs, _ := getExistingCheckRuns(ctx, suite)
+			for _, run := range runs {
+				if spec, _ := shared.ParseProductSpec(run.GetName()); spec.Matches(*testRun) {
+					existing = run
+				}
+			}
+		}
+
+		var created bool
+		var err error
+		if existing != nil {
+			created, err = updateExistingCheckRunSummary(ctx, summary, suite, existing)
+		} else {
+			state := summary.GetCheckState()
+			actions := summary.GetActions()
+
+			summaryStr, err := summary.GetSummary()
+			if err != nil {
+				log.Warningf("Failed to generate summary for %s: %s", state.HeadSHA, err.Error())
+				return false, err
+			}
+
+			detailsURLStr := state.DetailsURL.String()
+			title := state.Title()
+			opts := github.CreateCheckRunOptions{
+				Name:       state.Name(),
+				HeadSHA:    state.HeadSHA,
+				DetailsURL: &detailsURLStr,
+				Status:     &state.Status,
+				Conclusion: state.Conclusion,
+				Output: &github.CheckRunOutput{
+					Title:   &title,
+					Summary: &summaryStr,
+				},
+				Actions: actions,
+			}
+			if state.Conclusion != nil {
+				opts.CompletedAt = &github.Timestamp{Time: time.Now()}
+			}
+			created, err = createCheckRun(ctx, suite, opts)
+		}
+		if !created || err != nil {
+			return false, err
+		}
+		log.Debugf("Check for %s/%s @ %s (%s) updated", suite.Owner, suite.Repo, suite.SHA[:7], product.String())
+	}
+	return true, nil
+}
+
+func getExistingCheckRuns(ctx context.Context, suite shared.CheckSuite) ([]*github.CheckRun, error) {
+	log := shared.GetLogger(ctx)
+	client, err := getGitHubClient(ctx, suite.AppID, suite.InstallationID)
+	if err != nil {
+		log.Errorf("Failed to fetch runs for suite: %s", err.Error())
+		return nil, err
+	}
+
+	runs, _, err := client.Checks.ListCheckRunsForRef(ctx, suite.Owner, suite.Repo, suite.SHA, nil)
+	return runs.CheckRuns, err
+}
+
+func updateExistingCheckRunSummary(ctx context.Context, summary summaries.Summary, suite shared.CheckSuite, run *github.CheckRun) (bool, error) {
+	log := shared.GetLogger(ctx)
+
 	state := summary.GetCheckState()
 	actions := summary.GetActions()
 
@@ -26,9 +97,9 @@ func updateCheckRun(ctx context.Context, summary summaries.Summary, suites ...sh
 
 	detailsURLStr := state.DetailsURL.String()
 	title := state.Title()
-	opts := github.CreateCheckRunOptions{
+	opts := github.UpdateCheckRunOptions{
 		Name:       state.Name(),
-		HeadSHA:    state.HeadSHA,
+		HeadSHA:    &state.HeadSHA,
 		DetailsURL: &detailsURLStr,
 		Status:     &state.Status,
 		Conclusion: state.Conclusion,
@@ -42,12 +113,11 @@ func updateCheckRun(ctx context.Context, summary summaries.Summary, suites ...sh
 		opts.CompletedAt = &github.Timestamp{Time: time.Now()}
 	}
 
-	for _, suite := range suites {
-		created, err := createCheckRun(ctx, suite, opts)
-		if !created || err != nil {
-			return false, err
-		}
-		log.Debugf("Check for %s/%s @ %s (%s) updated", suite.Owner, suite.Repo, suite.SHA[:7], state.Product.String())
+	client, err := getGitHubClient(ctx, suite.AppID, suite.InstallationID)
+	if err != nil {
+		return false, err
 	}
-	return true, nil
+
+	_, _, err = client.Checks.UpdateCheckRun(ctx, suite.Owner, suite.Repo, run.GetID(), opts)
+	return err != nil, err
 }

--- a/api/checks/summaries/compile.go
+++ b/api/checks/summaries/compile.go
@@ -40,6 +40,7 @@ type Summary interface {
 
 // CheckState represents all the status fields for updating a check.
 type CheckState struct {
+	TestRun    *shared.TestRun // The (completed) TestRun, if applicable.
 	Product    shared.ProductSpec
 	HeadSHA    string
 	DetailsURL *url.URL

--- a/shared/models.go
+++ b/shared/models.go
@@ -114,6 +114,11 @@ type TestRun struct {
 	Labels []string `json:"labels"`
 }
 
+// IsExperimental returns true if the run is labelled experimental.
+func (r TestRun) IsExperimental() bool {
+	return len(r.Labels) > 0 && r.LabelsSet().Contains(ExperimentalLabel)
+}
+
 // TestRunStatus is an enum for PendingTestRun statuses.
 type TestRunStatus int64
 
@@ -150,9 +155,9 @@ type CheckSuite struct {
 }
 
 // LabelsSet creates a set from the run's labels.
-func (run TestRun) LabelsSet() mapset.Set {
+func (r TestRun) LabelsSet() mapset.Set {
 	runLabels := mapset.NewSet()
-	for _, label := range run.Labels {
+	for _, label := range r.Labels {
 		runLabels.Add(label)
 	}
 	return runLabels


### PR DESCRIPTION
## Description
Attempts to prevent check run name mismatching with a two-pronged approach:
- Include the experimental label when converting a TestRun into a product spec
- Pass the existing TestRun to the update method, and compare it to (any) existing run's name-specs