### PR TITLE
Search cache: Exclude missing tests from each run total

### DIFF
--- a/api/query/cache/index/aggregator.go
+++ b/api/query/cache/index/aggregator.go
@@ -41,9 +41,14 @@ func (a *indexAggregator) Add(t TestID) error {
 
 	for i, ru := range a.rus {
 		res := int64(a.runResults[ru].GetResult(t))
-		rus[i].Total++
-		if res == shared.TestStatusPass || res == shared.TestStatusOK {
-			rus[i].Passes++
+		// TODO: Switch to a consistent value for Total across all runs.
+		//
+		// Only include tests with non-UNKNOWN status for this run's total.
+		if res != shared.TestStatusUnknown {
+			rus[i].Total++
+			if res == shared.TestStatusPass || res == shared.TestStatusOK {
+				rus[i].Passes++
+			}
 		}
 	}
 	r.LegacyStatus = rus

--- a/api/query/cache/index/index_filter_test.go
+++ b/api/query/cache/index/index_filter_test.go
@@ -273,11 +273,12 @@ func TestBindExecute_TestStatus(t *testing.T) {
 					Passes: 0,
 					Total:  1,
 				},
-				// Run [1]: Safari: match1Name.match2Sub is missing,
-				//                  and no other subtests match: 0 / 1.
+				// Run [1]: Safari: match1Name.match2Sub is missing;
+				//                  by logic used in legacy test summaries, result
+				//                  should be: 0 / 0.
 				query.LegacySearchRunResult{
 					Passes: 0,
-					Total:  1,
+					Total:  0,
 				},
 			},
 		},


### PR DESCRIPTION
To achieve identical behaviour to existing test run summaries the search cache, which iterates over all (sub)tests for all runs in the cache, must exclude from each runs total those (sub)tests that have status=UNKNOWN, i.e., those tests that do not appear in the corresponding test run report.