### PR TITLE
Plumb run_id params through the UI

### DIFF
--- a/webapp/components/test-runs-query.html
+++ b/webapp/components/test-runs-query.html
@@ -238,7 +238,7 @@ found in the LICENSE file.
     (() => {
       // TODO(lukebjerring): Support to & from in the builder.
       const testRunsUIQueryComputer =
-        'computeTestRunUIQueryParams(pr, sha, aligned, master, labels, productSpecs, to, from, maxCount, diff, search)';
+        'computeTestRunUIQueryParams(sha, aligned, master, labels, productSpecs, to, from, maxCount, diff, search, pr, runIds)';
       /* global TestRunsQuery */
       window.TestRunsUIQuery = (superClass, opt_queryCompute) => class extends TestRunsQuery(
         superClass,
@@ -260,10 +260,12 @@ found in the LICENSE file.
               type: Number,
               notify: true,
             },
+            // Specific runs, listed by their IDs.
+            runIds: Array,
           };
         }
 
-        computeTestRunUIQueryParams(pr, sha, aligned, master, labels, productSpecs, to, from, maxCount, diff, search) {
+        computeTestRunUIQueryParams(sha, aligned, master, labels, productSpecs, to, from, maxCount, diff, search, pr, runIds) {
           const params = this.computeTestRunQueryParams(sha, aligned, master, labels, productSpecs, to, from, maxCount);
           if (diff || this.diff) {
             params.diff = true;
@@ -274,6 +276,9 @@ found in the LICENSE file.
           if (pr) {
             params.pr = pr;
           }
+          if (runIds) {
+            params['run_id'] = Array.from(this.runIds);
+          }
           return params;
         }
 
@@ -282,6 +287,9 @@ found in the LICENSE file.
           this.pr = params.pr;
           this.search = params.q;
           this.diff = params.diff;
+          if ('run_id' in params) {
+            this.runIds = Array.from(params['run_id']);
+          }
         }
       };
       window.TestRunsUIQuery.Computer = testRunsUIQueryComputer;

--- a/webapp/components/test-runs.html
+++ b/webapp/components/test-runs.html
@@ -65,7 +65,8 @@ found in the LICENSE file.
             runs.push(...preloaded);
           }
           // Fetch by products.
-          if (this.productSpecs && this.productSpecs.length) {
+          if ((this.productSpecs && this.productSpecs.length)
+            || (this.runIds && this.runIds.length)) {
             runs.push(
               fetch(`/api/runs${this.query}`)
                 .then(r => r.ok && r.json().then(runs => {

--- a/webapp/templates/_test_run_query_params.html
+++ b/webapp/templates/_test_run_query_params.html
@@ -5,3 +5,4 @@
           {{- if .From}} from="{{ .From }}"{{end}}
           {{- if .To}} to="{{ .To }}"{{end}}
           {{- if .Aligned}} aligned{{end}}
+          {{- if .TestRunIDs }} run-ids="{{ .TestRunIDs }}"{{end}}

--- a/webapp/test_results_handler.go
+++ b/webapp/test_results_handler.go
@@ -17,15 +17,16 @@ import (
 )
 
 type testRunUIFilter struct {
-	PR       *int // GitHub PR to fetch the results for.
-	Products string
-	Labels   string
-	SHA      string
-	Aligned  bool
-	MaxCount *int
-	From     string
-	To       string
-	Search   string
+	PR         *int // GitHub PR to fetch the results for.
+	TestRunIDs string
+	Products   string
+	Labels     string
+	SHA        string
+	Aligned    bool
+	MaxCount   *int
+	From       string
+	To         string
+	Search     string
 	// JSON blob of extra (arbitrary) test runs
 	TestRuns string
 }
@@ -86,6 +87,19 @@ func parseTestResultsUIFilter(r *http.Request) (filter testResultsUIFilter, err 
 	filter.PR, err = shared.ParsePRParam(q)
 	if err != nil {
 		return filter, err
+	}
+
+	runIDs, err := shared.ParseRunIDsParam(q)
+	if err != nil {
+		return filter, err
+	}
+
+	if len(runIDs) > 0 {
+		marshalled, err := json.Marshal(runIDs)
+		if err != nil {
+			return filter, err
+		}
+		filter.TestRunIDs = string(marshalled)
 	} else if filter.PR != nil {
 		one := 1
 		filter.MaxCount = &one


### PR DESCRIPTION
## Description
Support loading /results with a `run_id` param (or a few), by plumbing the params through to the component.

## Review Information
- Load /results?run_id=[A run ID]&run_id=[Another run ID]
- Be amazed

This is a precursor to a better fix for #889 