### PR TITLE
Keep the query message visible between submissions in /runs

### DIFF
--- a/webapp/components/test-runs-query-builder.html
+++ b/webapp/components/test-runs-query-builder.html
@@ -455,7 +455,7 @@ found in the LICENSE file.
           },
           channels: {
             type: Array,
-            value: window.wpt.Channels,
+            value: Array.from(window.wpt.Channels),
           },
           versionsURL: {
             type: String,

--- a/webapp/components/wpt-runs.html
+++ b/webapp/components/wpt-runs.html
@@ -88,36 +88,42 @@ found in the LICENSE file.
       }
     </style>
 
+    <template is="dom-if" if="[[resultsRangeMessage]]">
+      <info-banner>
+        [[resultsRangeMessage]]
+        <paper-button onclick="[[toggleBuilder]]" slot="small">Edit</paper-button>
+      </info-banner>
+    </template>
+
+    <template is="dom-if" if="[[queryBuilder]]">
+      <iron-collapse opened="[[editingQuery]]">
+        <test-runs-query-builder product-specs="[[productSpecs]]"
+                                labels="[[labels]]"
+                                master="[[master]]"
+                                sha="[[sha]]"
+                                aligned="[[aligned]]"
+                                on-submit="[[submitQuery]]"
+                                from="[[from]]"
+                                to="[[to]]"
+                                diff="[[diff]]"
+                                show-time-range>
+        </test-runs-query-builder>
+      </iron-collapse>
+    </template>
+
     <template is="dom-if" if="[[loadingFailed]]">
       <info-banner type="error">
         Failed to load test runs.
       </info-banner>
     </template>
 
+    <template is="dom-if" if="[[noResults]]">
+      <info-banner type="info">
+        No results.
+      </info-banner>
+    </template>
+
     <template is="dom-if" if="[[testRuns.length]]">
-      <template is="dom-if" if="[[resultsRangeMessage]]">
-        <info-banner>
-          [[resultsRangeMessage]]
-          <paper-button onclick="[[toggleBuilder]]" slot="small">Edit</paper-button>
-        </info-banner>
-      </template>
-
-      <template is="dom-if" if="[[queryBuilder]]">
-        <iron-collapse opened="[[editingQuery]]">
-          <test-runs-query-builder product-specs="[[productSpecs]]"
-                                  labels="[[labels]]"
-                                  master="[[master]]"
-                                  sha="[[sha]]"
-                                  aligned="[[aligned]]"
-                                  on-submit="[[submitQuery]]"
-                                  from="[[from]]"
-                                  to="[[to]]"
-                                  diff="[[diff]]"
-                                  show-time-range>
-          </test-runs-query-builder>
-        </iron-collapse>
-      </template>
-
       <table>
         <thead>
           <tr>
@@ -212,6 +218,7 @@ found in the LICENSE file.
         super();
         this.onLoadingComplete = () => {
           this.loadingFailed = !this.testRunsBySHA;
+          this.noResults = !this.loadingFailed && !this.testRunsBySHA.length;
         };
         this.toggleBuilder = () => {
           this.editingQuery = !this.editingQuery;
@@ -340,6 +347,7 @@ found in the LICENSE file.
         const queryBefore = this.query;
         const builder = this.shadowRoot.querySelector('test-runs-query-builder');
         this.editingQuery = false;
+        this.nextPageToken = null;
         this.updateQueryParams(builder.queryParams);
         if (queryBefore === this.query) {
           return;


### PR DESCRIPTION
## Description
Changes the message to be visible at all times, instead of only when runs are loaded.