### PR TITLE
Add a feature for including a service worker to cache components

### DIFF
--- a/webapp/app.yaml
+++ b/webapp/app.yaml
@@ -22,6 +22,11 @@ handlers:
   secure: always
 - url: /static
   static_dir: static
+  expiration: "1d"
+  secure: always
+- url: /service-worker-installer.js
+  static_files: service-worker-installer.js
+  upload: service-worker-installer.js
   secure: always
 - url: /favicon.ico
   static_files: static/favicon.ico

--- a/webapp/components/wpt-flags.html
+++ b/webapp/components/wpt-flags.html
@@ -45,6 +45,7 @@ found in the LICENSE file.
           'failChecksOnRegression',
           'checksAllUsers',
           'pendingChecks',
+          'serviceWorker',
         ];
       }
     });
@@ -248,6 +249,11 @@ found in the LICENSE file.
     <paper-item>
       <paper-checkbox checked="{{insightsTab}}">
         Show the "Insights" tab in the main navigation, (and enable <a href="/insights">/insights</a>).
+      </paper-checkbox>
+    </paper-item>
+    <paper-item>
+      <paper-checkbox checked="{{serviceWorker}}">
+        Install a service worker to cache all the web components.
       </paper-checkbox>
     </paper-item>
   </template>

--- a/webapp/routes.go
+++ b/webapp/routes.go
@@ -48,6 +48,8 @@ func RegisterRoutes() {
 	shared.AddRoute("/runs", "test-runs", testRunsHandler)
 	shared.AddRoute("/test-runs", "test-runs", testRunsHandler) // Legacy name
 
+	shared.AddRoute("/service-worker.js", "service-worker", serviceWorkerHandler)
+
 	// Admin-only manual results upload.
 	shared.AddRoute("/admin/results/upload", "admin-results-upload", adminUploadHandler)
 

--- a/webapp/service-worker-installer.js
+++ b/webapp/service-worker-installer.js
@@ -1,0 +1,18 @@
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker
+    .register('/service-worker.js', {
+      scope: '/'
+    })
+    .then(function (reg) {
+      if (reg.installing) {
+        console.log('Service worker installing');
+      } else if (reg.waiting) {
+        console.log('Service worker installed');
+      } else if (reg.active) {
+        console.log('Service worker active');
+      }
+    }).catch(function (error) {
+      // registration failed
+      console.log(`Registration failed with ${error}`);
+    });
+}

--- a/webapp/service_worker_handler.go
+++ b/webapp/service_worker_handler.go
@@ -6,12 +6,8 @@ package webapp
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
-	"path"
-	"path/filepath"
 	"regexp"
-	"runtime"
 	"strings"
 	"text/template"
 
@@ -41,35 +37,10 @@ func serviceWorkerHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var files []string
-	_, filename, _, _ := runtime.Caller(0)
-	dir := filepath.Dir(filename)
-	for _, folder := range []string{"components", "static"} {
-		appendFiles(path.Join(dir, folder), &files)
-	}
-
 	data := struct {
 		Version string
-		Files   []string
 	}{
 		Version: version,
-		Files:   files,
 	}
 	swTemplate.Execute(w, data)
-}
-
-func appendFiles(dirPath string, files *[]string) error {
-	dir, err := ioutil.ReadDir(dirPath)
-	if err != nil {
-		return err
-	}
-	for _, f := range dir {
-		name := path.Join(dirPath, f.Name())
-		if f.IsDir() {
-			appendFiles(name, files)
-		} else {
-			*files = append(*files, name)
-		}
-	}
-	return nil
 }

--- a/webapp/service_worker_handler.go
+++ b/webapp/service_worker_handler.go
@@ -1,0 +1,67 @@
+// Copyright 2018 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package webapp
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"text/template"
+
+	"github.com/web-platform-tests/wpt.fyi/shared"
+	"google.golang.org/appengine"
+)
+
+var (
+	swTemplate = template.Must(template.ParseFiles("templates/service-worker.js"))
+	// NOTE(lukebjerring): If tweaking service worker locally, change to
+	// sevenCharSHA, _ = regexp.Compile("^[0-9a-f]{7}|None$")
+	sevenCharSHA, _ = regexp.Compile("^[0-9a-f]{7}$")
+)
+
+func serviceWorkerHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := shared.NewAppEngineContext(r)
+	aeAPI := shared.NewAppEngineAPI(ctx)
+	if !aeAPI.IsFeatureEnabled("serviceWorker") {
+		http.NotFound(w, r)
+		return
+	}
+
+	w.Header().Add("Content-Type", "application/javascript")
+	version := strings.Split(appengine.VersionID(ctx), ".")[0]
+	if !sevenCharSHA.MatchString(version) {
+		http.Error(w, fmt.Sprintf("Service worker not implemented for version '%s'", version), http.StatusNotImplemented)
+		return
+	}
+
+	var files []string
+	for _, folder := range []string{"components", "static"} {
+		_, filename, _, _ := runtime.Caller(0)
+		dir := filepath.Dir(filename)
+		err := filepath.Walk(path.Join(dir, folder), func(path string, info os.FileInfo, err error) error {
+			if err == nil && !info.IsDir() {
+				files = append(files, path)
+			}
+			return err
+		})
+		if err != nil {
+			return
+		}
+	}
+
+	data := struct {
+		Version string
+		Files   []string
+	}{
+		Version: version,
+		Files:   files,
+	}
+	swTemplate.Execute(w, data)
+}

