### PR TITLE
Collapse flakes/anomalies queries into card with dropdown

### DIFF
--- a/webapp/components/browser-picker.js
+++ b/webapp/components/browser-picker.js
@@ -1,0 +1,45 @@
+import { PolymerElement } from '../node_modules/@polymer/polymer/polymer-element.js';
+import { html } from '../../node_modules/@polymer/polymer/lib/utils/html-tag.js';
+import '../node_modules/@polymer/paper-dropdown-menu/paper-dropdown-menu.js';
+import '../node_modules/@polymer/paper-listbox/paper-listbox.js';
+import '../node_modules/@polymer/polymer/lib/elements/dom-repeat.js';
+import '../node_modules/@polymer/paper-item/paper-icon-item.js';
+import './display-logo.js';
+import {ProductInfo, DefaultProducts, DefaultBrowserNames} from './product-info.js';
+
+class BrowserPicker extends ProductInfo(PolymerElement) {
+  static get is() {
+    return 'browser-picker';
+  }
+
+  static get template() {
+    return html`
+  <paper-dropdown-menu label="Browser" no-animations="">
+    <paper-listbox slot="dropdown-content" selected="{{ browser }}" attr-for-selected="value">
+      <template is="dom-repeat" items="[[defaultProducts]]" as="product">
+        <paper-icon-item value="[[product.browser_name]]">
+          <display-logo slot="item-icon" product="[[product]]" small=""></display-logo>
+          [[displayName(product.browser_name)]]
+        </paper-icon-item>
+      </template>
+    </paper-listbox>
+  </paper-dropdown-menu>
+`;
+  }
+
+  static get properties() {
+    return {
+      browser: {
+        type: String,
+        value: DefaultBrowserNames[0],
+        notify: true,
+      },
+      defaultProducts: {
+        type: Array,
+        value: DefaultProducts.map(p => Object.assign({}, p)),
+      },
+    };
+  }
+}
+window.customElements.define(BrowserPicker.is, BrowserPicker);
+export {BrowserPicker};

--- a/webapp/components/test-runs-query-builder.js
+++ b/webapp/components/test-runs-query-builder.js
@@ -20,6 +20,7 @@ import { html } from '../node_modules/@polymer/polymer/lib/utils/html-tag.js';
 import { PolymerElement } from '../node_modules/@polymer/polymer/polymer-element.js';
 import '../node_modules/@vaadin/vaadin-date-picker/vaadin-date-picker-light.js';
 import '../node_modules/@vaadin/vaadin-date-picker/vaadin-date-picker.js';
+import './browser-picker.js';
 import './display-logo.js';
 import './info-banner.js';
 import { Channels, DefaultBrowserNames, DefaultProducts, ProductInfo, SemanticLabels } from './product-info.js';
@@ -344,16 +345,7 @@ class ProductBuilder extends ProductInfo(PolymerElement) {
         </template>
 
         <br>
-        <paper-dropdown-menu label="Browser" no-animations="">
-          <paper-listbox slot="dropdown-content" selected="{{ browserName }}" attr-for-selected="value">
-            <template is="dom-repeat" items="[[defaultProducts]]" as="product">
-              <paper-icon-item value="[[product.browser_name]]">
-                <display-logo slot="item-icon" product="[[product]]" small=""></display-logo>
-                [[displayName(product.browser_name)]]
-              </paper-icon-item>
-            </template>
-          </paper-listbox>
-        </paper-dropdown-menu>
+        <browser-picker browser="{{browserName}}"></browser-picker>
 
         <br>
         <paper-dropdown-menu label="Channel" no-animations="">


### PR DESCRIPTION
## Description
Extracts the browser dropdown from the query builder into its own component, and re-uses that as a selector for the flakes/anomalies queries on the /insights tab (instead of 4 separated cards).