### PR TITLE
Allow multiple results per product when more than 1 sha

### DIFF
--- a/api/test_runs.go
+++ b/api/test_runs.go
@@ -103,8 +103,8 @@ func LoadTestRunKeysForFilters(store shared.Datastore, filters shared.TestRunFil
 	limit := filters.MaxCount
 	offset := filters.Offset
 	from := filters.From
-	if limit == nil && from == nil {
-		// Default to a single, latest run when from & max-count both empty.
+	// Default to a single, latest run when not using any "more than one results" filters.
+	if limit == nil && from == nil && len(filters.SHAs) < 2 {
 		one := 1
 		limit = &one
 	}


### PR DESCRIPTION
## Description
Changes the behaviour of querying for multiple shas, to not implicitly set a max-count of one result for each product. (For other queries, such as no params, the default is one result per product).

If a user wants exactly one result per product (across 2 shas) they can add the param explicitly.