### PR TITLE
Persist /runs query changes in the URL

### DIFF
--- a/webapp/components/interop.html
+++ b/webapp/components/interop.html
@@ -308,10 +308,6 @@ found in the LICENSE file.
       return '/interop';
     }
 
-    navigationQueryParams() {
-      return this.queryParams;
-    }
-
     interopQueryParams(sha, aligned, master, labels, productSpecs, maxCount, to, from, search) {
       const params = this.computeTestRunQueryParams(sha, aligned, master, labels, productSpecs, to, from, maxCount);
       if (search) {

--- a/webapp/components/self-navigator.html
+++ b/webapp/components/self-navigator.html
@@ -87,7 +87,7 @@
        * Defaults to the queryParams property.
        */
       navigationQueryParams() {
-        return Object.assign({}, this.queryParams);
+        return this.queryParams && JSON.parse(JSON.stringify(this.queryParams));
       }
 
       bindNavigate() {

--- a/webapp/components/self-navigator.html
+++ b/webapp/components/self-navigator.html
@@ -84,9 +84,10 @@
 
       /**
        * Get query params to persist when creating history.
+       * Defaults to the queryParams property.
        */
       navigationQueryParams() {
-        return {};
+        return Object.assign({}, this.queryParams);
       }
 
       bindNavigate() {

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -762,10 +762,6 @@ found in the LICENSE file.
         return '/results';
       }
 
-      navigationQueryParams() {
-        return Object.assign({}, this.queryParams);
-      }
-
       testResultClass(node, index, testRun, prop) {
         // Guard against incomplete data.
         if (!node || !testRun) {

--- a/webapp/components/wpt-runs.html
+++ b/webapp/components/wpt-runs.html
@@ -16,6 +16,7 @@ found in the LICENSE file.
 <link rel="import" href="./test-run.html">
 <link rel="import" href="./loading-state.html">
 <link rel="import" href="./product-info.html">
+<link rel="import" href="./self-navigator.html">
 <link rel="import" href="./test-runs-query-builder.html">
 <link rel="import" href="./wpt-flags.html">
 
@@ -179,8 +180,8 @@ found in the LICENSE file.
   </template>
 
   <script>
-    /* global WPTFlags, TestRunsUIBase, LoadingState */
-    class WPTRuns extends WPTFlags(LoadingState(TestRunsUIBase)) {
+    /* global WPTFlags, SelfNavigation, TestRunsUIBase, LoadingState */
+    class WPTRuns extends WPTFlags(SelfNavigation(LoadingState(TestRunsUIBase))) {
       static get is() {
         return 'wpt-runs';
       }
@@ -344,6 +345,8 @@ found in the LICENSE file.
         if (queryBefore === this.query) {
           return;
         }
+        // Trigger a virtual navigation.
+        this.navigateToLocation(window.location);
         this.setProperties({
           browsers: [],
           testRuns: [],


### PR DESCRIPTION
## Description
More builder work (https://github.com/web-platform-tests/wpt.fyi/issues/535)

When the query is submitted on /runs tab, persist it to the URL.

## Review Information
- Visit the /runs page
- Change the query, submit
- See the changes in the URL
- Reload the page, see the same results