### PR TITLE
Do not throw when normalizing version strings

### DIFF
--- a/results-processor/wptreport.py
+++ b/results-processor/wptreport.py
@@ -411,7 +411,7 @@ class WPTReport(object):
 
     def normalize_version(self):
         m = re.match(r'Technology Preview \(Release (\d+), (.*)\)',
-                     self.run_info.get('browser_version'))
+                     self.run_info.get('browser_version', ''))
         if m:
             self.run_info['browser_version'] = m.group(1) + ' preview'
 

--- a/results-processor/wptreport_test.py
+++ b/results-processor/wptreport_test.py
@@ -462,6 +462,13 @@ class WPTReportTest(unittest.TestCase):
         r.normalize_version()
         self.assertEqual(r.run_info['browser_version'], '67 preview')
 
+    def test_normalize_version_missing_version(self):
+        r = WPTReport()
+        r._report = {'run_info': {}}
+        r.normalize_version()
+        # Do not throw!
+        self.assertIsNone(r.run_info.get('browser_version'))
+
 
 class HelpersTest(unittest.TestCase):
     def test_prepare_labels_from_empty_str(self):


### PR DESCRIPTION
Code added in https://github.com/web-platform-tests/wpt.fyi/pull/911
would throw an uncaught exception if browser_version is missing in the
report. This PR fixes the issue. `browser_version` will still be checked
later in test_run_metadata.
