### PR TITLE
Prefix user, add user param

### DIFF
--- a/api/azure/webhook.go
+++ b/api/azure/webhook.go
@@ -70,7 +70,7 @@ func handleCheckRunEvent(log shared.Logger, azureAPI API, aeAPI shared.AppEngine
 		labels := mapset.NewSet()
 		sender := event.GetSender().GetLogin()
 		if sender != "" {
-			labels.Add("user:" + sender)
+			labels.Add(shared.GetUserLabel(sender))
 		}
 		if artifact.Name == "results" {
 			labels.Add(shared.PRHeadLabel)

--- a/api/azure/webhook.go
+++ b/api/azure/webhook.go
@@ -70,7 +70,7 @@ func handleCheckRunEvent(log shared.Logger, azureAPI API, aeAPI shared.AppEngine
 		labels := mapset.NewSet()
 		sender := event.GetSender().GetLogin()
 		if sender != "" {
-			labels.Add(sender)
+			labels.Add("user:" + sender)
 		}
 		if artifact.Name == "results" {
 			labels.Add(shared.PRHeadLabel)

--- a/api/taskcluster/webhook.go
+++ b/api/taskcluster/webhook.go
@@ -167,7 +167,7 @@ func handleStatusEvent(ctx context.Context, payload []byte) (bool, error) {
 	} else {
 		sender := status.GetCommit().GetAuthor().GetLogin()
 		if sender != "" {
-			labels.Add("user:" + sender)
+			labels.Add(shared.GetUserLabel(sender))
 		}
 	}
 	checksAPI := checks.NewAPI(ctx)

--- a/api/taskcluster/webhook.go
+++ b/api/taskcluster/webhook.go
@@ -345,10 +345,9 @@ func createAllRuns(
 			if aeAPI.IsFeatureEnabled(flagPendingChecks) {
 				spec := shared.ProductSpec{}
 				spec.BrowserName = bits[0]
-				spec.Labels = shared.NewSetFromStringSlice(labelsForRun)
 				if len(bits) > 1 {
 					if label := shared.ProductChannelToLabel(bits[1]); label != "" {
-						spec.Labels.Add(label)
+						spec.Labels = mapset.NewSet(label)
 					}
 				}
 				for _, suite := range suites {

--- a/api/taskcluster/webhook.go
+++ b/api/taskcluster/webhook.go
@@ -167,7 +167,7 @@ func handleStatusEvent(ctx context.Context, payload []byte) (bool, error) {
 	} else {
 		sender := status.GetCommit().GetAuthor().GetLogin()
 		if sender != "" {
-			labels.Add(sender)
+			labels.Add("user:" + sender)
 		}
 	}
 	checksAPI := checks.NewAPI(ctx)

--- a/shared/params.go
+++ b/shared/params.go
@@ -648,6 +648,9 @@ func ParseTestRunFilterParams(v url.Values) (filter TestRunFilter, err error) {
 	}
 	filter.SHA = runSHA
 	filter.Labels = NewSetFromStringSlice(ParseLabelsParam(v))
+	if user := v.Get("user"); user != "" {
+		filter.Labels.Add("user:" + user)
+	}
 	if filter.Aligned, err = ParseAlignedParam(v); err != nil {
 		return filter, err
 	}

--- a/shared/params.go
+++ b/shared/params.go
@@ -649,7 +649,7 @@ func ParseTestRunFilterParams(v url.Values) (filter TestRunFilter, err error) {
 	filter.SHA = runSHA
 	filter.Labels = NewSetFromStringSlice(ParseLabelsParam(v))
 	if user := v.Get("user"); user != "" {
-		filter.Labels.Add("user:" + user)
+		filter.Labels.Add(GetUserLabel(user))
 	}
 	if filter.Aligned, err = ParseAlignedParam(v); err != nil {
 		return filter, err

--- a/shared/util.go
+++ b/shared/util.go
@@ -43,6 +43,15 @@ const PRBaseLabel = "pr_base"
 // head of a PR (with the changes).
 const PRHeadLabel = "pr_head"
 
+// UserLabelPrefix is a prefix used to denote a label for a user's GitHub handle,
+// prefixed because usernames are essentially user input.
+const UserLabelPrefix = "user:"
+
+// GetUserLabel prefixes the given username with the prefix for using as a label.
+func GetUserLabel(username string) string {
+	return UserLabelPrefix + username
+}
+
 // ProductChannelToLabel maps known product-specific channel names
 // to the wpt.fyi model's equivalent.
 func ProductChannelToLabel(channel string) string {


### PR DESCRIPTION
## Description
Follow up some concerns about https://github.com/web-platform-tests/wpt.fyi/pull/961

Prefixes username labelling behaviour with `user:` to ensure we don't clash with existing semantic labels, like `master` or `firefox`. Little bit of paranoid programming here, but beats the headache of trying to retroactively fix the data if we manage to find a username that causes problems.

Treats `?user=lukebjerring` as an alias for `?label=user:lukebjerring`