### PR TITLE
Search cache: Add load-newer-runs update

### DIFF
--- a/api/query/cache/backfill/backfill.go
+++ b/api/query/cache/backfill/backfill.go
@@ -103,7 +103,7 @@ func (*backfillIndex) Bind([]shared.TestRun, query.AbstractQuery) (query.Plan, e
 // will halt either:
 // The first time a run is evicted from the index.Index via EvictAnyRun(), OR
 // the first time the returned monitor.Monitor is stopped via Stop().
-func FillIndex(fetcher RunFetcher, logger shared.Logger, rt monitor.Runtime, freq time.Duration, maxBytes uint64, idx index.Index) (monitor.Monitor, error) {
+func FillIndex(fetcher RunFetcher, logger shared.Logger, rt monitor.Runtime, interval time.Duration, maxBytes uint64, idx index.Index) (monitor.Monitor, error) {
 	if idx == nil {
 		return nil, errNilIndex
 	}
@@ -113,7 +113,7 @@ func FillIndex(fetcher RunFetcher, logger shared.Logger, rt monitor.Runtime, fre
 		backfilling: true,
 	}
 	bfMon := &backfillMonitor{
-		ProxyMonitor: monitor.NewProxyMonitor(monitor.NewIndexMonitor(logger, rt, freq, maxBytes, bfIdx)),
+		ProxyMonitor: monitor.NewProxyMonitor(monitor.NewIndexMonitor(logger, rt, interval, maxBytes, bfIdx)),
 		idx:          bfIdx,
 	}
 

--- a/api/query/cache/index/index.go
+++ b/api/query/cache/index/index.go
@@ -38,7 +38,7 @@ func ErrRunExists() error {
 	return errRunExists
 }
 
-// ErrRunExists returns the error associated with an attempt to perform
+// ErrRunLoading returns the error associated with an attempt to perform
 // operations on a run currently unknown to an Index when the Index, in fact,
 // is currently loading data associated with the run.
 func ErrRunLoading() error {

--- a/api/query/cache/index/index.go
+++ b/api/query/cache/index/index.go
@@ -31,6 +31,20 @@ var (
 	errZeroRun            = errors.New("Cannot ingest run with ID of 0")
 )
 
+// ErrRunExists returns the error associated with an attempt to perform
+// operations on a run currently unknown to an Index when the Index, in fact,
+// already knows about the run.
+func ErrRunExists() error {
+	return errRunExists
+}
+
+// ErrRunExists returns the error associated with an attempt to perform
+// operations on a run currently unknown to an Index when the Index, in fact,
+// is currently loading data associated with the run.
+func ErrRunLoading() error {
+	return errRunLoading
+}
+
 // Index is an index of test run results that can ingest and evict runs.
 type Index interface {
 	query.Binder

--- a/api/query/cache/poll/poll.go
+++ b/api/query/cache/poll/poll.go
@@ -13,13 +13,13 @@ import (
 )
 
 // KeepRunsUpdated implements updates to an index.Index via simple polling every
-// freq duration for at most limit runs loaded from fetcher.
-func KeepRunsUpdated(fetcher backfill.RunFetcher, logger shared.Logger, freq time.Duration, limit int, idx index.Index) {
-	// Start by waiting polling frequency. This reduces the chance of false alarms
+// interval duration for at most limit runs loaded from fetcher.
+func KeepRunsUpdated(fetcher backfill.RunFetcher, logger shared.Logger, interval time.Duration, limit int, idx index.Index) {
+	// Start by waiting polling interval. This reduces the chance of false alarms
 	// from log monitoring when KeepRunsUpdated is invoked around the same time as
 	// index backfilling.
-	logger.Infof("Starting index update via polling; waiting polling frequency first...")
-	time.Sleep(freq)
+	logger.Infof("Starting index update via polling; waiting polling interval first...")
+	time.Sleep(interval)
 	logger.Infof("Index update via polling started")
 
 	lastLoadTime := time.Now()
@@ -29,7 +29,7 @@ func KeepRunsUpdated(fetcher backfill.RunFetcher, logger shared.Logger, freq tim
 		runs, err := fetcher.FetchRuns(limit)
 		if err != nil {
 			logger.Errorf("Error fetching runs for update: %v", err)
-			wait(start, freq)
+			wait(start, interval)
 			continue
 		}
 
@@ -59,7 +59,7 @@ func KeepRunsUpdated(fetcher backfill.RunFetcher, logger shared.Logger, freq tim
 			logger.Warningf("No runs loaded throughout polling iteration. Last run update was at %v", lastLoadTime)
 		}
 
-		wait(start, freq)
+		wait(start, interval)
 	}
 }
 

--- a/api/query/cache/poll/poll.go
+++ b/api/query/cache/poll/poll.go
@@ -56,7 +56,7 @@ func KeepRunsUpdated(fetcher backfill.RunFetcher, logger shared.Logger, interval
 		}
 
 		if !found {
-			logger.Warningf("No runs loaded throughout polling iteration. Last run update was at %v", lastLoadTime)
+			logger.Infof("No runs loaded throughout polling iteration. Last run update was at %v", lastLoadTime)
 		}
 
 		wait(start, interval)

--- a/api/query/cache/poll/poll.go
+++ b/api/query/cache/poll/poll.go
@@ -1,0 +1,71 @@
+// Copyright 2018 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package poll
+
+import (
+	"time"
+
+	"github.com/web-platform-tests/wpt.fyi/api/query/cache/backfill"
+	"github.com/web-platform-tests/wpt.fyi/api/query/cache/index"
+	"github.com/web-platform-tests/wpt.fyi/shared"
+)
+
+// KeepRunsUpdated implements updates to an index.Index via simple polling every
+// freq duration for at most limit runs loaded from fetcher.
+func KeepRunsUpdated(fetcher backfill.RunFetcher, logger shared.Logger, freq time.Duration, limit int, idx index.Index) {
+	// Start by waiting polling frequency. This reduces the chance of false alarms
+	// from log monitoring when KeepRunsUpdated is invoked around the same time as
+	// index backfilling.
+	logger.Infof("Starting index update via polling; waiting polling frequency first...")
+	time.Sleep(freq)
+	logger.Infof("Index update via polling started")
+
+	lastLoadTime := time.Now()
+	for {
+		start := time.Now()
+
+		runs, err := fetcher.FetchRuns(limit)
+		if err != nil {
+			logger.Errorf("Error fetching runs for update: %v", err)
+			wait(start, freq)
+			continue
+		}
+
+		found := false
+		for i, run := range runs {
+			err := idx.IngestRun(run)
+			if err != nil {
+				if err == index.ErrRunExists() {
+					logger.Infof("Not updating run (already exists): %v", run)
+				} else if err == index.ErrRunLoading() {
+					logger.Infof("Not updating run (already loading): %v", run)
+				} else {
+					logger.Errorf("Error ingesting run: %v: %v", run, err)
+				}
+			} else {
+				logger.Infof("Updated run index; new run: %v", run)
+
+				if i != 0 && !found {
+					logger.Errorf("Runs loaded out of order: Skipped %d runs: %v, then loaded new run: %v", i, runs[:i], run)
+				}
+				found = true
+				lastLoadTime = time.Now()
+			}
+		}
+
+		if !found {
+			logger.Warningf("No runs loaded throughout polling iteration. Last run update was at %v", lastLoadTime)
+		}
+
+		wait(start, freq)
+	}
+}
+
+func wait(start time.Time, total time.Duration) {
+	t := total - time.Now().Sub(start)
+	if t > 0 {
+		time.Sleep(t)
+	}
+}

--- a/api/query/cache/service/main.go
+++ b/api/query/cache/service/main.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/web-platform-tests/wpt.fyi/api/query"
 	"github.com/web-platform-tests/wpt.fyi/api/query/cache/backfill"
+	"github.com/web-platform-tests/wpt.fyi/api/query/cache/poll"
 
 	"github.com/web-platform-tests/wpt.fyi/api/query/cache/index"
 	"github.com/web-platform-tests/wpt.fyi/api/query/cache/monitor"
@@ -31,6 +32,8 @@ var (
 	numShards          = flag.Int("num_shards", runtime.NumCPU(), "Number of shards for parallelizing query execution")
 	monitorFrequency   = flag.Duration("monitor_frequency", time.Second*5, "Polling frequency for memory usage monitor")
 	maxHeapBytes       = flag.Uint64("max_heap_bytes", uint64(1e+11), "Soft limit on heap-allocated bytes before evicting test runs from memory")
+	updateFrequency    = flag.Duration("updated_frequency", time.Second*10, "Update frequency for polling for new runs")
+	updateMaxRuns      = flag.Int("update_max_runs", 10, "The maximum number of latest runs to lookup in attempts to update indexes via polling")
 
 	idx index.Index
 	mon monitor.Monitor
@@ -129,10 +132,15 @@ func main() {
 		log.Fatalf("Failed to instantiate index: %v", err)
 	}
 
-	mon, err = backfill.FillIndex(backfill.NewDatastoreRunFetcher(*projectID, gcpCredentialsFile, logger), logger, monitor.GoRuntime{}, *monitorFrequency, *maxHeapBytes, idx)
+	fetcher := backfill.NewDatastoreRunFetcher(*projectID, gcpCredentialsFile, logger)
+	mon, err = backfill.FillIndex(fetcher, logger, monitor.GoRuntime{}, *monitorFrequency, *maxHeapBytes, idx)
 	if err != nil {
 		log.Fatalf("Failed to initiate index backkfill: %v", err)
 	}
+
+	// Index, backfiller, monitor now in place. Start polling to load runs added
+	// after backfilling was started.
+	go poll.KeepRunsUpdated(fetcher, logger, *updateFrequency, *updateMaxRuns, idx)
 
 	http.HandleFunc("/_ah/liveness_check", livenessCheckHandler)
 	http.HandleFunc("/_ah/readiness_check", readinessCheckHandler)

--- a/api/query/cache/service/main.go
+++ b/api/query/cache/service/main.go
@@ -30,9 +30,9 @@ var (
 	projectID          = flag.String("project_id", "", "Google Cloud Platform project ID, if different from ID detected from metadata service")
 	gcpCredentialsFile = flag.String("gcp_credentials_file", "", "Path to Google Cloud Platform credentials file, if necessary")
 	numShards          = flag.Int("num_shards", runtime.NumCPU(), "Number of shards for parallelizing query execution")
-	monitorFrequency   = flag.Duration("monitor_frequency", time.Second*5, "Polling frequency for memory usage monitor")
+	monitorInterval    = flag.Duration("monitor_interval", time.Second*5, "Polling interval for memory usage monitor")
 	maxHeapBytes       = flag.Uint64("max_heap_bytes", uint64(1e+11), "Soft limit on heap-allocated bytes before evicting test runs from memory")
-	updateFrequency    = flag.Duration("updated_frequency", time.Second*10, "Update frequency for polling for new runs")
+	updateInterval     = flag.Duration("updated_interval", time.Second*10, "Update interval for polling for new runs")
 	updateMaxRuns      = flag.Int("update_max_runs", 10, "The maximum number of latest runs to lookup in attempts to update indexes via polling")
 
 	idx index.Index
@@ -133,14 +133,14 @@ func main() {
 	}
 
 	fetcher := backfill.NewDatastoreRunFetcher(*projectID, gcpCredentialsFile, logger)
-	mon, err = backfill.FillIndex(fetcher, logger, monitor.GoRuntime{}, *monitorFrequency, *maxHeapBytes, idx)
+	mon, err = backfill.FillIndex(fetcher, logger, monitor.GoRuntime{}, *monitorInterval, *maxHeapBytes, idx)
 	if err != nil {
 		log.Fatalf("Failed to initiate index backkfill: %v", err)
 	}
 
 	// Index, backfiller, monitor now in place. Start polling to load runs added
 	// after backfilling was started.
-	go poll.KeepRunsUpdated(fetcher, logger, *updateFrequency, *updateMaxRuns, idx)
+	go poll.KeepRunsUpdated(fetcher, logger, *updateInterval, *updateMaxRuns, idx)
 
 	http.HandleFunc("/_ah/liveness_check", livenessCheckHandler)
 	http.HandleFunc("/_ah/readiness_check", readinessCheckHandler)


### PR DESCRIPTION
This change implements a polling strategy to load newer runs (runs added after cache backfill started). It also integrates polling into the cache's production setup routine.

Since, for now, this is the only mechanism for receiving new runs, the default polling configuration is relatively aggressive: Load up to 10 new runs every 10 seconds. The frequency can be reduced if/when we implement best effort pushing of runs from the processor to the cache on the processor's critical path. The purpose of implemention such a scheme would be to ensure that runs are cached before they are committed to datastore and begin showing up in the wpt.fyi UI.