### PR TITLE
Fix pr param for /results

### DIFF
--- a/api/checks/api.go
+++ b/api/checks/api.go
@@ -67,7 +67,7 @@ func (s checksAPIImpl) ScheduleResultsProcessing(sha string, product shared.Prod
 func (s checksAPIImpl) PendingCheckRun(suite shared.CheckSuite, product shared.ProductSpec) (bool, error) {
 	aeAPI := shared.NewAppEngineAPI(s.ctx)
 	host := aeAPI.GetHostname()
-	filter := shared.TestRunFilter{SHA: suite.SHA[:10]}
+	filter := shared.TestRunFilter{SHAs: shared.SHAs{suite.SHA}}
 	runsURL := aeAPI.GetRunsURL(filter)
 
 	pending := summaries.Pending{

--- a/api/checks/update.go
+++ b/api/checks/update.go
@@ -57,7 +57,7 @@ func updateCheckHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, msg, http.StatusBadRequest)
 		return
 	}
-	filter.SHA = sha
+	filter.SHAs = shared.SHAs{sha}
 	headRun, baseRun, err := loadRunsToCompare(ctx, filter)
 	if err != nil {
 		msg := "Could not find runs to compare"
@@ -104,13 +104,15 @@ func updateCheckHandler(w http.ResponseWriter, r *http.Request) {
 
 func loadRunsToCompare(ctx context.Context, filter shared.TestRunFilter) (headRun, baseRun *shared.TestRun, err error) {
 	one := 1
-	runs, err := shared.LoadTestRuns(ctx, filter.Products, filter.Labels, filter.SHA, filter.From, filter.To, &one, nil)
+	runs, err := shared.LoadTestRuns(ctx, filter.Products, filter.Labels, filter.SHAs, filter.From, filter.To, &one, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 	run := runs.First()
 	if run == nil {
-		return nil, nil, fmt.Errorf("no test run found for %s @ %s", filter.Products[0].String(), filter.SHA[:7])
+		return nil, nil, fmt.Errorf("no test run found for %s @ %s",
+			filter.Products[0].String(),
+			shared.CropString(filter.SHAs.FirstOrLatest(), 7))
 	}
 
 	labels := run.LabelsSet()
@@ -134,14 +136,14 @@ func loadPRRun(ctx context.Context, filter shared.TestRunFilter, extraLabel stri
 	// Find the corresponding pr_base or pr_head run.
 	one := 1
 	labels := mapset.NewSetWith(extraLabel)
-	runs, err := shared.LoadTestRuns(ctx, filter.Products, labels, filter.SHA, nil, nil, &one, nil)
+	runs, err := shared.LoadTestRuns(ctx, filter.Products, labels, filter.SHAs, nil, nil, &one, nil)
 	run := runs.First()
 	if err != nil {
 		return nil, err
 	}
 	if run == nil {
 		err = fmt.Errorf("no test run found for %s @ %s with label %s",
-			filter.Products[0].String(), filter.SHA, extraLabel)
+			filter.Products[0].String(), filter.SHAs.FirstOrLatest(), extraLabel)
 	}
 	return run, err
 }
@@ -151,14 +153,14 @@ func loadMasterRunBefore(ctx context.Context, filter shared.TestRunFilter, headR
 	one := 1
 	to := headRun.TimeStart.Add(-time.Millisecond)
 	labels := mapset.NewSetWith(headRun.Channel(), shared.MasterLabel)
-	runs, err := shared.LoadTestRuns(ctx, filter.Products, labels, shared.LatestSHA, nil, &to, &one, nil)
+	runs, err := shared.LoadTestRuns(ctx, filter.Products, labels, nil, nil, &to, &one, nil)
 	baseRun := runs.First()
 	if err != nil {
 		return nil, err
 	}
 	if baseRun == nil {
 		err = fmt.Errorf("no master run found for %s before %s",
-			filter.Products[0].String(), filter.SHA)
+			filter.Products[0].String(), filter.SHAs.FirstOrLatest())
 	}
 	return baseRun, err
 }

--- a/api/checks/update_medium_test.go
+++ b/api/checks/update_medium_test.go
@@ -41,7 +41,7 @@ func TestLoadRunsToCompare_master(t *testing.T) {
 
 	chrome, _ := shared.ParseProductSpec("chrome")
 	filter := shared.TestRunFilter{
-		SHA:      "1111111111",
+		SHAs:     shared.SHAs{"1111111111"},
 		Products: shared.ProductSpecs{chrome},
 	}
 	headRun, baseRun, err := loadRunsToCompare(ctx, filter)
@@ -78,7 +78,7 @@ func TestLoadRunsToCompare_pr_base_first(t *testing.T) {
 
 	chrome, _ := shared.ParseProductSpec("chrome")
 	filter := shared.TestRunFilter{
-		SHA:      "1234567890",
+		SHAs:     shared.SHAs{"1234567890"},
 		Products: shared.ProductSpecs{chrome},
 	}
 	headRun, baseRun, err := loadRunsToCompare(ctx, filter)
@@ -115,7 +115,7 @@ func TestLoadRunsToCompare_pr_head_first(t *testing.T) {
 
 	chrome, _ := shared.ParseProductSpec("chrome")
 	filter := shared.TestRunFilter{
-		SHA:      "1234567890",
+		SHAs:     shared.SHAs{"1234567890"},
 		Products: shared.ProductSpecs{chrome},
 	}
 	headRun, baseRun, err := loadRunsToCompare(ctx, filter)

--- a/api/checks/webhook.go
+++ b/api/checks/webhook.go
@@ -256,7 +256,7 @@ func handlePullRequestEvent(aeAPI shared.AppEngineAPI, checksAPI API, payload []
 func scheduleProcessingForExistingRuns(ctx context.Context, sha string, products ...shared.ProductSpec) (bool, error) {
 	// Jump straight to completed check_run for already-present runs for the SHA.
 	products = shared.ProductSpecs(products).OrDefault()
-	runsByProduct, err := shared.LoadTestRuns(ctx, products, nil, sha[:10], nil, nil, nil, nil)
+	runsByProduct, err := shared.LoadTestRuns(ctx, products, nil, []string{sha}, nil, nil, nil, nil)
 	if err != nil {
 		return false, fmt.Errorf("Failed to load test runs: %s", err.Error())
 	}

--- a/api/interop.go
+++ b/api/interop.go
@@ -93,7 +93,7 @@ func loadFallbackInteropRun(ctx context.Context, filters shared.TestRunFilter) (
 		// When ?aligned=true, make sure to show results for the same aligned run.
 		// We don't want to mismatch an interop which has runs from several different SHAs
 		// (but, each SHA being from an aligned run), so we need to keep the keys grouped.
-		if shared.IsLatest(filters.SHA) && filters.Aligned != nil && *filters.Aligned {
+		if filters.SHAs.EmptyOrLatest() && filters.Aligned != nil && *filters.Aligned {
 			ten := 10
 			_, shaKeys, err := shared.GetAlignedRunSHAs(ctx, products, filters.Labels, filters.From, filters.To, &ten, nil)
 			if err != nil {

--- a/api/manifest.go
+++ b/api/manifest.go
@@ -20,12 +20,13 @@ import (
 
 func apiManifestHandler(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
-	sha, err := shared.ParseSHAParam(q)
+	shas, err := shared.ParseSHAParam(q)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	paths := shared.ParsePathsParam(q)
+	sha := shas.FirstOrLatest()
 
 	ctx := shared.NewAppEngineContext(r)
 	manifestAPI := manifest.NewAPI(ctx)

--- a/api/query/query.go
+++ b/api/query/query.go
@@ -23,7 +23,7 @@ type summary map[string][]int
 type sharedInterface interface {
 	ParseQueryParamInt(r *http.Request, key string) (*int, error)
 	ParseQueryFilterParams(*http.Request) (shared.QueryFilter, error)
-	LoadTestRuns(shared.ProductSpecs, mapset.Set, string, *time.Time, *time.Time, *int, *int) (shared.TestRunsByProduct, error)
+	LoadTestRuns(shared.ProductSpecs, mapset.Set, shared.SHAs, *time.Time, *time.Time, *int, *int) (shared.TestRunsByProduct, error)
 	LoadTestRunsByIDs(ids shared.TestRunIDs) (result shared.TestRuns, err error)
 	LoadTestRun(int64) (*shared.TestRun, error)
 }
@@ -40,7 +40,7 @@ func (defaultShared) ParseQueryFilterParams(r *http.Request) (shared.QueryFilter
 	return shared.ParseQueryFilterParams(r.URL.Query())
 }
 
-func (sharedImpl defaultShared) LoadTestRuns(ps shared.ProductSpecs, ls mapset.Set, sha string, from *time.Time, to *time.Time, limit *int, offset *int) (shared.TestRunsByProduct, error) {
+func (sharedImpl defaultShared) LoadTestRuns(ps shared.ProductSpecs, ls mapset.Set, sha shared.SHAs, from *time.Time, to *time.Time, limit *int, offset *int) (shared.TestRunsByProduct, error) {
 	return shared.LoadTestRuns(sharedImpl.ctx, ps, ls, sha, from, to, limit, offset)
 }
 
@@ -90,7 +90,7 @@ func (qh queryHandler) getRunsAndFilters(in shared.QueryFilter) (shared.TestRuns
 		var err error
 		limit := 1
 		products := runFilters.GetProductsOrDefault()
-		runsByProduct, err := qh.sharedImpl.LoadTestRuns(products, runFilters.Labels, sha, runFilters.From, runFilters.To, &limit, nil)
+		runsByProduct, err := qh.sharedImpl.LoadTestRuns(products, runFilters.Labels, []string{sha}, runFilters.From, runFilters.To, &limit, nil)
 		if err != nil {
 			return testRuns, filters, err
 		}

--- a/api/query/query_mock.go
+++ b/api/query/query_mock.go
@@ -64,7 +64,7 @@ func (mr *MocksharedInterfaceMockRecorder) ParseQueryFilterParams(arg0 interface
 }
 
 // LoadTestRuns mocks base method
-func (m *MocksharedInterface) LoadTestRuns(arg0 shared.ProductSpecs, arg1 golang_set.Set, arg2 string, arg3, arg4 *time.Time, arg5, arg6 *int) (shared.TestRunsByProduct, error) {
+func (m *MocksharedInterface) LoadTestRuns(arg0 shared.ProductSpecs, arg1 golang_set.Set, arg2 shared.SHAs, arg3, arg4 *time.Time, arg5, arg6 *int) (shared.TestRunsByProduct, error) {
 	ret := m.ctrl.Call(m, "LoadTestRuns", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].(shared.TestRunsByProduct)
 	ret1, _ := ret[1].(error)

--- a/api/results_redirect_handler.go
+++ b/api/results_redirect_handler.go
@@ -30,14 +30,14 @@ func apiResultsRedirectHandler(w http.ResponseWriter, r *http.Request) {
 
 	ctx := shared.NewAppEngineContext(r)
 	one := 1
-	testRuns, err := shared.LoadTestRuns(ctx, filters.Products, filters.Labels, filters.SHA, nil, nil, &one, nil)
+	testRuns, err := shared.LoadTestRuns(ctx, filters.Products, filters.Labels, filters.SHAs, nil, nil, &one, nil)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	allRuns := testRuns.AllRuns()
 	if len(allRuns) == 0 {
-		http.Error(w, fmt.Sprintf("404 - Test run '%s' not found", filters.SHA), http.StatusNotFound)
+		http.Error(w, fmt.Sprintf("404 - Test run '%s' not found", filters.SHAs.FirstOrLatest()), http.StatusNotFound)
 		return
 	}
 

--- a/api/shas.go
+++ b/api/shas.go
@@ -43,7 +43,7 @@ func (h SHAsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	} else {
-		testRuns, err := shared.LoadTestRuns(ctx, products, filters.Labels, shared.LatestSHA, filters.From, filters.To, filters.MaxCount, filters.Offset)
+		testRuns, err := shared.LoadTestRuns(ctx, products, filters.Labels, nil, filters.From, filters.To, filters.MaxCount, filters.Offset)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/api/test_run.go
+++ b/api/test_run.go
@@ -56,7 +56,7 @@ func apiTestRunHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		one := 1
-		testRuns, err := shared.LoadTestRuns(ctx, filters.Products, filters.Labels, filters.SHA, nil, nil, &one, nil)
+		testRuns, err := shared.LoadTestRuns(ctx, filters.Products, filters.Labels, filters.SHAs, nil, nil, &one, nil)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/shared/datastore.go
+++ b/shared/datastore.go
@@ -59,7 +59,7 @@ func LoadTestRunKeys(
 	ctx context.Context,
 	products []ProductSpec,
 	labels mapset.Set,
-	sha string,
+	revisions []string,
 	from *time.Time,
 	to *time.Time,
 	limit *int,
@@ -76,14 +76,16 @@ func LoadTestRunKeys(
 		}
 	}
 	var globalKeyFilter mapset.Set
-	if !IsLatest(sha) {
-		var ids TestRunIDs
-		if ids, err = loadKeysForRevision(ctx, baseQuery, sha); err != nil {
-			return nil, err
-		}
-		globalKeyFilter = mapset.NewSet()
-		for _, id := range ids {
-			globalKeyFilter.Add(id)
+	if len(revisions) > 1 || len(revisions) == 1 && !IsLatest(revisions[0]) {
+		for _, sha := range revisions {
+			var ids TestRunIDs
+			if ids, err = loadKeysForRevision(ctx, baseQuery, sha); err != nil {
+				return nil, err
+			}
+			globalKeyFilter = mapset.NewSet()
+			for _, id := range ids {
+				globalKeyFilter.Add(id)
+			}
 		}
 	}
 	for i, product := range products {
@@ -163,12 +165,12 @@ func LoadTestRuns(
 	ctx context.Context,
 	products []ProductSpec,
 	labels mapset.Set,
-	sha string,
+	revisions []string,
 	from *time.Time,
 	to *time.Time,
 	limit,
 	offset *int) (result TestRunsByProduct, err error) {
-	keys, err := LoadTestRunKeys(ctx, products, labels, sha, from, to, limit, offset)
+	keys, err := LoadTestRunKeys(ctx, products, labels, revisions, from, to, limit, offset)
 	if err != nil {
 		return nil, err
 	}

--- a/shared/datastore_medium_test.go
+++ b/shared/datastore_medium_test.go
@@ -38,7 +38,7 @@ func TestLoadTestRuns(t *testing.T) {
 	key, _ = datastore.Put(ctx, key, &testRun)
 
 	chrome, _ := shared.ParseProductSpec("chrome")
-	loaded, err := shared.LoadTestRuns(ctx, shared.ProductSpecs{chrome}, nil, shared.LatestSHA, nil, nil, nil, nil)
+	loaded, err := shared.LoadTestRuns(ctx, shared.ProductSpecs{chrome}, nil, nil, nil, nil, nil, nil)
 	allRuns := loaded.AllRuns()
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(allRuns))
@@ -157,7 +157,7 @@ func TestLoadTestRuns_Experimental_Only(t *testing.T) {
 	labels := mapset.NewSet()
 	labels.Add("experimental")
 	ten := 10
-	loaded, err := shared.LoadTestRuns(ctx, products, labels, shared.LatestSHA, nil, nil, &ten, nil)
+	loaded, err := shared.LoadTestRuns(ctx, products, labels, nil, nil, nil, &ten, nil)
 	allRuns := loaded.AllRuns()
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(allRuns))
@@ -198,7 +198,7 @@ func TestLoadTestRuns_LabelinProductSpec(t *testing.T) {
 	products := make([]shared.ProductSpec, 1)
 	products[0].BrowserName = "chrome"
 	products[0].Labels = mapset.NewSetWith("foo")
-	loaded, err := shared.LoadTestRuns(ctx, products, nil, shared.LatestSHA, nil, nil, nil, nil)
+	loaded, err := shared.LoadTestRuns(ctx, products, nil, nil, nil, nil, nil, nil)
 	allRuns := loaded.AllRuns()
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(allRuns))
@@ -240,7 +240,7 @@ func TestLoadTestRuns_SHAinProductSpec(t *testing.T) {
 	products := make([]shared.ProductSpec, 1)
 	products[0].BrowserName = "chrome"
 	products[0].Revision = strings.Repeat("1", 10)
-	loaded, err := shared.LoadTestRuns(ctx, products, nil, "", nil, nil, nil, nil)
+	loaded, err := shared.LoadTestRuns(ctx, products, nil, nil, nil, nil, nil, nil)
 	assert.Nil(t, err)
 	allRuns := loaded.AllRuns()
 	assert.Equal(t, 1, len(allRuns))
@@ -248,14 +248,14 @@ func TestLoadTestRuns_SHAinProductSpec(t *testing.T) {
 
 	// Partial SHA
 	products[0].Revision = "11111"
-	loaded, err = shared.LoadTestRuns(ctx, products, nil, "", nil, nil, nil, nil)
+	loaded, err = shared.LoadTestRuns(ctx, products, nil, nil, nil, nil, nil, nil)
 	allRuns = loaded.AllRuns()
 	assert.Equal(t, 1, len(allRuns))
 	assert.Equal(t, "1111111111", allRuns[0].Revision)
 
 	// Partial SHA, Browser version
 	products[0].BrowserVersion = "63"
-	loaded, err = shared.LoadTestRuns(ctx, products, nil, "", nil, nil, nil, nil)
+	loaded, err = shared.LoadTestRuns(ctx, products, nil, nil, nil, nil, nil, nil)
 	allRuns = loaded.AllRuns()
 	assert.Equal(t, 1, len(allRuns))
 	assert.Equal(t, "1111111111", allRuns[0].Revision)
@@ -295,7 +295,7 @@ func TestLoadTestRuns_Ordering(t *testing.T) {
 	}
 
 	chrome, _ := shared.ParseProductSpec("chrome")
-	loaded, err := shared.LoadTestRuns(ctx, []shared.ProductSpec{chrome}, nil, shared.LatestSHA, nil, nil, nil, nil)
+	loaded, err := shared.LoadTestRuns(ctx, []shared.ProductSpec{chrome}, nil, nil, nil, nil, nil, nil)
 	assert.Nil(t, err)
 	allRuns := loaded.AllRuns()
 	assert.Equal(t, 2, len(allRuns))
@@ -339,7 +339,7 @@ func TestLoadTestRuns_From(t *testing.T) {
 	}
 
 	chrome, _ := shared.ParseProductSpec("chrome")
-	loaded, err := shared.LoadTestRuns(ctx, []shared.ProductSpec{chrome}, nil, shared.LatestSHA, &yesterday, nil, nil, nil)
+	loaded, err := shared.LoadTestRuns(ctx, []shared.ProductSpec{chrome}, nil, nil, &yesterday, nil, nil, nil)
 	assert.Nil(t, err)
 	allRuns := loaded.AllRuns()
 	assert.Equal(t, 1, len(allRuns))
@@ -380,7 +380,7 @@ func TestLoadTestRuns_To(t *testing.T) {
 	}
 
 	chrome, _ := shared.ParseProductSpec("chrome")
-	loaded, err := shared.LoadTestRuns(ctx, shared.ProductSpecs{chrome}, nil, shared.LatestSHA, nil, &now, nil, nil)
+	loaded, err := shared.LoadTestRuns(ctx, shared.ProductSpecs{chrome}, nil, nil, nil, &now, nil, nil)
 	assert.Nil(t, err)
 	allRuns := loaded.AllRuns()
 	assert.Equal(t, 1, len(allRuns))

--- a/shared/datastore_medium_test.go
+++ b/shared/datastore_medium_test.go
@@ -50,7 +50,7 @@ func TestLoadTestRunsBySHAs(t *testing.T) {
 	testRun.BrowserName = "chrome"
 	testRun.BrowserVersion = "63.0"
 	testRun.OSName = "linux"
-	testRun.CreatedAt = time.Now()
+	testRun.TimeStart = time.Now()
 
 	ctx, done, err := sharedtest.NewAEContext(true)
 	assert.Nil(t, err)
@@ -59,28 +59,30 @@ func TestLoadTestRunsBySHAs(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		testRun.FullRevisionHash = strings.Repeat(strconv.Itoa(i), 40)
 		testRun.Revision = testRun.FullRevisionHash[:10]
-		testRun.CreatedAt = time.Now().AddDate(0, 0, -i)
+		testRun.TimeStart = time.Now().AddDate(0, 0, -i)
 		key := datastore.NewIncompleteKey(ctx, "TestRun", nil)
 		datastore.Put(ctx, key, &testRun)
 	}
 
-	runs, err := shared.LoadTestRunsBySHAs(ctx, "1111111111", "3333333333")
+	runsByProduct, err := shared.LoadTestRuns(ctx, shared.GetDefaultProducts(), nil, shared.SHAs{"1111111111", "3333333333"}, nil, nil, nil, nil)
+	runs := runsByProduct.AllRuns()
 	assert.Nil(t, err)
 	assert.Len(t, runs, 2)
 	for _, run := range runs {
 		assert.True(t, run.ID > 0, "ID field should be populated.")
 	}
-	assert.Equal(t, runs[0].Revision, "1111111111")
-	assert.Equal(t, runs[1].Revision, "3333333333")
+	assert.Equal(t, "1111111111", runs[0].Revision)
+	assert.Equal(t, "3333333333", runs[1].Revision)
 
-	runs, err = shared.LoadTestRunsBySHAs(ctx, "11111", "33333")
+	runsByProduct, err = shared.LoadTestRuns(ctx, shared.GetDefaultProducts(), nil, shared.SHAs{"11111", "33333"}, nil, nil, nil, nil)
+	runs = runsByProduct.AllRuns()
 	assert.Nil(t, err)
 	assert.Len(t, runs, 2)
 	for _, run := range runs {
 		assert.True(t, run.ID > 0, "ID field should be populated.")
 	}
-	assert.Equal(t, runs[0].Revision, "1111111111")
-	assert.Equal(t, runs[1].Revision, "3333333333")
+	assert.Equal(t, "1111111111", runs[0].Revision)
+	assert.Equal(t, "3333333333", runs[1].Revision)
 }
 
 func TestLoadTestRuns_Experimental_Only(t *testing.T) {

--- a/shared/run_diff.go
+++ b/shared/run_diff.go
@@ -241,7 +241,7 @@ func FetchRunResultsJSONForSpec(
 // FetchRunForSpec loads the wpt.fyi TestRun metadata for the given spec.
 func FetchRunForSpec(ctx context.Context, spec ProductSpec) (*TestRun, error) {
 	one := 1
-	testRuns, err := LoadTestRuns(ctx, []ProductSpec{spec}, nil, spec.Revision, nil, nil, &one, nil)
+	testRuns, err := LoadTestRuns(ctx, []ProductSpec{spec}, nil, []string{spec.Revision}, nil, nil, &one, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/shared/test_run_filter.go
+++ b/shared/test_run_filter.go
@@ -15,10 +15,27 @@ import (
 	mapset "github.com/deckarep/golang-set"
 )
 
+// SHAs is a helper type for a slice of commit/revision SHAs.
+type SHAs []string
+
+// EmptyOrLatest returns whether the shas slice is empty, or only contains
+// one item, which is the latest keyword.
+func (s SHAs) EmptyOrLatest() bool {
+	return len(s) < 1 || len(s) == 1 && IsLatest(s[0])
+}
+
+// FirstOrLatest returns the first sha in the slice, or the latest keyword.
+func (s SHAs) FirstOrLatest() string {
+	if s.EmptyOrLatest() {
+		return LatestSHA
+	}
+	return s[0]
+}
+
 // TestRunFilter represents the ways TestRun entities can be filtered in
 // the webapp and api.
 type TestRunFilter struct {
-	SHA      string       `json:"sha,omitempty"`
+	SHAs     SHAs         `json:"shas,omitempty"`
 	Labels   mapset.Set   `json:"labels,omitempty"`
 	Aligned  *bool        `json:"aligned,omitempty"`
 	From     *time.Time   `json:"from,omitempty"`
@@ -31,7 +48,7 @@ type TestRunFilter struct {
 // IsDefaultQuery returns whether the params are just an empty query (or,
 // the equivalent defaults of an empty query).
 func (filter TestRunFilter) IsDefaultQuery() bool {
-	return IsLatest(filter.SHA) &&
+	return filter.SHAs.EmptyOrLatest() &&
 		(filter.Labels == nil || filter.Labels.Cardinality() < 1) &&
 		(filter.Aligned == nil) &&
 		(filter.From == nil) &&
@@ -122,8 +139,10 @@ func (filter TestRunFilter) GetProductsOrDefault() (products ProductSpecs) {
 func (filter TestRunFilter) ToQuery() (q url.Values) {
 	u := url.URL{}
 	q = u.Query()
-	if !IsLatest(filter.SHA) {
-		q.Set("sha", filter.SHA)
+	if !filter.SHAs.EmptyOrLatest() {
+		for _, sha := range filter.SHAs {
+			q.Add("sha", sha)
+		}
 	}
 	if filter.Labels != nil && filter.Labels.Cardinality() > 0 {
 		for label := range filter.Labels.Iter() {

--- a/webapp/components/interop.html
+++ b/webapp/components/interop.html
@@ -212,7 +212,7 @@ found in the LICENSE file.
   /* global WPTColors, TestRunsBase, SelfNavigation, LoadingState, QueryBuilder */
   class WPTInterop extends QueryBuilder(
     WPTColors(SelfNavigation(LoadingState(TestRunsBase))),
-    'interopQueryParams(sha, aligned, master, labels, productSpecs, to, from, maxCount, search)') {
+    'interopQueryParams(shas, aligned, master, labels, productSpecs, to, from, maxCount, search)') {
     static get is() {
       return 'wpt-interop';
     }
@@ -308,8 +308,8 @@ found in the LICENSE file.
       return '/interop';
     }
 
-    interopQueryParams(sha, aligned, master, labels, productSpecs, maxCount, to, from, search) {
-      const params = this.computeTestRunQueryParams(sha, aligned, master, labels, productSpecs, to, from, maxCount);
+    interopQueryParams(shas, aligned, master, labels, productSpecs, maxCount, to, from, search) {
+      const params = this.computeTestRunQueryParams(shas, aligned, master, labels, productSpecs, to, from, maxCount);
       if (search) {
         params.q = search;
       }

--- a/webapp/components/product-info.html
+++ b/webapp/components/product-info.html
@@ -165,6 +165,9 @@
       }
 
       computeIsLatest(sha) {
+        if (Array.isArray(sha)) {
+          return !sha.length || sha.length === 1 && this.computeIsLatest(sha[0]);
+        }
         return !sha || sha === 'latest';
       }
     };

--- a/webapp/components/test-results-history-grid.html
+++ b/webapp/components/test-results-history-grid.html
@@ -88,10 +88,6 @@ found in the LICENSE file.
         ];
       }
 
-      computeTestRunQueryParams(sha, aligned, master, labels, productSpecs, to, from, maxCount) {
-        return super.computeTestRunQueryParams(/*sha*/ null, aligned, master, labels, productSpecs, to, from, maxCount);
-      }
-
       bindResultHover(run, subTestName) {
         return () => {
           let statusElement = this.shadowRoot.querySelector('#status');

--- a/webapp/components/test-run.html
+++ b/webapp/components/test-run.html
@@ -159,9 +159,7 @@ See models.go for more details.
       }
 
       sevenCharSHA(sha) {
-        return sha.length > 7
-          ? sha.substr(0, 7)
-          : sha;
+        return sha.substr(0, 7);
       }
     }
 

--- a/webapp/components/test-run.html
+++ b/webapp/components/test-run.html
@@ -159,7 +159,9 @@ See models.go for more details.
       }
 
       sevenCharSHA(sha) {
-        return sha.substr(0, 7);
+        return sha.length > 7
+          ? sha.substr(0, 7)
+          : sha;
       }
     }
 

--- a/webapp/components/test-runs-query-builder.html
+++ b/webapp/components/test-runs-query-builder.html
@@ -105,7 +105,7 @@ found in the LICENSE file.
           <input name="os_version"
                  placeholder="(Latest)"
                  list="shas-datalist"
-                 value="{{ sha::input }}"
+                 value="{{ _sha::input }}"
                  slot="input">
           <datalist id="shas-datalist"></datalist>
         </paper-input-container>
@@ -150,7 +150,11 @@ found in the LICENSE file.
             computed: 'computeSHAsURL(query)',
             observer: 'shasURLUpdated',
           },
-          shas: {
+          _sha: {
+            type: String,
+            observer: 'shaUpdated'
+          },
+          matchingSHAs: {
             type: Array,
           },
           shasAutocomplete: {
@@ -188,7 +192,7 @@ found in the LICENSE file.
         this.clearAll = this.handleClearAll.bind(this);
         this.submit = this.handleSubmit.bind(this);
         this._createMethodObserver('labelsUpdated(labels, labels.*)');
-        this._createMethodObserver('shasUpdated(sha, shas)');
+        this._createMethodObserver('shasUpdated(_sha, matchingSHAs)');
       }
 
       ready() {
@@ -239,25 +243,29 @@ found in the LICENSE file.
       // Respond to shas URL changing by fetching the shas
       shasURLUpdated(url) {
         fetch(url).then(r => r.json()).then(s => {
-          this.shas = s;
+          this.matchingSHAs = s;
         });
       }
 
       // Respond to newly fetched shas, or user input, by filtering the autocomplete list.
-      shasUpdated(sha, shas) {
-        if (!shas || !shas.length || !this.queryBuilderSHA) {
+      shasUpdated(sha, matchingSHAs) {
+        if (!matchingSHAs || !matchingSHAs.length || !this.queryBuilderSHA) {
           return;
         }
         if (sha) {
-          shas = shas.filter(s => s.startsWith(sha));
+          matchingSHAs = matchingSHAs.filter(s => s.startsWith(sha));
         }
-        shas = shas.slice(0, 10);
+        matchingSHAs = matchingSHAs.slice(0, 10);
         // Check actually different from current.
         const current = new Set(this.shasAutocomplete || []);
-        if (current.size === shas.length && !shas.find(v => !current.has(v))) {
+        if (current.size === matchingSHAs.length && !matchingSHAs.find(v => !current.has(v))) {
           return;
         }
-        this.shasAutocomplete = shas;
+        this.shasAutocomplete = matchingSHAs;
+      }
+
+      shaUpdated(sha) {
+        this.shas = this.computeIsLatest(sha) ? [] : [sha];
       }
 
       shasAutocompleteUpdated(shasAutocomplete) {

--- a/webapp/components/test-runs-query.html
+++ b/webapp/components/test-runs-query.html
@@ -18,7 +18,7 @@ found in the LICENSE file.
     // eslint-disable-next-line no-unused-vars
     (() => {
       const testRunsQueryComputer =
-        'computeTestRunQueryParams(sha, aligned, master, labels, productSpecs, to, from, maxCount)';
+        'computeTestRunQueryParams(shas, aligned, master, labels, productSpecs, to, from, maxCount)';
       window.TestRunsQuery = (superClass, opt_queryCompute) => class extends QueryBuilder(
         ProductInfo(superClass),
         opt_queryCompute || testRunsQueryComputer) {
@@ -46,18 +46,18 @@ found in the LICENSE file.
               value: [],
             },
             maxCount: Number,
-            sha: String,
+            shas: Array,
             aligned: Boolean,
             master: Boolean,
             from: Date,
             to: Date,
             isLatest: {
               type: Boolean,
-              computed: 'computeIsLatest(sha)'
+              computed: 'computeIsLatest(shas)'
             },
             resultsRangeMessage: {
               type: String,
-              computed: 'computeResultsRangeMessage(sha, productSpecs, to, from, maxCount, labels, master)',
+              computed: 'computeResultsRangeMessage(shas, productSpecs, to, from, maxCount, labels, master)',
             },
           };
         }
@@ -74,6 +74,12 @@ found in the LICENSE file.
           this.updateQueryParams(this.queryParams);
         }
 
+        // sha is a convenience method for getting (the) single sha.
+        // Using multiple shas is rare.
+        get sha() {
+          return this.shas && this.shas.length && this.shas[0] || 'latest';
+        }
+
         // eslint-disable-next-line no-unused-vars
         productsUpdated(products, itemChange) {
           this.productSpecs = (products || []).map(p => this.getSpec(p));
@@ -82,10 +88,10 @@ found in the LICENSE file.
         /**
         * Convert the UI property values into their equivalent URI query params.
         */
-        computeTestRunQueryParams(sha, aligned, master, labels, productSpecs, to, from, maxCount) {
+        computeTestRunQueryParams(shas, aligned, master, labels, productSpecs, to, from, maxCount) {
           const params = {};
-          if (!this.computeIsLatest(sha)) {
-            params.sha = sha;
+          if (!this.computeIsLatest(shas)) {
+            params.sha = shas;
           }
           // Convert bool master to label 'master'
           labels = labels && Array.from(labels) || [];
@@ -132,7 +138,7 @@ found in the LICENSE file.
             }
           }
           // Requesting a specific SHA makes aligned redundant.
-          if (aligned && this.computeIsLatest(sha)) {
+          if (aligned && this.computeIsLatest(shas)) {
             params.aligned = true;
           }
           return params;
@@ -152,7 +158,7 @@ found in the LICENSE file.
             products: window.wpt.DefaultProducts,
             labels: [],
             maxCount: undefined,
-            sha: '',
+            shas: [],
             aligned: undefined,
           };
         }
@@ -171,7 +177,7 @@ found in the LICENSE file.
           }
           const batchUpdate = this.emptyQuery;
           if (!this.computeIsLatest(params.sha)) {
-            batchUpdate.sha = params.sha;
+            batchUpdate.shas = params.sha;
           }
           if ('product' in params) {
             batchUpdate.products = params.product.map(p => this.parseProductSpec(p));
@@ -213,12 +219,14 @@ found in the LICENSE file.
           this.setProperties(batchUpdate);
         }
 
-        computeResultsRangeMessage(sha, productSpecs, from, to, maxCount, labels, master) {
-          const latest = this.computeIsLatest(sha) ? 'the latest ' : '';
+        computeResultsRangeMessage(shas, productSpecs, from, to, maxCount, labels, master) {
+          const latest = this.computeIsLatest(shas) ? 'the latest ' : '';
           const branch = master ? 'master ' : '';
           let msg = `Showing ${latest}${branch}test runs`;
-          if (sha) {
-            msg += ` from revision ${sha}`;
+          if (shas && shas.length) {
+            // Shorten to 7 chars.
+            shas = shas.map(s => !this.computeIsLatest(s) && s.length > 7 ? s.substr(0, 7) : s);
+            msg += ` from ${pluralize('revision', shas.length)} ${shas.join(', ')}`;
           } else if (from) {
             const max = to || Date.now();
             var diff = Math.floor((max - from) / 86400000);
@@ -249,7 +257,7 @@ found in the LICENSE file.
     (() => {
       // TODO(lukebjerring): Support to & from in the builder.
       const testRunsUIQueryComputer =
-        'computeTestRunUIQueryParams(sha, aligned, master, labels, productSpecs, to, from, maxCount, diff, search, pr, runIds)';
+        'computeTestRunUIQueryParams(shas, aligned, master, labels, productSpecs, to, from, maxCount, diff, search, pr, runIds)';
       /* global TestRunsQuery */
       window.TestRunsUIQuery = (superClass, opt_queryCompute) => class extends TestRunsQuery(
         superClass,
@@ -276,8 +284,8 @@ found in the LICENSE file.
           };
         }
 
-        computeTestRunUIQueryParams(sha, aligned, master, labels, productSpecs, to, from, maxCount, diff, search, pr, runIds) {
-          const params = this.computeTestRunQueryParams(sha, aligned, master, labels, productSpecs, to, from, maxCount);
+        computeTestRunUIQueryParams(shas, aligned, master, labels, productSpecs, to, from, maxCount, diff, search, pr, runIds) {
+          const params = this.computeTestRunQueryParams(shas, aligned, master, labels, productSpecs, to, from, maxCount);
           if (diff || this.diff) {
             params.diff = true;
           }

--- a/webapp/components/test/test-runs-query-builder.html
+++ b/webapp/components/test/test-runs-query-builder.html
@@ -148,12 +148,19 @@
           }
         });
 
-        test('sha', () => {
-          const sha = '1234567890';
-          queryBuilder.sha = sha;
-          expect(queryBuilder.query).to.contain(`sha=${sha}`);
+        test('shas', () => {
+          const shas = ['1234567890', '0987654321'];
+          queryBuilder.shas = shas.slice(0, 1);
+          expect(queryBuilder.query).to.contain(`sha=${shas[0]}`);
 
-          queryBuilder.sha = 'latest';
+          queryBuilder.shas = shas;
+          expect(queryBuilder.query).to.contain(`sha=${shas[0]}`);
+          expect(queryBuilder.query).to.contain(`sha=${shas[1]}`);
+
+          queryBuilder.shas = ['latest'];
+          expect(queryBuilder.query).to.not.contain('sha');
+
+          queryBuilder.shas = [];
           expect(queryBuilder.query).to.not.contain('sha');
         });
 

--- a/webapp/components/test/test-runs-query.html
+++ b/webapp/components/test/test-runs-query.html
@@ -154,11 +154,14 @@
               expect(testRunsQuery.queryParams.aligned).to.be.true;
             });
 
-            test('sha', () => {
-              testRunsQuery.sha = '1234567890';
+            test('shas', () => {
+              testRunsQuery.shas = ['1234567890'];
               testRunsQuery.aligned = true;
-              expect(testRunsQuery.queryParams.sha).to.equal(testRunsQuery.sha);
+              expect(testRunsQuery.queryParams.sha).to.equal(testRunsQuery.shas);
               expect(testRunsQuery.queryParams.aligned).to.not.be.defined;
+
+              testRunsQuery.shas = [];
+              expect(testRunsQuery.sha).to.equal('latest');
             });
           });
 
@@ -177,6 +180,15 @@
               testRunsQuery.master = true;
               expect(testRunsQuery.resultsRangeMessage).to.contain('master test runs');
               expect(testRunsQuery.resultsRangeMessage).to.not.contain('with label');
+            });
+            test('shas', () => {
+              const sha = '1234567890';
+              testRunsQuery.shas = [sha];
+              expect(testRunsQuery.resultsRangeMessage).to.contain(`revision ${sha.substr(0, 7)}`);
+
+              const sha2 = 'abcdef1234abcdef1234abcdef1234abcdef1234';
+              testRunsQuery.shas = [sha, sha2];
+              expect(testRunsQuery.resultsRangeMessage).to.contain(`revisions ${sha.substr(0, 7)}, ${sha2.substr(0, 7)}`);
             });
           });
         });

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -188,7 +188,7 @@ found in the LICENSE file.
         <test-runs-query-builder product-specs="[[productSpecs]]"
                                 labels="[[labels]]"
                                 master="[[master]]"
-                                sha="[[sha]]"
+                                shas="[[shas]]"
                                 aligned="[[aligned]]"
                                 on-submit="[[submitQuery]]"
                                 from="[[from]]"

--- a/webapp/components/wpt-runs.html
+++ b/webapp/components/wpt-runs.html
@@ -101,7 +101,7 @@ found in the LICENSE file.
         <test-runs-query-builder product-specs="[[productSpecs]]"
                                 labels="[[labels]]"
                                 master="[[master]]"
-                                sha="[[sha]]"
+                                shas="[[shas]]"
                                 aligned="[[aligned]]"
                                 on-submit="[[submitQuery]]"
                                 from="[[from]]"

--- a/webapp/templates/_test_run_query_params.html
+++ b/webapp/templates/_test_run_query_params.html
@@ -1,5 +1,5 @@
           {{- if .Products}} product-specs="{{ .Products }}"{{end}}
-          {{- if .SHA}} sha="{{ .SHA }}" {{end}}
+          {{- if .SHAs}} shas="{{ .SHAs }}" {{end}}
           {{- if .Labels}} labels="{{ .Labels }}"{{end}}
           {{- if .MaxCount}} max-count="{{ .MaxCount }}"{{end}}
           {{- if .From}} from="{{ .From }}"{{end}}

--- a/webapp/templates/interoperability.html
+++ b/webapp/templates/interoperability.html
@@ -11,7 +11,7 @@
     <wpt-interop {{if .Metadata}}pass-rate-metadata="{{ .Metadata }}"{{end}}
                  {{- with .Filter}}
                    {{- if .Products}} product-specs="{{ .Products }}"{{end}}
-                   {{- if .SHA}} sha="{{ .SHA }}" {{end}}
+                   {{- if .SHAs}} shas="{{ .SHAs }}" {{end}}
                    {{- if .Labels}} labels="{{ .Labels }}"{{end}}
                    {{- if .Aligned}} aligned{{end}}
                  {{- end}}

--- a/webapp/test_runs_handler.go
+++ b/webapp/test_runs_handler.go
@@ -43,23 +43,24 @@ func parseTestRunsUIFilter(r *http.Request) (filter testRunUIFilter, err error) 
 		return filter, err
 	}
 
+	isDefault := testRunFilter.IsDefaultQuery() && pr == nil
+	if isDefault {
+		// Get runs from a week ago, onward, by default.
+		ctx := shared.NewAppEngineContext(r)
+		aeAPI := shared.NewAppEngineAPI(ctx)
+		aWeekAgo := time.Now().Truncate(time.Hour*24).AddDate(0, 0, -7)
+		testRunFilter.From = &aWeekAgo
+		if aeAPI.IsFeatureEnabled("masterRunsOnly") {
+			testRunFilter = testRunFilter.MasterOnly()
+		}
+	} else if testRunFilter.MaxCount == nil {
+		oneHundred := 100
+		testRunFilter.MaxCount = &oneHundred
+	}
+	filter = convertTestRunUIFilter(testRunFilter)
 	if pr != nil {
 		filter.PR = pr
-	} else {
-		if testRunFilter.IsDefaultQuery() {
-			// Get runs from a week ago, onward, by default.
-			ctx := shared.NewAppEngineContext(r)
-			aeAPI := shared.NewAppEngineAPI(ctx)
-			aWeekAgo := time.Now().Truncate(time.Hour*24).AddDate(0, 0, -7)
-			testRunFilter.From = &aWeekAgo
-			if aeAPI.IsFeatureEnabled("masterRunsOnly") {
-				testRunFilter = testRunFilter.MasterOnly()
-			}
-		} else if testRunFilter.MaxCount == nil {
-			oneHundred := 100
-			testRunFilter.MaxCount = &oneHundred
-		}
-		filter = convertTestRunUIFilter(testRunFilter)
 	}
+
 	return filter, nil
 }


### PR DESCRIPTION
## Description
Accompanies #976 for a resolution to #973 

Fixes the behaviour of the /results PR param.
It is fixed by having the server alias `pr` as a request for multiple SHAs, which we ask GitHub for.
So, to facilitate that, this PR refactors the behaviour of our datastore to accept multiple SHAs when loading runs.

This has side effects of:
- Allowing multiple `sha` params in queries. This can be useful for using `/runs` to see all runs across some known shas (a PR, of course, being a great example).
- Allowing other filtering params to be combined with a `pr` filter; e.g. just safari results for the PR.

Example PR with multiple commits: [14655](https://results-pr-dot-wptdashboard-staging.appspot.com/results?pr=14655)