### PR TITLE
Consolidate history query params

### DIFF
--- a/util/populate_dev_data.go
+++ b/util/populate_dev_data.go
@@ -183,6 +183,7 @@ func main() {
 	addFlag(ctx, "structuredQueries", enabledFlag)
 	addFlag(ctx, "diffRenames", enabledFlag)
 	addFlag(ctx, "masterRunsOnly", enabledFlag)
+	addFlag(ctx, "paginationTokens", enabledFlag)
 
 	log.Print("Adding uploader \"test\"...")
 	addData(ctx, "Uploader", []interface{}{

--- a/webapp/components/test-results-chart.html
+++ b/webapp/components/test-results-chart.html
@@ -150,7 +150,7 @@ found in the LICENSE file.
       }
 
       // eslint-disable-next-line no-unused-vars
-      loadResults(tests, query) {
+      async loadResults(tests, query) {
         if (!this.show || !this.tests || !this.tests.length) {
           return;
         }
@@ -158,19 +158,17 @@ found in the LICENSE file.
           this.reset();
         }
         this.currentTests = tests;
-        return this.loadRuns().then(runs =>
-          runs && Promise.all(runs.map(run => this.loadRun(this.currentTests, run)))
-        );
+        const runs = await this.loadRuns();
+        return runs && Promise.all(runs.map(run => this.loadRun(this.currentTests, run)));
       }
 
       // eslint-disable-next-line no-unused-vars
-      loadNext(tests, nextPageToken) {
+      async loadNext(tests, nextPageToken) {
         if (!this.show || this.values.length >= this.maxRuns) {
           return;
         }
-        return this.loadMoreRuns().then(runs =>
-          runs && Promise.all(runs.map(run => this.loadRun(this.currentTests, run)))
-        );
+        const runs = await this.loadMoreRuns();
+        return runs && Promise.all(runs.map(run => this.loadRun(this.currentTests, run)));
       }
 
       // Load results of `tests` from `run`.

--- a/webapp/components/test-results-chart.html
+++ b/webapp/components/test-results-chart.html
@@ -56,7 +56,7 @@ found in the LICENSE file.
           },
           browserNames: {
             type: Array,
-            value: wpt.DefaultBrowserNames,
+            value: window.wpt.DefaultBrowserNames,
           },
           cols: {
             type: Array,
@@ -148,6 +148,7 @@ found in the LICENSE file.
         return super.computeTestRunQueryParams(shas, aligned, master, labels, productSpecs, to, from, maxCount);
       }
 
+      // eslint-disable-next-line no-unused-vars
       loadNext(tests, query) {
         if (!this.show || tests.length === 0 || this.values.length >= this.maxRuns) {
           return;

--- a/webapp/components/test-results-chart.html
+++ b/webapp/components/test-results-chart.html
@@ -106,7 +106,8 @@ found in the LICENSE file.
       static get observers() {
         return [
           'updateShowForNow(tests, chunkSize, labels, isFeasible)',
-          'loadNext(tests, query)',
+          'loadResults(tests, query)',
+          'loadNext(tests, nextPageToken)',
         ];
       }
 
@@ -149,31 +150,27 @@ found in the LICENSE file.
       }
 
       // eslint-disable-next-line no-unused-vars
-      loadNext(tests, query) {
-        if (!this.show || tests.length === 0 || this.values.length >= this.maxRuns) {
+      loadResults(tests, query) {
+        if (!this.show || !this.tests || !this.tests.length) {
           return;
         }
         if (this.currentTests !== tests) {
           this.reset();
         }
         this.currentTests = tests;
+        return this.loadRuns().then(runs =>
+          runs && Promise.all(runs.map(run => this.loadRun(this.currentTests, run)))
+        );
+      }
 
-        return this.loadRuns().then(runs => {
-          if (runs.length === 0) {
-            return;
-          }
-
-          // Update "to" parameter for fetching more runs after these runs have
-          // been processed, regardless of whether an error occurs.
-          const latch = () => {
-            const dt = this.getDT(runs[runs.length - 1]);
-            if (!this.to || dt.getTime() < this.to.getTime()) {
-              this.to = dt;
-            }
-          };
-          return Promise.all(runs.map(run => this.loadRun(this.currentTests, run)))
-            .then(latch, latch);
-        });
+      // eslint-disable-next-line no-unused-vars
+      loadNext(tests, nextPageToken) {
+        if (!this.show || this.values.length >= this.maxRuns) {
+          return;
+        }
+        return this.loadMoreRuns().then(runs =>
+          runs && Promise.all(runs.map(run => this.loadRun(this.currentTests, run)))
+        );
       }
 
       // Load results of `tests` from `run`.

--- a/webapp/components/test-results-chart.html
+++ b/webapp/components/test-results-chart.html
@@ -7,6 +7,7 @@ found in the LICENSE file.
 <link rel="import" href="../bower_components/polymer/polymer-element.html">
 <link rel="import" href="../bower_components/google-chart/google-chart.html">
 <link rel="import" href="test-file-results.html">
+<link rel="import" href="product-info.html">
 
 <dom-module id="test-results-chart">
   <template>
@@ -38,12 +39,6 @@ found in the LICENSE file.
 
       static get properties() {
         return {
-          labels: {
-            type: Array,
-          },
-          latest: {
-            type: Date,
-          },
           tests: {
             type: Array,
           },
@@ -61,12 +56,7 @@ found in the LICENSE file.
           },
           browserNames: {
             type: Array,
-            value: [
-              'chrome',
-              'edge',
-              'firefox',
-              'safari',
-            ],
+            value: wpt.DefaultBrowserNames,
           },
           cols: {
             type: Array,
@@ -79,10 +69,6 @@ found in the LICENSE file.
           values: {
             type: Array,
             value: [],
-          },
-          to: {
-            type: Date,
-            value: new Date(),
           },
           currentTests: {
             type: Array,
@@ -120,7 +106,7 @@ found in the LICENSE file.
       static get observers() {
         return [
           'updateShowForNow(tests, chunkSize, labels, isFeasible)',
-          'loadNext(tests, chunkSize, maxRuns, labels, to, show)',
+          'loadNext(tests, query)',
         ];
       }
 
@@ -157,41 +143,36 @@ found in the LICENSE file.
         this.showForNow = false;
       }
 
-      // Load results of `tests` from `chunkSize` runs labeled with `labels`
-      // from prior to `to` iff `show`.
-      async loadNext(tests, chunkSize, maxRuns, labels, to, show) {
-        if (!show || tests.length === 0 || this.values.length >= maxRuns) {
+      computeTestRunQueryParams(shas, aligned, master, labels, productSpecs, to, from, maxCount) {
+        maxCount = this.chunkSize;
+        return super.computeTestRunQueryParams(shas, aligned, master, labels, productSpecs, to, from, maxCount);
+      }
+
+      loadNext(tests, query) {
+        if (!this.show || tests.length === 0 || this.values.length >= this.maxRuns) {
           return;
         }
         if (this.currentTests !== tests) {
           this.reset();
         }
         this.currentTests = tests;
-        labels = labels || [];
 
-        const url = new URL('/api/runs', window.location);
-        url.searchParams.append('aligned', true);
-        url.searchParams.append('max-count', chunkSize);
-        if (labels && labels.length) {
-          url.searchParams.append('labels', labels.join(','));
-        }
-        const resp = await window.fetch(url.toString());
-        const runs = await resp.json();
-
-        if (runs.length === 0) {
-          return;
-        }
-
-        // Update "to" parameter for fetching more runs after these runs have
-        // been processed, regardless of whether an error occurs.
-        const latch = () => {
-          const dt = this.getDT(runs[runs.length - 1]);
-          if (dt.getTime() < this.to.getTime()) {
-            this.to = dt;
+        return this.loadRuns().then(runs => {
+          if (runs.length === 0) {
+            return;
           }
-        };
-        return Promise.all(runs.map(run => this.loadRun(this.currentTests, run)))
-          .then(latch, latch);
+
+          // Update "to" parameter for fetching more runs after these runs have
+          // been processed, regardless of whether an error occurs.
+          const latch = () => {
+            const dt = this.getDT(runs[runs.length - 1]);
+            if (!this.to || dt.getTime() < this.to.getTime()) {
+              this.to = dt;
+            }
+          };
+          return Promise.all(runs.map(run => this.loadRun(this.currentTests, run)))
+            .then(latch, latch);
+        });
       }
 
       // Load results of `tests` from `run`.

--- a/webapp/components/test-results-history-grid.html
+++ b/webapp/components/test-results-history-grid.html
@@ -63,7 +63,7 @@ found in the LICENSE file.
   </template>
   <script>
     /* global TestRunsQuery, TestFileResults */
-    class TestFileResultsTimeSeries extends TestRunsQuery(TestFileResults) {
+    class TestFileResultsTimeSeries extends TestFileResults {
       static get is() {
         return 'test-results-history-grid';
       }
@@ -83,8 +83,7 @@ found in the LICENSE file.
 
       static get observers() {
         return [
-          'onPathChanged(path)',
-          'onRunsLoaded(testRuns, path)',
+          'loadResults(path, query)',
         ];
       }
 
@@ -97,35 +96,33 @@ found in the LICENSE file.
         };
       }
 
-      async onPathChanged(path) {
+      loadResults(path, query) {
         if (!path) {
           return;
         }
-        this.loadRuns();
-      }
-
-      async onRunsLoaded(runs, path) {
-        if (!runs) {
-          return;
-        }
-        this.results = runs.reduce((acc, run) => {
-          const browserResultsIdx = acc
-            .findIndex(br => br.browserName === run.browser_name);
-          let browserResults = acc[browserResultsIdx];
-          if (!browserResults) {
-            browserResults = {
-              browserName: run.browser_name,
-              runResults: [],
-            };
-            acc.push(browserResults);
+        return this.loadRuns().then(runs => {
+          if (!runs) {
+            return;
           }
-          browserResults.runResults.push({run, results: []});
+          this.results = runs.reduce((acc, run) => {
+            const browserResultsIdx = acc
+              .findIndex(br => br.browserName === run.browser_name);
+            let browserResults = acc[browserResultsIdx];
+            if (!browserResults) {
+              browserResults = {
+                browserName: run.browser_name,
+                runResults: [],
+              };
+              acc.push(browserResults);
+            }
+            browserResults.runResults.push({run, results: []});
 
-          return acc;
-        }, []);
-        this.results.forEach((browserResults, i) => {
-          browserResults.runResults.forEach((runResult, j) => {
-            this.loadRun(runResult, j, browserResults, i, path);
+            return acc;
+          }, []);
+          this.results.forEach((browserResults, i) => {
+            browserResults.runResults.forEach((runResult, j) => {
+              this.loadRun(runResult, j, browserResults, i, path);
+            });
           });
         });
       }

--- a/webapp/components/test-results-history-grid.html
+++ b/webapp/components/test-results-history-grid.html
@@ -97,35 +97,36 @@ found in the LICENSE file.
       }
 
       // eslint-disable-next-line no-unused-vars
-      loadResults(path, query) {
+      async loadResults(path, query) {
         if (!path) {
           return;
         }
-        return this.loadRuns().then(runs => {
-          if (!runs) {
-            return;
+        const runs = await this.loadRuns();
+        if (!runs) {
+          return;
+        }
+        this.results = runs.reduce((acc, run) => {
+          const browserResultsIdx = acc
+            .findIndex(br => br.browserName === run.browser_name);
+          let browserResults = acc[browserResultsIdx];
+          if (!browserResults) {
+            browserResults = {
+              browserName: run.browser_name,
+              runResults: [],
+            };
+            acc.push(browserResults);
           }
-          this.results = runs.reduce((acc, run) => {
-            const browserResultsIdx = acc
-              .findIndex(br => br.browserName === run.browser_name);
-            let browserResults = acc[browserResultsIdx];
-            if (!browserResults) {
-              browserResults = {
-                browserName: run.browser_name,
-                runResults: [],
-              };
-              acc.push(browserResults);
-            }
-            browserResults.runResults.push({run, results: []});
+          browserResults.runResults.push({run, results: []});
 
-            return acc;
-          }, []);
-          this.results.forEach((browserResults, i) => {
-            browserResults.runResults.forEach((runResult, j) => {
-              this.loadRun(runResult, j, browserResults, i, path);
-            });
+          return acc;
+        }, []);
+        const promises = [];
+        this.results.forEach((browserResults, i) => {
+          browserResults.runResults.forEach((runResult, j) => {
+            promises.push(this.loadRun(runResult, j, browserResults, i, path));
           });
         });
+        return Promise.all(promises);
       }
 
       async loadRun(runResult, j, browserResults, i, path) {

--- a/webapp/components/test-results-history-grid.html
+++ b/webapp/components/test-results-history-grid.html
@@ -62,7 +62,7 @@ found in the LICENSE file.
     <pre id="status">&nbsp;</pre>
   </template>
   <script>
-    /* global TestRunsQuery, TestFileResults */
+    /* global TestFileResults */
     class TestFileResultsTimeSeries extends TestFileResults {
       static get is() {
         return 'test-results-history-grid';
@@ -96,6 +96,7 @@ found in the LICENSE file.
         };
       }
 
+      // eslint-disable-next-line no-unused-vars
       loadResults(path, query) {
         if (!path) {
           return;

--- a/webapp/components/test-runs.html
+++ b/webapp/components/test-runs.html
@@ -95,7 +95,11 @@ found in the LICENSE file.
           const url = new URL('/api/runs', window.location);
           url.searchParams.set('page', this.nextPageToken);
           this.nextPageToken = null;
-          const runs = await fetch(url).then(r => r.ok && r.json());
+          const r = await fetch(url);
+          if (!r.ok) {
+            return;
+          }
+          const runs = await r.json();
           this.splice('testRuns', this.testRuns.length - 1, 0, ...runs);
           this.nextPageToken = r.headers && r.headers.get('wpt-next-page');
           return runs;

--- a/webapp/components/test-runs.html
+++ b/webapp/components/test-runs.html
@@ -58,7 +58,7 @@ found in the LICENSE file.
           return '/' + parts.join('/');
         }
 
-        async loadRuns() {
+        loadRuns() {
           const preloaded = this.testRuns;
           const runs = [];
           if (preloaded) {
@@ -75,15 +75,15 @@ found in the LICENSE file.
                 }))
             );
           }
-          const fetches = await Promise.all(runs);
-
-          // Filter unresolved fetches and flatten any array-fetches into the array.
-          const nonEmpty = fetches.filter(e => e);
-          const flattened = nonEmpty.reduce((sum, item) => {
-            return sum.concat(Array.isArray(item) ? item : [item]);
-          }, []);
-          this.testRuns = flattened;
-          return flattened;
+          return Promise.all(runs).then(fetches => {
+            // Filter unresolved fetches and flatten any array-fetches into the array.
+            const nonEmpty = fetches.filter(e => e);
+            const flattened = nonEmpty.reduce((sum, item) => {
+              return sum.concat(Array.isArray(item) ? item : [item]);
+            }, []);
+            this.testRuns = flattened;
+            return flattened;
+          });
         }
 
         /**

--- a/webapp/components/test-runs.html
+++ b/webapp/components/test-runs.html
@@ -58,7 +58,7 @@ found in the LICENSE file.
           return '/' + parts.join('/');
         }
 
-        loadRuns() {
+        async loadRuns() {
           const preloaded = this.testRuns;
           const runs = [];
           if (preloaded) {
@@ -75,32 +75,30 @@ found in the LICENSE file.
                 }))
             );
           }
-          return Promise.all(runs).then(fetches => {
-            // Filter unresolved fetches and flatten any array-fetches into the array.
-            const nonEmpty = fetches.filter(e => e);
-            const flattened = nonEmpty.reduce((sum, item) => {
-              return sum.concat(Array.isArray(item) ? item : [item]);
-            }, []);
-            this.testRuns = flattened;
-            return flattened;
-          });
+          const fetches = await Promise.all(runs);
+          // Filter unresolved fetches and flatten any array-fetches into the array.
+          const nonEmpty = fetches.filter(e => e);
+          const flattened = nonEmpty.reduce((sum, item) => {
+            return sum.concat(Array.isArray(item) ? item : [item]);
+          }, []);
+          this.testRuns = flattened;
+          return flattened;
         }
 
         /**
          * Fetch the next page of runs, using nextPageToken, if applicable.
          */
-        loadMoreRuns() {
+        async loadMoreRuns() {
           if (!this.nextPageToken) {
-            return Promise.resolve();
+            return;
           }
           const url = new URL('/api/runs', window.location);
           url.searchParams.set('page', this.nextPageToken);
           this.nextPageToken = null;
-          return fetch(url).then(r => r.ok && r.json().then(runs => {
-            this.splice('testRuns', this.testRuns.length - 1, 0, ...runs);
-            this.nextPageToken = r.headers && r.headers.get('wpt-next-page');
-            return runs;
-          }));
+          const runs = await fetch(url).then(r => r.ok && r.json());
+          this.splice('testRuns', this.testRuns.length - 1, 0, ...runs);
+          this.nextPageToken = r.headers && r.headers.get('wpt-next-page');
+          return runs;
         }
 
         splitPathIntoLinkedParts(inputPath) {

--- a/webapp/components/test-runs.html
+++ b/webapp/components/test-runs.html
@@ -91,7 +91,7 @@ found in the LICENSE file.
          */
         loadMoreRuns() {
           if (!this.nextPageToken) {
-            return;
+            return Promise.resolve();
           }
           const url = new URL('/api/runs', window.location);
           url.searchParams.set('page', this.nextPageToken);
@@ -99,6 +99,7 @@ found in the LICENSE file.
           return fetch(url).then(r => r.ok && r.json().then(runs => {
             this.splice('testRuns', this.testRuns.length - 1, 0, ...runs);
             this.nextPageToken = r.headers && r.headers.get('wpt-next-page');
+            return runs;
           }));
         }
 

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -279,8 +279,11 @@ found in the LICENSE file.
             History <span>(Experimental)</span>
           </h3>
           <test-results-chart
+              product-specs="[[productSpecs]]"
               path="[[path]]"
               labels="[[labels]]"
+              master="true"
+              aligned="[[aligned]]"
               tests="[[displayedTests]]">
           </test-results-chart>
 

--- a/webapp/components/wpt-results.html
+++ b/webapp/components/wpt-results.html
@@ -289,6 +289,8 @@ found in the LICENSE file.
                 product-specs="[[productSpecs]]"
                 path="[[path]]"
                 labels="[[labels]]"
+                master="true"
+                aligned="[[aligned]]"
                 tests="[[displayedTests]]">
             </test-results-history-grid>
           </template>


### PR DESCRIPTION
## Description
Changes the behaviour of the history components to correctly re-use the query parameters.
In turn, this ensures that we're fetching runs that match the query for the main results above the history section.