### PR TITLE
Add ignore action to cancelled check

### DIFF
--- a/api/checks/api.go
+++ b/api/checks/api.go
@@ -147,6 +147,7 @@ func (s checksAPIImpl) CancelRun(sender, owner, repo string, run *github.CheckRu
 		CompletedAt: &github.Timestamp{Time: time.Now()},
 		Actions: []*github.CheckRunAction{
 			summaries.RecomputeAction(),
+			summaries.IgnoreAction(),
 		},
 	}
 	_, _, err = client.Checks.UpdateCheckRun(s.ctx, owner, repo, run.GetID(), opts)

--- a/api/checks/summaries/actions.go
+++ b/api/checks/summaries/actions.go
@@ -1,0 +1,37 @@
+// Copyright 2018 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package summaries
+
+import "github.com/google/go-github/github"
+
+// RecomputeAction is an action that can be taken to
+// trigger a recompute of the diff, against the latest
+// master run's results.
+func RecomputeAction() *github.CheckRunAction {
+	return &github.CheckRunAction{
+		Identifier:  "recompute",
+		Label:       "Recompute",
+		Description: "Recompute against the latest available runs",
+	}
+}
+
+// IgnoreAction is an action that can be taken to ignore a fail
+// outcome, marking it as passing.
+func IgnoreAction() *github.CheckRunAction {
+	return &github.CheckRunAction{
+		Identifier:  "ignore",
+		Label:       "Ignore",
+		Description: "Mark these results as expected (passing)",
+	}
+}
+
+// CancelAction is an action that can be taken to cancel a pending check run.
+func CancelAction() *github.CheckRunAction {
+	return &github.CheckRunAction{
+		Identifier:  "cancel",
+		Label:       "Cancel",
+		Description: "Cancel this pending check run",
+	}
+}

--- a/api/checks/summaries/pending.go
+++ b/api/checks/summaries/pending.go
@@ -24,15 +24,6 @@ func (p Pending) GetSummary() (string, error) {
 	return compile(&p, "pending.md")
 }
 
-// CancelAction is an action that can be taken to cancel a pending check run.
-func CancelAction() *github.CheckRunAction {
-	return &github.CheckRunAction{
-		Identifier:  "cancel",
-		Label:       "Cancel",
-		Description: "Cancel this pending check run",
-	}
-}
-
 // GetActions returns the actions that can be taken by the user.
 func (p Pending) GetActions() []*github.CheckRunAction {
 	return []*github.CheckRunAction{

--- a/api/checks/summaries/regressed.go
+++ b/api/checks/summaries/regressed.go
@@ -33,27 +33,6 @@ func (r Regressed) GetSummary() (string, error) {
 	return compile(&r, "regressed.md")
 }
 
-// RecomputeAction is an action that can be taken to
-// trigger a recompute of the diff, against the latest
-// master run's results.
-func RecomputeAction() *github.CheckRunAction {
-	return &github.CheckRunAction{
-		Identifier:  "recompute",
-		Label:       "Recompute",
-		Description: "Recompute against the latest master run",
-	}
-}
-
-// IgnoreAction is an action that can be taken to ignore a fail
-// outcome, marking it as passing.
-func IgnoreAction() *github.CheckRunAction {
-	return &github.CheckRunAction{
-		Identifier:  "ignore",
-		Label:       "Ignore",
-		Description: "Mark these results as expected (passing)",
-	}
-}
-
 // GetActions returns the actions that can be taken by the user.
 func (r Regressed) GetActions() []*github.CheckRunAction {
 	return []*github.CheckRunAction{


### PR DESCRIPTION
## Description
wpt blocks on cancelled checks, so include the ignore action to mark them successful.

Also, drive-by reorganization of the actions to all be in one file.