### PR TITLE
Add /api/labels endpoint

### DIFF
--- a/api/labels.go
+++ b/api/labels.go
@@ -20,7 +20,7 @@ type LabelsHandler struct {
 	ctx context.Context
 }
 
-// apiLabelsHandler is responsible for emitting just the revision SHAs for test runs.
+// apiLabelsHandler is responsible for emitting just all labels used for test runs.
 func apiLabelsHandler(w http.ResponseWriter, r *http.Request) {
 	// Serve cached with 5 minute expiry. Delegate to LabelsHandler on cache miss.
 	ctx := shared.NewAppEngineContext(r)

--- a/api/labels.go
+++ b/api/labels.go
@@ -1,0 +1,53 @@
+// Copyright 2019 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"sort"
+	"time"
+
+	mapset "github.com/deckarep/golang-set"
+	"github.com/web-platform-tests/wpt.fyi/shared"
+)
+
+// LabelsHandler is an http.Handler for the /api/labels endpoint.
+type LabelsHandler struct {
+	ctx context.Context
+}
+
+// apiLabelsHandler is responsible for emitting just the revision SHAs for test runs.
+func apiLabelsHandler(w http.ResponseWriter, r *http.Request) {
+	// Serve cached with 5 minute expiry. Delegate to LabelsHandler on cache miss.
+	ctx := shared.NewAppEngineContext(r)
+	shared.NewCachingHandler(ctx, LabelsHandler{ctx}, shared.NewGZReadWritable(shared.NewMemcacheReadWritable(ctx, 5*time.Minute)), shared.AlwaysCachable, shared.URLAsCacheKey, shared.CacheStatusOK).ServeHTTP(w, r)
+}
+
+func (h LabelsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	store := shared.NewAppEngineDatastore(h.ctx)
+	var runs shared.TestRuns
+	_, err := store.GetAll(store.NewQuery("TestRun").Project("Labels").Distinct(), &runs)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	all := mapset.NewSet()
+	for _, run := range runs {
+		for _, label := range run.Labels {
+			all.Add(label)
+		}
+	}
+	labels := shared.ToStringSlice(all)
+	sort.Strings(labels)
+	data, err := json.Marshal(labels)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Write(data)
+}

--- a/api/labels_medium_test.go
+++ b/api/labels_medium_test.go
@@ -1,0 +1,74 @@
+// +build medium
+
+// Copyright 2019 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package api
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/web-platform-tests/wpt.fyi/shared"
+	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
+	"google.golang.org/appengine/datastore"
+)
+
+func TestLabelsHandler(t *testing.T) {
+	ctx, done, err := sharedtest.NewAEContext(true)
+	assert.Nil(t, err)
+	defer done()
+
+	key := datastore.NewIncompleteKey(ctx, "TestRun", nil)
+	_, err = datastore.Put(ctx, key, &shared.TestRun{Labels: []string{"a"}})
+	_, err = datastore.Put(ctx, key, &shared.TestRun{Labels: []string{"b", "c"}})
+	assert.Nil(t, err)
+
+	handler := LabelsHandler{ctx: ctx}
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/api/labels", nil)
+	handler.ServeHTTP(w, r)
+	labels := parseLabelsResponse(t, w)
+	assert.Equal(t, labels, []string{"a", "b", "c"})
+}
+
+func TestLabelsHandler_Caches(t *testing.T) {
+	instance, err := sharedtest.NewAEInstance(true)
+	assert.Nil(t, err)
+	defer instance.Close()
+
+	r, _ := instance.NewRequest("GET", "/api/labels", nil)
+	ctx := shared.NewAppEngineContext(r)
+
+	key := datastore.NewIncompleteKey(ctx, "TestRun", nil)
+	_, err = datastore.Put(ctx, key, &shared.TestRun{
+		Labels: []string{"a"},
+	})
+	assert.Nil(t, err)
+
+	w := httptest.NewRecorder()
+	apiLabelsHandler(w, r)
+	labels := parseLabelsResponse(t, w)
+	assert.Equal(t, labels, []string{"a"})
+
+	// Should cache; add a "b" and don't find it.
+	_, err = datastore.Put(ctx, key, &shared.TestRun{
+		Labels: []string{"b"},
+	})
+	apiLabelsHandler(w, r)
+	labels = parseLabelsResponse(t, w)
+	assert.Equal(t, labels, []string{"a"})
+}
+
+func parseLabelsResponse(t *testing.T, w *httptest.ResponseRecorder) []string {
+	assert.Equal(t, http.StatusOK, w.Result().StatusCode)
+	out, _ := ioutil.ReadAll(w.Body)
+	var labels []string
+	json.Unmarshal(out, &labels)
+	return labels
+}

--- a/api/labels_medium_test.go
+++ b/api/labels_medium_test.go
@@ -25,8 +25,8 @@ func TestLabelsHandler(t *testing.T) {
 	defer done()
 
 	key := datastore.NewIncompleteKey(ctx, "TestRun", nil)
-	_, err = datastore.Put(ctx, key, &shared.TestRun{Labels: []string{"a"}})
 	_, err = datastore.Put(ctx, key, &shared.TestRun{Labels: []string{"b", "c"}})
+	_, err = datastore.Put(ctx, key, &shared.TestRun{Labels: []string{"b", "a"}})
 	assert.Nil(t, err)
 
 	handler := LabelsHandler{ctx: ctx}
@@ -34,7 +34,7 @@ func TestLabelsHandler(t *testing.T) {
 	r := httptest.NewRequest("GET", "/api/labels", nil)
 	handler.ServeHTTP(w, r)
 	labels := parseLabelsResponse(t, w)
-	assert.Equal(t, labels, []string{"a", "b", "c"})
+	assert.Equal(t, labels, []string{"a", "b", "c"}) // Ordered and deduped
 }
 
 func TestLabelsHandler_Caches(t *testing.T) {

--- a/api/routes.go
+++ b/api/routes.go
@@ -18,6 +18,11 @@ func RegisterRoutes() {
 		shared.WrapApplicationJSON(
 			shared.WrapPermissiveCORS(apiInteropHandler)))
 
+	// API endpoint for fetching all labels.
+	shared.AddRoute("/api/labels", "api-labels",
+		shared.WrapApplicationJSON(
+			shared.WrapPermissiveCORS(apiLabelsHandler)))
+
 	// API endpoint for fetching a manifest for a commit SHA.
 	shared.AddRoute("/api/manifest", "api-manifest",
 		shared.WrapApplicationJSON(


### PR DESCRIPTION
## Description
Resolves https://github.com/web-platform-tests/wpt.fyi/issues/329

Adds a endpoint /api/labels that lists all of the labels used on any runs.

Loads `TestRun` entities with all distinct `Labels`, aggregates them into a set, spits out a sorted array, caches the whole request for 5 min.