### PR TITLE
Test, implement & integrate: LRU strategy for test runs in searchcache

### DIFF
--- a/api/query/cache/index/index.go
+++ b/api/query/cache/index/index.go
@@ -290,6 +290,7 @@ func NewShardedWPTIndex(loader ReportLoader, numShards int) (Index, error) {
 
 	return &shardedWPTIndex{
 		runs:     make(map[RunID]shared.TestRun),
+		lru:      lru.NewLRU(),
 		inFlight: mapset.NewSet(),
 		loader:   loader,
 		shards:   shards,

--- a/api/query/cache/lru/lru.go
+++ b/api/query/cache/lru/lru.go
@@ -1,0 +1,93 @@
+// Copyright 2018 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package lru
+
+import (
+	"errors"
+	"sort"
+	"sync"
+	"time"
+)
+
+// LRU is a least recently used collection that supports element acces and
+// item eviction. The first access of an unevicted value implicitly adds the
+// value to the collection.
+type LRU interface {
+	// Access stores the current time as the "last accessed" time for the given
+	// value in the collection. The first access of an unevicted value implicitly
+	// adds the value to the collection.
+	Access(int64)
+	// EvictLRU deletes the oldest value from the collection and returns it. If
+	// the collection is empty, then an error is returned.
+	EvictLRU() (int64, error)
+}
+
+type lru struct {
+	byRunID map[int64]time.Time
+	m       *sync.Mutex
+}
+
+type lruEntry struct {
+	int64
+	time.Time
+}
+
+type byTime []lruEntry
+
+func (s byTime) Len() int {
+	return len(s)
+}
+
+func (s byTime) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s byTime) Less(i, j int) bool {
+	return s[i].Time.Before(s[j].Time)
+}
+
+var errEmpty = errors.New("LRU is empty")
+
+func (l *lru) Access(r int64) {
+	l.syncAccess(r)
+}
+
+func (l *lru) EvictLRU() (int64, error) {
+	if len(l.byRunID) == 0 {
+		return int64(0), errEmpty
+	}
+
+	return l.syncEvictLRU(), nil
+}
+
+// NewLRU constructs a new empty LRU.
+func NewLRU() LRU {
+	return &lru{
+		byRunID: make(map[int64]time.Time),
+		m:       &sync.Mutex{},
+	}
+}
+
+func (l *lru) syncAccess(r int64) {
+	l.m.Lock()
+	defer l.m.Unlock()
+
+	l.byRunID[r] = time.Now()
+}
+
+func (l *lru) syncEvictLRU() int64 {
+	l.m.Lock()
+	defer l.m.Unlock()
+
+	rs := make(byTime, 0, len(l.byRunID))
+	for r, t := range l.byRunID {
+		rs = append(rs, lruEntry{r, t})
+	}
+	sort.Sort(rs)
+	toRemove := rs[0].int64
+	delete(l.byRunID, toRemove)
+
+	return toRemove
+}

--- a/api/query/cache/lru/lru.go
+++ b/api/query/cache/lru/lru.go
@@ -37,17 +37,9 @@ type lruEntry struct {
 
 type byTime []lruEntry
 
-func (s byTime) Len() int {
-	return len(s)
-}
-
-func (s byTime) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-func (s byTime) Less(i, j int) bool {
-	return s[i].Time.Before(s[j].Time)
-}
+func (s byTime) Len() int           { return len(s) }
+func (s byTime) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s byTime) Less(i, j int) bool { return s[i].Time.Before(s[j].Time) }
 
 var errEmpty = errors.New("LRU is empty")
 

--- a/api/query/cache/lru/lru_test.go
+++ b/api/query/cache/lru/lru_test.go
@@ -1,0 +1,61 @@
+// +build small
+
+// Copyright 2018 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package lru
+
+import (
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLRUEmpty(t *testing.T) {
+	l := NewLRU()
+	_, err := l.EvictLRU()
+	assert.NotNil(t, err)
+}
+
+func TestSimpleOrder(t *testing.T) {
+	l := NewLRU()
+	l.Access(1)
+	l.Access(2)
+	r, err := l.EvictLRU()
+	assert.Nil(t, err)
+	assert.Equal(t, int64(1), r)
+}
+
+func TestRepeatAccess(t *testing.T) {
+	l := NewLRU()
+	l.Access(1)
+	l.Access(2)
+	l.Access(1)
+	r, err := l.EvictLRU()
+	assert.Nil(t, err)
+	assert.Equal(t, int64(2), r)
+}
+
+func TestConcurrency(t *testing.T) {
+	l := NewLRU()
+	var wg sync.WaitGroup
+	for i := 1; i <= 100; i++ {
+		wg.Add(1)
+		go func(id int64) {
+			defer wg.Done()
+			l.Access(id)
+			wait := rand.Int() % 1000
+			time.Sleep(time.Nanosecond * time.Duration(wait))
+			_, err := l.EvictLRU()
+			assert.Nil(t, err)
+		}(int64(i))
+	}
+	wg.Wait()
+
+	_, err := l.EvictLRU()
+	assert.NotNil(t, err)
+}

--- a/api/query/cache/lru/lru_test.go
+++ b/api/query/cache/lru/lru_test.go
@@ -17,17 +17,32 @@ import (
 
 func TestLRUEmpty(t *testing.T) {
 	l := NewLRU()
-	_, err := l.EvictLRU()
-	assert.NotNil(t, err)
+	removed := l.EvictLRU(1.0)
+	assert.Nil(t, removed)
 }
 
-func TestSimpleOrder(t *testing.T) {
+func TestSimple(t *testing.T) {
 	l := NewLRU()
 	l.Access(1)
 	l.Access(2)
-	r, err := l.EvictLRU()
-	assert.Nil(t, err)
-	assert.Equal(t, int64(1), r)
+	removed := l.EvictLRU(0.5)
+	assert.Equal(t, []int64{int64(1)}, removed)
+}
+
+func TestRoundUpToOne(t *testing.T) {
+	l := NewLRU()
+	l.Access(1)
+	l.Access(2)
+	removed := l.EvictLRU(-1000.0)
+	assert.Equal(t, []int64{int64(1)}, removed)
+}
+
+func TestRoundDown(t *testing.T) {
+	l := NewLRU()
+	l.Access(1)
+	l.Access(2)
+	removed := l.EvictLRU(0.99999)
+	assert.Equal(t, []int64{int64(1)}, removed)
 }
 
 func TestRepeatAccess(t *testing.T) {
@@ -35,9 +50,8 @@ func TestRepeatAccess(t *testing.T) {
 	l.Access(1)
 	l.Access(2)
 	l.Access(1)
-	r, err := l.EvictLRU()
-	assert.Nil(t, err)
-	assert.Equal(t, int64(2), r)
+	removed := l.EvictLRU(0.5)
+	assert.Equal(t, []int64{int64(2)}, removed)
 }
 
 func TestConcurrency(t *testing.T) {
@@ -50,12 +64,12 @@ func TestConcurrency(t *testing.T) {
 			l.Access(id)
 			wait := rand.Int() % 1000
 			time.Sleep(time.Nanosecond * time.Duration(wait))
-			_, err := l.EvictLRU()
-			assert.Nil(t, err)
+			removed := l.EvictLRU(0.0)
+			assert.Equal(t, 1, len(removed))
 		}(int64(i))
 	}
 	wg.Wait()
 
-	_, err := l.EvictLRU()
-	assert.NotNil(t, err)
+	removed := l.EvictLRU(0.0)
+	assert.Nil(t, removed)
 }


### PR DESCRIPTION
Currently `searchcache` evicts runs according to their "time started". This change usees an LRU strategy for evicting test runs instead.