### PR TITLE
Don't process pr_head/pr_base if the counterpart's task didn't succeed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ FIREFOX_PATH := /usr/bin/firefox
 CHROME_PATH := /usr/bin/google-chrome
 USE_FRAME_BUFFER := true
 STAGING := false
+VERBOSE := -v
 
 GO_FILES := $(shell find $(WPTD_PATH) -type f -name '*.go')
 GO_TEST_FILES := $(shell find $(WPTD_PATH) -type f -name '*_test.go')
@@ -41,6 +42,7 @@ test: go_test python_test
 
 lint: go_lint eslint
 
+prepush: VERBOSE := $() # Empty out the verbose flag.
 prepush: go_build test lint
 
 python_test: python3 tox
@@ -67,10 +69,10 @@ go_test_tag_lint:
 go_test: go_small_test go_medium_test
 
 go_small_test: go_deps
-	cd $(WPTD_GO_PATH); go test -tags=small -v ./...
+	cd $(WPTD_GO_PATH); go test -tags=small $(VERBOSE) ./...
 
 go_medium_test: go_deps dev_appserver_deps
-	cd $(WPTD_GO_PATH); go test -tags=medium -v $(FLAGS) ./...
+	cd $(WPTD_GO_PATH); go test -tags=medium $(VERBOSE) $(FLAGS) ./...
 
 # Use sub-make because otherwise make would only execute the first invocation
 # of _go_webdriver_test. Variables will be passed into sub-make implicitly.
@@ -94,7 +96,7 @@ _go_webdriver_test: var-BROWSER java go_deps xvfb node-web-component-tester webs
 	GECKODRIVER_PATH="$(shell find $(NODE_SELENIUM_PATH)geckodriver/ -type f -name '*geckodriver')"; \
 	CHROMEDRIVER_PATH="$(shell find $(NODE_SELENIUM_PATH)chromedriver/ -type f -name '*chromedriver')"; \
 	cd $(WPTD_PATH)webdriver; \
-	go test -v -tags=large -args \
+	go test $(VERBOSE) -tags=large -args \
 		-firefox_path=$(FIREFOX_PATH) \
 		-geckodriver_path=$$GECKODRIVER_PATH \
 		-chrome_path=$(CHROME_PATH) \

--- a/api/taskcluster/webhook.go
+++ b/api/taskcluster/webhook.go
@@ -315,8 +315,19 @@ func createAllRuns(
 			// chrome-dev-pr_head => [chrome, dev, pr_head]
 			bits := strings.Split(product, "-")
 			labelsForRun := labels
-			if bits[len(bits)-1] == shared.PRBaseLabel || bits[len(bits)-1] == shared.PRHeadLabel {
-				labelsForRun = append(labelsForRun, bits[len(bits)-1])
+			// Don't bother with pr_base/pr_head if the other one didn't make it.
+			switch lastBit := bits[len(bits)-1]; lastBit {
+			case shared.PRBaseLabel, shared.PRHeadLabel:
+				otherLabel := shared.PRBaseLabel
+				if lastBit == shared.PRBaseLabel {
+					otherLabel = shared.PRHeadLabel
+				}
+				otherProduct := fmt.Sprintf("%s-%s-%s", bits[0], bits[1], otherLabel)
+				if _, ok := urlsByProduct[otherProduct]; !ok {
+					log.Warningf("Skipping %s since %s not present", product, otherProduct)
+					return
+				}
+				labelsForRun = append(labelsForRun, lastBit)
 			}
 			err := createRun(log, client, aeAPI, sha, uploadURL, username, password, urls, labelsForRun)
 			if err != nil {

--- a/api/taskcluster/webhook.go
+++ b/api/taskcluster/webhook.go
@@ -322,7 +322,7 @@ func createAllRuns(
 				if lastBit == shared.PRBaseLabel {
 					otherLabel = shared.PRHeadLabel
 				}
-				otherProduct := fmt.Sprintf("%s-%s-%s", bits[0], bits[1], otherLabel)
+				otherProduct := strings.Join(append(bits[:len(bits)-1], otherLabel), "-")
 				if _, ok := urlsByProduct[otherProduct]; !ok {
 					log.Warningf("Skipping %s since %s not present", product, otherProduct)
 					return

--- a/api/taskcluster/webhook_test.go
+++ b/api/taskcluster/webhook_test.go
@@ -241,6 +241,10 @@ func TestCreateAllRuns_success_pr(t *testing.T) {
 			"chrome-dev-pr_base": []string{"1"},
 			"firefox-pr_head":    []string{"1"},
 			"firefox-pr_base":    []string{"1"},
+			"safari-pr_base":     []string{"1"},
+			// Missing "safari-pr_head": []string{"1"},
+			// Missing "edge-pr_base": []string{"1"},
+			"edge-pr_head": []string{"1"},
 		},
 		nil,
 	)


### PR DESCRIPTION
## Description
Prevents permanently-pending PRs when one, but not both, fail.

Unrelated driveby to make `prepush` not verbose.