### PR TITLE
Search API: Server-side changes for 'browser NEQ status' syntax

### DIFF
--- a/api/query/cache/index/index_filter_test.go
+++ b/api/query/cache/index/index_filter_test.go
@@ -242,7 +242,7 @@ func TestBindExecute_TestStatus(t *testing.T) {
 
 	runs := mockTestRuns(loader, idx, data)
 
-	q := query.TestStatusConstraint{
+	q := query.TestStatusEq{
 		BrowserName: "Chrome",
 		Status:      shared.TestStatusFail,
 	}

--- a/api/query/cache/index/index_test.go
+++ b/api/query/cache/index/index_test.go
@@ -212,7 +212,7 @@ func TestSync(t *testing.T) {
 				makeRun(int64(n - 3)),
 				makeRun(int64(n - 4)),
 			}
-			plan, err := i.Bind(runs, query.TestStatusConstraint{
+			plan, err := i.Bind(runs, query.TestStatusEq{
 				BrowserName: "Chrome",
 				Status:      shared.TestStatusPass,
 			}.BindToRuns(runs))

--- a/api/query/cache/query/query.go
+++ b/api/query/cache/query/query.go
@@ -19,11 +19,9 @@ func PrepareUserQuery(runIDs []int64, q query.ConcreteQuery) query.ConcreteQuery
 		Args: make([]query.ConcreteQuery, len(runIDs)),
 	}
 	for i, runID := range runIDs {
-		baseQuery.Args[i] = query.Not{
-			Arg: query.RunTestStatusConstraint{
-				Run:    runID,
-				Status: shared.TestStatusUnknown,
-			},
+		baseQuery.Args[i] = query.RunTestStatusNeq{
+			Run:    runID,
+			Status: shared.TestStatusUnknown,
 		}
 	}
 

--- a/api/query/concrete_query.go
+++ b/api/query/concrete_query.go
@@ -31,11 +31,20 @@ type ConcreteQuery interface {
 	Size() int
 }
 
-// RunTestStatusConstraint is constrains search results to include only test
-// results from a particular run that have a particular test status value. Run
-// IDs are those values automatically assigned to shared.TestRun instances by
-// Datastore. Status IDs are those codified in shared.TestStatus* symbols.
-type RunTestStatusConstraint struct {
+// RunTestStatusEq constrains search results to include only test results from a
+// particular run that have a particular test status value. Run IDs are those
+// values automatically assigned to shared.TestRun instances by Datastore.
+// Status IDs are those codified in shared.TestStatus* symbols.
+type RunTestStatusEq struct {
+	Run    int64
+	Status int64
+}
+
+// RunTestStatusNeq constrains search results to include only test results from a
+// particular run that do not have a particular test status value. Run IDs are
+// those values automatically assigned to shared.TestRun instances by Datastore.
+// Status IDs are those codified in shared.TestStatus* symbols.
+type RunTestStatusNeq struct {
 	Run    int64
 	Status int64
 }
@@ -65,9 +74,13 @@ type False struct{}
 // substring match per test.
 func (TestNamePattern) Size() int { return 1 }
 
-// Size of RunTestStatusConstraint is 1: servicing such a query requires a
-// single lookup in a test run result mapping per test.
-func (RunTestStatusConstraint) Size() int { return 1 }
+// Size of RunTestStatusEq is 1: servicing such a query requires a single lookup
+// in a test run result mapping per test.
+func (RunTestStatusEq) Size() int { return 1 }
+
+// Size of RunTestStatusNeq is 1: servicing such a query requires a single
+// lookup in a test run result mapping per test.
+func (RunTestStatusNeq) Size() int { return 1 }
 
 // Size of Or is the sum of the sizes of its constituent ConcretQuery instances.
 func (o Or) Size() int { return size(o.Args) }


### PR DESCRIPTION
This change implements server-side changes for a search syntax like `edge:!PASS`. This is different from `!edge:PASS` because if there are two Edge runs being queried, `e1` and `e2`, the new syntax (former) expands to `e1-status != PASS | e2-status != PASS`, whereas the existing syntax (latter) expands to `!(e1-status = PASS | e2-status = PASS)` or `e1-status != PASS & e2-status != PASS`.