### PR TITLE
Put pending checks behind a feature

### DIFF
--- a/api/taskcluster/webhook.go
+++ b/api/taskcluster/webhook.go
@@ -27,6 +27,7 @@ import (
 )
 
 const flagTaskclusterAllBranches = "taskclusterAllBranches"
+const flagPendingChecks = "pendingChecks"
 
 var (
 	// This should follow https://github.com/web-platform-tests/wpt/blob/master/.taskcluster.yml
@@ -335,16 +336,18 @@ func createAllRuns(
 				return
 			}
 
-			spec := shared.ProductSpec{}
-			spec.BrowserName = bits[0]
-			spec.Labels = shared.NewSetFromStringSlice(labelsForRun)
-			if len(bits) > 1 {
-				if label := shared.ProductChannelToLabel(bits[1]); label != "" {
-					spec.Labels.Add(label)
+			if aeAPI.IsFeatureEnabled(flagPendingChecks) {
+				spec := shared.ProductSpec{}
+				spec.BrowserName = bits[0]
+				spec.Labels = shared.NewSetFromStringSlice(labelsForRun)
+				if len(bits) > 1 {
+					if label := shared.ProductChannelToLabel(bits[1]); label != "" {
+						spec.Labels.Add(label)
+					}
 				}
-			}
-			for _, suite := range suites {
-				checksAPI.PendingCheckRun(suite, spec)
+				for _, suite := range suites {
+					checksAPI.PendingCheckRun(suite, spec)
+				}
 			}
 		}(product, urls)
 	}

--- a/api/taskcluster/webhook_test.go
+++ b/api/taskcluster/webhook_test.go
@@ -182,6 +182,7 @@ func TestCreateAllRuns_success_master(t *testing.T) {
 	checksAPI.EXPECT().PendingCheckRun(suite, sharedtest.SameProductSpec("firefox[master]"))
 	aeAPI := sharedtest.NewMockAppEngineAPI(mockC)
 	aeAPI.EXPECT().GetHostname().MinTimes(1).Return("localhost:8080")
+	aeAPI.EXPECT().IsFeatureEnabled(flagPendingChecks).MinTimes(1).Return(true)
 
 	err := createAllRuns(
 		shared.NewNilLogger(),
@@ -226,6 +227,7 @@ func TestCreateAllRuns_success_pr(t *testing.T) {
 	checksAPI.EXPECT().PendingCheckRun(suite, sharedtest.SameProductSpec("firefox[pr_head]"))
 	aeAPI := sharedtest.NewMockAppEngineAPI(mockC)
 	aeAPI.EXPECT().GetHostname().MinTimes(1).Return("localhost:8080")
+	aeAPI.EXPECT().IsFeatureEnabled(flagPendingChecks).MinTimes(1).Return(true)
 
 	err := createAllRuns(
 		shared.NewNilLogger(),
@@ -277,6 +279,7 @@ func TestCreateAllRuns_one_error(t *testing.T) {
 	checksAPI.EXPECT().PendingCheckRun(suite, gomock.Any())
 	aeAPI := sharedtest.NewMockAppEngineAPI(mockC)
 	aeAPI.EXPECT().GetHostname().MinTimes(1).Return("localhost:8080")
+	aeAPI.EXPECT().IsFeatureEnabled(flagPendingChecks).MinTimes(1).Return(true)
 
 	err := createAllRuns(
 		shared.NewNilLogger(),

--- a/webapp/components/wpt-flags.html
+++ b/webapp/components/wpt-flags.html
@@ -44,6 +44,7 @@ found in the LICENSE file.
           'runsByPRNumber',
           'failChecksOnRegression',
           'checksAllUsers',
+          'pendingChecks',
         ];
       }
     });
@@ -192,7 +193,7 @@ found in the LICENSE file.
 <dom-module id="wpt-environment-flags-editor">
   <template>
     <!-- WPTFlags template prepended in code, below. -->
-    <h4>Server-side only features</h4>
+    <h3>Server-side only features</h3>
     <paper-item>
       <paper-checkbox checked="{{diffRenames}}">
         Compute renames in diffs with the GitHub API
@@ -228,14 +229,20 @@ found in the LICENSE file.
         Allow /api/runs?pr=[GitHub PR number]
       </paper-checkbox>
     </paper-item>
-    <paper-item>
+    <h5>GitHub Status Checks</h5>
+    <paper-item sub-item>
       <paper-checkbox checked="{{failChecksOnRegression}}">
         Fail the wpt.fyi GitHub status check if regressions are found, and pass them if not.
       </paper-checkbox>
     </paper-item>
-    <paper-item>
+    <paper-item sub-item>
       <paper-checkbox checked="{{checksAllUsers}}">
         Run the wpt.fyi GitHub status check for all users, not just whitelisted ones.
+      </paper-checkbox>
+    </paper-item>
+    <paper-item sub-item>
+      <paper-checkbox checked="{{pendingChecks}}">
+        Create pending GitHub status check when results first arrive, and are being processed.
       </paper-checkbox>
     </paper-item>
     <paper-item>


### PR DESCRIPTION
## Description
Stops pending checks for now, until we've resolved empty report behaviour.