### PR TITLE
Search cache: Implement query handler with backfilling only

### DIFF
--- a/api/query/atoms.go
+++ b/api/query/atoms.go
@@ -25,7 +25,7 @@ type AbstractQuery interface {
 // client, including the IDs of the test runs to query, and the structured query
 // to run.
 type RunQuery struct {
-	runIDs []int64
+	RunIDs []int64
 	AbstractQuery
 }
 
@@ -162,7 +162,7 @@ func (rq *RunQuery) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	rq.runIDs = data.RunIDs
+	rq.RunIDs = data.RunIDs
 	rq.AbstractQuery = q
 	return nil
 }

--- a/api/query/atoms_test.go
+++ b/api/query/atoms_test.go
@@ -93,7 +93,7 @@ func TestStructuredQuery_unknownStatus(t *testing.T) {
 		}
 	}`), &rq)
 	assert.Nil(t, err)
-	assert.Equal(t, RunQuery{runIDs: []int64{0, 1, 2}, AbstractQuery: TestStatusConstraint{"chrome", shared.TestStatusValueFromString("UNKNOWN")}}, rq)
+	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2}, AbstractQuery: TestStatusConstraint{"chrome", shared.TestStatusValueFromString("UNKNOWN")}}, rq)
 }
 
 func TestStructuredQuery_pattern(t *testing.T) {
@@ -105,7 +105,7 @@ func TestStructuredQuery_pattern(t *testing.T) {
 		}
 	}`), &rq)
 	assert.Nil(t, err)
-	assert.Equal(t, RunQuery{runIDs: []int64{0, 1, 2}, AbstractQuery: TestNamePattern{"/2dcontext/"}}, rq)
+	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2}, AbstractQuery: TestNamePattern{"/2dcontext/"}}, rq)
 }
 
 func TestStructuredQuery_status(t *testing.T) {
@@ -118,7 +118,7 @@ func TestStructuredQuery_status(t *testing.T) {
 		}
 	}`), &rq)
 	assert.Nil(t, err)
-	assert.Equal(t, RunQuery{runIDs: []int64{0, 1, 2}, AbstractQuery: TestStatusConstraint{"firefox", shared.TestStatusValueFromString("PASS")}}, rq)
+	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2}, AbstractQuery: TestStatusConstraint{"firefox", shared.TestStatusValueFromString("PASS")}}, rq)
 }
 
 func TestStructuredQuery_not(t *testing.T) {
@@ -132,7 +132,7 @@ func TestStructuredQuery_not(t *testing.T) {
 		}
 	}`), &rq)
 	assert.Nil(t, err)
-	assert.Equal(t, RunQuery{runIDs: []int64{0, 1, 2}, AbstractQuery: AbstractNot{TestNamePattern{"cssom"}}}, rq)
+	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2}, AbstractQuery: AbstractNot{TestNamePattern{"cssom"}}}, rq)
 }
 
 func TestStructuredQuery_or(t *testing.T) {
@@ -147,7 +147,7 @@ func TestStructuredQuery_or(t *testing.T) {
 		}
 	}`), &rq)
 	assert.Nil(t, err)
-	assert.Equal(t, RunQuery{runIDs: []int64{0, 1, 2}, AbstractQuery: AbstractOr{[]AbstractQuery{TestNamePattern{"cssom"}, TestNamePattern{"html"}}}}, rq)
+	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2}, AbstractQuery: AbstractOr{[]AbstractQuery{TestNamePattern{"cssom"}, TestNamePattern{"html"}}}}, rq)
 }
 
 func TestStructuredQuery_and(t *testing.T) {
@@ -162,7 +162,7 @@ func TestStructuredQuery_and(t *testing.T) {
 		}
 	}`), &rq)
 	assert.Nil(t, err)
-	assert.Equal(t, RunQuery{runIDs: []int64{0, 1, 2}, AbstractQuery: AbstractAnd{[]AbstractQuery{TestNamePattern{"cssom"}, TestNamePattern{"html"}}}}, rq)
+	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2}, AbstractQuery: AbstractAnd{[]AbstractQuery{TestNamePattern{"cssom"}, TestNamePattern{"html"}}}}, rq)
 }
 
 func TestStructuredQuery_nested(t *testing.T) {
@@ -186,7 +186,7 @@ func TestStructuredQuery_nested(t *testing.T) {
 	}`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(t, RunQuery{
-		runIDs: []int64{0, 1, 2},
+		RunIDs: []int64{0, 1, 2},
 		AbstractQuery: AbstractOr{
 			Args: []AbstractQuery{
 				AbstractAnd{

--- a/api/query/cache/index/index_mock.go
+++ b/api/query/cache/index/index_mock.go
@@ -5,12 +5,11 @@
 package index
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	metrics "github.com/web-platform-tests/results-analysis/metrics"
 	query "github.com/web-platform-tests/wpt.fyi/api/query"
 	shared "github.com/web-platform-tests/wpt.fyi/shared"
+	reflect "reflect"
 )
 
 // MockIndex is a mock of Index interface
@@ -47,6 +46,19 @@ func (m *MockIndex) Bind(arg0 []shared.TestRun, arg1 query.AbstractQuery) (query
 // Bind indicates an expected call of Bind
 func (mr *MockIndexMockRecorder) Bind(arg0, arg1 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bind", reflect.TypeOf((*MockIndex)(nil).Bind), arg0, arg1)
+}
+
+// Runs mocks base method
+func (m *MockIndex) Runs(arg0 []RunID) ([]shared.TestRun, error) {
+	ret := m.ctrl.Call(m, "Runs", arg0)
+	ret0, _ := ret[0].([]shared.TestRun)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Runs indicates an expected call of Runs
+func (mr *MockIndexMockRecorder) Runs(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Runs", reflect.TypeOf((*MockIndex)(nil).Runs), arg0)
 }
 
 // IngestRun mocks base method

--- a/api/query/search.go
+++ b/api/query/search.go
@@ -121,8 +121,8 @@ func (sh structuredSearchHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 	r2url := *r.URL
 	r2.URL = &r2url
 	r2.Method = "GET"
-	runIDStrs := make([]string, 0, len(rq.runIDs))
-	for _, id := range rq.runIDs {
+	runIDStrs := make([]string, 0, len(rq.RunIDs))
+	for _, id := range rq.RunIDs {
 		runIDStrs = append(runIDStrs, strconv.FormatInt(id, 10))
 	}
 	runIDsStr := strings.Join(runIDStrs, ",")


### PR DESCRIPTION
This change implements the `/api/search/cache` endpoint with a cache that backfills from the time it is started.

Tests for this endpoint and integration for posting new test runs will be implemented in follow-up PRs.