### PR TITLE
Search cache: Update backfill params

### DIFF
--- a/api/query/cache/backfill/backfill.go
+++ b/api/query/cache/backfill/backfill.go
@@ -45,7 +45,7 @@ type backfillMonitor struct {
 // bytesPerRun is a slight over estimate of the memory requirements for one WPT
 // run's indexed data. This value was determined experimentally in the early
 // phases of search cache development.
-const bytesPerRun = uint64(1.45e+8)
+const bytesPerRun = uint64(6.5e+7)
 
 var errNilIndex = errors.New("Index to backfill is nil")
 

--- a/api/query/cache/service/main.go
+++ b/api/query/cache/service/main.go
@@ -32,7 +32,7 @@ var (
 	gcpCredentialsFile = flag.String("gcp_credentials_file", "", "Path to Google Cloud Platform credentials file, if necessary")
 	numShards          = flag.Int("num_shards", runtime.NumCPU(), "Number of shards for parallelizing query execution")
 	monitorInterval    = flag.Duration("monitor_interval", time.Second*5, "Polling interval for memory usage monitor")
-	maxHeapBytes       = flag.Uint64("max_heap_bytes", uint64(1e+11), "Soft limit on heap-allocated bytes before evicting test runs from memory")
+	maxHeapBytes       = flag.Uint64("max_heap_bytes", uint64(2e+11), "Soft limit on heap-allocated bytes before evicting test runs from memory")
 	updateInterval     = flag.Duration("updated_interval", time.Second*10, "Update interval for polling for new runs")
 	updateMaxRuns      = flag.Int("update_max_runs", 10, "The maximum number of latest runs to lookup in attempts to update indexes via polling")
 


### PR DESCRIPTION
Two changes:

## Reduce expected size of run

Between:

- A conservative initial size-of-run estimate;
- The fact that many runs only contain affected tests from PRs now;
- Backfill infrastructure should stop backfill when running low on space anyway...

this change proposes decreasing the estimated bytes-per-run that is used to limit the Datastore query for backfilling a search cache instance.

## Increase default soft memory limit

Recent changes to the `app.yaml` deployment spec for the `searchcache` service mean that we can safely double our soft memory limit.