### PR TITLE
Connect search API frontend to cache backend

### DIFF
--- a/api/query/search.go
+++ b/api/query/search.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -134,13 +135,11 @@ func (sh structuredSearchHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 			return
 		}
 
-		data, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			http.Error(w, "Error reading response from search API cache", http.StatusInternalServerError)
-		}
-
 		w.WriteHeader(resp.StatusCode)
-		w.Write(data)
+		_, err = io.Copy(w, resp.Body)
+		if err != nil {
+			shared.GetLogger(ctx).Errorf("Error forwarding response payload from search cache: %v", err)
+		}
 		return
 	}
 

--- a/api/query/search_medium_test.go
+++ b/api/query/search_medium_test.go
@@ -238,11 +238,15 @@ func TestStructuredSearchHandler_equivalentToUnstructured(t *testing.T) {
 
 	// TODO: This is parroting apiSearchHandler details. Perhaps they should be
 	// abstracted and tested directly.
+	api := shared.NewAppEngineAPI(ctx)
 	mc := shared.NewGZReadWritable(shared.NewMemcacheReadWritable(ctx, 48*time.Hour))
-	sh := structuredSearchHandler{queryHandler{
-		sharedImpl: defaultShared{ctx},
-		dataSource: shared.NewByteCachedStore(ctx, mc, store),
-	}}
+	sh := structuredSearchHandler{
+		queryHandler{
+			sharedImpl: defaultShared{ctx},
+			dataSource: shared.NewByteCachedStore(ctx, mc, store),
+		},
+		api,
+	}
 	sc := NewShouldCache(t, true, shouldCacheSearchResponse)
 
 	ch := shared.NewCachingHandler(ctx, sh, mc, isRequestCacheable, shared.URLAsCacheKey, sc.ShouldCache)
@@ -459,11 +463,15 @@ func TestStructuredSearchHandler_doNotCacheEmptyResult(t *testing.T) {
 
 	// TODO: This is parroting apiSearchHandler details. Perhaps they should be
 	// abstracted and tested directly.
+	api := shared.NewAppEngineAPI(ctx)
 	mc := shared.NewGZReadWritable(shared.NewMemcacheReadWritable(ctx, 48*time.Hour))
-	sh := structuredSearchHandler{queryHandler{
-		sharedImpl: defaultShared{ctx},
-		dataSource: shared.NewByteCachedStore(ctx, mc, store),
-	}}
+	sh := structuredSearchHandler{
+		queryHandler{
+			sharedImpl: defaultShared{ctx},
+			dataSource: shared.NewByteCachedStore(ctx, mc, store),
+		},
+		api,
+	}
 	sc := NewShouldCache(t, false, shouldCacheSearchResponse)
 
 	ch := shared.NewCachingHandler(ctx, sh, mc, isRequestCacheable, shared.URLAsCacheKey, sc.ShouldCache)

--- a/api/query/search_test.go
+++ b/api/query/search_test.go
@@ -131,9 +131,7 @@ func TestStructuredSearchHandler_success(t *testing.T) {
 	api := sharedtest.NewMockAppEngineAPI(ctrl)
 
 	api.EXPECT().GetHostname().Return(hostname)
-	api.EXPECT().GetHTTPClient().DoAndReturn(func() *http.Client {
-		return server.Client()
-	})
+	api.EXPECT().GetHTTPClient().Return(server.Client())
 	r := httptest.NewRequest("POST", "https://example.com/api/query", bytes.NewBuffer([]byte(`{"run_ids":[1,2,3,4],"query":{"browser_name":"chrome","status":"PASS"}}`)))
 	w := httptest.NewRecorder()
 	structuredSearchHandler{queryHandler{}, api}.ServeHTTP(w, r)

--- a/api/query/search_test.go
+++ b/api/query/search_test.go
@@ -7,12 +7,19 @@
 package query
 
 import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"sort"
 	"strings"
 	"testing"
 
+	"github.com/golang/mock/gomock"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/web-platform-tests/wpt.fyi/shared"
+	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
 )
 
 func doTestIC(t *testing.T, p, q string) {
@@ -103,4 +110,65 @@ func TestPrepareSearchResponse_qUC(t *testing.T) {
 
 func TestPrepareSearchResponse_pUC(t *testing.T) {
 	testIC(t, "/b/", false)
+}
+
+func TestStructuredSearchHandler_success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	respBytes := []byte(`{}`)
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/search/cache", r.URL.Path)
+		w.Write(respBytes)
+	}))
+
+	serverURL, err := url.Parse(server.URL)
+	assert.Nil(t, err)
+	hostname := serverURL.Host
+
+	api := sharedtest.NewMockAppEngineAPI(ctrl)
+
+	api.EXPECT().GetHostname().Return(hostname)
+	api.EXPECT().GetHTTPClient().DoAndReturn(func() *http.Client {
+		return server.Client()
+	})
+	r := httptest.NewRequest("POST", "https://example.com/api/query", bytes.NewBuffer([]byte(`{"run_ids":[1,2,3,4],"query":{"browser_name":"chrome","status":"PASS"}}`)))
+	w := httptest.NewRecorder()
+	structuredSearchHandler{queryHandler{}, api}.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, respBytes, w.Body.Bytes())
+}
+
+func TestStructuredSearchHandler_failure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	respBytes := []byte(`Unknown run ID: 42`)
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/api/search/cache", r.URL.Path)
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write(respBytes)
+	}))
+
+	serverURL, err := url.Parse(server.URL)
+	assert.Nil(t, err)
+	hostname := serverURL.Host
+
+	api := sharedtest.NewMockAppEngineAPI(ctrl)
+
+	api.EXPECT().GetHostname().Return(hostname)
+	api.EXPECT().GetHTTPClient().DoAndReturn(func() *http.Client {
+		return server.Client()
+	})
+	r := httptest.NewRequest("POST", "https://example.com/api/query", bytes.NewBuffer([]byte(`{"run_ids":[42],"query":{"browser_name":"chrome","status":"PASS"}}`)))
+	w := httptest.NewRecorder()
+	structuredSearchHandler{queryHandler{}, api}.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, respBytes, w.Body.Bytes())
 }