--- a/webapp/service_worker_handler_test.go
+++ b/webapp/service_worker_handler_test.go
@@ -1,0 +1,24 @@
+// +build small
+
+// Copyright 2018 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package webapp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSevenCharSHARegex(t *testing.T) {
+	assert.True(t, sevenCharSHA.MatchString("0000000"))
+	assert.True(t, sevenCharSHA.MatchString("1234567"))
+	assert.True(t, sevenCharSHA.MatchString("9876543"))
+	assert.True(t, sevenCharSHA.MatchString("abcdef0"))
+	assert.True(t, sevenCharSHA.MatchString("fedcba9"))
+
+	assert.False(t, sevenCharSHA.MatchString("aaa"))
+	assert.False(t, sevenCharSHA.MatchString("aaaaaaaaaaaaa"))
+}

--- a/webapp/templates/_head_common.html
+++ b/webapp/templates/_head_common.html
@@ -1,4 +1,5 @@
 <title>web-platform-tests dashboard</title>
 <link rel="stylesheet" href="/static/common.css">
+<script src="/service-worker-installer.js"></script>
 <script src="/bower_components/webcomponentsjs/webcomponents-lite.js"></script>
 <link rel="import" href="/components/wpt-header.html">

--- a/webapp/templates/service-worker.js
+++ b/webapp/templates/service-worker.js
@@ -1,3 +1,19 @@
+// Clean up old caches.
+self.addEventListener(
+  'activate',
+  e => {
+    e.waitUntil(
+      caches.keys()
+        .then(cacheNames => Promise.all(
+          cacheNames
+            .filter(v => '{{ .Version }}' !== v)
+            .map(v => caches.delete(v))
+        ))
+    );
+  }
+);
+
+// Locally cache eligible components/files.
 self.addEventListener(
   'fetch',
   e => {
@@ -9,12 +25,14 @@ self.addEventListener(
           }
           return fetch(e.request)
             .then(r => {
-              const components = new RegExp('^/((bower_)?components|static)/');
-              if (components.test(e.request.url.toString())) {
-                let clone = r.clone();
-                caches.open('{{ .Version }}').then(cache => {
-                  cache.put(e.request, clone);
-                });
+              if (r.ok) {
+                const components = new RegExp('^/((bower_)?components|static)/');
+                if (components.test(e.request.url.toString())) {
+                  let clone = r.clone();
+                  caches.open('{{ .Version }}').then(cache => {
+                    cache.put(e.request, clone);
+                  });
+                }
               }
               return r;
             });

--- a/webapp/templates/service-worker.js
+++ b/webapp/templates/service-worker.js
@@ -1,0 +1,39 @@
+self.addEventListener(
+  'install',
+  e => e.waitUntil(
+    caches.open('{{ .Version }}').then(cache => cache.addAll([
+      {{- range .Files }}
+      '/{{ . }}',
+      {{- end }}
+    ])).catch(e => {
+      console.error(e);
+    })
+  )
+);
+
+self.addEventListener(
+  'fetch',
+  e => {
+    return e.respondWith(
+      caches.match(e.request)
+        .then(r => {
+          if (r) {
+            return r;
+          }
+          return fetch(e.request)
+            .then(r => {
+              // NOTE(lukebjerring): wait for actually-used bower_components,
+              // to avoid bloating the cache with unused files.
+              if (e.request.url.toString().includes('/bower_components/')) {
+                let clone = r.clone();
+                caches.open('{{ .Version }}').then(cache => {
+                  cache.put(e.request, clone);
+                });
+              }
+              return r;
+            });
+        }
+      )
+    );
+  }
+);

--- a/webapp/templates/service-worker.js
+++ b/webapp/templates/service-worker.js
@@ -1,17 +1,4 @@
 self.addEventListener(
-  'install',
-  e => e.waitUntil(
-    caches.open('{{ .Version }}').then(cache => cache.addAll([
-      {{- range .Files }}
-      '/{{ . }}',
-      {{- end }}
-    ])).catch(e => {
-      console.error(e);
-    })
-  )
-);
-
-self.addEventListener(
   'fetch',
   e => {
     return e.respondWith(
@@ -22,9 +9,8 @@ self.addEventListener(
           }
           return fetch(e.request)
             .then(r => {
-              // NOTE(lukebjerring): wait for actually-used bower_components,
-              // to avoid bloating the cache with unused files.
-              if (e.request.url.toString().includes('/bower_components/')) {
+              const components = new RegExp('^/((bower_)?components|static)/');
+              if (components.test(e.request.url.toString())) {
                 let clone = r.clone();
                 caches.open('{{ .Version }}').then(cache => {
                   cache.put(e.request, clone);


### PR DESCRIPTION
## Description
Adds a dynamic endpoint for `/service-worker.js` that, for valid releases (versions that are a 7-char SHA), crawls the /static/ and /components/ dirs in webapp and preemptively caches all of those requests.

Also caches /bower_components/ requests, but waits for a caller to have requested them (so that we can filter down to files that are actually in use. The directory tree is huge).

Also adds a 1d public-cache duration for the /static/ dir (was 10m).