### PR TITLE
Normalize version strings in processor

### DIFF
--- a/results-processor/wptreport.py
+++ b/results-processor/wptreport.py
@@ -409,6 +409,12 @@ class WPTReport(object):
 
         return payload
 
+    def normalize_version(self):
+        m = re.match(r'Technology Preview \(Release (\d+), (.*)\)',
+                     self.run_info.get('browser_version'))
+        if m:
+            self.run_info['browser_version'] = m.group(1) + ' preview'
+
     def finalize(self):
         """Checks and finalizes the report.
 
@@ -419,6 +425,10 @@ class WPTReport(object):
             Exceptions inherited from WPTReportError.
         """
         self.summarize()
+        # Additonal final fixup:
+        self.normalize_version()
+        # Access two property methods which will raise exceptions if any
+        # required field is missing.
         self.sha_product_path
         self.test_run_metadata
 

--- a/results-processor/wptreport_test.py
+++ b/results-processor/wptreport_test.py
@@ -454,6 +454,14 @@ class WPTReportTest(unittest.TestCase):
                          '0bdaaf9c1622ca49eb140381af1ece6d8001c934/'
                          'firefox-59.0-linux-afa59408e1-summary.json.gz')
 
+    def test_normalize_version(self):
+        r = WPTReport()
+        r._report = {'run_info': {
+            'browser_version': 'Technology Preview (Release 67, 13607.1.9.0.1)'
+        }}
+        r.normalize_version()
+        self.assertEqual(r.run_info['browser_version'], '67 preview')
+
 
 class HelpersTest(unittest.TestCase):
     def test_prepare_labels_from_empty_str(self):


### PR DESCRIPTION
## Description

Another attempt to fix https://github.com/web-platform-tests/wpt/issues/14465 from the wpt.fyi side. This PR normalizes the version string of STP in the results processor. The raw report stored to GCS won't be modified, but the browser version field in Datastore will store the normalized version.

e.g. "Technology Preview (Release 67, 13607.1.9.0.1)" -> "67 preview" (which will be parsed by the Go code into: major=67, channel=preview)