### PR TITLE
Bind backfill+monitor+LRU to percent of runs to evict

### DIFF
--- a/api/query/cache/backfill/backfill.go
+++ b/api/query/cache/backfill/backfill.go
@@ -84,9 +84,9 @@ func (f datastoreRunFetcher) FetchRuns(limit int) ([]shared.TestRun, error) {
 	return runs, nil
 }
 
-func (i *backfillIndex) EvictAnyRun() error {
+func (i *backfillIndex) EvictRuns(percent float64) (int, error) {
 	i.backfilling = false
-	return i.ProxyIndex.EvictAnyRun()
+	return i.ProxyIndex.EvictRuns(percent)
 }
 
 func (m *backfillMonitor) Stop() error {
@@ -103,7 +103,7 @@ func (*backfillIndex) Bind([]shared.TestRun, query.ConcreteQuery) (query.Plan, e
 // will halt either:
 // The first time a run is evicted from the index.Index via EvictAnyRun(), OR
 // the first time the returned monitor.Monitor is stopped via Stop().
-func FillIndex(fetcher RunFetcher, logger shared.Logger, rt monitor.Runtime, interval time.Duration, maxBytes uint64, idx index.Index) (monitor.Monitor, error) {
+func FillIndex(fetcher RunFetcher, logger shared.Logger, rt monitor.Runtime, interval time.Duration, maxBytes uint64, evictionPercent float64, idx index.Index) (monitor.Monitor, error) {
 	if idx == nil {
 		return nil, errNilIndex
 	}
@@ -112,12 +112,16 @@ func FillIndex(fetcher RunFetcher, logger shared.Logger, rt monitor.Runtime, int
 		ProxyIndex:  index.NewProxyIndex(idx),
 		backfilling: true,
 	}
+	idxMon, err := monitor.NewIndexMonitor(logger, rt, interval, maxBytes, evictionPercent, bfIdx)
+	if err != nil {
+		return nil, err
+	}
 	bfMon := &backfillMonitor{
-		ProxyMonitor: monitor.NewProxyMonitor(monitor.NewIndexMonitor(logger, rt, interval, maxBytes, bfIdx)),
+		ProxyMonitor: monitor.NewProxyMonitor(idxMon),
 		idx:          bfIdx,
 	}
 
-	err := startBackfillMonitor(fetcher, logger, maxBytes, bfMon)
+	err = startBackfillMonitor(fetcher, logger, maxBytes, bfMon)
 	if err != nil {
 		return nil, err
 	}

--- a/api/query/cache/backfill/backfill_medium_test.go
+++ b/api/query/cache/backfill/backfill_medium_test.go
@@ -37,14 +37,14 @@ func (i *countingIndex) IngestRun(r shared.TestRun) error {
 	return nil
 }
 
-func (i *countingIndex) EvictAnyRun() error {
-	err := i.ProxyIndex.EvictAnyRun()
+func (i *countingIndex) EvictRuns(percent float64) (int, error) {
+	n, err := i.ProxyIndex.EvictRuns(percent)
 	if err != nil {
-		return err
+		return n, err
 	}
 
-	i.count--
-	return nil
+	i.count -= n
+	return n, nil
 }
 
 func (*countingIndex) Bind([]shared.TestRun, query.ConcreteQuery) (query.Plan, error) {
@@ -66,7 +66,7 @@ func TestStopImmediately(t *testing.T) {
 	mockIdx := index.NewMockIndex(ctrl)
 	mockIdx.EXPECT().IngestRun(gomock.Any()).Return(nil).AnyTimes()
 	idx := countingIndex{index.NewProxyIndex(mockIdx), 0}
-	m, err := FillIndex(fetcher, shared.NewNilLogger(), rt, time.Millisecond*10, 1, &idx)
+	m, err := FillIndex(fetcher, shared.NewNilLogger(), rt, time.Millisecond*10, 1, 0.0, &idx)
 	assert.Nil(t, err)
 	m.Stop()
 	time.Sleep(time.Second)
@@ -108,9 +108,9 @@ func TestIngestSomeRuns(t *testing.T) {
 		return nil
 	}).AnyTimes()
 
-	mockIdx.EXPECT().EvictAnyRun().Return(nil).AnyTimes()
+	mockIdx.EXPECT().EvictRuns(gomock.Any()).Return(1, nil).AnyTimes()
 
-	m, err := FillIndex(fetcher, shared.NewNilLogger(), rt, freq, maxBytes, &idx)
+	m, err := FillIndex(fetcher, shared.NewNilLogger(), rt, freq, maxBytes, 0.0, &idx)
 	assert.Nil(t, err)
 	defer m.Stop()
 

--- a/api/query/cache/backfill/backfill_test.go
+++ b/api/query/cache/backfill/backfill_test.go
@@ -19,7 +19,7 @@ func TestNilIndex(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	fetcher := NewMockRunFetcher(ctrl)
-	_, err := FillIndex(fetcher, nil, nil, 1, uint64(1), nil)
+	_, err := FillIndex(fetcher, nil, nil, 1, uint64(1), 0.0, nil)
 	assert.Equal(t, errNilIndex, err)
 }
 
@@ -30,6 +30,6 @@ func TestFetchErr(t *testing.T) {
 	idx := index.NewMockIndex(ctrl)
 	expected := errors.New("Fetch error")
 	fetcher.EXPECT().FetchRuns(gomock.Any()).Return(nil, expected)
-	_, err := FillIndex(fetcher, nil, nil, 1, uint64(1), idx)
+	_, err := FillIndex(fetcher, nil, nil, 1, uint64(1), 0.0, idx)
 	assert.Equal(t, expected, err)
 }

--- a/api/query/cache/index/index_medium_test.go
+++ b/api/query/cache/index/index_medium_test.go
@@ -54,7 +54,9 @@ func TestEvictAnyRunRelievesMemoryPressure(t *testing.T) {
 	runtime.ReadMemStats(&stats)
 	baseline := stats.HeapAlloc
 
-	assert.Nil(t, i.EvictAnyRun())
+	n, err := i.EvictRuns(0.0)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, n)
 
 	runtime.GC()
 	runtime.ReadMemStats(&stats)

--- a/api/query/cache/index/index_mock.go
+++ b/api/query/cache/index/index_mock.go
@@ -5,12 +5,11 @@
 package index
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	metrics "github.com/web-platform-tests/results-analysis/metrics"
 	query "github.com/web-platform-tests/wpt.fyi/api/query"
 	shared "github.com/web-platform-tests/wpt.fyi/shared"
+	reflect "reflect"
 )
 
 // MockIndex is a mock of Index interface
@@ -74,16 +73,17 @@ func (mr *MockIndexMockRecorder) IngestRun(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IngestRun", reflect.TypeOf((*MockIndex)(nil).IngestRun), arg0)
 }
 
-// EvictAnyRun mocks base method
-func (m *MockIndex) EvictAnyRun() error {
-	ret := m.ctrl.Call(m, "EvictAnyRun")
-	ret0, _ := ret[0].(error)
-	return ret0
+// EvictRuns mocks base method
+func (m *MockIndex) EvictRuns(arg0 float64) (int, error) {
+	ret := m.ctrl.Call(m, "EvictRuns", arg0)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// EvictAnyRun indicates an expected call of EvictAnyRun
-func (mr *MockIndexMockRecorder) EvictAnyRun() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EvictAnyRun", reflect.TypeOf((*MockIndex)(nil).EvictAnyRun))
+// EvictRuns indicates an expected call of EvictRuns
+func (mr *MockIndexMockRecorder) EvictRuns(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EvictRuns", reflect.TypeOf((*MockIndex)(nil).EvictRuns), arg0)
 }
 
 // MockReportLoader is a mock of ReportLoader interface

--- a/api/query/cache/index/index_test.go
+++ b/api/query/cache/index/index_test.go
@@ -36,7 +36,8 @@ func TestEvictEmpty(t *testing.T) {
 	loader := NewMockReportLoader(ctrl)
 	i, err := NewShardedWPTIndex(loader, 1)
 	assert.Nil(t, err)
-	assert.NotNil(t, i.EvictAnyRun())
+	_, err = i.EvictRuns(0.0)
+	assert.NotNil(t, err)
 }
 
 func TestIngestRun_zeroID(t *testing.T) {
@@ -148,7 +149,94 @@ func TestEvictNonEmpty(t *testing.T) {
 	}
 	loader.EXPECT().Load(run).Return(results, nil)
 	assert.Nil(t, i.IngestRun(run))
-	assert.Nil(t, i.EvictAnyRun())
+	n, err := i.EvictRuns(0.0)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, n)
+}
+
+func TestEvictMultiple(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	loader := NewMockReportLoader(ctrl)
+	i, err := NewShardedWPTIndex(loader, 1)
+	assert.Nil(t, err)
+
+	run1 := shared.TestRun{
+		ID:            1,
+		RawResultsURL: "http://example.com/results1.json",
+	}
+	results1 := &metrics.TestResultsReport{
+		Results: []*metrics.TestResults{
+			&metrics.TestResults{
+				Test:     "a",
+				Status:   "PASS",
+				Subtests: []metrics.SubTest{},
+			},
+			&metrics.TestResults{
+				Test:   "b",
+				Status: "OK",
+				Subtests: []metrics.SubTest{
+					metrics.SubTest{
+						Name:   "sub",
+						Status: "FAIL",
+					},
+				},
+			},
+		},
+	}
+	run2 := shared.TestRun{
+		ID:            2,
+		RawResultsURL: "http://example.com/results2.json",
+	}
+	results2 := &metrics.TestResultsReport{
+		Results: []*metrics.TestResults{
+			&metrics.TestResults{
+				Test:     "a",
+				Status:   "FAIL",
+				Subtests: []metrics.SubTest{},
+			},
+			&metrics.TestResults{
+				Test:   "b",
+				Status: "OK",
+				Subtests: []metrics.SubTest{
+					metrics.SubTest{
+						Name:   "sub",
+						Status: "TIMEOUT",
+					},
+				},
+			},
+		},
+	}
+	run3 := shared.TestRun{
+		ID:            3,
+		RawResultsURL: "http://example.com/results2.json",
+	}
+	results3 := &metrics.TestResultsReport{
+		Results: []*metrics.TestResults{
+			&metrics.TestResults{
+				Test:     "a",
+				Status:   "PASS",
+				Subtests: []metrics.SubTest{},
+			},
+			&metrics.TestResults{
+				Test:     "b",
+				Status:   "TIMEOUT",
+				Subtests: []metrics.SubTest{},
+			},
+		},
+	}
+
+	loader.EXPECT().Load(run1).Return(results1, nil)
+	loader.EXPECT().Load(run2).Return(results2, nil)
+	loader.EXPECT().Load(run3).Return(results3, nil)
+
+	assert.Nil(t, i.IngestRun(run1))
+	assert.Nil(t, i.IngestRun(run2))
+	assert.Nil(t, i.IngestRun(run3))
+
+	n, err := i.EvictRuns(0.7)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, n)
 }
 
 func TestSync(t *testing.T) {
@@ -196,7 +284,9 @@ func TestSync(t *testing.T) {
 		wg.Add(1)
 		go func(n int) {
 			defer wg.Done()
-			i.EvictAnyRun()
+			n, err := i.EvictRuns(0.0)
+			assert.Nil(t, err)
+			assert.Equal(t, 1, n)
 		}(j)
 		wg.Add(1)
 		go func(id int64) {

--- a/api/query/cache/service/main.go
+++ b/api/query/cache/service/main.go
@@ -32,6 +32,7 @@ var (
 	numShards          = flag.Int("num_shards", runtime.NumCPU(), "Number of shards for parallelizing query execution")
 	monitorInterval    = flag.Duration("monitor_interval", time.Second*5, "Polling interval for memory usage monitor")
 	maxHeapBytes       = flag.Uint64("max_heap_bytes", uint64(2e+11), "Soft limit on heap-allocated bytes before evicting test runs from memory")
+	evictRunsPercent   = flag.Float64("evict_runs_percent", 0.1, "Decimal percentage indicating what fraction of runs to evict when soft memory limit is reached")
 	updateInterval     = flag.Duration("update_interval", time.Second*10, "Update interval for polling for new runs")
 	updateMaxRuns      = flag.Int("update_max_runs", 10, "The maximum number of latest runs to lookup in attempts to update indexes via polling")
 
@@ -135,7 +136,7 @@ func main() {
 	}
 
 	fetcher := backfill.NewDatastoreRunFetcher(*projectID, gcpCredentialsFile, logger)
-	mon, err = backfill.FillIndex(fetcher, logger, monitor.GoRuntime{}, *monitorInterval, *maxHeapBytes, idx)
+	mon, err = backfill.FillIndex(fetcher, logger, monitor.GoRuntime{}, *monitorInterval, *maxHeapBytes, *evictRunsPercent, idx)
 	if err != nil {
 		log.Fatalf("Failed to initiate index backkfill: %v", err)
 	}


### PR DESCRIPTION
This change follows up from #935, which created `EvictLRU(percent)` in the LRU. This change passes a percentage of runs to evict to `FillIndex(...)`, which is responsible for setting up a monitor for the given index. The percentage is passed from the `Monitor through the `Index` to the `LRU` when performing a synchronized operation to evict a collection of LRU runs to reduce memory pressure.