### PR TITLE
[receiver] Allow multiple result_file fields

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -355,7 +355,8 @@ __`callback_url`__: (Optional) A URL that the processor should `POST` when succe
 create the TestRun. Defaults to /api/results/create in the current project's environment (e.g. wpt.fyi for
 wptdashboard, staging.wpt.fyi for wptdashboard-staging).
 
-__`result_file`__: A **gzipped** JSON file produced by `wpt run --log-wptreport`.
+__`result_file`__: A **gzipped** JSON file produced by `wpt run --log-wptreport`. This field can be
+repeated to include multiple files (for chunked reports).
 
 The JSON file roughly looks like this:
 

--- a/api/receiver/create_run_test.go
+++ b/api/receiver/create_run_test.go
@@ -7,7 +7,6 @@
 package receiver
 
 import (
-	"context"
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
@@ -47,7 +46,7 @@ func TestHandleResultsCreate(t *testing.T) {
 	req.SetBasicAuth("_processor", "secret-token")
 	w := httptest.NewRecorder()
 	mockAE := NewMockAppEngineAPI(mockCtrl)
-	mockAE.EXPECT().Context().AnyTimes().Return(context.Background())
+	mockAE.EXPECT().Context().AnyTimes().Return(sharedtest.NewTestContext())
 	mockS := checks.NewMockAPI(mockCtrl)
 	gomock.InOrder(
 		mockAE.EXPECT().authenticateUploader("_processor", "secret-token").Return(true),
@@ -87,7 +86,7 @@ func TestHandleResultsCreate_NoTimestamps(t *testing.T) {
 	req.SetBasicAuth("_processor", "secret-token")
 	w := httptest.NewRecorder()
 	mockAE := NewMockAppEngineAPI(mockCtrl)
-	mockAE.EXPECT().Context().AnyTimes().Return(context.Background())
+	mockAE.EXPECT().Context().AnyTimes().Return(sharedtest.NewTestContext())
 	mockS := checks.NewMockAPI(mockCtrl)
 	gomock.InOrder(
 		mockAE.EXPECT().authenticateUploader("_processor", "secret-token").Return(true),
@@ -124,7 +123,7 @@ func TestHandleResultsCreate_BadRevision(t *testing.T) {
 	req.SetBasicAuth("_processor", "secret-token")
 	w := httptest.NewRecorder()
 	mockAE := NewMockAppEngineAPI(mockCtrl)
-	mockAE.EXPECT().Context().AnyTimes().Return(context.Background())
+	mockAE.EXPECT().Context().AnyTimes().Return(sharedtest.NewTestContext())
 	mockS := checks.NewMockAPI(mockCtrl)
 	gomock.InOrder(
 		mockAE.EXPECT().authenticateUploader("_processor", "secret-token").Return(true),
@@ -155,7 +154,7 @@ func TestHandleResultsCreate_NoBasicAuth(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/results/create", nil)
 	resp := httptest.NewRecorder()
 	mockAE := NewMockAppEngineAPI(mockCtrl)
-	mockAE.EXPECT().Context().AnyTimes().Return(context.Background())
+	mockAE.EXPECT().Context().AnyTimes().Return(sharedtest.NewTestContext())
 	mockS := checks.NewMockAPI(mockCtrl)
 
 	HandleResultsCreate(mockAE, mockS, resp, req)
@@ -170,7 +169,7 @@ func TestHandleResultsCreate_WrongUser(t *testing.T) {
 	req.SetBasicAuth("wrong-user", "secret-token")
 	resp := httptest.NewRecorder()
 	mockAE := NewMockAppEngineAPI(mockCtrl)
-	mockAE.EXPECT().Context().AnyTimes().Return(context.Background())
+	mockAE.EXPECT().Context().AnyTimes().Return(sharedtest.NewTestContext())
 	mockS := checks.NewMockAPI(mockCtrl)
 
 	HandleResultsCreate(mockAE, mockS, resp, req)
@@ -185,7 +184,7 @@ func TestHandleResultsCreate_WrongPassword(t *testing.T) {
 	req.SetBasicAuth("_processor", "wrong-password")
 	resp := httptest.NewRecorder()
 	mockAE := NewMockAppEngineAPI(mockCtrl)
-	mockAE.EXPECT().Context().AnyTimes().Return(context.Background())
+	mockAE.EXPECT().Context().AnyTimes().Return(sharedtest.NewTestContext())
 	mockAE.EXPECT().authenticateUploader("_processor", "wrong-password").Return(false)
 	mockS := checks.NewMockAPI(mockCtrl)
 

--- a/api/receiver/receive_results_test.go
+++ b/api/receiver/receive_results_test.go
@@ -7,7 +7,9 @@
 package receiver
 
 import (
+	"bytes"
 	"fmt"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -46,6 +48,17 @@ func matchRegex(r string) *regexMatcher {
 	return &regexMatcher{regex: regexp.MustCompile(r)}
 }
 
+// An empty (default) extraParams
+var emptyParams = map[string]string{
+	"browser_name":    "",
+	"labels":          "",
+	"revision":        "",
+	"browser_version": "",
+	"os_name":         "",
+	"os_version":      "",
+	"callback_url":    "",
+}
+
 func TestHandleResultsUpload_not_admin(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
@@ -56,7 +69,6 @@ func TestHandleResultsUpload_not_admin(t *testing.T) {
 	mockAE.EXPECT().IsAdmin().Return(false)
 
 	HandleResultsUpload(mockAE, resp, req)
-
 	assert.Equal(t, resp.Code, http.StatusUnauthorized)
 }
 
@@ -74,35 +86,7 @@ func TestHandleResultsUpload_http_basic_auth_invalid(t *testing.T) {
 	)
 
 	HandleResultsUpload(mockAE, resp, req)
-
 	assert.Equal(t, resp.Code, http.StatusUnauthorized)
-}
-
-func TestHandleResultsUpload_success(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	payload := url.Values{
-		"result_url": {"http://wpt.fyi/test.json.gz"},
-	}
-	req := httptest.NewRequest("POST", "/api/results/upload", strings.NewReader(payload.Encode()))
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.SetBasicAuth("blade-runner", "123")
-	resp := httptest.NewRecorder()
-	mockAE := NewMockAppEngineAPI(mockCtrl)
-	f := &os.File{}
-	task := &taskqueue.Task{Name: "task"}
-	mockAE.EXPECT().Context().Return(sharedtest.NewTestContext()).AnyTimes()
-	gomock.InOrder(
-		mockAE.EXPECT().IsAdmin().Return(false),
-		mockAE.EXPECT().authenticateUploader("blade-runner", "123").Return(true),
-		mockAE.EXPECT().fetchWithTimeout("http://wpt.fyi/test.json.gz", DownloadTimeout).Return(f, nil),
-		mockAE.EXPECT().uploadToGCS(matchRegex(`^/wptd-results-buffer/blade-runner/.*\.json$`), f, true).Return(nil),
-		mockAE.EXPECT().scheduleResultsTask("blade-runner", gomock.Any(), "single", gomock.Any()).Return(task, nil),
-	)
-
-	HandleResultsUpload(mockAE, resp, req)
-	assert.Equal(t, resp.Code, http.StatusOK)
 }
 
 func TestHandleResultsUpload_extra_params(t *testing.T) {
@@ -119,7 +103,7 @@ func TestHandleResultsUpload_extra_params(t *testing.T) {
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.SetBasicAuth("blade-runner", "123")
 	resp := httptest.NewRecorder()
-	mockAE := NewMockAppEngineAPI(mockCtrl)
+
 	f := &os.File{}
 	extraParams := map[string]string{
 		"browser_name":    "firefox",
@@ -131,6 +115,7 @@ func TestHandleResultsUpload_extra_params(t *testing.T) {
 		"callback_url":    "",
 	}
 	task := &taskqueue.Task{Name: "task"}
+	mockAE := NewMockAppEngineAPI(mockCtrl)
 	mockAE.EXPECT().Context().Return(sharedtest.NewTestContext()).AnyTimes()
 	gomock.InOrder(
 		mockAE.EXPECT().IsAdmin().Return(false),
@@ -144,120 +129,203 @@ func TestHandleResultsUpload_extra_params(t *testing.T) {
 	assert.Equal(t, resp.Code, http.StatusOK)
 }
 
-func TestHandleFilePayload(t *testing.T) {
+func TestHandleResultsUpload_single_file(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	f := &os.File{}
-	extraParams := map[string]string{
-		"browser_name": "firefox",
-	}
+	buffer := &bytes.Buffer{}
+	writer := multipart.NewWriter(buffer)
+	writer.CreateFormFile("result_file", "test.json.gz")
+	writer.Close()
+	req := httptest.NewRequest("POST", "/api/results/upload", buffer)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.SetBasicAuth("blade-runner", "123")
+	resp := httptest.NewRecorder()
 
-	mockAE := NewMockAppEngineAPI(mockCtrl)
-	gomock.InOrder(
-		mockAE.EXPECT().uploadToGCS(matchRegex(`^/wptd-results-buffer/blade-runner/.*\.json$`), f, true).Return(nil),
-		mockAE.EXPECT().scheduleResultsTask("blade-runner", gomock.Any(), "single", extraParams),
-	)
-
-	handleFilePayload(mockAE, "blade-runner", f, extraParams)
-}
-
-func TestHandleURLPayload_single(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	f := &os.File{}
-	extraParams := map[string]string{
-		"browser_name": "firefox",
-	}
-
+	task := &taskqueue.Task{Name: "task"}
 	mockAE := NewMockAppEngineAPI(mockCtrl)
 	mockAE.EXPECT().Context().Return(sharedtest.NewTestContext()).AnyTimes()
 	gomock.InOrder(
-		mockAE.EXPECT().fetchWithTimeout("http://wpt.fyi/test.json.gz", DownloadTimeout).Return(f, nil),
-		mockAE.EXPECT().uploadToGCS(matchRegex(`^/wptd-results-buffer/blade-runner/.*\.json$`), f, true).Return(nil),
-		mockAE.EXPECT().scheduleResultsTask("blade-runner", gomock.Any(), "single", extraParams),
+		mockAE.EXPECT().IsAdmin().Return(false),
+		mockAE.EXPECT().authenticateUploader("blade-runner", "123").Return(true),
+		mockAE.EXPECT().uploadToGCS(matchRegex(`^/wptd-results-buffer/blade-runner/.*\.json$`), gomock.Any(), true).Return(nil),
+		mockAE.EXPECT().scheduleResultsTask("blade-runner", gomock.Any(), "single", emptyParams).Return(task, nil),
 	)
 
-	handleURLPayload(mockAE, "blade-runner", []string{"http://wpt.fyi/test.json.gz"}, extraParams)
+	HandleResultsUpload(mockAE, resp, req)
+	assert.Equal(t, resp.Code, http.StatusOK)
 }
 
-func TestHandleURLPayload_multiple(t *testing.T) {
+func TestHandleResultsUpload_single_url(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
+	payload := url.Values{
+		"result_url": {"http://wpt.fyi/test.json.gz"},
+	}
+	req := httptest.NewRequest("POST", "/api/results/upload", strings.NewReader(payload.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth("blade-runner", "123")
+	resp := httptest.NewRecorder()
+
 	f := &os.File{}
+	task := &taskqueue.Task{Name: "task"}
+	mockAE := NewMockAppEngineAPI(mockCtrl)
+	mockAE.EXPECT().Context().Return(sharedtest.NewTestContext()).AnyTimes()
+	gomock.InOrder(
+		mockAE.EXPECT().IsAdmin().Return(false),
+		mockAE.EXPECT().authenticateUploader("blade-runner", "123").Return(true),
+		mockAE.EXPECT().fetchWithTimeout("http://wpt.fyi/test.json.gz", DownloadTimeout).Return(f, nil),
+		mockAE.EXPECT().uploadToGCS(matchRegex(`^/wptd-results-buffer/blade-runner/.*\.json$`), f, true).Return(nil),
+		mockAE.EXPECT().scheduleResultsTask("blade-runner", gomock.Any(), "single", emptyParams).Return(task, nil),
+	)
+
+	HandleResultsUpload(mockAE, resp, req)
+	assert.Equal(t, resp.Code, http.StatusOK)
+}
+
+func TestHandleResultsUpload_multiple_files(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	buffer := &bytes.Buffer{}
+	writer := multipart.NewWriter(buffer)
+	writer.CreateFormFile("result_file", "foo.json.gz")
+	writer.CreateFormFile("result_file", "bar.json.gz")
+	writer.Close()
+	req := httptest.NewRequest("POST", "/api/results/upload", buffer)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.SetBasicAuth("blade-runner", "123")
+	resp := httptest.NewRecorder()
+
+	task := &taskqueue.Task{Name: "task"}
+	mockAE := NewMockAppEngineAPI(mockCtrl)
+	mockAE.EXPECT().Context().Return(sharedtest.NewTestContext()).AnyTimes()
+	gomock.InOrder(
+		mockAE.EXPECT().IsAdmin().Return(false),
+		mockAE.EXPECT().authenticateUploader("blade-runner", "123").Return(true),
+	)
+	mockAE.EXPECT().uploadToGCS(matchRegex(`^/wptd-results-buffer/blade-runner/.*/0\.json$`), gomock.Any(), true).Return(nil)
+	mockAE.EXPECT().uploadToGCS(matchRegex(`^/wptd-results-buffer/blade-runner/.*/1\.json$`), gomock.Any(), true).Return(nil)
+	mockAE.EXPECT().scheduleResultsTask("blade-runner", gomock.Any(), "multiple", emptyParams).Return(task, nil)
+
+	HandleResultsUpload(mockAE, resp, req)
+	assert.Equal(t, resp.Code, http.StatusOK)
+}
+
+func TestHandleResultsUpload_multiple_urls(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
 	urls := []string{"http://wpt.fyi/foo.json.gz", "http://wpt.fyi/bar.json.gz"}
+	payload := url.Values{"result_url": urls}
+	req := httptest.NewRequest("POST", "/api/results/upload", strings.NewReader(payload.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth("blade-runner", "123")
+	resp := httptest.NewRecorder()
 
+	f1 := &os.File{}
+	f2 := &os.File{}
+	task := &taskqueue.Task{Name: "task"}
 	mockAE := NewMockAppEngineAPI(mockCtrl)
 	mockAE.EXPECT().Context().Return(sharedtest.NewTestContext()).AnyTimes()
 	gomock.InOrder(
-		mockAE.EXPECT().fetchWithTimeout(urls[0], DownloadTimeout).Return(f, nil),
-		mockAE.EXPECT().uploadToGCS(matchRegex(`^/wptd-results-buffer/blade-runner/.*/0\.json$`), f, true).Return(nil),
+		mockAE.EXPECT().IsAdmin().Return(false),
+		mockAE.EXPECT().authenticateUploader("blade-runner", "123").Return(true),
+		mockAE.EXPECT().fetchWithTimeout(urls[0], DownloadTimeout).Return(f1, nil),
+		mockAE.EXPECT().uploadToGCS(matchRegex(`^/wptd-results-buffer/blade-runner/.*/0\.json$`), f1, true).Return(nil),
 	)
 	gomock.InOrder(
-		mockAE.EXPECT().fetchWithTimeout(urls[1], DownloadTimeout).Return(f, nil),
-		mockAE.EXPECT().uploadToGCS(matchRegex(`^/wptd-results-buffer/blade-runner/.*/1\.json$`), f, true).Return(nil),
+		mockAE.EXPECT().fetchWithTimeout(urls[1], DownloadTimeout).Return(f2, nil),
+		mockAE.EXPECT().uploadToGCS(matchRegex(`^/wptd-results-buffer/blade-runner/.*/1\.json$`), f2, true).Return(nil),
 	)
-	mockAE.EXPECT().scheduleResultsTask("blade-runner", gomock.Any(), "multiple", nil)
+	mockAE.EXPECT().scheduleResultsTask("blade-runner", gomock.Any(), "multiple", emptyParams).Return(task, nil)
 
-	handleURLPayload(mockAE, "blade-runner", urls, nil)
+	HandleResultsUpload(mockAE, resp, req)
+	assert.Equal(t, resp.Code, http.StatusOK)
 }
 
-func TestHandleURLPayload_retry_fetching(t *testing.T) {
+func TestHandleResultsUpload_retry_fetching(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
+	payload := url.Values{
+		"result_url": {"http://wpt.fyi/test.json.gz"},
+	}
+	req := httptest.NewRequest("POST", "/api/results/upload", strings.NewReader(payload.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth("blade-runner", "123")
+	resp := httptest.NewRecorder()
+
 	f := &os.File{}
 	errTimeout := fmt.Errorf("server timed out")
-
+	task := &taskqueue.Task{Name: "task"}
 	mockAE := NewMockAppEngineAPI(mockCtrl)
 	mockAE.EXPECT().Context().Return(sharedtest.NewTestContext()).AnyTimes()
 	gomock.InOrder(
+		mockAE.EXPECT().IsAdmin().Return(false),
+		mockAE.EXPECT().authenticateUploader("blade-runner", "123").Return(true),
 		mockAE.EXPECT().fetchWithTimeout("http://wpt.fyi/test.json.gz", DownloadTimeout).Return(nil, errTimeout),
 		mockAE.EXPECT().fetchWithTimeout("http://wpt.fyi/test.json.gz", DownloadTimeout).Return(nil, errTimeout),
 		mockAE.EXPECT().fetchWithTimeout("http://wpt.fyi/test.json.gz", DownloadTimeout).Return(f, nil),
 		mockAE.EXPECT().uploadToGCS(matchRegex(`^/wptd-results-buffer/blade-runner/.*\.json$`), f, true).Return(nil),
-		mockAE.EXPECT().scheduleResultsTask("blade-runner", gomock.Any(), "single", nil),
+		mockAE.EXPECT().scheduleResultsTask("blade-runner", gomock.Any(), "single", emptyParams).Return(task, nil),
 	)
 
-	handleURLPayload(mockAE, "blade-runner", []string{"http://wpt.fyi/test.json.gz"}, nil)
+	HandleResultsUpload(mockAE, resp, req)
+	assert.Equal(t, resp.Code, http.StatusOK)
 }
 
-func TestHandleURLPayload_fail_fetching(t *testing.T) {
+func TestHandleResultsUpload_fail_fetching(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	errTimeout := fmt.Errorf("server timed out")
+	payload := url.Values{
+		"result_url": {"http://wpt.fyi/test.json.gz"},
+	}
+	req := httptest.NewRequest("POST", "/api/results/upload", strings.NewReader(payload.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth("blade-runner", "123")
+	resp := httptest.NewRecorder()
 
+	errTimeout := fmt.Errorf("server timed out")
 	mockAE := NewMockAppEngineAPI(mockCtrl)
 	mockAE.EXPECT().Context().Return(sharedtest.NewTestContext()).AnyTimes()
 	gomock.InOrder(
+		mockAE.EXPECT().IsAdmin().Return(false),
+		mockAE.EXPECT().authenticateUploader("blade-runner", "123").Return(true),
 		mockAE.EXPECT().fetchWithTimeout("http://wpt.fyi/test.json.gz", DownloadTimeout).Return(nil, errTimeout),
 		mockAE.EXPECT().fetchWithTimeout("http://wpt.fyi/test.json.gz", DownloadTimeout).Return(nil, errTimeout),
 		mockAE.EXPECT().fetchWithTimeout("http://wpt.fyi/test.json.gz", DownloadTimeout).Return(nil, errTimeout),
 	)
 
-	task, err := handleURLPayload(mockAE, "blade-runner", []string{"http://wpt.fyi/test.json.gz"}, nil)
-	assert.Nil(t, task)
-	assert.NotNil(t, err)
+	HandleResultsUpload(mockAE, resp, req)
+	assert.Equal(t, resp.Code, http.StatusInternalServerError)
 }
 
-func TestHandleURLPayload_fail_uploading(t *testing.T) {
+func TestHandleResultsUpload_fail_uploading(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
+
+	payload := url.Values{
+		"result_url": {"http://wpt.fyi/test.json.gz"},
+	}
+	req := httptest.NewRequest("POST", "/api/results/upload", strings.NewReader(payload.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth("blade-runner", "123")
+	resp := httptest.NewRecorder()
 
 	f := &os.File{}
 	errGCS := fmt.Errorf("failed to upload to GCS")
-
 	mockAE := NewMockAppEngineAPI(mockCtrl)
 	mockAE.EXPECT().Context().Return(sharedtest.NewTestContext()).AnyTimes()
 	gomock.InOrder(
+		mockAE.EXPECT().IsAdmin().Return(false),
+		mockAE.EXPECT().authenticateUploader("blade-runner", "123").Return(true),
 		mockAE.EXPECT().fetchWithTimeout("http://wpt.fyi/test.json.gz", DownloadTimeout).Return(f, nil),
 		mockAE.EXPECT().uploadToGCS(matchRegex(`^/wptd-results-buffer/blade-runner/.*\.json$`), f, true).Return(errGCS),
 	)
 
-	task, err := handleURLPayload(mockAE, "blade-runner", []string{"http://wpt.fyi/test.json.gz"}, nil)
-	assert.Nil(t, task)
-	assert.NotNil(t, err)
+	HandleResultsUpload(mockAE, resp, req)
+	assert.Equal(t, resp.Code, http.StatusInternalServerError)
 }


### PR DESCRIPTION
This PR allows uploaders to send multiple (chunked) files in a multipart
/api/results/upload request.

Works alongside with #1022 .