### PR TITLE
Default to master runs in the /runs ui

### DIFF
--- a/webapp/routes_test.go
+++ b/webapp/routes_test.go
@@ -46,7 +46,6 @@ func TestInteropAnomaliesBound(t *testing.T) {
 
 func TestRunsBoundHSTS(t *testing.T) {
 	assertHandlerIs(t, "/test-runs", "test-runs")
-	assertHSTS(t, "/test-runs")
 }
 
 func TestApiDiffBoundCORS(t *testing.T) {


### PR DESCRIPTION
## Description
Adds a label of `master` by default for /runs

Fixes https://github.com/web-platform-tests/wpt.fyi/issues/914