### PR TITLE
Plumb the pr param in /runs view

### DIFF
--- a/webapp/templates/test-runs.html
+++ b/webapp/templates/test-runs.html
@@ -9,7 +9,8 @@
 <div id="content">
   <wpt-header></wpt-header>
   <div>
-    <wpt-runs {{ template "_test_run_query_params.html" .Filter }}></wpt-runs>
+    <wpt-runs {{ template "_test_run_query_params.html" . }}
+              {{- if .PR }} pr="{{.PR}}"{{end}}></wpt-runs>
   </div>
 </div>
 {{ template "_ga.html" }}

--- a/webapp/test_runs_handler.go
+++ b/webapp/test_runs_handler.go
@@ -17,36 +17,49 @@ func testRunsHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Only GET is supported.", http.StatusMethodNotAllowed)
 		return
 	}
-	ctx := shared.NewAppEngineContext(r)
-	aeAPI := shared.NewAppEngineAPI(ctx)
-	testRunFilter, err := shared.ParseTestRunFilterParams(r.URL.Query())
+	filter, err := parseTestRunsUIFilter(r)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	// Get runs from a month ago, onward, by default.
-	if testRunFilter.IsDefaultQuery() {
-		aWeekAgo := time.Now().Truncate(time.Hour*24).AddDate(0, 0, -7)
-		testRunFilter.From = &aWeekAgo
-		if aeAPI.IsFeatureEnabled("masterRunsOnly") {
-			testRunFilter = testRunFilter.MasterOnly()
-		}
-	} else if testRunFilter.MaxCount == nil {
-		oneHundred := 100
-		testRunFilter.MaxCount = &oneHundred
-	}
-
-	filter := convertTestRunUIFilter(testRunFilter)
-
-	data := struct {
-		Filter testRunUIFilter
-	}{
-		Filter: filter,
-	}
-
-	if err := templates.ExecuteTemplate(w, "test-runs.html", data); err != nil {
+	if err := templates.ExecuteTemplate(w, "test-runs.html", filter); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+}
+
+// parseTestRunsUIFilter parses the standard TestRunFilter, as well as the extra
+// pr param.
+func parseTestRunsUIFilter(r *http.Request) (filter testRunUIFilter, err error) {
+	q := r.URL.Query()
+	testRunFilter, err := shared.ParseTestRunFilterParams(q)
+	if err != nil {
+		return filter, err
+	}
+
+	pr, err := shared.ParsePRParam(q)
+	if err != nil {
+		return filter, err
+	}
+
+	if pr != nil {
+		filter.PR = pr
+	} else {
+		if testRunFilter.IsDefaultQuery() {
+			// Get runs from a month ago, onward, by default.
+			ctx := shared.NewAppEngineContext(r)
+			aeAPI := shared.NewAppEngineAPI(ctx)
+			aWeekAgo := time.Now().Truncate(time.Hour*24).AddDate(0, 0, -7)
+			testRunFilter.From = &aWeekAgo
+			if aeAPI.IsFeatureEnabled("masterRunsOnly") {
+				testRunFilter = testRunFilter.MasterOnly()
+			}
+		} else if testRunFilter.MaxCount == nil {
+			oneHundred := 100
+			testRunFilter.MaxCount = &oneHundred
+		}
+		filter = convertTestRunUIFilter(testRunFilter)
+	}
+	return filter, nil
 }

--- a/webapp/test_runs_handler.go
+++ b/webapp/test_runs_handler.go
@@ -47,7 +47,7 @@ func parseTestRunsUIFilter(r *http.Request) (filter testRunUIFilter, err error) 
 		filter.PR = pr
 	} else {
 		if testRunFilter.IsDefaultQuery() {
-			// Get runs from a month ago, onward, by default.
+			// Get runs from a week ago, onward, by default.
 			ctx := shared.NewAppEngineContext(r)
 			aeAPI := shared.NewAppEngineAPI(ctx)
 			aWeekAgo := time.Now().Truncate(time.Hour*24).AddDate(0, 0, -7)


### PR DESCRIPTION
## Description
Part of #973 

Fixes the behaviour of the pr param in /runs, by including parsing + plumbing to the UI (the rest of the code is already present from #786 