### PR TITLE
Drop dev from builder channels

### DIFF
--- a/webapp/components/product-info.html
+++ b/webapp/components/product-info.html
@@ -15,8 +15,10 @@
       // Channels
       m.set('stable', 'Stable');
       m.set('beta', 'Beta');
-      m.set('dev', 'Dev');
       m.set('experimental', 'Experimental');
+      m.set('dev', 'Dev'); // Chrome
+      m.set('preview', 'Technology Preview'); // Safari
+      m.set('nightly', 'Nightly'); // Firefox
       // Sources
       m.set('taskcluster', 'Taskcluster');
       m.set('buildbot', 'Buildbot');
@@ -28,16 +30,20 @@
       major: /(\d+)/,
       majorAndMinor: /(\d+\.\d+)/
     };
-    const CHANNELS = new Set(['stable', 'beta', 'dev', 'experimental']);
-    const SOURCES = new Set(['buildbot', 'taskcluster', 'msedge']);
     const DEFAULT_BROWSER_NAMES = ['chrome', 'edge', 'firefox', 'safari'];
     const DEFAULT_PRODUCT_SPECS = Array.from(DEFAULT_BROWSER_NAMES);
     const DEFAULT_PRODUCTS = DEFAULT_PRODUCT_SPECS.map(p => parseProductSpec(p));
 
+    Object.defineProperty(window.wpt, 'Channels', {
+      get: () => new Set(['stable', 'beta', 'experimental']),
+    });
+    Object.defineProperty(window.wpt, 'Sources', {
+      get: () => new Set(['buildbot', 'taskcluster', 'msedge']),
+    });
     Object.defineProperty(window.wpt, 'SemanticLabels', {
       get: () => [
-        { property: '_channel', values: CHANNELS },
-        { property: '_source', values: SOURCES },
+        { property: '_channel', values: window.wpt.Channels },
+        { property: '_source', values: window.wpt.Sources },
       ],
     });
 

--- a/webapp/components/test-runs-query-builder.html
+++ b/webapp/components/test-runs-query-builder.html
@@ -396,7 +396,7 @@ found in the LICENSE file.
     </paper-card>
   </template>
   <script>
