### PR TITLE
Show deleted changes in diff

### DIFF
--- a/api/checks/update.go
+++ b/api/checks/update.go
@@ -158,7 +158,7 @@ func loadMasterRunBefore(ctx context.Context, filter shared.TestRunFilter, headR
 }
 
 func getDiffSummary(aeAPI shared.AppEngineAPI, diffAPI shared.DiffAPI, baseRun, headRun shared.TestRun) (summaries.Summary, error) {
-	diffFilter := shared.DiffFilterParam{Added: true, Changed: true, Unchanged: true}
+	diffFilter := shared.DiffFilterParam{Added: true, Changed: true, Deleted: true}
 	diff, err := diffAPI.GetRunsDiff(baseRun, headRun, diffFilter, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Description
Prior to #881 we were deliberately not including `D` in the diff filter, since comparisons from a full master run to affected tests on a PR will always make it seem like we deleted a huge number of tests.

Now, we compare either `master` to a less recent run of `master`, or affected tests with/without the change; in both cases, deleted tests matter a lot.