### PR TITLE
Fix nil pointer error for pagination

### DIFF
--- a/shared/params.go
+++ b/shared/params.go
@@ -632,8 +632,10 @@ func ParseQueryFilterParams(v url.Values) (filter QueryFilter, err error) {
 
 // ParseTestRunFilterParams parses all of the filter params for a TestRun query.
 func ParseTestRunFilterParams(v url.Values) (filter TestRunFilter, err error) {
-	if page, err := ParsePageToken(v); page != nil || err != nil {
+	if page, err := ParsePageToken(v); page != nil {
 		return *page, err
+	} else if err != nil {
+		return filter, err
 	}
 
 	runSHA, err := ParseSHAParam(v)

--- a/shared/params_test.go
+++ b/shared/params_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
@@ -692,4 +693,11 @@ func TestExtractRunIDsBodyParam_Replayable(t *testing.T) {
 	replayed, err := ioutil.ReadAll(req.Body)
 	assert.Nil(t, err)
 	assert.Equal(t, payload, replayed)
+}
+
+func TestParseTestRunFilterParams_Page(t *testing.T) {
+	values := make(url.Values)
+	values.Set("page", "bogus value")
+	_, err := ParseTestRunFilterParams(values)
+	assert.NotNil(t, err)
 }


### PR DESCRIPTION
## Description
Fixes a runtime error seen in prod.

> runtime error: invalid memory address or nil pointer dereference
> at panic (go/src/runtime/panic.go:491)
> at github.com/web-platform-tests/wpt.fyi/shared.ParseTestRunFilterParams (params.go:641)
> at github.com/web-platform-tests/wpt.fyi/api.apiTestRunsHandler (test_runs.go:61)
> at github.com/web-platform-tests/wpt.fyi/shared.WrapPermissiveCORS.func1 (routing.go:46)
> at github.com/web-platform-tests/wpt.fyi/shared.WrapApplicationJSON.func1 (routing.go:55)
> at github.com/web-platform-tests/wpt.fyi/shared.WrapHSTS.func1 (routing.go:37)
> at net/http.HandlerFunc.ServeHTTP (server.go:1918)
> at github.com/gorilla/mux.(*Router).ServeHTTP (mux.go:162)