### PR TITLE
Search cache: Abstract and test "preparing" a "user query"

### DIFF
--- a/api/query/cache/query/query.go
+++ b/api/query/cache/query/query.go
@@ -1,0 +1,44 @@
+// Copyright 2018 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package query
+
+import (
+	"github.com/web-platform-tests/wpt.fyi/api/query"
+	"github.com/web-platform-tests/wpt.fyi/shared"
+)
+
+// PrepareUserQuery transforms a user query to a form suitable for planning and
+// execution against an index. For example, the query may be extended to filter
+// out tests that do not appear in the reports of any test run over which the
+// query will be executed. PrepareUserQuery should be executed exactly once on a
+// user query.
+func PrepareUserQuery(runIDs []int64, q query.ConcreteQuery) query.ConcreteQuery {
+	baseQuery := query.Or{
+		Args: make([]query.ConcreteQuery, len(runIDs)),
+	}
+	for i, runID := range runIDs {
+		baseQuery.Args[i] = query.Not{
+			Arg: query.RunTestStatusConstraint{
+				Run:    runID,
+				Status: shared.TestStatusUnknown,
+			},
+		}
+	}
+
+	// Add baseQuery to existing AND in q=AND(...), or create AND(baseQuery, q).
+	if andQ, ok := q.(query.And); ok {
+		andQ.Args = append([]query.ConcreteQuery{baseQuery}, andQ.Args...)
+		q = andQ
+	} else {
+		q = query.And{
+			Args: []query.ConcreteQuery{
+				baseQuery,
+				q,
+			},
+		}
+	}
+
+	return q
+}

--- a/api/query/cache/query/query_test.go
+++ b/api/query/cache/query/query_test.go
@@ -1,0 +1,49 @@
+// +build small
+
+// Copyright 2018 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package query
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/web-platform-tests/wpt.fyi/api/query"
+)
+
+func TestPrepareUserQuery_basic(t *testing.T) {
+	runIDs := []int64{1, 2, 3, 4}
+	q := query.TestNamePattern{Pattern: ""}
+	q2 := PrepareUserQuery(runIDs, q)
+
+	// Assert structrure: AND(OR(...), q)
+	and, ok := q2.(query.And)
+	assert.True(t, ok)
+	assert.Equal(t, 2, len(and.Args))
+	assert.Equal(t, q, and.Args[1])
+	_, ok = and.Args[0].(query.Or)
+	assert.True(t, ok)
+}
+
+func TestPrepareUserQuery_and(t *testing.T) {
+	runIDs := []int64{1, 2, 3, 4}
+	q := query.And{
+		Args: []query.ConcreteQuery{
+			query.TestNamePattern{Pattern: "a"},
+			query.TestNamePattern{Pattern: "b"},
+		},
+	}
+	q2 := PrepareUserQuery(runIDs, q)
+
+	// Assert structrure: AND(OR(...), q...)
+	and, ok := q2.(query.And)
+	assert.True(t, ok)
+	assert.Equal(t, 1+len(q.Args), len(and.Args))
+	_, ok = and.Args[0].(query.Or)
+	assert.True(t, ok)
+	for i, arg := range q.Args {
+		assert.Equal(t, arg, and.Args[1+i])
+	}
+}


### PR DESCRIPTION
This change abstracts and tests the step of filtering out tests that appear nowhere in the result reports of relevant test runs.

The unit tests are offer loose constraints. It may be worth adding medium or large tests that validate that index behaviour under the transformed query matches expectations.