### PR TITLE
Search cache: Fix query shim that ignores irrelevant tests

### DIFF
--- a/api/query/cache/backfill/backfill.go
+++ b/api/query/cache/backfill/backfill.go
@@ -94,7 +94,7 @@ func (m *backfillMonitor) Stop() error {
 	return m.ProxyMonitor.Stop()
 }
 
-func (*backfillIndex) Bind([]shared.TestRun, query.AbstractQuery) (query.Plan, error) {
+func (*backfillIndex) Bind([]shared.TestRun, query.ConcreteQuery) (query.Plan, error) {
 	return nil, nil
 }
 

--- a/api/query/cache/backfill/backfill_medium_test.go
+++ b/api/query/cache/backfill/backfill_medium_test.go
@@ -47,7 +47,7 @@ func (i *countingIndex) EvictAnyRun() error {
 	return nil
 }
 
-func (*countingIndex) Bind([]shared.TestRun, query.AbstractQuery) (query.Plan, error) {
+func (*countingIndex) Bind([]shared.TestRun, query.ConcreteQuery) (query.Plan, error) {
 	return nil, errNotImplemented
 }
 

--- a/api/query/cache/index/index.go
+++ b/api/query/cache/index/index.go
@@ -221,10 +221,10 @@ func (i *shardedWPTIndex) EvictAnyRun() error {
 	return i.syncEvictRun()
 }
 
-func (i *shardedWPTIndex) Bind(runs []shared.TestRun, aq query.AbstractQuery) (query.Plan, error) {
+func (i *shardedWPTIndex) Bind(runs []shared.TestRun, q query.ConcreteQuery) (query.Plan, error) {
 	if len(runs) == 0 {
 		return nil, errNoRuns
-	} else if aq == nil {
+	} else if q == nil {
 		return nil, errNoQuery
 	}
 
@@ -237,7 +237,6 @@ func (i *shardedWPTIndex) Bind(runs []shared.TestRun, aq query.AbstractQuery) (q
 		return nil, err
 	}
 
-	q := aq.BindToRuns(runs)
 	fs := make(ShardedFilter, len(idxs))
 	for j, idx := range idxs {
 		f, err := newFilter(idx, q)

--- a/api/query/cache/index/index_filter_test.go
+++ b/api/query/cache/index/index_filter_test.go
@@ -36,7 +36,7 @@ func mockTestRuns(loader *MockReportLoader, idx Index, data []testRunData) []sha
 }
 
 func planAndExecute(t *testing.T, runs []shared.TestRun, idx Index, q query.AbstractQuery) []query.SearchResult {
-	plan, err := idx.Bind(runs, q)
+	plan, err := idx.Bind(runs, q.BindToRuns(runs))
 	assert.Nil(t, err)
 
 	res := plan.Execute(runs)
@@ -68,7 +68,7 @@ func TestBindFail_NoRuns(t *testing.T) {
 	idx, err := NewShardedWPTIndex(loader, testNumShards)
 	assert.Nil(t, err)
 
-	_, err = idx.Bind(nil, query.TestNamePattern{Pattern: "/"})
+	_, err = idx.Bind(nil, query.TestNamePattern{Pattern: "/"}.BindToRuns(nil))
 	assert.NotNil(t, err)
 }
 
@@ -90,7 +90,8 @@ func TestBindFail_MissingRun(t *testing.T) {
 	idx, err := NewShardedWPTIndex(loader, testNumShards)
 	assert.Nil(t, err)
 
-	_, err = idx.Bind([]shared.TestRun{shared.TestRun{ID: 1}}, query.TestNamePattern{Pattern: "/"})
+	runs := []shared.TestRun{shared.TestRun{ID: 1}}
+	_, err = idx.Bind(runs, query.TestNamePattern{Pattern: "/"}.BindToRuns(runs))
 	assert.NotNil(t, err)
 }
 

--- a/api/query/cache/index/index_mock.go
+++ b/api/query/cache/index/index_mock.go
@@ -5,11 +5,12 @@
 package index
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	metrics "github.com/web-platform-tests/results-analysis/metrics"
 	query "github.com/web-platform-tests/wpt.fyi/api/query"
 	shared "github.com/web-platform-tests/wpt.fyi/shared"
-	reflect "reflect"
 )
 
 // MockIndex is a mock of Index interface
@@ -36,7 +37,7 @@ func (m *MockIndex) EXPECT() *MockIndexMockRecorder {
 }
 
 // Bind mocks base method
-func (m *MockIndex) Bind(arg0 []shared.TestRun, arg1 query.AbstractQuery) (query.Plan, error) {
+func (m *MockIndex) Bind(arg0 []shared.TestRun, arg1 query.ConcreteQuery) (query.Plan, error) {
 	ret := m.ctrl.Call(m, "Bind", arg0, arg1)
 	ret0, _ := ret[0].(query.Plan)
 	ret1, _ := ret[1].(error)

--- a/api/query/cache/index/index_test.go
+++ b/api/query/cache/index/index_test.go
@@ -215,7 +215,7 @@ func TestSync(t *testing.T) {
 			plan, err := i.Bind(runs, query.TestStatusConstraint{
 				BrowserName: "Chrome",
 				Status:      shared.TestStatusPass,
-			})
+			}.BindToRuns(runs))
 			if err != nil {
 				return
 			}

--- a/api/query/concrete_query.go
+++ b/api/query/concrete_query.go
@@ -16,7 +16,7 @@ type Binder interface {
 	// given runs are in the cache and extract results data subsets that pertain
 	// to the runs before producing a Plan implementation that can operate over
 	// the subsets directly.
-	Bind([]shared.TestRun, AbstractQuery) (Plan, error)
+	Bind([]shared.TestRun, ConcreteQuery) (Plan, error)
 }
 
 // Plan a query execution plan that returns results.


### PR DESCRIPTION
This change fixes the logic that was erroneously interpreting query execution plans as concrete queries. This required a change to accept concrete (not abstract) queries on the Bind() interface method.