### PR TITLE
Tweak the backfill behaviour to get the same number of each product

### DIFF
--- a/api/checks/update.go
+++ b/api/checks/update.go
@@ -104,7 +104,8 @@ func updateCheckHandler(w http.ResponseWriter, r *http.Request) {
 
 func loadRunsToCompare(ctx context.Context, filter shared.TestRunFilter) (headRun, baseRun *shared.TestRun, err error) {
 	one := 1
-	runs, err := shared.LoadTestRuns(ctx, filter.Products, filter.Labels, filter.SHA, filter.From, filter.To, &one, nil)
+	store := shared.NewAppEngineDatastore(ctx)
+	runs, err := shared.LoadTestRuns(store, filter.Products, filter.Labels, filter.SHA, filter.From, filter.To, &one, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -133,8 +134,9 @@ func loadRunsToCompare(ctx context.Context, filter shared.TestRunFilter) (headRu
 func loadPRRun(ctx context.Context, filter shared.TestRunFilter, extraLabel string) (*shared.TestRun, error) {
 	// Find the corresponding pr_base or pr_head run.
 	one := 1
+	store := shared.NewAppEngineDatastore(ctx)
 	labels := mapset.NewSetWith(extraLabel)
-	runs, err := shared.LoadTestRuns(ctx, filter.Products, labels, filter.SHA, nil, nil, &one, nil)
+	runs, err := shared.LoadTestRuns(store, filter.Products, labels, filter.SHA, nil, nil, &one, nil)
 	run := runs.First()
 	if err != nil {
 		return nil, err
@@ -148,10 +150,11 @@ func loadPRRun(ctx context.Context, filter shared.TestRunFilter, extraLabel stri
 
 func loadMasterRunBefore(ctx context.Context, filter shared.TestRunFilter, headRun *shared.TestRun) (*shared.TestRun, error) {
 	// Get the most recent, but still earlier, master run to compare.
+	store := shared.NewAppEngineDatastore(ctx)
 	one := 1
 	to := headRun.TimeStart.Add(-time.Millisecond)
 	labels := mapset.NewSetWith(headRun.Channel(), shared.MasterLabel)
-	runs, err := shared.LoadTestRuns(ctx, filter.Products, labels, shared.LatestSHA, nil, &to, &one, nil)
+	runs, err := shared.LoadTestRuns(store, filter.Products, labels, shared.LatestSHA, nil, &to, &one, nil)
 	baseRun := runs.First()
 	if err != nil {
 		return nil, err

--- a/api/checks/webhook.go
+++ b/api/checks/webhook.go
@@ -255,8 +255,9 @@ func handlePullRequestEvent(aeAPI shared.AppEngineAPI, checksAPI API, payload []
 
 func scheduleProcessingForExistingRuns(ctx context.Context, sha string, products ...shared.ProductSpec) (bool, error) {
 	// Jump straight to completed check_run for already-present runs for the SHA.
+	store := shared.NewAppEngineDatastore(ctx)
 	products = shared.ProductSpecs(products).OrDefault()
-	runsByProduct, err := shared.LoadTestRuns(ctx, products, nil, sha[:10], nil, nil, nil, nil)
+	runsByProduct, err := shared.LoadTestRuns(store, products, nil, sha[:10], nil, nil, nil, nil)
 	if err != nil {
 		return false, fmt.Errorf("Failed to load test runs: %s", err.Error())
 	}

--- a/api/diff.go
+++ b/api/diff.go
@@ -86,7 +86,8 @@ func handleAPIDiffGet(w http.ResponseWriter, r *http.Request) {
 			runFilter.Products = beforeAndAfter
 		}
 		var runsByProduct shared.TestRunsByProduct
-		runsByProduct, err = LoadTestRunsForFilters(ctx, runFilter)
+		store := shared.NewAppEngineDatastore(ctx)
+		runsByProduct, err = LoadTestRunsForFilters(store, runFilter)
 		if err != nil {
 			runs = runsByProduct.AllRuns()
 		}

--- a/api/interop.go
+++ b/api/interop.go
@@ -58,10 +58,11 @@ func apiInteropHandler(w http.ResponseWriter, r *http.Request) {
 func loadMostRecentInteropRun(ctx context.Context, filters shared.TestRunFilter) (result *metrics.PassRateMetadataLegacy, err error) {
 	// Load default browser runs for SHA.
 	// Force any max-count to one; more than one of each product makes no sense for a interop run.
+	store := shared.NewAppEngineDatastore(ctx)
 	shaFilters := filters
 	limit := 1
 	shaFilters.MaxCount = &limit
-	keys, err := LoadTestRunKeysForFilters(ctx, shaFilters)
+	keys, err := LoadTestRunKeysForFilters(store, shaFilters)
 	if err != nil {
 		return nil, err
 	} else if len(keys) < 1 {
@@ -83,7 +84,8 @@ func loadMostRecentInteropRun(ctx context.Context, filters shared.TestRunFilter)
 
 func loadFallbackInteropRun(ctx context.Context, filters shared.TestRunFilter) (result *metrics.PassRateMetadataLegacy, err error) {
 	passRateType := metrics.GetDatastoreKindName(metrics.PassRateMetadata{})
-	query := datastore.NewQuery(passRateType).Order("-StartTime").Limit(100)
+	store := shared.NewAppEngineDatastore(ctx)
+	query := store.NewQuery(passRateType).Order("-StartTime").Limit(100)
 
 	// We load non-default queries by fetching any interop result with all their
 	// TestRunIDs present in the TestRuns matching the query.
@@ -95,7 +97,7 @@ func loadFallbackInteropRun(ctx context.Context, filters shared.TestRunFilter) (
 		// (but, each SHA being from an aligned run), so we need to keep the keys grouped.
 		if shared.IsLatest(filters.SHA) && filters.Aligned != nil && *filters.Aligned {
 			ten := 10
-			_, shaKeys, err := shared.GetAlignedRunSHAs(ctx, products, filters.Labels, filters.From, filters.To, &ten, nil)
+			_, shaKeys, err := shared.GetAlignedRunSHAs(store, products, filters.Labels, filters.From, filters.To, &ten, nil)
 			if err != nil {
 				return nil, err
 			} else if len(shaKeys) < 1 {
@@ -107,7 +109,7 @@ func loadFallbackInteropRun(ctx context.Context, filters shared.TestRunFilter) (
 			shaFilters := filters
 			limit := 16 * len(products)
 			shaFilters.MaxCount = &limit
-			keys, err := LoadTestRunKeysForFilters(ctx, shaFilters)
+			keys, err := LoadTestRunKeysForFilters(store, shaFilters)
 
 			if err != nil {
 				return nil, err
@@ -120,7 +122,7 @@ func loadFallbackInteropRun(ctx context.Context, filters shared.TestRunFilter) (
 
 	// Iterate until we find interop data where its TestRunIDs match the query.
 	var interop metrics.PassRateMetadataLegacy
-	it := query.Run(ctx)
+	it := query.Run(store)
 	found := false
 	for {
 		_, err := it.Next(&interop)

--- a/api/query/cache/backfill/backfill.go
+++ b/api/query/cache/backfill/backfill.go
@@ -116,7 +116,8 @@ func FillIndex(fetcher RunFetcher, logger shared.Logger, rt monitor.Runtime, int
 }
 
 func startBackfillMonitor(fetcher RunFetcher, logger shared.Logger, maxBytes uint64, m *backfillMonitor) error {
-	runsByProduct, err := fetcher.FetchRuns(int(maxBytes/bytesPerRun) / 4)
+	// FetchRuns will return at most N runs for each product, so divide the upper bound by the number of products.
+	runsByProduct, err := fetcher.FetchRuns(int(maxBytes/bytesPerRun) / len(shared.GetDefaultProducts()))
 	if err != nil {
 		return err
 	}

--- a/api/query/cache/backfill/backfill.go
+++ b/api/query/cache/backfill/backfill.go
@@ -21,7 +21,7 @@ import (
 // RunFetcher provides an interface for loading a limited number of runs
 // suitable for backfilling an index.
 type RunFetcher interface {
-	FetchRuns(limit int) ([]shared.TestRun, error)
+	FetchRuns(limit int) (shared.TestRunsByProduct, error)
 }
 
 type datastoreRunFetcher struct {
@@ -55,7 +55,7 @@ func NewDatastoreRunFetcher(projectID string, gcpCredentialsFile *string, logger
 	return datastoreRunFetcher{projectID, gcpCredentialsFile, logger}
 }
 
-func (f datastoreRunFetcher) FetchRuns(limit int) ([]shared.TestRun, error) {
+func (f datastoreRunFetcher) FetchRuns(limit int) (shared.TestRunsByProduct, error) {
 	ctx := context.Background()
 	var client *datastore.Client
 	var err error
@@ -67,20 +67,10 @@ func (f datastoreRunFetcher) FetchRuns(limit int) ([]shared.TestRun, error) {
 	if err != nil {
 		return nil, err
 	}
+	store := shared.NewCloudDatastore(ctx, client)
 
 	// Query Datastore for latest maxBytes/bytesPerRun test runs.
-	q := datastore.NewQuery("TestRun").Order("-TimeStart").Limit(limit)
-	var runs []shared.TestRun
-	keys, err := client.GetAll(ctx, q, &runs)
-	if err != nil {
-		return nil, err
-	}
-
-	// Ensure that runs contain IDs corresponding to Datastore keys.
-	for i := range keys {
-		runs[i].ID = keys[i].ID
-	}
-
+	runs, err := shared.LoadTestRuns(store, nil, nil, shared.LatestSHA, nil, nil, &limit, nil)
 	return runs, nil
 }
 
@@ -126,9 +116,12 @@ func FillIndex(fetcher RunFetcher, logger shared.Logger, rt monitor.Runtime, int
 }
 
 func startBackfillMonitor(fetcher RunFetcher, logger shared.Logger, maxBytes uint64, m *backfillMonitor) error {
-	runs, err := fetcher.FetchRuns(int(maxBytes / bytesPerRun))
+	runsByProduct, err := fetcher.FetchRuns(int(maxBytes/bytesPerRun) / 4)
 	if err != nil {
 		return err
+	}
+	if len(runsByProduct.AllRuns()) < 1 {
+		return nil
 	}
 
 	// Start the monitor to ensure that memory pressure is tracked.
@@ -137,20 +130,31 @@ func startBackfillMonitor(fetcher RunFetcher, logger shared.Logger, maxBytes uin
 	// Backfill index until its backfilling parameter is set to false, or
 	// collection of test runs is exhausted.
 	go func() {
-		for _, run := range runs {
-			if !m.idx.backfilling {
-				logger.Warningf("Backfilling halted mid-iteration")
-				break
-			}
-			logger.Infof("Backfilling index with run %v", run)
-			err = m.idx.IngestRun(run)
-			if err != nil {
-				logger.Errorf("Failed to ingest run during backfill: %v: %v", run, err)
-			} else {
-				logger.Infof("Backfilled index with run %v", run)
+		most := 0
+		for _, productRuns := range runsByProduct {
+			if most < len(productRuns.TestRuns) {
+				most = len(productRuns.TestRuns)
 			}
 		}
-		logger.Infof("Backfilling complete")
+		for i := 0; i < most && m.idx.backfilling; i++ {
+			for _, productRuns := range runsByProduct {
+				if !m.idx.backfilling {
+					logger.Warningf("Backfilling halted mid-iteration")
+					break
+				} else if i >= len(productRuns.TestRuns) {
+					continue
+				}
+				run := productRuns.TestRuns[i]
+				logger.Infof("Backfilling index with run %v", run)
+				err = m.idx.IngestRun(run)
+				if err != nil {
+					logger.Errorf("Failed to ingest run during backfill: %v: %v", run, err)
+				} else {
+					logger.Infof("Backfilled index with run %v", run)
+				}
+			}
+			logger.Infof("Backfilling complete")
+		}
 	}()
 
 	return nil

--- a/api/query/cache/backfill/backfill_medium_test.go
+++ b/api/query/cache/backfill/backfill_medium_test.go
@@ -55,11 +55,14 @@ func TestStopImmediately(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	fetcher := NewMockRunFetcher(ctrl)
-	fetcher.EXPECT().FetchRuns(gomock.Any()).Return([]shared.TestRun{
-		shared.TestRun{ID: 1},
-		shared.TestRun{ID: 2},
-		shared.TestRun{ID: 3},
-		shared.TestRun{ID: 4},
+	product, _ := shared.ParseProductSpec("chrome")
+	fetcher.EXPECT().FetchRuns(gomock.Any()).Return(shared.TestRunsByProduct{
+		shared.ProductTestRuns{Product: product, TestRuns: shared.TestRuns{
+			shared.TestRun{ID: 1},
+			shared.TestRun{ID: 2},
+			shared.TestRun{ID: 3},
+			shared.TestRun{ID: 4},
+		}},
 	}, nil)
 	rt := monitor.NewMockRuntime(ctrl)
 	rt.EXPECT().GetHeapBytes().Return(uint64(0)).AnyTimes()
@@ -78,11 +81,17 @@ func TestIngestSomeRuns(t *testing.T) {
 	defer ctrl.Finish()
 
 	fetcher := NewMockRunFetcher(ctrl)
-	fetcher.EXPECT().FetchRuns(gomock.Any()).Return([]shared.TestRun{
-		shared.TestRun{ID: 1},
-		shared.TestRun{ID: 2},
-		shared.TestRun{ID: 3},
-		shared.TestRun{ID: 4},
+	product, _ := shared.ParseProductSpec("chrome")
+	fetcher.EXPECT().FetchRuns(gomock.Any()).Return(shared.TestRunsByProduct{
+		shared.ProductTestRuns{
+			Product: product,
+			TestRuns: shared.TestRuns{
+				shared.TestRun{ID: 1},
+				shared.TestRun{ID: 2},
+				shared.TestRun{ID: 3},
+				shared.TestRun{ID: 4},
+			},
+		},
 	}, nil)
 
 	freq := time.Millisecond * 10

--- a/api/query/cache/backfill/backfill_mock.go
+++ b/api/query/cache/backfill/backfill_mock.go
@@ -5,9 +5,10 @@
 package backfill
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	shared "github.com/web-platform-tests/wpt.fyi/shared"
-	reflect "reflect"
 )
 
 // MockRunFetcher is a mock of RunFetcher interface
@@ -34,9 +35,9 @@ func (m *MockRunFetcher) EXPECT() *MockRunFetcherMockRecorder {
 }
 
 // FetchRuns mocks base method
-func (m *MockRunFetcher) FetchRuns(limit int) ([]shared.TestRun, error) {
+func (m *MockRunFetcher) FetchRuns(limit int) (shared.TestRunsByProduct, error) {
 	ret := m.ctrl.Call(m, "FetchRuns", limit)
-	ret0, _ := ret[0].([]shared.TestRun)
+	ret0, _ := ret[0].(shared.TestRunsByProduct)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/api/query/cache/poll/poll.go
+++ b/api/query/cache/poll/poll.go
@@ -40,21 +40,23 @@ func KeepRunsUpdated(fetcher backfill.RunFetcher, logger shared.Logger, interval
 
 		errs := make([]error, len(runs))
 		found := false
-		for i, run := range runs {
-			err := idx.IngestRun(run)
-			errs[i] = err
-			if err != nil {
-				if err == index.ErrRunExists() {
-					logger.Infof("Not updating run (already exists): %v", run)
-				} else if err == index.ErrRunLoading() {
-					logger.Infof("Not updating run (already loading): %v", run)
+		for i, browserRuns := range runs {
+			for _, run := range browserRuns.TestRuns {
+				err := idx.IngestRun(run)
+				errs[i] = err
+				if err != nil {
+					if err == index.ErrRunExists() {
+						logger.Infof("Not updating run (already exists): %v", run)
+					} else if err == index.ErrRunLoading() {
+						logger.Infof("Not updating run (already loading): %v", run)
+					} else {
+						logger.Errorf("Error ingesting run: %v: %v", run, err)
+					}
 				} else {
-					logger.Errorf("Error ingesting run: %v: %v", run, err)
+					logger.Infof("Updated run index; new run: %v", run)
+					found = true
+					lastLoadTime = time.Now()
 				}
-			} else {
-				logger.Infof("Updated run index; new run: %v", run)
-				found = true
-				lastLoadTime = time.Now()
 			}
 		}
 

--- a/api/query/query.go
+++ b/api/query/query.go
@@ -41,7 +41,8 @@ func (defaultShared) ParseQueryFilterParams(r *http.Request) (shared.QueryFilter
 }
 
 func (sharedImpl defaultShared) LoadTestRuns(ps shared.ProductSpecs, ls mapset.Set, sha string, from *time.Time, to *time.Time, limit *int, offset *int) (shared.TestRunsByProduct, error) {
-	return shared.LoadTestRuns(sharedImpl.ctx, ps, ls, sha, from, to, limit, offset)
+	return shared.LoadTestRuns(
+		shared.NewAppEngineDatastore(sharedImpl.ctx), ps, ls, sha, from, to, limit, offset)
 }
 
 func (sharedImpl defaultShared) LoadTestRunsByIDs(ids shared.TestRunIDs) (result shared.TestRuns, err error) {
@@ -49,7 +50,7 @@ func (sharedImpl defaultShared) LoadTestRunsByIDs(ids shared.TestRunIDs) (result
 }
 
 func (sharedImpl defaultShared) LoadTestRun(id int64) (*shared.TestRun, error) {
-	return shared.LoadTestRun(sharedImpl.ctx, id)
+	return shared.LoadTestRun(shared.NewAppEngineDatastore(sharedImpl.ctx), id)
 }
 
 type queryHandler struct {

--- a/api/results_redirect_handler.go
+++ b/api/results_redirect_handler.go
@@ -29,8 +29,9 @@ func apiResultsRedirectHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ctx := shared.NewAppEngineContext(r)
+	store := shared.NewAppEngineDatastore(ctx)
 	one := 1
-	testRuns, err := shared.LoadTestRuns(ctx, filters.Products, filters.Labels, filters.SHA, nil, nil, &one, nil)
+	testRuns, err := shared.LoadTestRuns(store, filters.Products, filters.Labels, filters.SHA, nil, nil, &one, nil)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/api/shas.go
+++ b/api/shas.go
@@ -34,16 +34,17 @@ func (h SHAsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ctx := h.ctx
+	store := shared.NewAppEngineDatastore(ctx)
 
 	var shas []string
 	products := filters.GetProductsOrDefault()
 	if filters.Aligned != nil && *filters.Aligned {
-		if shas, _, err = shared.GetAlignedRunSHAs(ctx, products, filters.Labels, filters.From, filters.To, filters.MaxCount, filters.Offset); err != nil {
+		if shas, _, err = shared.GetAlignedRunSHAs(store, products, filters.Labels, filters.From, filters.To, filters.MaxCount, filters.Offset); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 	} else {
-		testRuns, err := shared.LoadTestRuns(ctx, products, filters.Labels, shared.LatestSHA, filters.From, filters.To, filters.MaxCount, filters.Offset)
+		testRuns, err := shared.LoadTestRuns(store, products, filters.Labels, shared.LatestSHA, filters.From, filters.To, filters.MaxCount, filters.Offset)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/api/test_run.go
+++ b/api/test_run.go
@@ -26,6 +26,7 @@ func apiTestRunHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	idParam := vars["id"]
 	ctx := shared.NewAppEngineContext(r)
+	store := shared.NewAppEngineDatastore(ctx)
 	var testRun shared.TestRun
 	if idParam != "" {
 		id, err := strconv.ParseInt(idParam, 10, 0)
@@ -33,7 +34,7 @@ func apiTestRunHandler(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, fmt.Sprintf("Invalid id '%s'", idParam), http.StatusBadRequest)
 			return
 		}
-		run, err := shared.LoadTestRun(ctx, id)
+		run, err := shared.LoadTestRun(store, id)
 		if err != nil {
 			if err == datastore.ErrNoSuchEntity {
 				http.NotFound(w, r)
@@ -56,7 +57,7 @@ func apiTestRunHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		one := 1
-		testRuns, err := shared.LoadTestRuns(ctx, filters.Products, filters.Labels, filters.SHA, nil, nil, &one, nil)
+		testRuns, err := shared.LoadTestRuns(store, filters.Products, filters.Labels, filters.SHA, nil, nil, &one, nil)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/shared/datastore.go
+++ b/shared/datastore.go
@@ -16,14 +16,17 @@ import (
 	"google.golang.org/appengine/datastore"
 )
 
+// Key abstracts an int64 based datastore.Key
 type Key interface {
 	IntID() int64
 }
 
+// Iterator abstracts a datastore.Iterator
 type Iterator interface {
 	Next(dst interface{}) (Key, error)
 }
 
+// Query abstracts a datastore.Query
 type Query interface {
 	Filter(filterStr string, value interface{}) Query
 	Project(project string) Query
@@ -35,6 +38,8 @@ type Query interface {
 	Run(Datastore) Iterator
 }
 
+// Datastore abstracts a datastore, hiding the distinctions between cloud and
+// appengine's datastores.
 type Datastore interface {
 	Context() context.Context
 	NewQuery(typeName string) Query

--- a/shared/datastore_ae.go
+++ b/shared/datastore_ae.go
@@ -46,11 +46,11 @@ type aeQuery struct {
 }
 
 func (q aeQuery) Filter(filterStr string, value interface{}) Query {
-	return aeQuery{query: q.query.Filter(filterStr, value)}
+	return aeQuery{q.query.Filter(filterStr, value)}
 }
 
 func (q aeQuery) Project(project string) Query {
-	return aeQuery{query: q.query.Project(project)}
+	return aeQuery{q.query.Project(project)}
 }
 
 func (q aeQuery) Offset(offset int) Query {
@@ -66,11 +66,11 @@ func (q aeQuery) Order(order string) Query {
 }
 
 func (q aeQuery) KeysOnly() Query {
-	return aeQuery{query: q.query.KeysOnly()}
+	return aeQuery{q.query.KeysOnly()}
 }
 
 func (q aeQuery) Distinct() Query {
-	return aeQuery{query: q.query.Distinct()}
+	return aeQuery{q.query.Distinct()}
 }
 
 func (q aeQuery) Run(store Datastore) Iterator {

--- a/shared/datastore_ae.go
+++ b/shared/datastore_ae.go
@@ -10,6 +10,8 @@ import (
 	"google.golang.org/appengine/datastore"
 )
 
+// NewAppEngineDatastore creates a Datastore implementation that is backed by
+// the appengine libraries, used in AppEngine standard.
 func NewAppEngineDatastore(ctx context.Context) Datastore {
 	return aeDatastore{
 		ctx: ctx,

--- a/shared/datastore_ae.go
+++ b/shared/datastore_ae.go
@@ -1,0 +1,86 @@
+// Copyright 2018 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package shared
+
+import (
+	"context"
+
+	"google.golang.org/appengine/datastore"
+)
+
+func NewAppEngineDatastore(ctx context.Context) Datastore {
+	return aeDatastore{
+		ctx: ctx,
+	}
+}
+
+type aeDatastore struct {
+	ctx context.Context
+}
+
+func (d aeDatastore) Context() context.Context {
+	return d.ctx
+}
+
+func (d aeDatastore) NewQuery(typeName string) Query {
+	return aeQuery{
+		query: datastore.NewQuery(typeName),
+	}
+}
+
+func (d aeDatastore) GetAll(q Query, dst interface{}) ([]Key, error) {
+	keys, err := q.(aeQuery).query.GetAll(d.ctx, dst)
+	cast := make([]Key, len(keys))
+	for i := range keys {
+		cast[i] = keys[i]
+	}
+	return cast, err
+}
+
+type aeQuery struct {
+	query *datastore.Query
+}
+
+func (q aeQuery) Filter(filterStr string, value interface{}) Query {
+	return aeQuery{query: q.query.Filter(filterStr, value)}
+}
+
+func (q aeQuery) Project(project string) Query {
+	return aeQuery{query: q.query.Project(project)}
+}
+
+func (q aeQuery) Offset(offset int) Query {
+	return aeQuery{q.query.Offset(offset)}
+}
+
+func (q aeQuery) Limit(limit int) Query {
+	return aeQuery{q.query.Limit(limit)}
+}
+
+func (q aeQuery) Order(order string) Query {
+	return aeQuery{q.query.Order(order)}
+}
+
+func (q aeQuery) KeysOnly() Query {
+	return aeQuery{query: q.query.KeysOnly()}
+}
+
+func (q aeQuery) Distinct() Query {
+	return aeQuery{query: q.query.Distinct()}
+}
+
+func (q aeQuery) Run(store Datastore) Iterator {
+	return aeIterator{
+		iter: q.query.Run(store.(aeDatastore).ctx),
+	}
+}
+
+type aeIterator struct {
+	iter *datastore.Iterator
+}
+
+func (i aeIterator) Next(dst interface{}) (Key, error) {
+	return i.iter.Next(dst)
+}

--- a/shared/datastore_cloud.go
+++ b/shared/datastore_cloud.go
@@ -18,6 +18,8 @@ func (k cloudKey) IntID() int64 {
 	return k.key.ID
 }
 
+// NewCloudDatastore creates a Datastore implementation that is backed by a
+// standard cloud datastore client (i.e. not running in AppEngine standard).
 func NewCloudDatastore(ctx context.Context, client *datastore.Client) Datastore {
 	return cloudDatastore{
 		ctx:    ctx,

--- a/shared/datastore_cloud.go
+++ b/shared/datastore_cloud.go
@@ -56,11 +56,11 @@ type cloudQuery struct {
 }
 
 func (q cloudQuery) Filter(filterStr string, value interface{}) Query {
-	return cloudQuery{query: q.query.Filter(filterStr, value)}
+	return cloudQuery{q.query.Filter(filterStr, value)}
 }
 
 func (q cloudQuery) Project(project string) Query {
-	return cloudQuery{query: q.query.Project(project)}
+	return cloudQuery{q.query.Project(project)}
 }
 
 func (q cloudQuery) Offset(offset int) Query {

--- a/shared/datastore_medium_test.go
+++ b/shared/datastore_medium_test.go
@@ -38,7 +38,8 @@ func TestLoadTestRuns(t *testing.T) {
 	key, _ = datastore.Put(ctx, key, &testRun)
 
 	chrome, _ := shared.ParseProductSpec("chrome")
-	loaded, err := shared.LoadTestRuns(ctx, shared.ProductSpecs{chrome}, nil, shared.LatestSHA, nil, nil, nil, nil)
+	store := shared.NewAppEngineDatastore(ctx)
+	loaded, err := shared.LoadTestRuns(store, shared.ProductSpecs{chrome}, nil, shared.LatestSHA, nil, nil, nil, nil)
 	allRuns := loaded.AllRuns()
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(allRuns))
@@ -64,7 +65,8 @@ func TestLoadTestRunsBySHAs(t *testing.T) {
 		datastore.Put(ctx, key, &testRun)
 	}
 
-	runs, err := shared.LoadTestRunsBySHAs(ctx, "1111111111", "3333333333")
+	store := shared.NewAppEngineDatastore(ctx)
+	runs, err := shared.LoadTestRunsBySHAs(store, "1111111111", "3333333333")
 	assert.Nil(t, err)
 	assert.Len(t, runs, 2)
 	for _, run := range runs {
@@ -73,7 +75,7 @@ func TestLoadTestRunsBySHAs(t *testing.T) {
 	assert.Equal(t, runs[0].Revision, "1111111111")
 	assert.Equal(t, runs[1].Revision, "3333333333")
 
-	runs, err = shared.LoadTestRunsBySHAs(ctx, "11111", "33333")
+	runs, err = shared.LoadTestRunsBySHAs(store, "11111", "33333")
 	assert.Nil(t, err)
 	assert.Len(t, runs, 2)
 	for _, run := range runs {
@@ -157,7 +159,8 @@ func TestLoadTestRuns_Experimental_Only(t *testing.T) {
 	labels := mapset.NewSet()
 	labels.Add("experimental")
 	ten := 10
-	loaded, err := shared.LoadTestRuns(ctx, products, labels, shared.LatestSHA, nil, nil, &ten, nil)
+	store := shared.NewAppEngineDatastore(ctx)
+	loaded, err := shared.LoadTestRuns(store, products, labels, shared.LatestSHA, nil, nil, &ten, nil)
 	allRuns := loaded.AllRuns()
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(allRuns))
@@ -198,7 +201,8 @@ func TestLoadTestRuns_LabelinProductSpec(t *testing.T) {
 	products := make([]shared.ProductSpec, 1)
 	products[0].BrowserName = "chrome"
 	products[0].Labels = mapset.NewSetWith("foo")
-	loaded, err := shared.LoadTestRuns(ctx, products, nil, shared.LatestSHA, nil, nil, nil, nil)
+	store := shared.NewAppEngineDatastore(ctx)
+	loaded, err := shared.LoadTestRuns(store, products, nil, shared.LatestSHA, nil, nil, nil, nil)
 	allRuns := loaded.AllRuns()
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(allRuns))
@@ -240,7 +244,8 @@ func TestLoadTestRuns_SHAinProductSpec(t *testing.T) {
 	products := make([]shared.ProductSpec, 1)
 	products[0].BrowserName = "chrome"
 	products[0].Revision = strings.Repeat("1", 10)
-	loaded, err := shared.LoadTestRuns(ctx, products, nil, "", nil, nil, nil, nil)
+	store := shared.NewAppEngineDatastore(ctx)
+	loaded, err := shared.LoadTestRuns(store, products, nil, "", nil, nil, nil, nil)
 	assert.Nil(t, err)
 	allRuns := loaded.AllRuns()
 	assert.Equal(t, 1, len(allRuns))
@@ -248,14 +253,14 @@ func TestLoadTestRuns_SHAinProductSpec(t *testing.T) {
 
 	// Partial SHA
 	products[0].Revision = "11111"
-	loaded, err = shared.LoadTestRuns(ctx, products, nil, "", nil, nil, nil, nil)
+	loaded, err = shared.LoadTestRuns(store, products, nil, "", nil, nil, nil, nil)
 	allRuns = loaded.AllRuns()
 	assert.Equal(t, 1, len(allRuns))
 	assert.Equal(t, "1111111111", allRuns[0].Revision)
 
 	// Partial SHA, Browser version
 	products[0].BrowserVersion = "63"
-	loaded, err = shared.LoadTestRuns(ctx, products, nil, "", nil, nil, nil, nil)
+	loaded, err = shared.LoadTestRuns(store, products, nil, "", nil, nil, nil, nil)
 	allRuns = loaded.AllRuns()
 	assert.Equal(t, 1, len(allRuns))
 	assert.Equal(t, "1111111111", allRuns[0].Revision)
@@ -295,7 +300,8 @@ func TestLoadTestRuns_Ordering(t *testing.T) {
 	}
 
 	chrome, _ := shared.ParseProductSpec("chrome")
-	loaded, err := shared.LoadTestRuns(ctx, []shared.ProductSpec{chrome}, nil, shared.LatestSHA, nil, nil, nil, nil)
+	store := shared.NewAppEngineDatastore(ctx)
+	loaded, err := shared.LoadTestRuns(store, []shared.ProductSpec{chrome}, nil, shared.LatestSHA, nil, nil, nil, nil)
 	assert.Nil(t, err)
 	allRuns := loaded.AllRuns()
 	assert.Equal(t, 2, len(allRuns))
@@ -339,7 +345,8 @@ func TestLoadTestRuns_From(t *testing.T) {
 	}
 
 	chrome, _ := shared.ParseProductSpec("chrome")
-	loaded, err := shared.LoadTestRuns(ctx, []shared.ProductSpec{chrome}, nil, shared.LatestSHA, &yesterday, nil, nil, nil)
+	store := shared.NewAppEngineDatastore(ctx)
+	loaded, err := shared.LoadTestRuns(store, []shared.ProductSpec{chrome}, nil, shared.LatestSHA, &yesterday, nil, nil, nil)
 	assert.Nil(t, err)
 	allRuns := loaded.AllRuns()
 	assert.Equal(t, 1, len(allRuns))
@@ -380,7 +387,8 @@ func TestLoadTestRuns_To(t *testing.T) {
 	}
 
 	chrome, _ := shared.ParseProductSpec("chrome")
-	loaded, err := shared.LoadTestRuns(ctx, shared.ProductSpecs{chrome}, nil, shared.LatestSHA, nil, &now, nil, nil)
+	store := shared.NewAppEngineDatastore(ctx)
+	loaded, err := shared.LoadTestRuns(store, shared.ProductSpecs{chrome}, nil, shared.LatestSHA, nil, &now, nil, nil)
 	assert.Nil(t, err)
 	allRuns := loaded.AllRuns()
 	assert.Equal(t, 1, len(allRuns))
@@ -395,7 +403,8 @@ func TestGetAlignedRunSHAs(t *testing.T) {
 	browserNames := shared.GetDefaultBrowserNames()
 
 	// Nothing in datastore.
-	shas, _, _ := shared.GetAlignedRunSHAs(ctx, shared.GetDefaultProducts(), nil, nil, nil, nil, nil)
+	store := shared.NewAppEngineDatastore(ctx)
+	shas, _, _ := shared.GetAlignedRunSHAs(store, shared.GetDefaultProducts(), nil, nil, nil, nil, nil)
 	assert.Equal(t, 0, len(shas))
 
 	// Only 3 browsers.
@@ -410,7 +419,7 @@ func TestGetAlignedRunSHAs(t *testing.T) {
 		run.BrowserName = browser
 		datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
 	}
-	shas, _, _ = shared.GetAlignedRunSHAs(ctx, shared.GetDefaultProducts(), nil, nil, nil, nil, nil)
+	shas, _, _ = shared.GetAlignedRunSHAs(store, shared.GetDefaultProducts(), nil, nil, nil, nil, nil)
 	assert.Len(t, shas, 0)
 
 	// But, if request by any subset of those 3 browsers, we find the SHA.
@@ -419,13 +428,13 @@ func TestGetAlignedRunSHAs(t *testing.T) {
 		product := shared.ProductSpec{}
 		product.BrowserName = browser
 		products = append(products, product)
-		shas, _, _ = shared.GetAlignedRunSHAs(ctx, products, nil, nil, nil, nil, nil)
+		shas, _, _ = shared.GetAlignedRunSHAs(store, products, nil, nil, nil, nil, nil)
 		assert.Len(t, shas, 1)
 	}
 	// And labels
-	shas, _, _ = shared.GetAlignedRunSHAs(ctx, products, mapset.NewSetWith("foo"), nil, nil, nil, nil)
+	shas, _, _ = shared.GetAlignedRunSHAs(store, products, mapset.NewSetWith("foo"), nil, nil, nil, nil)
 	assert.Len(t, shas, 1)
-	shas, _, _ = shared.GetAlignedRunSHAs(ctx, products, mapset.NewSetWith("bar"), nil, nil, nil, nil)
+	shas, _, _ = shared.GetAlignedRunSHAs(store, products, mapset.NewSetWith("bar"), nil, nil, nil, nil)
 	assert.Len(t, shas, 0)
 
 	// All 4 browsers, but experimental.
@@ -435,7 +444,7 @@ func TestGetAlignedRunSHAs(t *testing.T) {
 		run.BrowserName = browser + "-" + shared.ExperimentalLabel
 		datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
 	}
-	shas, _, _ = shared.GetAlignedRunSHAs(ctx, shared.GetDefaultProducts(), nil, nil, nil, nil, nil)
+	shas, _, _ = shared.GetAlignedRunSHAs(store, shared.GetDefaultProducts(), nil, nil, nil, nil, nil)
 	assert.Equal(t, 0, len(shas))
 
 	// 2 browsers, and other 2, but experimental.
@@ -448,7 +457,7 @@ func TestGetAlignedRunSHAs(t *testing.T) {
 		}
 		datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
 	}
-	shas, _, _ = shared.GetAlignedRunSHAs(ctx, shared.GetDefaultProducts(), nil, nil, nil, nil, nil)
+	shas, _, _ = shared.GetAlignedRunSHAs(store, shared.GetDefaultProducts(), nil, nil, nil, nil, nil)
 	assert.Equal(t, 0, len(shas))
 
 	// 2 browsers which are twice.
@@ -459,7 +468,7 @@ func TestGetAlignedRunSHAs(t *testing.T) {
 		datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
 		datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
 	}
-	shas, _, _ = shared.GetAlignedRunSHAs(ctx, shared.GetDefaultProducts(), nil, nil, nil, nil, nil)
+	shas, _, _ = shared.GetAlignedRunSHAs(store, shared.GetDefaultProducts(), nil, nil, nil, nil, nil)
 	assert.Equal(t, 0, len(shas))
 
 	// All 4 browsers.
@@ -469,7 +478,7 @@ func TestGetAlignedRunSHAs(t *testing.T) {
 		run.BrowserName = browser
 		datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
 	}
-	shas, _, _ = shared.GetAlignedRunSHAs(ctx, shared.GetDefaultProducts(), nil, nil, nil, nil, nil)
+	shas, _, _ = shared.GetAlignedRunSHAs(store, shared.GetDefaultProducts(), nil, nil, nil, nil, nil)
 	assert.Equal(t, []string{"abcdef0123"}, shas)
 
 	// Another (earlier) run, also all 4 browsers.
@@ -479,18 +488,18 @@ func TestGetAlignedRunSHAs(t *testing.T) {
 		run.BrowserName = browser
 		datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
 	}
-	shas, _, _ = shared.GetAlignedRunSHAs(ctx, shared.GetDefaultProducts(), nil, nil, nil, nil, nil)
+	shas, _, _ = shared.GetAlignedRunSHAs(store, shared.GetDefaultProducts(), nil, nil, nil, nil, nil)
 	assert.Equal(t, []string{"abcdef0123", "abcdef9999"}, shas)
 	// Limit 1
 	one := 1
-	shas, _, _ = shared.GetAlignedRunSHAs(ctx, shared.GetDefaultProducts(), nil, nil, nil, &one, nil)
+	shas, _, _ = shared.GetAlignedRunSHAs(store, shared.GetDefaultProducts(), nil, nil, nil, &one, nil)
 	assert.Equal(t, []string{"abcdef0123"}, shas)
 	// Limit 1, Offset 1
-	shas, _, _ = shared.GetAlignedRunSHAs(ctx, shared.GetDefaultProducts(), nil, nil, nil, &one, &one)
+	shas, _, _ = shared.GetAlignedRunSHAs(store, shared.GetDefaultProducts(), nil, nil, nil, &one, &one)
 	assert.Equal(t, []string{"abcdef9999"}, shas)
 	// From 4 days ago @ midnight.
 	from := time.Now().AddDate(0, 0, -4).Truncate(24 * time.Hour)
-	shas, _, _ = shared.GetAlignedRunSHAs(ctx, shared.GetDefaultProducts(), nil, &from, nil, nil, nil)
+	shas, _, _ = shared.GetAlignedRunSHAs(store, shared.GetDefaultProducts(), nil, &from, nil, nil, nil)
 	assert.Equal(t, []string{"abcdef0123"}, shas)
 }
 

--- a/shared/models.go
+++ b/shared/models.go
@@ -254,7 +254,7 @@ func (t TestRunsByProduct) First() *TestRun {
 // ProductTestRunKeys is a tuple of a product and test run keys loaded for it.
 type ProductTestRunKeys struct {
 	Product ProductSpec
-	Keys    []*datastore.Key
+	Keys    []Key
 }
 
 // KeysByProduct is an array of tuples of {product, matching keys}, returned
@@ -262,8 +262,8 @@ type ProductTestRunKeys struct {
 type KeysByProduct []ProductTestRunKeys
 
 // AllKeys returns an array of all the loaded keys.
-func (t KeysByProduct) AllKeys() []*datastore.Key {
-	var keys []*datastore.Key
+func (t KeysByProduct) AllKeys() []Key {
+	var keys []Key
 	for _, v := range t {
 		keys = append(keys, v.Keys...)
 	}
@@ -274,7 +274,7 @@ func (t KeysByProduct) AllKeys() []*datastore.Key {
 type TestRunIDs []int64
 
 // GetTestRunIDs extracts the TestRunIDs from loaded datastore keys.
-func GetTestRunIDs(keys []*datastore.Key) TestRunIDs {
+func GetTestRunIDs(keys []Key) TestRunIDs {
 	result := make(TestRunIDs, len(keys))
 	for i := range keys {
 		result[i] = keys[i].IntID()

--- a/shared/run_diff.go
+++ b/shared/run_diff.go
@@ -241,7 +241,8 @@ func FetchRunResultsJSONForSpec(
 // FetchRunForSpec loads the wpt.fyi TestRun metadata for the given spec.
 func FetchRunForSpec(ctx context.Context, spec ProductSpec) (*TestRun, error) {
 	one := 1
-	testRuns, err := LoadTestRuns(ctx, []ProductSpec{spec}, nil, spec.Revision, nil, nil, &one, nil)
+	store := NewAppEngineDatastore(ctx)
+	testRuns, err := LoadTestRuns(store, []ProductSpec{spec}, nil, spec.Revision, nil, nil, &one, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -289,8 +290,8 @@ func (d diffAPIImpl) GetRunsDiff(before, after TestRun, filter DiffFilterParam, 
 
 	var renames map[string]string
 	if IsFeatureEnabled(d.ctx, "diffRenames") {
- 		beforeSHA := before.FullRevisionHash
- 		// Use HEAD...[sha] for PR results, since PR run results always override the value of 'revision' to the PRs HEAD revision.
+		beforeSHA := before.FullRevisionHash
+		// Use HEAD...[sha] for PR results, since PR run results always override the value of 'revision' to the PRs HEAD revision.
 		if before.FullRevisionHash == after.FullRevisionHash && before.IsPRBase() {
 			beforeSHA = "HEAD"
 		}

--- a/util/populate_dev_data.go
+++ b/util/populate_dev_data.go
@@ -223,6 +223,7 @@ func main() {
 }
 
 func copyProdRuns(ctx context.Context, filters shared.TestRunFilter) {
+	store := shared.NewAppEngineDatastore(ctx)
 	for _, aligned := range []bool{false, true} {
 		if aligned {
 			filters.Aligned = &aligned
@@ -257,13 +258,13 @@ func copyProdRuns(ctx context.Context, filters shared.TestRunFilter) {
 		if aligned {
 			var shas []string
 			var keys map[string]shared.KeysByProduct
-			if shas, keys, err = shared.GetAlignedRunSHAs(ctx, shared.GetDefaultProducts(), filters.Labels, nil, nil, &one, nil); err != nil {
+			if shas, keys, err = shared.GetAlignedRunSHAs(store, shared.GetDefaultProducts(), filters.Labels, nil, nil, &one, nil); err != nil {
 				log.Printf("Failed to load a aligned run SHA: %s", err.Error())
 				continue
 			}
 			if len(shas) > 0 {
 				sha = shas[0]
-				if loaded, err := shared.LoadTestRunsByKeys(ctx, keys[sha]); err != nil {
+				if loaded, err := shared.LoadTestRunsByKeys(store, keys[sha]); err != nil {
 					log.Printf("Failed to load test runs by keys: %s", err.Error())
 					continue
 				} else {


### PR DESCRIPTION
## Description
Refactors the datastore code to support being inside or outside appengine standard, so that we can call the shared library methods for fetching runs with our query params (max-count, etc).

Then, uses the shared library to ensure we get the same number of each product, instead of a disproportionately large number of runs for chrome/firefox (which happen much, much more frequently).

This will allow us to run the flakiness queries against safari / edge.