### PR TITLE
Distinguish release version and promote

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,7 +216,11 @@ gcloud-login: gcloud  $(WPTD_PATH)client-secret.json
 
 deploy_staging: gcloud-login webapp_deps package_service var-BRANCH_NAME var-APP_PATH
 	gcloud config set project wptdashboard-staging
-	cd $(WPTD_PATH); util/deploy.sh -q -b $(BRANCH_NAME) $(APP_PATH)
+	if [[ "$(BRANCH_NAME)" == "master" ]]; then \
+		cd $(WPTD_PATH); util/deploy.sh -r -p $(APP_PATH); \
+	else \
+		cd $(WPTD_PATH); util/deploy.sh -q -b $(BRANCH_NAME) $(APP_PATH); \
+	fi
 	rm -rf $(WPTD_PATH)revisions/service/wpt.fyi
 	rm -rf $(WPTD_PATH)api/spanner/service/wpt.fyi
 	rm -rf $(WPTD_PATH)api/query/cache/service/wpt.fyi
@@ -226,7 +230,7 @@ cleanup_staging_versions: gcloud-login
 
 deploy_production: gcloud webapp_deps package_service var-APP_PATH
 	gcloud config set project wptdashboard
-	cd $(WPTD_PATH); util/deploy.sh -p $(APP_PATH)
+	cd $(WPTD_PATH); util/deploy.sh -r $(APP_PATH)
 	rm -rf $(WPTD_PATH)revisions/service/wpt.fyi
 	rm -rf $(WPTD_PATH)api/spanner/service/wpt.fyi
 	rm -rf $(WPTD_PATH)api/query/cache/service/wpt.fyi

--- a/util/cleanup-versions.sh
+++ b/util/cleanup-versions.sh
@@ -20,9 +20,10 @@ function cleanup() {
   info "Cleaning stale versions of $1..."
 
   local SERVICE_ARG="-s $1"
+  local FILTER_ARG="traffic_split=0.0 last_deployed_time.datetime<$CUTOFF"
   local versions_to_delete=()
 
-  for version in $( gcloud app versions list $PROJECT_ARG $SERVICE_ARG --filter="last_deployed_time.datetime<$CUTOFF" --format="value(id)" ); do
+  for version in $( gcloud app versions list $PROJECT_ARG $SERVICE_ARG --filter="$FILTER_ARG" --format="value(id)" ); do
     if ! git show-ref --quiet --verify refs/remotes/origin/$version; then
       debug "'$version' is not a branch in upstream and will be deleted."
       versions_to_delete+=($version)

--- a/util/deploy.sh
+++ b/util/deploy.sh
@@ -9,7 +9,8 @@ WPTD_PATH=${WPTD_PATH:-$(absdir ${REPO_DIR})}
 
 usage() {
   USAGE="Usage: deploy.sh [-p] [-q] [-b] [-h] [app path]
-    -p : Production deploy (to wptdashboard, no-promote)
+    -p : Promote (i.e. pass --promote flag to deploy)
+    -r : Release (use the git-hash as the version)
     -q : Quiet (no user prompts, debugging off)
     -b : Branch name - defaults to current Git branch
     -h : Show (this) help information
@@ -20,8 +21,9 @@ usage() {
 APP_PATH=${@: -1}
 while getopts ':b:phq:g:' flag; do
   case "${flag}" in
+    r) RELEASE='true' ;;
     b) BRANCH_NAME="${OPTARG}" ;;
-    p) PRODUCTION='true' ;;
+    p) PROMOTE='true' ;;
     q) QUIET='true' ;;
     h|*) usage && exit 0;;
   esac
@@ -46,10 +48,16 @@ USER="$(git remote -v get-url origin | sed -E 's#(https?:\/\/|git@)github.com(\/
 if [[ "${USER}" == "web-platform-tests-" ]]; then USER=""; fi
 
 VERSION="${USER}${VERSION_BRANCH_NAME}"
-PROMOTE="--no-promote"
-
-if [[ -n ${PRODUCTION} ]]
+if [[ -n ${RELEASE} ]]
 then
+  # Use SHA for releases.
+  VERSION="$(git rev-parse --short HEAD)"
+fi
+
+PROMOTE_FLAG="--no-promote"
+if [[ -n ${PROMOTE} ]]
+then
+  PROMOTE_FLAG="--promote"
   if [[ -z "${QUIET}" ]]; then debug "Producing production configuration..."; fi
   if [[ "${USER}" != "" ]]
   then
@@ -59,8 +67,6 @@ then
       if [ "${?}" != "0" ]; then fatal "User cancelled the deploy"; fi
     fi
   fi
-  # Use SHA for prod-pushes.
-  VERSION="$(git rev-parse --short HEAD)"
 fi
 
 if [[ -n "${QUIET}" ]]
@@ -69,7 +75,7 @@ then
 else
     QUIET_FLAG=""
 fi
-COMMAND="gcloud app deploy ${PROMOTE} ${QUIET_FLAG} --version=${VERSION} ${APP_PATH}"
+COMMAND="gcloud app deploy ${PROMOTE_FLAG} ${QUIET_FLAG} --version=${VERSION} ${APP_PATH}"
 
 if [[ -z "${QUIET}" ]]
 then


### PR DESCRIPTION
## Description
Changes the staging pushes to deploy and promote a versioned release, rather than clobbering the `master` version (which happens to serve all the traffic).

No tangible change to our release flow, except that staging.wpt.fyi's version will we a 7-char SHA, same as prod, which allows us to leverage a service-worker without risk of stale cache (see #979)