### PR TITLE
Fix backfill test run metadata loading

### DIFF
--- a/api/query/cache/backfill/backfill.go
+++ b/api/query/cache/backfill/backfill.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/api/option"
 
 	"cloud.google.com/go/datastore"
+	log "github.com/sirupsen/logrus"
 	"github.com/web-platform-tests/wpt.fyi/api/query"
 	"github.com/web-platform-tests/wpt.fyi/api/query/cache/index"
 	"github.com/web-platform-tests/wpt.fyi/api/query/cache/monitor"
@@ -56,7 +57,9 @@ func NewDatastoreRunFetcher(projectID string, gcpCredentialsFile *string, logger
 }
 
 func (f datastoreRunFetcher) FetchRuns(limit int) (shared.TestRunsByProduct, error) {
-	ctx := context.Background()
+	ctx := context.WithValue(context.Background(), shared.DefaultLoggerCtxKey(), log.WithFields(log.Fields{
+		"fetch_runs_limit": limit,
+	}))
 	var client *datastore.Client
 	var err error
 	if f.gcpCredentialsFile != nil && *f.gcpCredentialsFile != "" {
@@ -70,7 +73,7 @@ func (f datastoreRunFetcher) FetchRuns(limit int) (shared.TestRunsByProduct, err
 	store := shared.NewCloudDatastore(ctx, client)
 
 	// Query Datastore for latest maxBytes/bytesPerRun test runs.
-	runs, err := store.LoadTestRuns(nil, nil, nil, nil, nil, &limit, nil)
+	runs, err := store.LoadTestRuns(shared.GetDefaultProducts(), nil, nil, nil, nil, &limit, nil)
 	return runs, nil
 }
 


### PR DESCRIPTION
- Provide logger on context
- Use `shared.GetDefaultProducts()`, not `nil`