### PR TITLE
Fix the length of all action fields

### DIFF
--- a/api/checks/summaries/actions.go
+++ b/api/checks/summaries/actions.go
@@ -13,7 +13,7 @@ func RecomputeAction() *github.CheckRunAction {
 	return &github.CheckRunAction{
 		Identifier:  "recompute",
 		Label:       "Recompute",
-		Description: "Recompute against the latest available runs",
+		Description: "Recompute with the latest available runs",
 	}
 }
 
@@ -23,7 +23,7 @@ func IgnoreAction() *github.CheckRunAction {
 	return &github.CheckRunAction{
 		Identifier:  "ignore",
 		Label:       "Ignore",
-		Description: "Mark these results as expected (passing)",
+		Description: "Mark results as expected (passing)",
 	}
 }
 

--- a/api/checks/summaries/actions_test.go
+++ b/api/checks/summaries/actions_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// https://developer.github.com/v3/checks/runs/#actions-object
 func TestActionCharacterLimits(t *testing.T) {
 	actions := []*github.CheckRunAction{
 		RecomputeAction(),

--- a/api/checks/summaries/actions_test.go
+++ b/api/checks/summaries/actions_test.go
@@ -1,0 +1,27 @@
+// +build small
+
+// Copyright 2018 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package summaries
+
+import (
+	"testing"
+
+	"github.com/google/go-github/github"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestActionCharacterLimits(t *testing.T) {
+	actions := []*github.CheckRunAction{
+		RecomputeAction(),
+		IgnoreAction(),
+		CancelAction(),
+	}
+	for _, action := range actions {
+		assert.True(t, len(action.Identifier) <= 20, "Action %s's ID is too long", action.Identifier)
+		assert.True(t, len(action.Description) <= 40, "Action %s's desc is too long", action.Identifier)
+		assert.True(t, len(action.Label) <= 20, "Action %s's label is too long", action.Identifier)
+	}
+}


### PR DESCRIPTION
## Description
The actions were tweaked in #949 and totally broke things in a not-obvious way. This adds a test that prevents future changes and brings the descriptions back to accepted lengths.