### PR TITLE
Fix crashing in integration tests

### DIFF
--- a/api/taskcluster/webhook_test.go
+++ b/api/taskcluster/webhook_test.go
@@ -263,7 +263,7 @@ func TestCreateAllRuns_one_error(t *testing.T) {
 		} else if atomic.CompareAndSwapUint32(&requested, 1, 2) {
 			http.Error(w, "Not found", http.StatusNotFound)
 		} else {
-			panic("requested != 0 && requested != 1")
+			assert.FailNow(t, "requested != 0 && requested != 1")
 		}
 	}
 	server := httptest.NewServer(http.HandlerFunc(handler))

--- a/util/commands.sh
+++ b/util/commands.sh
@@ -8,14 +8,15 @@ function wptd_chown() {
 function wptd_useradd() {
   # Allow the exit code of groupadd to be 4 (GID not unique).
   docker exec -u 0:0 "${DOCKER_INSTANCE}" groupadd -g $(id -g $USER) user || [ $? == 4 ]
-  docker exec -u 0:0 "${DOCKER_INSTANCE}" useradd -u $(id -u $USER) -g $(id -g $USER) user
+  # Add user to audio & video groups to ensure Chrome can use sandbox.
+  docker exec -u 0:0 "${DOCKER_INSTANCE}" useradd -u $(id -u $USER) -g $(id -g $USER) -G audio,video user
   docker exec -u 0:0 "${DOCKER_INSTANCE}" sh -c 'echo "%user ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers'
 }
 function wptd_exec() {
-  docker exec -u $(id -u $USER):$(id -g $USER) "${DOCKER_INSTANCE}" sh -c "$*"
+  docker exec -u $(id -u $USER) "${DOCKER_INSTANCE}" sh -c "$*"
 }
 function wptd_exec_it() {
-  docker exec -it -u $(id -u $USER):$(id -g $USER) "${DOCKER_INSTANCE}" sh -c "$*"
+  docker exec -it -u $(id -u $USER) "${DOCKER_INSTANCE}" sh -c "$*"
 }
 # function wptd_run() {}
 function wptd_stop() {

--- a/util/docker-dev/run.sh
+++ b/util/docker-dev/run.sh
@@ -48,18 +48,6 @@ while getopts ':dhaq' FLAG; do
   esac
 done
 
-# Create a docker instance:
-#
-# --rm                                      Auto-remove when stopped
-# -it                                       Interactive mode (Ctrl+c will halt
-#                                           instance)
-# -v "${WPTD_PATH}":/wpt.fyi                Mount the repository
-# -u $(id -u $USER)                         Run as current user
-# -p "${WPTD_HOST_WEB_PORT}:8080"           Expose web server port
-# --name "${DOCKER_INSTANCE}"               Name the instance
-# wptd-dev                                  Identify image to use
-# /wpt.fyi/util/docker/inner/watch.sh       Identify code to execute
-
 info "Creating docker instance for dev server. Instance name: wptd-dev-instance"
 docker inspect "${DOCKER_INSTANCE}" > /dev/null 2>&1
 INSPECT_STATUS="${?}"
@@ -96,6 +84,17 @@ if [ "${INSPECT_STATUS}" == "0" ]; then
 fi
 
 set -e
+
+# Create a docker instance:
+#
+# -t                                     Give the container a TTY
+# -v "${WPTD_PATH}":/wpt.fyi             Mount the repository
+# -u $(id -u $USER)                      Run as current user
+# --cap-add=SYS_ADMIN                    Allow Chrome to use sandbox:
+#   https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md
+# -p "${WPTD_HOST_WEB_PORT}:8080"        Expose web server port
+# --name "${DOCKER_INSTANCE}"            Name the instance
+# wptd-dev                               Identify image to use
 
 VOLUMES="-v ${WPTD_PATH}:/home/user/wpt.fyi"
 if [[ "${RESULTS_ANALYSIS}" == "true" ]]; then

--- a/util/docker-dev/run.sh
+++ b/util/docker-dev/run.sh
@@ -54,7 +54,7 @@ done
 # -it                                       Interactive mode (Ctrl+c will halt
 #                                           instance)
 # -v "${WPTD_PATH}":/wpt.fyi                Mount the repository
-# -u $(id -u $USER):$(id -g $USER)          Run as current user and group
+# -u $(id -u $USER)                         Run as current user
 # -p "${WPTD_HOST_WEB_PORT}:8080"           Expose web server port
 # --name "${DOCKER_INSTANCE}"               Name the instance
 # wptd-dev                                  Identify image to use
@@ -106,7 +106,8 @@ if [[ "${INSPECT_STATUS}" != 0 ]] || [[ "${PR}" == "r" ]]; then
   info "Starting docker instance ${DOCKER_INSTANCE}..."
   docker run -t -d --entrypoint /bin/bash \
       ${VOLUMES} \
-      -u $(id -u $USER):$(id -g $USER) \
+      -u $(id -u $USER) \
+      --cap-add=SYS_ADMIN \
       -p "${WPTD_HOST_WEB_PORT}:8080" \
       -p "${WPTD_HOST_ADMIN_WEB_PORT}:8000" \
       -p "${WPTD_HOST_API_WEB_PORT}:9999" \

--- a/webdriver/chrome.go
+++ b/webdriver/chrome.go
@@ -33,11 +33,7 @@ func ChromeWebDriver(port int, options []selenium.ServiceOption) (*selenium.Serv
 		"browserName": "chrome",
 	}
 
-	ChromeCapabilities := chrome.Capabilities{
-		Args: []string{
-			"--no-sandbox",
-		},
-	}
+	ChromeCapabilities := chrome.Capabilities{}
 	chromeAbsPath, err := filepath.Abs(*chromePath)
 	if err != nil {
 		panic(err)

--- a/webdriver/chrome.go
+++ b/webdriver/chrome.go
@@ -33,7 +33,11 @@ func ChromeWebDriver(port int, options []selenium.ServiceOption) (*selenium.Serv
 		"browserName": "chrome",
 	}
 
-	ChromeCapabilities := chrome.Capabilities{}
+	ChromeCapabilities := chrome.Capabilities{
+		Args: []string{
+			"--no-sandbox",
+		},
+	}
 	chromeAbsPath, err := filepath.Abs(*chromePath)
 	if err != nil {
 		panic(err)

--- a/webdriver/label_test.go
+++ b/webdriver/label_test.go
@@ -70,7 +70,7 @@ func testLabel(
 	}
 	url := fmt.Sprintf("%s?%s", path, filters.ToQuery().Encode())
 	if err := wd.Get(app.GetWebappURL(url)); err != nil {
-		panic(fmt.Sprintf("Failed to load %s: %s", url, err.Error()))
+		assert.FailNow(t, fmt.Sprintf("Failed to load %s: %s", url, err.Error()))
 	}
 
 	// Wait for the results view to load.
@@ -82,13 +82,13 @@ func testLabel(
 		return len(testRuns) > 0, nil
 	}
 	if err := wd.WaitWithTimeout(runsLoadedCondition, time.Second*10); err != nil {
-		panic(fmt.Sprintf("Error waiting for test runs: %s", err.Error()))
+		assert.FailNow(t, fmt.Sprintf("Error waiting for test runs: %s", err.Error()))
 	}
 
 	// Check loaded test runs
 	testRuns, err := getTestRunElements(wd, elementName)
 	if err != nil {
-		panic(fmt.Sprintf("Failed to get test runs: %s", err.Error()))
+		assert.FailNow(t, fmt.Sprintf("Failed to get test runs: %s", err.Error()))
 	}
 	assert.Lenf(t, testRuns, runs, "Expected exactly %v TestRuns search result.", runs)
 	if aligned {

--- a/webdriver/path_test.go
+++ b/webdriver/path_test.go
@@ -3,6 +3,7 @@
 package webdriver
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -34,7 +35,7 @@ func testPath(t *testing.T, path, elementName string) {
 
 	// Navigate to the wpt.fyi homepage.
 	if err := wd.Get(app.GetWebappURL(path + "2dcontext/building-paths")); err != nil {
-		panic(err)
+		assert.FailNow(t, fmt.Sprintf("Error navigating to homepage: %s", err.Error()))
 	}
 
 	// Wait for the results view to load.

--- a/webdriver/product_test.go
+++ b/webdriver/product_test.go
@@ -69,7 +69,7 @@ func testProducts(
 	}
 	path := fmt.Sprintf("/results?%s", filters.ToQuery().Encode())
 	if err := wd.Get(app.GetWebappURL(path)); err != nil {
-		panic(fmt.Sprintf("Failed to load %s: %s", path, err.Error()))
+		assert.FailNow(t, fmt.Sprintf("Failed to load %s: %s", path, err.Error()))
 	}
 
 	// Wait for the results view to load.
@@ -81,13 +81,13 @@ func testProducts(
 		return len(testRuns) > 0, nil
 	}
 	if err := wd.WaitWithTimeout(runsLoadedCondition, time.Second*10); err != nil {
-		panic(fmt.Sprintf("Error waiting for test runs: %s", err.Error()))
+		assert.FailNow(t, fmt.Sprintf("Error waiting for test runs: %s", err.Error()))
 	}
 
 	// Check loaded test runs
 	testRuns, err := getTestRunElements(wd, "wpt-results")
 	if err != nil {
-		panic(fmt.Sprintf("Failed to get test runs: %s", err.Error()))
+		assert.FailNow(t, fmt.Sprintf("Failed to get test runs: %s", err.Error()))
 	}
 
 	// Check tab URLs propagate label

--- a/webdriver/search_test.go
+++ b/webdriver/search_test.go
@@ -35,7 +35,7 @@ func testSearch(t *testing.T, path, elementName string) {
 
 	// Navigate to the wpt.fyi homepage.
 	if err := wd.Get(app.GetWebappURL(path)); err != nil {
-		panic(err)
+		assert.FailNow(t, fmt.Sprintf("Error navigating to homepage: %s", err.Error()))
 	}
 
 	// Wait for the results view to load.
@@ -52,18 +52,19 @@ func testSearch(t *testing.T, path, elementName string) {
 	// Run the search.
 	searchBox, err := getSearchElement(wd, elementName)
 	if err != nil {
-		panic(err)
+		assert.FailNow(t, fmt.Sprintf("Error getting search element: %s", err.Error()))
 	}
 	folder := "2dcontext"
 	if err := searchBox.SendKeys(folder + selenium.EnterKey); err != nil {
-		panic(err)
+		assert.FailNow(t, fmt.Sprintf("Error sending keys: %s", err.Error()))
 	}
 	assertListIsFiltered(t, wd, elementName, folder+"/")
 
 	// Navigate to the wpt.fyi homepage.
 	if err := wd.Get(app.GetWebappURL(path) + "?q=" + folder); err != nil {
-		panic(err)
+		assert.FailNow(t, fmt.Sprintf("Error navigating to homepage: %s", err.Error()))
 	}
+
 	err = wd.WaitWithTimeout(resultsLoadedCondition, time.Second*10)
 	assert.Nil(t, err)
 	assertListIsFiltered(t, wd, elementName, folder+"/")

--- a/webdriver/test_runs_test.go
+++ b/webdriver/test_runs_test.go
@@ -3,6 +3,7 @@
 package webdriver
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -26,7 +27,7 @@ func TestTestRuns(t *testing.T) {
 
 	// Navigate to the wpt.fyi homepage.
 	if err := wd.Get(app.GetWebappURL("/test-runs")); err != nil {
-		panic(err)
+		assert.FailNow(t, fmt.Sprintf("Error navigating to homepage: %s", err.Error()))
 	}
 
 	// Wait for the results view to load.


### PR DESCRIPTION
1. Stop panicking unnecessarily in webdriver tests.
2. Properly set up the user group inside Docker and start the container with the SYS_ADMIN cap to allow ensure Chrome can use sandbox inside Docker.