### PR TITLE
Fix 500s for HEAD rev

### DIFF
--- a/api/checks/runs.go
+++ b/api/checks/runs.go
@@ -53,7 +53,8 @@ func updateCheckRunSummary(ctx context.Context, summary summaries.Summary, suite
 			state := summary.GetCheckState()
 			actions := summary.GetActions()
 
-			summaryStr, err := summary.GetSummary()
+			var summaryStr string
+			summaryStr, err = summary.GetSummary()
 			if err != nil {
 				log.Warningf("Failed to generate summary for %s: %s", state.HeadSHA, err.Error())
 				return false, err

--- a/shared/run_diff.go
+++ b/shared/run_diff.go
@@ -289,8 +289,8 @@ func (d diffAPIImpl) GetRunsDiff(before, after TestRun, filter DiffFilterParam, 
 
 	var renames map[string]string
 	if IsFeatureEnabled(d.ctx, "diffRenames") {
- 		beforeSHA := before.FullRevisionHash
- 		// Use HEAD...[sha] for PR results, since PR run results always override the value of 'revision' to the PRs HEAD revision.
+		beforeSHA := before.FullRevisionHash
+		// Use HEAD...[sha] for PR results, since PR run results always override the value of 'revision' to the PRs HEAD revision.
 		if before.FullRevisionHash == after.FullRevisionHash && before.IsPRBase() {
 			beforeSHA = "HEAD"
 		}
@@ -374,7 +374,7 @@ func getDiffRenames(ctx context.Context, shaBefore, shaAfter string) map[string]
 	}
 	comparison, _, err := githubClient.Repositories.CompareCommits(ctx, "web-platform-tests", "wpt", shaBefore, shaAfter)
 	if err != nil || comparison == nil {
-		log.Errorf("Failed to fetch diff for %s...%s: %s", shaBefore[:7], shaAfter[:7], err.Error())
+		log.Errorf("Failed to fetch diff for %s...%s: %s", CropString(shaBefore, 7), CropString(shaAfter, 7), err.Error())
 		return nil
 	}
 
@@ -388,7 +388,7 @@ func getDiffRenames(ctx context.Context, shaBefore, shaAfter string) map[string]
 		}
 	}
 	if len(renames) < 1 {
-		log.Debugf("No renames for %s...%s", shaBefore[:7], shaAfter[:7])
+		log.Debugf("No renames for %s...%s", CropString(shaBefore, 7), CropString(shaAfter, 7))
 	}
 	return renames
 }

--- a/shared/util.go
+++ b/shared/util.go
@@ -276,3 +276,12 @@ func GetResultsURL(run TestRun, testFile string) (resultsURL string) {
 	}
 	return resultsURL
 }
+
+// CropString conditionally crops a string to the given length, if it is longer.
+// Returns the original string otherwise.
+func CropString(s string, i int) string {
+	if len(s) <= i {
+		return s
+	}
+	return s[:i]
+}


### PR DESCRIPTION
## Description
We sometimes use "HEAD" for the before in the diff, but are trying to log a 7 char slice of that.