### PR TITLE
Ensure same runs: `q.PrepareUserQuery(runIDs)` and `idx.Bind(runs, q)`

### DIFF
--- a/api/query/cache/service/main.go
+++ b/api/query/cache/service/main.go
@@ -117,6 +117,7 @@ func searchHandler(w http.ResponseWriter, r *http.Request) {
 			go idx.IngestRun(*runPtr)
 			missing = append(missing, *runPtr)
 		} else {
+			// Ensure that both `ids` and `runs` correspond to the same test runs.
 			ids = append(ids, rq.RunIDs[i])
 			runs = append(runs, run)
 		}
@@ -137,7 +138,8 @@ func searchHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Prepare user query based on `ids` that are (or at least were a moment ago)
-	// resident in `idx`.
+	// resident in `idx`. In the unlikely event that a run in `ids`/`runs` is no
+	// longer in `idx`, `idx.Bind()` below will return an error.
 	q := cq.PrepareUserQuery(ids, rq.AbstractQuery.BindToRuns(runs))
 	plan, err := idx.Bind(runs, q)
 	if err != nil {

--- a/api/query/cache/service/main.go
+++ b/api/query/cache/service/main.go
@@ -90,11 +90,6 @@ func searchHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ids := make([]index.RunID, len(rq.RunIDs))
-	for i := range rq.RunIDs {
-		ids[i] = index.RunID(rq.RunIDs[i])
-	}
-
 	// Ensure runs are loaded before executing query. This is best effort: It is
 	// possible, though unlikely, that a run may exist in the cache at this point
 	// and be evicted before binding the query to a query execution plan. In such
@@ -103,9 +98,14 @@ func searchHandler(w http.ResponseWriter, r *http.Request) {
 	// Accumulate missing runs in `missing` to report which runs have initiated
 	// write-on-read. Return to client `http.StatusUnprocessableEntity`
 	// immediately if any runs are missing.
-	runs := make([]shared.TestRun, 0, len(ids))
-	missing := make([]shared.TestRun, 0, len(ids))
-	for _, id := range ids {
+	//
+	// `ids` and `runs` tracks run IDs and run metadata for requested runs that
+	// are currently resident in `idx`.
+	ids := make([]int64, 0, len(rq.RunIDs))
+	runs := make([]shared.TestRun, 0, len(rq.RunIDs))
+	missing := make([]shared.TestRun, 0, len(rq.RunIDs))
+	for i := range rq.RunIDs {
+		id := index.RunID(rq.RunIDs[i])
 		run, err := idx.Run(id)
 		// If getting run metadata fails, attempt write-on-read for this run.
 		if err != nil {
@@ -117,6 +117,7 @@ func searchHandler(w http.ResponseWriter, r *http.Request) {
 			go idx.IngestRun(*runPtr)
 			missing = append(missing, *runPtr)
 		} else {
+			ids = append(ids, rq.RunIDs[i])
 			runs = append(runs, run)
 		}
 	}
@@ -135,7 +136,9 @@ func searchHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	q := cq.PrepareUserQuery(rq.RunIDs, rq.AbstractQuery.BindToRuns(runs))
+	// Prepare user query based on `ids` that are (or at least were a moment ago)
+	// resident in `idx`.
+	q := cq.PrepareUserQuery(ids, rq.AbstractQuery.BindToRuns(runs))
 	plan, err := idx.Bind(runs, q)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
This change fault that occurs during query execution that can be traced to expanding a query with `PrepareUserQuery` using different run IDs than those that correspond to the runs that are later used to bind the query.

The change accumulates `ids` (for expansion) and `runs` (for binding) together, tracking only the runs that are resident in the `Index`. This ensures correct prep+bind+execute behaviour, including correct error handling if one of the runs is removed from the `Index` between `ids`/`runs` accumulation and one of prep|bind|execute.