### PR TITLE
Filter manifest tests by prefix

### DIFF
--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -649,7 +649,9 @@ found in the LICENSE file.
             if (['manual', 'reftest', 'testharness', 'wdspec'].includes(type)) {
               for (const file of Object.keys(this.manifest.items[type])) {
                 for (const test of this.manifest.items[type][file]) {
-                  collapsePathOnto(test[0], knownNodes);
+                  if (test[0].startsWith(prefix)) {
+                    collapsePathOnto(test[0], knownNodes);
+                  }
                 }
               }
             }


### PR DESCRIPTION
## Description
Fixes the manifest-based test-list feature, currently broken for navigation to any folder/path.

## Review
Head to /flags, enable the manifest one, navigate to any path, see a normal-looking list.