### PR TITLE
Make date/time query param parsing more flexible

### DIFF
--- a/shared/params.go
+++ b/shared/params.go
@@ -415,10 +415,14 @@ func ParseMaxCountParamWithDefault(v url.Values, defaultValue int) (count int, e
 	return defaultValue, nil
 }
 
-// ParseDateTimeParam parses the date/time param named "name" as a timestamp.
+// ParseDateTimeParam flexibly parses a date/time param with the given name as a time.Time.
 func ParseDateTimeParam(v url.Values, name string) (*time.Time, error) {
 	if fromParam := v.Get(name); fromParam != "" {
-		parsed, err := time.Parse(time.RFC3339, fromParam)
+		format := time.RFC3339
+		if len(fromParam) < strings.Index(time.RFC3339, "Z") {
+			format = format[:len(fromParam)]
+		}
+		parsed, err := time.Parse(format, fromParam)
 		if err != nil {
 			return nil, err
 		}

--- a/shared/params_test.go
+++ b/shared/params_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
@@ -209,6 +210,45 @@ func TestParseMaxCountParam(t *testing.T) {
 	count, err := ParseMaxCountParam(r.URL.Query())
 	assert.Nil(t, err)
 	assert.Equal(t, 2, *count)
+}
+
+func TestParseDateTimeParam(t *testing.T) {
+	values := make(url.Values)
+	values.Set("foo", "1999")
+	parsed, err := ParseDateTimeParam(values, "foo")
+	assert.Nil(t, err)
+	assert.Equal(t, time.Date(1999, 1, 1, 0, 0, 0, 0, time.UTC), *parsed)
+
+	values.Set("foo", "2001-02")
+	parsed, err = ParseDateTimeParam(values, "foo")
+	assert.Nil(t, err)
+	assert.Equal(t, time.Date(2001, 2, 1, 0, 0, 0, 0, time.UTC), *parsed)
+
+	values.Set("foo", "2002-06-13")
+	parsed, err = ParseDateTimeParam(values, "foo")
+	assert.Nil(t, err)
+	assert.Equal(t, time.Date(2002, 6, 13, 0, 0, 0, 0, time.UTC), *parsed)
+
+	values.Set("foo", "2002-06-13T15:04")
+	parsed, err = ParseDateTimeParam(values, "foo")
+	assert.Nil(t, err)
+	assert.Equal(t, time.Date(2002, 6, 13, 15, 4, 0, 0, time.UTC), *parsed)
+
+	values.Set("foo", "2007-11-21T01:04:55Z")
+	parsed, err = ParseDateTimeParam(values, "foo")
+	assert.Nil(t, err)
+	assert.Equal(t, time.Date(2007, 11, 21, 1, 4, 55, 0, time.UTC), *parsed)
+
+	values.Set("foo", "2007-11-21T01:04:55.123Z")
+	parsed, err = ParseDateTimeParam(values, "foo")
+	assert.Nil(t, err)
+	assert.Equal(t, time.Date(2007, 11, 21, 1, 4, 55, 123000000, time.UTC), *parsed)
+
+	oneHourEastOfUTC := time.FixedZone("Plus One", int((1 * time.Hour).Seconds()))
+	values.Set("foo", "2007-11-21T01:04:55.456+01:00")
+	parsed, err = ParseDateTimeParam(values, "foo")
+	assert.Nil(t, err)
+	assert.Equal(t, time.Date(2007, 11, 21, 1, 4, 55, 456000000, oneHourEastOfUTC).UnixNano(), parsed.UnixNano())
 }
 
 func TestParsePathsParam_Missing(t *testing.T) {


### PR DESCRIPTION
## Description
Typing a date that requires RFC3339 is tedious, so we should just consider anything we're given for parsing and do a best-effort. 

The unit test's cases demonstrate the possibilities.