### PR TITLE
Use pr_head label when looking at latest results for a PR

### DIFF
--- a/api/checks/summaries/_pr_runs_links.md
+++ b/api/checks/summaries/_pr_runs_links.md
@@ -1,0 +1,4 @@
+{{- range $pr := .CheckState.PRNumbers }}
+- [Latest results for PR #{{ $pr }}]({{ $.HostURL }}results/?pr={{ $pr }}&label=pr_head)
+- [All runs for PR #{{ $pr }}]({{ $.HostURL }}runs/?pr={{ $pr }})
+{{- end}}

--- a/api/checks/summaries/completed.md
+++ b/api/checks/summaries/completed.md
@@ -18,10 +18,7 @@ And {{ .More }} others...
 [Visual comparison of the results]({{ .DiffURL }})
 
 Other links that might be useful:
-{{- range $pr := .CheckState.PRNumbers }}
-- [Latest results for PR #{{ $pr }}]({{ $.HostURL }}results/?pr={{ $pr }})
-- [All runs for PR #{{ $pr }}]({{ $.HostURL }}runs/?pr={{ $pr }})
-{{- end}}
+{{ template "_pr_runs_links.md" . }}
 - [`{{ printf "%.7s" .HeadRun.FullRevisionHash }}` vs its merge base]({{ .DiffURL }})
 {{- if .MasterDiffURL }}
 - [`{{ printf "%.7s" .HeadRun.FullRevisionHash }}` vs latest master]({{ .MasterDiffURL }})

--- a/api/checks/summaries/regressed.md
+++ b/api/checks/summaries/regressed.md
@@ -19,10 +19,7 @@ And {{ .More }} others...
 [Visual comparison of the results]({{ .DiffURL }})
 
 Other links that might be useful:
-{{- range $pr := .CheckState.PRNumbers }}
-- [Latest results for PR #{{ $pr }}]({{ $.HostURL }}results/?pr={{ $pr }})
-- [All runs for PR #{{ $pr }}]({{ $.HostURL }}runs/?pr={{ $pr }})
-{{- end}}
+{{ template "_pr_runs_links.md" . }}
 - [`{{ printf "%.7s" .HeadRun.FullRevisionHash }}` vs its merge base]({{ .DiffURL }})
 {{- if .MasterDiffURL }}
 - [`{{ printf "%.7s" .HeadRun.FullRevisionHash }}` vs latest master]({{ .MasterDiffURL }})


### PR DESCRIPTION
## Description
Tweaks the PR links in the checks to include pr_head for the view across all browsers.