### PR TITLE
Move WCT out of Makefile and ensure it fails reliably

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,13 +29,6 @@ VERBOSE := -v
 GO_FILES := $(shell find $(WPTD_PATH) -type f -name '*.go')
 GO_TEST_FILES := $(shell find $(WPTD_PATH) -type f -name '*_test.go')
 
-# Recursively expanded variables so that USE_FRAME_BUFFER can be expanded.
-# These two macros are intended to run in the same shell as the test runners,
-# which means they need to be in the same (continued) line.
-START_XVFB = if [ "$(USE_FRAME_BUFFER)" == "true" ]; then \
-	export DISPLAY=:99; (Xvfb :99 -screen 0 1024x768x24 -ac +extension GLX +render -noreset &); fi
-STOP_XVFB = if [ "$(USE_FRAME_BUFFER)" == "true" ]; then killall Xvfb; fi
-
 build: go_build
 
 test: go_test python_test
@@ -107,10 +100,7 @@ _go_webdriver_test: var-BROWSER java go_deps xvfb node-web-component-tester webs
 		$(FLAGS)
 
 web_components_test: xvfb firefox chrome web_components_tester webserver_deps
-	$(START_XVFB); \
-	cd $(WPTD_PATH)webapp; \
-	npm test || (($(STOP_XVFB)) && exit 1); \
-	$(STOP_XVFB)
+	util/wct.sh $(USE_FRAME_BUFFER)
 
 web_components_tester: git node-bower node-web-component-tester
 	cd $(WPTD_PATH)webapp; npm run bower-components

--- a/util/wct.sh
+++ b/util/wct.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# wct.sh [true|false]
+# Run web component tests with or without Xvfb.
+
+set -ex
+
+USE_FRAME_BUFFER=$1
+
+function stop_xvfb() {
+  if [ "$USE_FRAME_BUFFER" == "true" ]; then
+    # It's fine if Xvfb has already exited.
+    killall Xvfb || true
+  fi
+}
+
+trap stop_xvfb EXIT SIGINT SIGTERM
+
+if [ "$USE_FRAME_BUFFER" == "true" ]; then
+  export DISPLAY=:99
+  (Xvfb :99 -screen 0 1024x768x24 -ac +extension GLX +render -noreset &)
+fi
+
+cd webapp
+npm test


### PR DESCRIPTION
Based on my observation, L112 in the original `Makefile` behaves differently on Travis. Namely, the `exit 1` statement seems to kill the whole `make` process. For example, this [Travis log](https://travis-ci.com/web-platform-tests/wpt.fyi/jobs/169019618#L3330) did not have the following critical lines as on my local workstation:

```
Makefile:103: recipe for target 'web_components_test' failed
make: *** [web_components_test] Error 1   
```

L112 has too much magic after all (subshells connected with boolean operators). The reason was to ensure we could kill Xvfb regardless of test results. This can be better achieved by using a `trap` in a separate Bash script, which is what this PR does.

## Review

We should see web components test **red** on Travis with this PR.