### PR TITLE
[processor] Allow reports with zero results

### DIFF
--- a/results-processor/wptreport.py
+++ b/results-processor/wptreport.py
@@ -63,7 +63,7 @@ class MissingMetadataError(WPTReportError):
 
 class InsufficientDataError(WPTReportError):
     def __init__(self):
-        super(InsufficientDataError, self).__init__("Zero results available")
+        super(InsufficientDataError, self).__init__("Missing 'results' field")
 
 
 class ConflictingDataError(WPTReportError):
@@ -151,7 +151,7 @@ class WPTReport(object):
             fileobj: A JSON file object (must be in binary mode).
 
         Raises:
-            InsufficientDataError if the dataset contains zero test results;
+            InsufficientDataError if the file does not contain a results field;
             ConflictingDataError if the current file contains information
             conflicting with existing data (from previous files).
         """
@@ -248,14 +248,11 @@ class WPTReport(object):
             A summary dictionary.
 
         Raises:
-            InsufficientDataError if the dataset contains zero test results;
             ConflictingDataError if a test appears multiple times in results.
+            MissingMetadataError if any required metadata is missing.
         """
         if self._summary:
             return self._summary
-
-        if not self.results:
-            raise InsufficientDataError
 
         for result in self.results:
             test_file = result['test']

--- a/results-processor/wptreport_test.py
+++ b/results-processor/wptreport_test.py
@@ -214,8 +214,8 @@ class WPTReportTest(unittest.TestCase):
 
     def test_summarize_zero_results(self):
         r = WPTReport()
-        with self.assertRaises(InsufficientDataError):
-            r.summarize()
+        # Do not throw!
+        r.summarize()
 
     def test_summarize_duplicate_results(self):
         r = WPTReport()


### PR DESCRIPTION
We still require a field called `results` but it can be empty so that
we can create an empty run if no tests are affected (related to #950).
