### PR TITLE
Diff with HEAD for finding renames in pr_base

### DIFF
--- a/shared/models.go
+++ b/shared/models.go
@@ -119,6 +119,11 @@ func (r TestRun) IsExperimental() bool {
 	return len(r.Labels) > 0 && r.LabelsSet().Contains(ExperimentalLabel)
 }
 
+// IsPRBase returns true if the run is labelled pr_base.
+func (r TestRun) IsPRBase() bool {
+	return len(r.Labels) > 0 && r.LabelsSet().Contains(PRBaseLabel)
+}
+
 // Channel return the channel label, if any, for the given run.
 func (r TestRun) Channel() string {
 	for _, label := range r.Labels {

--- a/shared/run_diff.go
+++ b/shared/run_diff.go
@@ -289,7 +289,11 @@ func (d diffAPIImpl) GetRunsDiff(before, after TestRun, filter DiffFilterParam, 
 
 	var renames map[string]string
 	if IsFeatureEnabled(d.ctx, "diffRenames") {
-		renames = getDiffRenames(d.ctx, before.FullRevisionHash, after.FullRevisionHash)
+		beforeSHA := before.FullRevisionHash
+		if before.FullRevisionHash == after.FullRevisionHash && before.IsPRBase() {
+			beforeSHA = "HEAD"
+		}
+		renames = getDiffRenames(d.ctx, beforeSHA, after.FullRevisionHash)
 	}
 	return RunDiff{
 		Before:        before,

--- a/shared/run_diff.go
+++ b/shared/run_diff.go
@@ -289,7 +289,8 @@ func (d diffAPIImpl) GetRunsDiff(before, after TestRun, filter DiffFilterParam, 
 
 	var renames map[string]string
 	if IsFeatureEnabled(d.ctx, "diffRenames") {
-		beforeSHA := before.FullRevisionHash
+ 		beforeSHA := before.FullRevisionHash
+ 		// Use HEAD...[sha] for PR results, since PR run results always override the value of 'revision' to the PRs HEAD revision.
 		if before.FullRevisionHash == after.FullRevisionHash && before.IsPRBase() {
 			beforeSHA = "HEAD"
 		}


### PR DESCRIPTION
## Description
Further work on #663 

Note that GitHub uses the triple-dot algorithm when comparing, so even if master runs away from the PR's commit, the differences will be the master-branch point to tip-of-PR-branch, which is exactly what we want.

## Review Information
- Load /api/diff?run_id=5969501392732160&run_id=5487233003945984
- See a rename of /workers/importscripts_mime.tentative.any.js