### PR TITLE
Add FullRevisionHash indexes

### DIFF
--- a/webapp/index.yaml
+++ b/webapp/index.yaml
@@ -91,6 +91,10 @@ indexes:
   - name: InstallationID
 - kind: TestRun
   properties:
+  - name: BrowserName
+  - name: FullRevisionHash
+- kind: TestRun
+  properties:
   - name: FullRevisionHash
   - name: TimeStart
     direction: desc

--- a/webapp/index.yaml
+++ b/webapp/index.yaml
@@ -89,3 +89,31 @@ indexes:
   - name: Repo
   - name: AppID
   - name: InstallationID
+- kind: TestRun
+  properties:
+  - name: FullRevisionHash
+  - name: TimeStart
+    direction: desc
+- kind: TestRun
+  properties:
+  - name: Browser
+  - name: FullRevisionHash
+  - name: TimeStart
+    direction: desc
+- kind: TestRun
+  properties:
+  - name: BrowserName
+  - name: FullRevisionHash
+  - name: TimeStart
+    direction: desc
+- kind: TestRun
+  properties:
+  - name: FullRevisionHash
+  - name: BrowserVersion
+    direction: desc
+- kind: TestRun
+  properties:
+  - name: TimeStart
+    direction: desc
+  - name: BrowserName
+  - name: FullRevisionHash


### PR DESCRIPTION
## Description
#929 changed `sha` param behaviour, but forgot to create the indexes (because locally, everything is indexed).

This takes all indexes with `Revision` and duplicates them to the same index with `FullRevisionHash`.