### PR TITLE
searchcache: When some runs missing, HTTP 422 + partial results

### DIFF
--- a/api/query/cache/service/main.go
+++ b/api/query/cache/service/main.go
@@ -116,9 +116,9 @@ func searchHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Return to client `http.StatusUnprocessableEntity`immediately if any runs
+	// Return to client `http.StatusUnprocessableEntity` immediately if any runs
 	// are missing.
-	if len(runs) == 0 {
+	if len(runs) == 0 && len(missing) > 0 {
 		data, err = json.Marshal(query.SearchResponse{
 			IgnoredRuns: missing,
 		})

--- a/api/query/search.go
+++ b/api/query/search.go
@@ -52,6 +52,11 @@ type SearchResponse struct {
 	// Runs is the specific runs for which results were retrieved. Each run, in
 	// order, corresponds to a Status entry in each SearchResult in Results.
 	Runs []shared.TestRun `json:"runs"`
+	// IgnoredRuns is any runs that the client requested to be included in the
+	// query, but were not included. This optional field may be non-nil if, for
+	// example, results are being served from an incompelte cache of runs and some
+	// runs described in the query request are not resident in the cache.
+	IgnoredRuns []shared.TestRun `json:"ignored_runs,omitempty"`
 	// Results is the collection of test results, grouped by test file name.
 	Results []SearchResult `json:"results"`
 }


### PR DESCRIPTION
This change allows `searchcache` to return `HTTP 422` and partial results when at least one, but not all, runs needed to service a query are found in the cache.

This allows clients to render partial results and decide whether or not to retry the query later to get more complete results.