### PR TITLE
Allow shorter shas in /api/checks/[SHA]

### DIFF
--- a/api/checks/update.go
+++ b/api/checks/update.go
@@ -31,11 +31,10 @@ func updateCheckHandler(w http.ResponseWriter, r *http.Request) {
 	log := shared.GetLogger(ctx)
 
 	vars := mux.Vars(r)
-	sha := vars["commit"]
-	if len(sha) != 40 {
-		msg := fmt.Sprintf("Invalid commit: %s", sha)
-		log.Warningf(msg)
-		http.Error(w, msg, http.StatusBadRequest)
+	sha, err := shared.ParseSHA(vars["commit"])
+	if err != nil {
+		log.Warningf(err.Error())
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
@@ -58,7 +57,7 @@ func updateCheckHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, msg, http.StatusBadRequest)
 		return
 	}
-	filter.SHA = sha[:10]
+	filter.SHA = sha
 	headRun, baseRun, err := loadRunsToCompare(ctx, filter)
 	if err != nil {
 		msg := "Could not find runs to compare"

--- a/shared/params.go
+++ b/shared/params.go
@@ -155,16 +155,16 @@ func ParseSHAParam(v url.Values) (runSHA string, err error) {
 
 // ParseSHA parses and validates the given 'sha'.
 // It returns "latest" by default (and in error cases).
-func ParseSHA(runParam string) (runSHA string, err error) {
+func ParseSHA(shaParam string) (sha string, err error) {
 	// Get the SHA for the run being loaded (the first part of the path.)
-	runSHA = "latest"
-	if runParam != "" && runParam != "latest" {
-		runSHA = runParam
-		if !SHARegex.MatchString(runParam) {
-			return "latest", fmt.Errorf("Invalid sha param value: %s", runParam)
+	sha = "latest"
+	if shaParam != "" && shaParam != "latest" {
+		sha = shaParam
+		if !SHARegex.MatchString(shaParam) {
+			return "latest", fmt.Errorf("Invalid sha param value: %s", shaParam)
 		}
 	}
-	return runSHA, err
+	return sha, err
 }
 
 // ParseProductSpecs parses multiple product specs


### PR DESCRIPTION
## Description
Right now the `/api/shas` endpoint serves 10-char SHAs, which makes piping those into /api/checks/[SHA:40] a problem.

I'll change the SHAs endpoint to take a `length` param later, but this makes life easier now.