### PR TITLE
Optimize the front-end performance

### DIFF
--- a/webapp/templates/_head.html
+++ b/webapp/templates/_head.html
@@ -1,4 +1,0 @@
-<head>
-{{ template "_head_common.html" }}
-<script type="module" src="/components/wpt-results.js"></script>
-</head>

--- a/webapp/templates/_head_common.html
+++ b/webapp/templates/_head_common.html
@@ -1,5 +1,5 @@
 <title>web-platform-tests dashboard</title>
 <link rel="stylesheet" href="/static/common.css">
-<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
+<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 <script type="module" src="/components/wpt-header.js"></script>
 <script src="/service-worker-installer.js"></script>

--- a/webapp/templates/results.html
+++ b/webapp/templates/results.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html>
-{{ template "_head.html" }}
+<head>
+{{ template "_head_common.html" }}
+<script type="module" src="/components/wpt-results.js"></script>
+</head>
 <body>
 <div id="content">
   <wpt-header></wpt-header>


### PR DESCRIPTION
1. Use `webcomponents-loader.js` instead of `webcomponents-bundle.js` to
   load only the necessary polyfills on demand.
2. Fix the path matching in servieworker to make it actually functional.

## Review

To be verified in staging deployment.