### PR TITLE
Modify TestNamePattern unmarshaling to handle empty string pattern

### DIFF
--- a/api/query/atoms.go
+++ b/api/query/atoms.go
@@ -170,18 +170,21 @@ func (rq *RunQuery) UnmarshalJSON(b []byte) error {
 // UnmarshalJSON for TestNamePattern attempts to interpret a query atom as
 // {"pattern":<test name pattern string>}.
 func (tnp *TestNamePattern) UnmarshalJSON(b []byte) error {
-	var data struct {
-		Pattern string `json:"pattern"`
-	}
+	var data map[string]*json.RawMessage
 	err := json.Unmarshal(b, &data)
 	if err != nil {
 		return err
 	}
-	if len(data.Pattern) == 0 {
-		return errors.New(`Missing testn mae pattern property: "pattern"`)
+	patternMsg, ok := data["pattern"]
+	if !ok {
+		return errors.New(`Missing test name pattern property: "pattern"`)
+	}
+	var pattern string
+	if err := json.Unmarshal(*patternMsg, &pattern); err != nil {
+		return errors.New(`Missing test name pattern property "pattern" is not a string`)
 	}
 
-	tnp.Pattern = data.Pattern
+	tnp.Pattern = pattern
 	return nil
 }
 

--- a/api/query/atoms_test.go
+++ b/api/query/atoms_test.go
@@ -96,6 +96,27 @@ func TestStructuredQuery_unknownStatus(t *testing.T) {
 	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2}, AbstractQuery: TestStatusConstraint{"chrome", shared.TestStatusValueFromString("UNKNOWN")}}, rq)
 }
 
+func TestStructuredQuery_missingPattern(t *testing.T) {
+	var rq RunQuery
+	err := json.Unmarshal([]byte(`{
+		"run_ids": [0, 1, 2],
+		"query": {}
+	}`), &rq)
+	assert.NotNil(t, err)
+}
+
+func TestStructuredQuery_emptyPattern(t *testing.T) {
+	var rq RunQuery
+	err := json.Unmarshal([]byte(`{
+		"run_ids": [0, 1, 2],
+		"query": {
+			"pattern": ""
+		}
+	}`), &rq)
+	assert.Nil(t, err)
+	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2}, AbstractQuery: TestNamePattern{""}}, rq)
+}
+
 func TestStructuredQuery_pattern(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{


### PR DESCRIPTION
`POST` to `/api/search` is returning `HTTP 400`. The source of this appears to be that `{"query": {"pattern": ""}...}` is interpreted as `"pattern"` being missing. This change fixes the issue by differentiating between a missing `"pattern"` key and a key that contains the empty string value.