### PR TITLE
Harvest the "without changes" runs from Taskcluster

### DIFF
--- a/shared/util.go
+++ b/shared/util.go
@@ -33,9 +33,13 @@ const BetaLabel = "beta"
 // i.e. run from the master branch.
 const MasterLabel = "master"
 
-// WithoutPatchLabel is the label for running just the affected tests on a PR
-// but without the patch.
-const WithoutPatchLabel = "without_patch"
+// PRBaseLabel is the implicit label for running just the affected tests on a
+// PR but without the changes (i.e. against the base branch).
+const PRBaseLabel = "pr_base"
+
+// PRHeadLabel is the implicit label for running just the affected tests on the
+// head of a PR (with the changes).
+const PRHeadLabel = "pr_head"
 
 // ProductChannelToLabel maps known product-specific channel names
 // to the wpt.fyi model's equivalent.

--- a/shared/util.go
+++ b/shared/util.go
@@ -33,6 +33,10 @@ const BetaLabel = "beta"
 // i.e. run from the master branch.
 const MasterLabel = "master"
 
+// WithoutPatchLabel is the label for running just the affected tests on a PR
+// but without the patch.
+const WithoutPatchLabel = "without_patch"
+
 // ProductChannelToLabel maps known product-specific channel names
 // to the wpt.fyi model's equivalent.
 func ProductChannelToLabel(channel string) string {


### PR DESCRIPTION
This change extends the set of valid task names to accept the
"*-results-without-changes" tasks that are being added in
https://github.com/web-platform-tests/wpt/pull/14382 . The change also
adds a "pr_base" label to these special runs, and "pr_head" to the PR
runs with the changes to prepare for the next step: using these runs
to calculate PR regressions (not implemented in this change).

Related to #708 .