--- a/api/receiver/appengine_mock.go
+++ b/api/receiver/appengine_mock.go
@@ -7,6 +7,7 @@ package receiver
 import (
 	context "context"
 	io "io"
+	"net/http"
 	url "net/url"
 	reflect "reflect"
 	time "time"
@@ -134,6 +135,18 @@ func (m *MockAppEngineAPI) LoginURL(arg0 string) (string, error) {
 // LoginURL indicates an expected call of LoginURL
 func (mr *MockAppEngineAPIMockRecorder) LoginURL(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoginURL", reflect.TypeOf((*MockAppEngineAPI)(nil).LoginURL), arg0)
+}
+
+// GetHTTPClient mocks base method
+func (m *MockAppEngineAPI) GetHTTPClient() *http.Client {
+	ret := m.ctrl.Call(m, "GetHTTPClient")
+	ret0, _ := ret[0].(*http.Client)
+	return ret0
+}
+
+// GetHTTPClient indicates an expected call of GetHTTPClient
+func (mr *MockAppEngineAPIMockRecorder) GetHTTPClient() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHTTPClient", reflect.TypeOf((*MockAppEngineAPI)(nil).GetHTTPClient))
 }
 
 // addTestRun mocks base method

--- a/shared/appengine.go
+++ b/shared/appengine.go
@@ -3,10 +3,12 @@ package shared
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strings"
 
 	"google.golang.org/appengine"
+	"google.golang.org/appengine/urlfetch"
 	"google.golang.org/appengine/user"
 )
 
@@ -17,6 +19,8 @@ type AppEngineAPI interface {
 	IsLoggedIn() bool
 	IsAdmin() bool
 	LoginURL(redirect string) (string, error)
+
+	GetHTTPClient() *http.Client
 
 	IsFeatureEnabled(featureName string) bool
 
@@ -42,6 +46,11 @@ type AppEngineAPIImpl struct {
 // Context returns the context.Context for the API impl.
 func (a AppEngineAPIImpl) Context() context.Context {
 	return a.ctx
+}
+
+// GetHTTPClient returns an HTTP client for the current context.
+func (a AppEngineAPIImpl) GetHTTPClient() *http.Client {
+	return urlfetch.Client(a.ctx)
 }
 
 // IsLoggedIn returns true if a user is logged in for the current context.

--- a/shared/sharedtest/appengine_mock.go
+++ b/shared/sharedtest/appengine_mock.go
@@ -6,11 +6,11 @@ package sharedtest
 
 import (
 	context "context"
+	gomock "github.com/golang/mock/gomock"
+	shared "github.com/web-platform-tests/wpt.fyi/shared"
+	http "net/http"
 	url "net/url"
 	reflect "reflect"
-
-	gomock "github.com/golang/mock/gomock"
-	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
 // MockAppEngineAPI is a mock of AppEngineAPI interface
@@ -83,6 +83,18 @@ func (m *MockAppEngineAPI) LoginURL(redirect string) (string, error) {
 // LoginURL indicates an expected call of LoginURL
 func (mr *MockAppEngineAPIMockRecorder) LoginURL(redirect interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoginURL", reflect.TypeOf((*MockAppEngineAPI)(nil).LoginURL), redirect)
+}
+
+// GetHTTPClient mocks base method
+func (m *MockAppEngineAPI) GetHTTPClient() *http.Client {
+	ret := m.ctrl.Call(m, "GetHTTPClient")
+	ret0, _ := ret[0].(*http.Client)
+	return ret0
+}
+
+// GetHTTPClient indicates an expected call of GetHTTPClient
+func (mr *MockAppEngineAPIMockRecorder) GetHTTPClient() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHTTPClient", reflect.TypeOf((*MockAppEngineAPI)(nil).GetHTTPClient))
 }
 
 // IsFeatureEnabled mocks base method


### PR DESCRIPTION
This change tests and implements `/api/search` delegating to `/api/search/cache` when the request is a structured query that cannot be serviced using summary files.

The change required some refactoring of the handlers in `search.go` to ensure that an `AppEngineAPI` instance is attached to the handlers. The `AppEngineAPI` is used to instantiate a `*http.Client`, which is done in a special way in AppEngine Standard, and is mocked in tests.