### PR TITLE
Handle azure completed events

### DIFF
--- a/api/checks/webhook.go
+++ b/api/checks/webhook.go
@@ -28,12 +28,7 @@ const (
 )
 
 func isWPTFYIApp(appID int64) bool {
-	switch appID {
-	case wptfyiCheckAppID,
-		checksStagingAppID:
-		return true
-	}
-	return false
+	return appID == wptfyiCheckAppID || appID == checksStagingAppID
 }
 
 // checkWebhookHandler listens for check_suite and check_run events,
@@ -258,6 +253,7 @@ func handleAzurePipelinesEvent(log shared.Logger, event checkRunEvent) (bool, er
 		log.Errorf("Failed to extract build ID from details_url \"%s\"", detailsURL)
 		return false, nil
 	}
+	// https://docs.microsoft.com/en-us/rest/api/azure/devops/build/artifacts/get?view=azure-devops-rest-4.1
 	artifact := fmt.Sprintf(
 		"https://dev.azure.com/%s/%s/_apis/build/builds/%s/artifacts?artifactName=drop&api-version=5.0-preview.5&%%24format=zip",
 		event.GetRepo().GetOwner().GetLogin(),

--- a/api/checks/webhook_test.go
+++ b/api/checks/webhook_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-github/github"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
 )
@@ -234,4 +235,25 @@ func getOpenedPREvent(user, sha string) github.PullRequestEvent {
 		},
 		Action: &opened,
 	}
+}
+
+func TestHandleAzurePipelinesEvent(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	sha := strings.Repeat("0123456789", 4)
+	detailsURL := "https://dev.azure.com/web-platform-tests/b14026b4-9423-4454-858f-bf76cf6d1faa/_build/results?buildId=123"
+	ghEvent := getCheckRunCreatedEvent("completed", "lukebjerring", sha)
+	event := checkRunEvent{
+		CheckRunEvent: ghEvent,
+		CheckRun:      &checkRun{CheckRun: *ghEvent.CheckRun},
+	}
+	event.CheckRun.DetailsURL = &detailsURL
+
+	log, hook := logrustest.NewNullLogger()
+	processed, err := handleAzurePipelinesEvent(log, event)
+	assert.Nil(t, err)
+	assert.False(t, processed)
+	assert.Len(t, hook.Entries, 2)
+	assert.Contains(t, hook.Entries[0].Message, "/123/")
 }


### PR DESCRIPTION
## Description
Step towards #714 by currying an artifact URL from the details URL.

Unfortunately I've had to wrap the `CheckRunEvent` to get the `detailts_url` field, until I land https://github.com/google/go-github/pull/1065