### PR TITLE
Fix go_firefox_test

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -701,6 +701,15 @@
         }
       }
     },
+    "@google-web-components/google-chart": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@google-web-components/google-chart/-/google-chart-3.0.0.tgz",
+      "integrity": "sha512-nSUeyoIOfqJcaqLMQlCvtcLZcC9FhLW1hmLHtRSr6YOjzq6HshB+7Ss+TxkAiVts4E0ywIOl7GFxEM7+tmyPQA==",
+      "requires": {
+        "@polymer/iron-ajax": "^3.0.0-pre.18",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
     "@polymer/esm-amd-loader": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@polymer/esm-amd-loader/-/esm-amd-loader-1.0.4.tgz",
@@ -4989,15 +4998,6 @@
         "object-assign": "^4.0.1",
         "pify": "^2.0.0",
         "pinkie-promise": "^2.0.0"
-      }
-    },
-    "google-chart-polymer-3": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/google-chart-polymer-3/-/google-chart-polymer-3-3.0.1.tgz",
-      "integrity": "sha512-T+Hid85rKecqbEpU1EZnC/AqkBPTbKU4ehicJs9A8LEw0o1T+0bXVkZLb/ARuknxVYycGBdF7dzDqmpc+GIo3Q==",
-      "requires": {
-        "@polymer/iron-ajax": "^3.0.0-pre.18",
-        "@polymer/polymer": "^3.0.0"
       }
     },
     "got": {

--- a/webdriver/anomalies_test.go
+++ b/webdriver/anomalies_test.go
@@ -44,14 +44,9 @@ func TestAnomalies(t *testing.T) {
 }
 
 func getAnomalyElements(wd selenium.WebDriver) ([]selenium.WebElement, error) {
-	switch *browser {
-	case "firefox":
-		return wd.FindElements(selenium.ByCSSSelector, "wpt-anomalies h2 ~ a")
-	default:
-		e, err := wd.FindElement(selenium.ByCSSSelector, "wpt-anomalies")
-		if err != nil {
-			return nil, err
-		}
-		return FindShadowElements(wd, e, "h2 ~ a")
+	e, err := wd.FindElement(selenium.ByCSSSelector, "wpt-anomalies")
+	if err != nil {
+		return nil, err
 	}
+	return FindShadowElements(wd, e, "h2 ~ a")
 }

--- a/webdriver/file_results_test.go
+++ b/webdriver/file_results_test.go
@@ -41,14 +41,9 @@ func TestFileResults(t *testing.T) {
 }
 
 func getFileResultRows(wd selenium.WebDriver) ([]selenium.WebElement, error) {
-	switch *browser {
-	case "firefox":
-		return wd.FindElements(selenium.ByCSSSelector, "tbody tr")
-	default:
-		e, err := wd.FindElement(selenium.ByCSSSelector, "wpt-results")
-		if err != nil {
-			return nil, err
-		}
-		return FindShadowElements(wd, e, "test-file-results", "tbody tr")
+	e, err := wd.FindElement(selenium.ByCSSSelector, "wpt-results")
+	if err != nil {
+		return nil, err
 	}
+	return FindShadowElements(wd, e, "test-file-results", "tbody tr")
 }

--- a/webdriver/label_test.go
+++ b/webdriver/label_test.go
@@ -109,29 +109,19 @@ func testLabel(
 }
 
 func getTestRunElements(wd selenium.WebDriver, element string) ([]selenium.WebElement, error) {
-	switch *browser {
-	case "firefox":
-		return wd.FindElements(selenium.ByCSSSelector, "test-run")
-	default:
-		e, err := wd.FindElement(selenium.ByCSSSelector, element)
-		if err != nil {
-			return nil, err
-		}
-		return FindShadowElements(wd, e, "test-run")
+	e, err := wd.FindElement(selenium.ByCSSSelector, element)
+	if err != nil {
+		return nil, err
 	}
+	return FindShadowElements(wd, e, "test-run")
 }
 
 func getTabElements(wd selenium.WebDriver, element string) ([]selenium.WebElement, error) {
-	switch *browser {
-	case "firefox":
-		return wd.FindElements(selenium.ByCSSSelector, "results-tabs paper-tab")
-	default:
-		e, err := wd.FindElement(selenium.ByCSSSelector, element)
-		if err != nil {
-			return nil, err
-		}
-		return FindShadowElements(wd, e, "results-tabs", "paper-tab")
+	e, err := wd.FindElement(selenium.ByCSSSelector, element)
+	if err != nil {
+		return nil, err
 	}
+	return FindShadowElements(wd, e, "results-tabs", "paper-tab")
 }
 
 func assertAligned(t *testing.T, wd selenium.WebDriver, testRuns []selenium.WebElement) {

--- a/webdriver/test_runs_test.go
+++ b/webdriver/test_runs_test.go
@@ -43,14 +43,9 @@ func TestTestRuns(t *testing.T) {
 }
 
 func getRunRowElements(wd selenium.WebDriver) ([]selenium.WebElement, error) {
-	switch *browser {
-	case "firefox":
-		return wd.FindElements(selenium.ByCSSSelector, "wpt-runs tr")
-	default:
-		e, err := wd.FindElement(selenium.ByCSSSelector, "wpt-runs")
-		if err != nil {
-			return nil, err
-		}
-		return FindShadowElements(wd, e, "tr")
+	e, err := wd.FindElement(selenium.ByCSSSelector, "wpt-runs")
+	if err != nil {
+		return nil, err
 	}
+	return FindShadowElements(wd, e, "tr")
 }

--- a/webdriver/webdriver.go
+++ b/webdriver/webdriver.go
@@ -128,6 +128,19 @@ func FindShadowElement(
 	return elements[0], nil
 }
 
+// FindShadowText returns the Text of the element returned by an equivalent
+// call to FindShadowElement.
+func FindShadowText(
+	d selenium.WebDriver,
+	e selenium.WebElement,
+	selectors ...string) (string, error) {
+	element, err := FindShadowElement(d, e, selectors...)
+	if err != nil {
+		return "", err
+	}
+	return element.Text()
+}
+
 func extractScriptRawValue(bytes []byte, key string) (value interface{}, err error) {
 	var parsed map[string]interface{}
 	if err = json.Unmarshal(bytes, &parsed); err != nil {


### PR DESCRIPTION
## Description
#999 updated FF v62 to v64, which we didn't notice fully breaking go_firefox_test because of other ongoing issues.
It's broken because they launched shadow dom in v63 (yay!) but don't support sending keys to shadow dom inputs (boo!)