### PR TITLE
Aggregate search results

### DIFF
--- a/api/query/cache/index/aggregator.go
+++ b/api/query/cache/index/aggregator.go
@@ -1,0 +1,69 @@
+// Copyright 2018 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package index
+
+import (
+	"github.com/web-platform-tests/wpt.fyi/api/query"
+	"github.com/web-platform-tests/wpt.fyi/shared"
+)
+
+type aggregator interface {
+	Add(t TestID) error
+	Done() []query.SearchResult
+}
+
+type indexAggregator struct {
+	index
+
+	rus []RunID
+	agg map[uint64]query.SearchResult
+}
+
+func (a *indexAggregator) Add(t TestID) error {
+	id := t.testID
+	ts := a.tests
+	r, ok := a.agg[id]
+	if !ok {
+		name, _, err := ts.GetName(t)
+		if err != nil {
+			return err
+		}
+
+		r = query.SearchResult{Test: name, LegacyStatus: nil}
+	}
+
+	rus := r.LegacyStatus
+	if rus == nil {
+		rus = make([]query.LegacySearchRunResult, len(a.rus))
+	}
+
+	for i, ru := range a.rus {
+		res := int64(a.runResults[ru].GetResult(t))
+		rus[i].Total++
+		if res == shared.TestStatusPass || res == shared.TestStatusOK {
+			rus[i].Passes++
+		}
+	}
+	r.LegacyStatus = rus
+	a.agg[id] = r
+
+	return nil
+}
+
+func (a *indexAggregator) Done() []query.SearchResult {
+	res := make([]query.SearchResult, 0, len(a.agg))
+	for _, r := range a.agg {
+		res = append(res, r)
+	}
+	return res
+}
+
+func newIndexAggregator(idx index, rus []RunID) aggregator {
+	return &indexAggregator{
+		index: idx,
+		rus:   rus,
+		agg:   make(map[uint64]query.SearchResult),
+	}
+}

--- a/api/query/cache/index/index_test.go
+++ b/api/query/cache/index/index_test.go
@@ -206,12 +206,13 @@ func TestSync(t *testing.T) {
 		wg.Add(1)
 		go func(n int) {
 			defer wg.Done()
-			plan, err := i.Bind([]shared.TestRun{
+			runs := []shared.TestRun{
 				makeRun(int64(n - 1)),
 				makeRun(int64(n - 2)),
 				makeRun(int64(n - 3)),
 				makeRun(int64(n - 4)),
-			}, query.TestStatusConstraint{
+			}
+			plan, err := i.Bind(runs, query.TestStatusConstraint{
 				BrowserName: "Chrome",
 				Status:      shared.TestStatusPass,
 			})
@@ -219,7 +220,7 @@ func TestSync(t *testing.T) {
 				return
 			}
 
-			plan.Execute()
+			plan.Execute(runs)
 		}(j)
 	}
 	wg.Wait()

--- a/api/query/concrete_query.go
+++ b/api/query/concrete_query.go
@@ -4,7 +4,9 @@
 
 package query
 
-import "github.com/web-platform-tests/wpt.fyi/shared"
+import (
+	"github.com/web-platform-tests/wpt.fyi/shared"
+)
 
 // Binder is a mechanism for binding a query over a slice of test runs to
 // a particular query service mechanism.
@@ -21,7 +23,7 @@ type Binder interface {
 type Plan interface {
 	// Execute runs the query execution plan. The result set type depends on the
 	// underlying query service mechanism that the Plan was bound with.
-	Execute() interface{}
+	Execute([]shared.TestRun) interface{}
 }
 
 // ConcreteQuery is an AbstractQuery that has been bound to specific test runs.


### PR DESCRIPTION
This change introduces aggregating of search results.

The initial design for this was to separate `Query -> []TestID` "indexed querying" from `[]TestID -> []SearchResult` "result aggregation". The intention was to reuse aggregation across different storage strategies. However, aggregation in the cache requires access to the appropriate shard's test+result data.

This PR implements "result aggregation" as an implementation detail of the cache filters' `Plan.Execute()`. Tests for bind+execute are updated accordingly.