### PR TITLE
Treat sha as a prefix of FullRevisionHash

### DIFF
--- a/api/checks/update_medium_test.go
+++ b/api/checks/update_medium_test.go
@@ -32,7 +32,8 @@ func TestLoadRunsToCompare_master(t *testing.T) {
 	}
 	yesterday := time.Now().AddDate(0, 0, -1)
 	for i := 0; i < 2; i++ {
-		testRun.Revision = strings.Repeat(strconv.Itoa(i), 10)
+		testRun.FullRevisionHash = strings.Repeat(strconv.Itoa(i), 40)
+		testRun.Revision = testRun.FullRevisionHash[:10]
 		testRun.TimeStart = yesterday.Add(time.Duration(i) * time.Hour)
 		key := datastore.NewIncompleteKey(ctx, "TestRun", nil)
 		key, _ = datastore.Put(ctx, key, &testRun)
@@ -65,7 +66,8 @@ func TestLoadRunsToCompare_pr_base_first(t *testing.T) {
 				Product: shared.Product{
 					BrowserName: "chrome",
 				},
-				Revision: "1234567890",
+				Revision:         "1234567890",
+				FullRevisionHash: "1234567890123456789012345678901234567890",
 			},
 			TimeStart: yesterday.Add(time.Duration(i) * time.Hour),
 			Labels:    labelsForRuns[i],
@@ -101,7 +103,8 @@ func TestLoadRunsToCompare_pr_head_first(t *testing.T) {
 				Product: shared.Product{
 					BrowserName: "chrome",
 				},
-				Revision: "1234567890",
+				Revision:         "1234567890",
+				FullRevisionHash: "1234567890123456789012345678901234567890",
 			},
 			TimeStart: yesterday.Add(time.Duration(i) * time.Hour),
 			Labels:    labelsForRuns[i],

--- a/api/interop_medium_test.go
+++ b/api/interop_medium_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -31,11 +32,13 @@ func TestApiInteropHandler_CompleteRunFallback(t *testing.T) {
 
 	firstRun := shared.TestRun{}
 	firstRun.Labels = []string{"stable"}
-	firstRun.Revision = "0000000000"
+	firstRun.FullRevisionHash = strings.Repeat("0000000000", 4)
+	firstRun.Revision = firstRun.FullRevisionHash[:10]
 	firstRun.TimeStart = time.Now().AddDate(0, 0, -1)
 
 	secondRun := shared.TestRun{}
-	secondRun.Revision = "1111111111"
+	secondRun.FullRevisionHash = strings.Repeat("1111111111", 4)
+	secondRun.Revision = secondRun.FullRevisionHash[:10]
 	secondRun.TimeStart = time.Now()
 
 	products := shared.GetDefaultProducts()

--- a/api/manifest.go
+++ b/api/manifest.go
@@ -22,7 +22,7 @@ import (
 
 func apiManifestHandler(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
-	sha, err := shared.ParseSHAParamFull(q)
+	sha, err := shared.ParseSHAParam(q)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return

--- a/api/shas_medium_test.go
+++ b/api/shas_medium_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -44,7 +45,8 @@ func TestApiSHAsHandler(t *testing.T) {
 		run.BrowserName = browser
 		datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
 	}
-	run.Revision = "abcdef0000"
+	run.FullRevisionHash = strings.Repeat("abcdef0000", 4)
+	run.Revision = run.FullRevisionHash[:10]
 	datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
 
 	// Aligned

--- a/api/test_runs_medium_test.go
+++ b/api/test_runs_medium_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -101,7 +102,8 @@ func TestGetTestRuns_RunIDs(t *testing.T) {
 	now := time.Now()
 	run := shared.TestRun{}
 	run.BrowserVersion = "66.0.3359.139"
-	run.Revision = "abcdef0123"
+	run.FullRevisionHash = strings.Repeat("abcdef0123", 4)
+	run.Revision = run.FullRevisionHash[:10]
 	run.CreatedAt = now.AddDate(0, 0, -1)
 	keys := make([]*datastore.Key, 2)
 
@@ -148,7 +150,8 @@ func TestGetTestRuns_SHA(t *testing.T) {
 	now := time.Now()
 	run := shared.TestRun{}
 	run.BrowserVersion = "66.0.3359.139"
-	run.Revision = "abcdef0123"
+	run.FullRevisionHash = strings.Repeat("abcdef0123", 4)
+	run.Revision = run.FullRevisionHash[:10]
 	run.CreatedAt = now.AddDate(0, 0, -1)
 
 	run.BrowserName = "chrome"
@@ -156,11 +159,13 @@ func TestGetTestRuns_SHA(t *testing.T) {
 	run.BrowserName = "safari"
 	datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
 
-	run.Revision = "9876543210"
+	run.FullRevisionHash = strings.Repeat("9876543210", 4)
+	run.Revision = run.FullRevisionHash[:10]
 	run.BrowserName = "firefox"
 	datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
 
-	run.Revision = "9999999999"
+	run.FullRevisionHash = strings.Repeat("9999999999", 4)
+	run.Revision = run.FullRevisionHash[:10]
 	run.BrowserName = "edge"
 	datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
 
@@ -191,7 +196,8 @@ func TestGetTestRuns_SHA(t *testing.T) {
 	body, _ = ioutil.ReadAll(resp.Result().Body)
 	assert.Equal(t, http.StatusNotFound, resp.Code)
 
-	run.Revision = "1111111111"
+	run.FullRevisionHash = strings.Repeat("1111111111", 4)
+	run.Revision = run.FullRevisionHash[:10]
 	for _, name := range shared.GetDefaultBrowserNames() {
 		run.BrowserName = name
 		datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)

--- a/shared/datastore.go
+++ b/shared/datastore.go
@@ -31,10 +31,18 @@ func LoadTestRunsBySHAs(ctx context.Context, shas ...string) (runs TestRuns, err
 		if len(sha) > 10 {
 			sha = sha[:10]
 		}
-		var shaRuns TestRuns
-		keys, err := datastore.NewQuery("TestRun").Filter("Revision =", sha).GetAll(ctx, &shaRuns)
+		q := datastore.NewQuery("TestRun")
+		keys, err := loadKeysForRevision(ctx, q, sha)
 		if err != nil {
 			return runs, err
+		}
+		shaRuns := make(TestRuns, len(keys))
+		for i := range keys {
+			run, err := LoadTestRun(ctx, keys[i].IntID())
+			if err != nil {
+				return nil, err
+			}
+			shaRuns[i] = *run
 		}
 		shaRuns.SetTestRunIDs(keys)
 		runs = append(runs, shaRuns...)
@@ -56,9 +64,6 @@ func LoadTestRunKeys(
 	offset *int) (result KeysByProduct, err error) {
 	result = make(KeysByProduct, len(products))
 	baseQuery := datastore.NewQuery("TestRun")
-	if !IsLatest(sha) {
-		baseQuery = baseQuery.Filter("Revision =", sha)
-	}
 	if offset != nil {
 		baseQuery = baseQuery.Offset(*offset)
 	}
@@ -68,8 +73,19 @@ func LoadTestRunKeys(
 			baseQuery = baseQuery.Filter("Labels =", i.(string))
 		}
 	}
+	var globalKeyFilter mapset.Set
+	if !IsLatest(sha) {
+		var keys []*datastore.Key
+		if keys, err = loadKeysForRevision(ctx, baseQuery, sha); err != nil {
+			return nil, err
+		}
+		globalKeyFilter = mapset.NewSet()
+		for _, k := range keys {
+			globalKeyFilter.Add(k.IntID())
+		}
+	}
 	for i, product := range products {
-		var prefiltered *mapset.Set
+		var productKeyFilter = merge(globalKeyFilter, nil)
 		query := baseQuery.Filter("BrowserName =", product.BrowserName)
 		if product.Labels != nil {
 			for i := range product.Labels.Iter() {
@@ -77,12 +93,22 @@ func LoadTestRunKeys(
 			}
 		}
 		if !IsLatest(product.Revision) {
-			query = query.Filter("Revision = ", product.Revision)
-		}
-		if product.BrowserVersion != "" {
-			if prefiltered, err = loadKeysForBrowserVersion(ctx, query, product.BrowserVersion); err != nil {
+			var revKeys []*datastore.Key
+			if revKeys, err = loadKeysForRevision(ctx, query, product.Revision); err != nil {
 				return nil, err
 			}
+			revKeyFilter := mapset.NewSet()
+			for _, key := range revKeys {
+				revKeyFilter.Add(key.IntID())
+			}
+			productKeyFilter = merge(productKeyFilter, revKeyFilter)
+		}
+		if product.BrowserVersion != "" {
+			var versionKeys mapset.Set
+			if versionKeys, err = loadKeysForBrowserVersion(ctx, query, product.BrowserVersion); err != nil {
+				return nil, err
+			}
+			productKeyFilter = merge(productKeyFilter, versionKeys)
 		}
 		// TODO(lukebjerring): Indexes + filtering for OS + version.
 		query = query.Order("-TimeStart")
@@ -104,7 +130,7 @@ func LoadTestRunKeys(
 				return result, err
 			} else if (limit != nil && len(keys) >= *limit) || len(keys) >= MaxCountMaxValue {
 				break
-			} else if prefiltered != nil && !(*prefiltered).Contains(key.String()) {
+			} else if productKeyFilter != nil && !productKeyFilter.Contains(key.IntID()) {
 				continue
 			}
 			keys = append(keys, key)
@@ -115,6 +141,17 @@ func LoadTestRunKeys(
 		}
 	}
 	return result, nil
+}
+
+func merge(s1, s2 mapset.Set) mapset.Set {
+	if s1 == nil && s2 == nil {
+		return nil
+	} else if s1 == nil {
+		return merge(s2, nil)
+	} else if s2 == nil {
+		return mapset.NewSetWith(s1.ToSlice()...)
+	}
+	return s1.Intersect(s2)
 }
 
 // LoadTestRuns loads the test runs for the TestRun entities for the given parameters.
@@ -181,8 +218,29 @@ func contains(s []string, x string) bool {
 	return false
 }
 
-// Loads any keys for a full string match or a version prefix (Between [version].* and [version].9*)
-func loadKeysForBrowserVersion(ctx context.Context, query *datastore.Query, version string) (result *mapset.Set, err error) {
+// Loads any keys for a revision prefix or full string match
+func loadKeysForRevision(ctx context.Context, query *datastore.Query, sha string) (result []*datastore.Key, err error) {
+	var revQuery *datastore.Query
+	if len(sha) < 40 {
+		revQuery = query.
+			Order("FullRevisionHash").
+			Limit(MaxCountMaxValue).
+			Filter("FullRevisionHash >=", sha).
+			Filter("FullRevisionHash <", sha+"g") // g > f
+	} else {
+		revQuery = query.Filter("FullRevisionHash =", sha[:40])
+	}
+
+	var keys []*datastore.Key
+	if keys, err = revQuery.KeysOnly().GetAll(ctx, nil); err != nil {
+		return nil, err
+	}
+	return keys, nil
+}
+
+// Loads any keys for a full string match or a version prefix (Between [version].* and [version].9*).
+// Entries in the set are the int64 value of the keys.
+func loadKeysForBrowserVersion(ctx context.Context, query *datastore.Query, version string) (result mapset.Set, err error) {
 	versionQuery := VersionPrefix(query, "BrowserVersion", version, true)
 	var keys []*datastore.Key
 	keyset := mapset.NewSet()
@@ -190,15 +248,15 @@ func loadKeysForBrowserVersion(ctx context.Context, query *datastore.Query, vers
 		return nil, err
 	}
 	for _, key := range keys {
-		keyset.Add(key.String())
+		keyset.Add(key.IntID())
 	}
 	if keys, err = query.Filter("BrowserVersion =", version).KeysOnly().GetAll(ctx, nil); err != nil {
 		return nil, err
 	}
 	for _, key := range keys {
-		keyset.Add(key.String())
+		keyset.Add(key.IntID())
 	}
-	return &keyset, nil
+	return keyset, nil
 }
 
 // VersionPrefix returns the given query with a prefix filter on the given

--- a/shared/models.go
+++ b/shared/models.go
@@ -183,10 +183,10 @@ func (t TestRuns) Len() int           { return len(t) }
 func (t TestRuns) Less(i, j int) bool { return t[i].TimeStart.Before(t[j].TimeStart) }
 func (t TestRuns) Swap(i, j int)      { t[i], t[j] = t[j], t[i] }
 
-// SetTestRunIDs sets the ID field for each run, from the given keys.
-func (t TestRuns) SetTestRunIDs(keys []*datastore.Key) {
-	for i := 0; i < len(keys) && i < len(t); i++ {
-		t[i].ID = keys[i].IntID()
+// SetTestRunIDs sets the ID field for each run, from the given ids.
+func (t TestRuns) SetTestRunIDs(ids TestRunIDs) {
+	for i := 0; i < len(ids) && i < len(t); i++ {
+		t[i].ID = ids[i]
 	}
 }
 
@@ -262,6 +262,15 @@ func (t KeysByProduct) AllKeys() []*datastore.Key {
 
 // TestRunIDs is a helper for an array of TestRun IDs.
 type TestRunIDs []int64
+
+// GetTestRunIDs extracts the TestRunIDs from loaded datastore keys.
+func GetTestRunIDs(keys []*datastore.Key) TestRunIDs {
+	result := make(TestRunIDs, len(keys))
+	for i := range keys {
+		result[i] = keys[i].IntID()
+	}
+	return result
+}
 
 // LoadTestRuns is a helper for fetching the TestRuns from the datastore,
 // for the gives TestRunIDs.

--- a/shared/params.go
+++ b/shared/params.go
@@ -140,39 +140,22 @@ const MaxCountMaxValue = 500
 // MaxCountMinValue is the minimum allowed value for the max-count param.
 const MaxCountMinValue = 1
 
-// SHARegex is a regex for SHA[0:10] slice of a git hash.
-var SHARegex = regexp.MustCompile("[0-9a-fA-F]{10,40}")
+// SHARegex is a regex for 7 to 40 char prefix of a git hash.
+var SHARegex = regexp.MustCompile("[0-9a-fA-F]{7,40}")
 
-// ParseSHAParam parses and validates the 'sha' param for the request,
-// cropping it to 10 chars. It returns "latest" by default. (and in error cases).
+// ParseSHAParam parses and validates the 'sha' param for the request.
+// If the param is not present, it returns "latest" by default (and in error cases).
 func ParseSHAParam(v url.Values) (runSHA string, err error) {
-	sha, err := ParseSHAParamFull(v)
+	sha, err := ParseSHA(v.Get("sha"))
 	if err != nil || !SHARegex.MatchString(sha) {
 		return sha, err
 	}
-	return sha[:10], nil
+	return sha, nil
 }
 
-// ParseSHA validates the given 'sha' value, cropping it to 10 chars.
+// ParseSHA parses and validates the given 'sha'.
 // It returns "latest" by default (and in error cases).
-func ParseSHA(sha string) (runSHA string, err error) {
-	sha, err = ParseSHAFull(sha)
-	if err != nil || !SHARegex.MatchString(sha) {
-		return sha, err
-	}
-	return sha[:10], nil
-}
-
-// ParseSHAParamFull parses and validates the 'sha' param for the request.
-// It returns "latest" by default (and in error cases).
-func ParseSHAParamFull(v url.Values) (runSHA string, err error) {
-	// Get the SHA for the run being loaded (the first part of the path.)
-	return ParseSHAFull(v.Get("sha"))
-}
-
-// ParseSHAFull parses and validates the given 'sha'.
-// It returns "latest" by default (and in error cases).
-func ParseSHAFull(runParam string) (runSHA string, err error) {
+func ParseSHA(runParam string) (runSHA string, err error) {
 	// Get the SHA for the run being loaded (the first part of the path.)
 	runSHA = "latest"
 	if runParam != "" && runParam != "latest" {

--- a/shared/params_test.go
+++ b/shared/params_test.go
@@ -44,7 +44,7 @@ func TestParseSHAParam_FullSHA(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?sha="+sha, nil)
 	runSHA, err := ParseSHAParam(r.URL.Query())
 	assert.Nil(t, err)
-	assert.Equal(t, sha[:10], runSHA)
+	assert.Equal(t, sha, runSHA)
 }
 
 func TestParseSHAParam_NonSHA(t *testing.T) {
@@ -376,7 +376,7 @@ func TestParseProductSpec_FullSHA(t *testing.T) {
 	products := filters.GetProductsOrDefault()
 	assert.Len(t, products, 1)
 	if len(products) > 0 {
-		assert.Equal(t, sha[:10], products[0].Revision)
+		assert.Equal(t, sha, products[0].Revision)
 	}
 }
 

--- a/util/populate_dev_data.go
+++ b/util/populate_dev_data.go
@@ -45,7 +45,7 @@ func main() {
 	staticDataTime, _ := time.Parse(time.RFC3339, "2017-10-18T00:00:00Z")
 
 	// Follow pattern established in run/*.py data collection code.
-	const staticRunSHA = "b952881825"
+	const staticRunSHA = "b952881825e7d3974f5c513e13e544d525c0a631"
 	const summaryURLFmtString = "http://localhost:8080/static/" + staticRunSHA + "/%s"
 	staticTestRuns := shared.TestRuns{
 		{
@@ -56,7 +56,8 @@ func main() {
 					OSName:         "linux",
 					OSVersion:      "3.16",
 				},
-				Revision: staticRunSHA,
+				FullRevisionHash: staticRunSHA,
+				Revision:         staticRunSHA[:10],
 			},
 			ResultsURL: fmt.Sprintf(summaryURLFmtString, "chrome-63.0-linux-summary.json.gz"),
 			CreatedAt:  staticDataTime,
@@ -70,7 +71,8 @@ func main() {
 					OSName:         "windows",
 					OSVersion:      "10",
 				},
-				Revision: staticRunSHA,
+				FullRevisionHash: staticRunSHA,
+				Revision:         staticRunSHA[:10],
 			},
 			ResultsURL: fmt.Sprintf(summaryURLFmtString, "edge-15-windows-10-sauce-summary.json.gz"),
 			CreatedAt:  staticDataTime,
@@ -84,7 +86,8 @@ func main() {
 					OSName:         "linux",
 					OSVersion:      "*",
 				},
-				Revision: staticRunSHA,
+				FullRevisionHash: staticRunSHA,
+				Revision:         staticRunSHA[:10],
 			},
 			ResultsURL: fmt.Sprintf(summaryURLFmtString, "firefox-57.0-linux-summary.json.gz"),
 			CreatedAt:  staticDataTime,
@@ -98,7 +101,8 @@ func main() {
 					OSName:         "macos",
 					OSVersion:      "10.12",
 				},
-				Revision: staticRunSHA,
+				FullRevisionHash: staticRunSHA,
+				Revision:         staticRunSHA[:10],
 			},
 			ResultsURL: fmt.Sprintf(summaryURLFmtString, "safari-10-macos-10.12-sauce-summary.json.gz"),
 			CreatedAt:  staticDataTime,

--- a/util/populate_dev_data.go
+++ b/util/populate_dev_data.go
@@ -46,7 +46,7 @@ func main() {
 
 	// Follow pattern established in run/*.py data collection code.
 	const staticRunSHA = "b952881825e7d3974f5c513e13e544d525c0a631"
-	const summaryURLFmtString = "http://localhost:8080/static/" + staticRunSHA + "/%s"
+	summaryURLFmtString := "http://localhost:8080/static/" + staticRunSHA[:10] + "/%s"
 	staticTestRuns := shared.TestRuns{
 		{
 			ProductAtRevision: shared.ProductAtRevision{

--- a/util/populate_dev_data.py
+++ b/util/populate_dev_data.py
@@ -69,6 +69,7 @@ def main(args):  # type: (argparse.Namespace) -> None
             OSName='linux',
             OSVersion='3.16',
             Revision='b952881825',
+            FullRevisionHash='b952881825e7d3974f5c513e13e544d525c0a631',
             ResultsURL=path % 'chrome-63.0-linux-summary.json.gz'),
         TestRun(
             id='dev-testrun-edge-15',
@@ -77,6 +78,7 @@ def main(args):  # type: (argparse.Namespace) -> None
             OSName='windows',
             OSVersion='10',
             Revision='b952881825',
+            FullRevisionHash='b952881825e7d3974f5c513e13e544d525c0a631',
             ResultsURL=path % 'edge-15-windows-10-sauce-summary.json.gz'),
         TestRun(
             id='dev-testrun-firefox-57',
@@ -85,6 +87,7 @@ def main(args):  # type: (argparse.Namespace) -> None
             OSName='linux',
             OSVersion='*',
             Revision='b952881825',
+            FullRevisionHash='b952881825e7d3974f5c513e13e544d525c0a631',
             ResultsURL=path % 'firefox-57.0-linux-summary.json.gz'),
         TestRun(
             id='dev-testrun-safari-10',
@@ -93,6 +96,7 @@ def main(args):  # type: (argparse.Namespace) -> None
             OSName='macos',
             OSVersion='10.12',
             Revision='b952881825',
+            FullRevisionHash='b952881825e7d3974f5c513e13e544d525c0a631',
             ResultsURL=path % 'safari-10-macos-10.12-sauce-summary.json.gz'),
     ]  # type: List[TestRun]
 

--- a/webdriver/webapp_server.go
+++ b/webdriver/webapp_server.go
@@ -14,6 +14,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/web-platform-tests/results-analysis/metrics"
@@ -28,7 +29,7 @@ var (
 )
 
 // StaticTestDataRevision is the SHA for the local (static) test run summaries.
-const StaticTestDataRevision = "b952881825"
+const StaticTestDataRevision = "b952881825e7d3974f5c513e13e544d525c0a631"
 
 // AppServer is an abstraction for navigating an instance of the webapp.
 type AppServer interface {
@@ -258,7 +259,8 @@ func addStaticData(i DevAppServerInstance) (err error) {
 					OSName:         "linux",
 					OSVersion:      "3.16",
 				},
-				Revision: sha,
+				FullRevisionHash: sha,
+				Revision:         sha[:10],
 			},
 			ResultsURL: fmt.Sprintf(summaryURLFmtString, "chrome-63.0-linux-summary.json.gz"),
 			TimeStart:  staticDataTime,
@@ -272,7 +274,8 @@ func addStaticData(i DevAppServerInstance) (err error) {
 					OSName:         "windows",
 					OSVersion:      "10",
 				},
-				Revision: sha,
+				FullRevisionHash: sha,
+				Revision:         sha[:10],
 			},
 			ResultsURL: fmt.Sprintf(summaryURLFmtString, "edge-15-windows-10-sauce-summary.json.gz"),
 			TimeStart:  staticDataTime,
@@ -286,7 +289,8 @@ func addStaticData(i DevAppServerInstance) (err error) {
 					OSName:         "linux",
 					OSVersion:      "*",
 				},
-				Revision: sha,
+				FullRevisionHash: sha,
+				Revision:         sha[:10],
 			},
 			ResultsURL: fmt.Sprintf(summaryURLFmtString, "firefox-57.0-linux-summary.json.gz"),
 			TimeStart:  staticDataTime,
@@ -300,7 +304,8 @@ func addStaticData(i DevAppServerInstance) (err error) {
 					OSName:         "macos",
 					OSVersion:      "10.12",
 				},
-				Revision: sha,
+				FullRevisionHash: sha,
+				Revision:         sha[:10],
 			},
 			ResultsURL: fmt.Sprintf(summaryURLFmtString, "safari-10-macos-10.12-sauce-summary.json.gz"),
 			TimeStart:  staticDataTime,
@@ -317,7 +322,8 @@ func addStaticData(i DevAppServerInstance) (err error) {
 					OSName:         "linux",
 					OSVersion:      "*",
 				},
-				Revision: "0123456789",
+				FullRevisionHash: strings.Repeat("0123456789", 4),
+				Revision:         "0123456789",
 			},
 			ResultsURL: fmt.Sprintf(summaryURLFmtString, "chrome-63.0-linux-summary.json.gz"),
 			TimeStart:  staticDataTime,
@@ -331,7 +337,8 @@ func addStaticData(i DevAppServerInstance) (err error) {
 					OSName:         "linux",
 					OSVersion:      "*",
 				},
-				Revision: "0123456789",
+				FullRevisionHash: strings.Repeat("0123456789", 4),
+				Revision:         "0123456789",
 			},
 			ResultsURL: fmt.Sprintf(summaryURLFmtString, "firefox-57.0-linux-summary.json.gz"),
 			TimeStart:  staticDataTime,

--- a/webdriver/webapp_server.go
+++ b/webdriver/webapp_server.go
@@ -249,7 +249,7 @@ func addStaticData(i DevAppServerInstance) (err error) {
 	staticDataTime := time.Now()
 	// Follow pattern established in run/*.py data collection code.
 	const sha = StaticTestDataRevision
-	var summaryURLFmtString = i.GetWebappURL("/static/" + sha + "/%s")
+	var summaryURLFmtString = i.GetWebappURL("/static/" + sha[:10] + "/%s")
 	stableTestRuns := shared.TestRuns{
 		{
 			ProductAtRevision: shared.ProductAtRevision{


### PR DESCRIPTION
## Description
Changes the datastore treatment of the `sha` param to be "a prefix of the `FullRevisionHash` field".
This steps towards #49 and also supports 7-char SHAs.