### PR TITLE
Fix intrashard concurrency bug

### DIFF
--- a/api/query/cache/index/results.go
+++ b/api/query/cache/index/results.go
@@ -102,8 +102,3 @@ func (rrs *runResultsMap) GetResult(t TestID) ResultID {
 	}
 	return re
 }
-
-// TODO: Add filter binding function:
-// func ResultFilter(ru RunID, re ResultID) UnboundFilter {
-// 	return NewResultEQFilter(ru, re)
-// }


### PR DESCRIPTION
Presently there is a mutex guarding read and write to the entire searchcache index. However, one of its read operations gives an index-type object shared custody of test+result data, which leads to a concurrency bug when the index-type object attempts to read from the shared structures while the enclosing Index shard is performing a write operation on the same shared structure.

This change introduces a sync.RWMutex for each shard. A pointer to the mutex is passed to index-type objects so they can acquire a read lock. The Index-type implementation is updated to synchronize its access to shard data as too.