-    /* global ProductInfo, CHANNELS, DEFAULT_BROWSER_NAMES, DEFAULT_PRODUCTS */
+    /* global ProductInfo, DEFAULT_BROWSER_NAMES, DEFAULT_PRODUCTS */
     class ProductBuilder extends ProductInfo(window.Polymer.Element) {
       static get is() {
         return 'product-builder';
@@ -455,7 +455,7 @@ found in the LICENSE file.
           },
           channels: {
             type: Array,
-            value: Array.from(CHANNELS),
+            value: Array.from(window.wpt.Channels),
           },
           versionsURL: {
             type: String,
@@ -526,7 +526,7 @@ found in the LICENSE file.
 
       productWithChannel(product, channel) {
         return Object.assign({}, product, {
-          labels: (product.labels || []).filter(l => !CHANNELS.has(l)).concat(channel)
+          labels: (product.labels || []).filter(l => !window.wpt.Channels.has(l)).concat(channel)
         });
       }
 

--- a/webapp/components/test-runs-query.html
+++ b/webapp/components/test-runs-query.html
@@ -12,7 +12,7 @@ found in the LICENSE file.
     /**
      * Behaviour class for re-use of test-runs fetching behaviour.
      */
-    /* global QueryBuilder, ProductInfo, CHANNELS, DEFAULT_PRODUCTS, DEFAULT_PRODUCT_SPECS */
+    /* global QueryBuilder, ProductInfo, DEFAULT_PRODUCTS, DEFAULT_PRODUCT_SPECS */
     // eslint-disable-next-line no-unused-vars
     (() => {
       const testRunsQueryComputer =
@@ -107,7 +107,7 @@ found in the LICENSE file.
           // Collapse a globally shared channel into a single label.
           if (this.products.length) {
             let allChannelsSame = true;
-            const channel = (this.products[0].labels || []).find(l => CHANNELS.has(l));
+            const channel = (this.products[0].labels || []).find(l => window.wpt.Channels.has(l));
             for (const p of this.products) {
               if (!(p.labels || []).find(l => l === channel)) {
                 allChannelsSame = false;
@@ -116,7 +116,7 @@ found in the LICENSE file.
             let productSpecs;
             if (allChannelsSame) {
               productSpecs = this.products.map(p => {
-                const nonChannel = (p.labels || []).filter(l => !CHANNELS.has(l));
+                const nonChannel = (p.labels || []).filter(l => !window.wpt.Channels.has(l));
                 return this.getSpec(Object.assign({}, p, {labels: nonChannel}));
               });
               if (!labels.includes(channel)) {
@@ -177,12 +177,12 @@ found in the LICENSE file.
           // Expand any global channel labels into the separate products
           let sharedChannel;
           if ('label' in params) {
-            sharedChannel = params.label.find(l => CHANNELS.has(l));
-            batchUpdate.labels = params.label.filter(l => !CHANNELS.has(l));
+            sharedChannel = params.label.find(l => window.wpt.Channels.has(l));
+            batchUpdate.labels = params.label.filter(l => !window.wpt.Channels.has(l));
           }
           if (sharedChannel) {
             for (const i in batchUpdate.products) {
-              const labels = batchUpdate.products[i].labels.filter(l => !CHANNELS.has(l) || l === sharedChannel);
+              const labels = batchUpdate.products[i].labels.filter(l => !window.wpt.Channels.has(l) || l === sharedChannel);
               if (!batchUpdate.products[i].labels.includes(sharedChannel)) {
                 labels.push(sharedChannel);
               }

--- a/webapp/components/test/test-runs-query-builder.html
+++ b/webapp/components/test/test-runs-query-builder.html
@@ -33,7 +33,6 @@
   </test-fixture>
 
   <script>
-    /* global CHANNELS */
     document.addEventListener('WebComponentsReady', () => {
       suite('TestRunsQueryBuilder', () => {
         let queryBuilder, sandbox;
@@ -123,7 +122,7 @@
             });
           });
 
-          for (const channel of CHANNELS) {
+          for (const channel of window.wpt.Channels) {
             test(channel, done => {
               flush(() => {
                 for (const productBuilder of queryBuilder.shadowRoot.querySelectorAll('product-builder')) {
@@ -135,7 +134,7 @@
             });
           }
 
-          for (const channel of CHANNELS) {
+          for (const channel of window.wpt.Channels) {
             test(channel, done => {
               flush(() => {
                 queryBuilder.set('labels', [channel]);
@@ -219,8 +218,8 @@
               assert.isTrue(productBuilder.labels.includes('stable'));
             });
             test('updates the spec when value changes', () => {
-              productBuilder._channel = 'dev';
-              assert.equal(productBuilder.spec, 'chrome[dev]');
+              productBuilder._channel = 'experimental';
+              assert.equal(productBuilder.spec, 'chrome[experimental]');
             });
             test('changes value when labels are updated', () => {
               productBuilder.set('labels', ['experimental']);

--- a/webapp/components/test/test-runs-query.html
+++ b/webapp/components/test/test-runs-query.html
@@ -39,7 +39,7 @@
 <body>
   <script>
     document.addEventListener('WebComponentsReady', () => {
-      /* global DEFAULT_PRODUCTS, CHANNELS */
+      /* global DEFAULT_PRODUCTS */
       suite('TestRunsQuery', () => {
         let testRunsQuery, testRunsUIQuery;
 
@@ -60,7 +60,7 @@
         });
 
         suite('collapses shared channels', () => {
-          for (const channel of CHANNELS) {
+          for (const channel of window.wpt.Channels) {
             test(channel, () => {
               testRunsQuery.products = DEFAULT_PRODUCTS
                 .map(p => Object.assign({}, p, { labels: [channel] }));
@@ -70,7 +70,7 @@
         });
 
         suite('expands channel labels', () => {
-          for (const channel of CHANNELS) {
+          for (const channel of window.wpt.Channels) {
             test(channel, () => {
               testRunsQuery.updateQueryParams({ label: [channel] });
               expect(testRunsQuery.products.length).to.equal(DEFAULT_PRODUCTS.length);
@@ -124,7 +124,7 @@
             test('label', () => {
               testRunsQuery.products =
                 DEFAULT_PRODUCTS.map(p => Object.assign({}, p, { labels: ['experimental'] }));
-              for (const channel of CHANNELS) {
+              for (const channel of window.wpt.Channels) {
                 testRunsQuery.updateQueryParams({
                   label: [channel],
                 });


### PR DESCRIPTION
## Description
See #538 

"Dev" is a Chrome-specific name, and not something we reflect on wpt.fyi.
Also moves the set into a property-accessor on a namespacing wpt object as a cleanup.