### PR TITLE
Add feature for copying a permalink

### DIFF
--- a/webapp/components/results-navigation.js
+++ b/webapp/components/results-navigation.js
@@ -20,9 +20,9 @@ document.head.appendChild($_documentContainer.content);
  * an object of params.
  */
 // eslint-disable-next-line no-unused-vars
-const QueryBuilder = (superClass, queryParamsComputer) => class extends superClass {
+const QueryBuilder = (superClass, opts_queryParamsComputer) => class extends superClass {
   static get properties() {
-    return {
+    const props = {
       query: {
         type: String,
         computed: 'computeQuery(queryParams)',
@@ -32,9 +32,12 @@ const QueryBuilder = (superClass, queryParamsComputer) => class extends superCla
       queryParams: {
         type: Object,
         notify: true,
-        computed: queryParamsComputer,
       },
     };
+    if (opts_queryParamsComputer) {
+      props.queryParams.computed = opts_queryParamsComputer;
+    }
+    return props;
   }
 
   computeQuery(params) {

--- a/webapp/components/wpt-flags.js
+++ b/webapp/components/wpt-flags.js
@@ -38,6 +38,7 @@ Object.defineProperty(wpt, 'ClientSideFeatures', {
       'insightsTab',
       'showTestType',
       'searchPRsForDirectories',
+      'permalinks',
     ];
   }
 });
@@ -181,6 +182,11 @@ class WPTFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ false) {
     <paper-item>
       <paper-checkbox checked="{{searchPRsForDirectories}}">
         On /results, list open PRs involving the current directory.
+      </paper-checkbox>
+    </paper-item>
+    <paper-item>
+      <paper-checkbox checked="{{permalinks}}">
+        Show dialog for copying a permalink (on /results page).
       </paper-checkbox>
     </paper-item>
 `;

--- a/webapp/components/wpt-permalinks.js
+++ b/webapp/components/wpt-permalinks.js
@@ -4,13 +4,13 @@
  * found in the LICENSE file.
  */
 
-import '../node_modules/@polymer/paper-dialog/paper-dialog.js';
-import '../node_modules/@polymer/paper-item/paper-item.js';
-import '../node_modules/@polymer/paper-toast/paper-toast.js';
-import '../node_modules/@polymer/paper-input/paper-input.js';
 import '../node_modules/@polymer/paper-checkbox/paper-checkbox.js';
+import '../node_modules/@polymer/paper-dialog/paper-dialog.js';
+import '../node_modules/@polymer/paper-input/paper-input.js';
+import '../node_modules/@polymer/paper-item/paper-item.js';
+import '../node_modules/@polymer/paper-tab/paper-tab.js';
 import '../node_modules/@polymer/paper-tabs/paper-tabs.js';
-import '../node_modules/@polymer/polymer/lib/elements/dom-repeat.js';
+import '../node_modules/@polymer/paper-toast/paper-toast.js';
 import { html } from '../node_modules/@polymer/polymer/lib/utils/html-tag.js';
 import { PolymerElement } from '../node_modules/@polymer/polymer/polymer-element.js';
 import { QueryBuilder } from './results-navigation.js';
@@ -103,6 +103,9 @@ class Permalinks extends QueryBuilder(PolymerElement) {
       params = {};
       if (testRuns && testRuns.length) {
         params.run_id = testRuns.map(r => r.id);
+      }
+      if (queryParams.diff) {
+        params.diff = queryParams.diff;
       }
     } else {
       params = Object.assign({}, this.queryParams);

--- a/webapp/components/wpt-permalinks.js
+++ b/webapp/components/wpt-permalinks.js
@@ -1,0 +1,147 @@
+/**
+ * Copyright 2018 The WPT Dashboard Project. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+import '../node_modules/@polymer/paper-dialog/paper-dialog.js';
+import '../node_modules/@polymer/paper-item/paper-item.js';
+import '../node_modules/@polymer/paper-toast/paper-toast.js';
+import '../node_modules/@polymer/paper-input/paper-input.js';
+import '../node_modules/@polymer/paper-checkbox/paper-checkbox.js';
+import '../node_modules/@polymer/paper-tabs/paper-tabs.js';
+import '../node_modules/@polymer/polymer/lib/elements/dom-repeat.js';
+import { html } from '../node_modules/@polymer/polymer/lib/utils/html-tag.js';
+import { PolymerElement } from '../node_modules/@polymer/polymer/polymer-element.js';
+import { QueryBuilder } from './results-navigation.js';
+
+class Permalinks extends QueryBuilder(PolymerElement) {
+  static get is() {
+    return 'wpt-permalinks';
+  }
+
+  static get template() {
+    return html`
+      <style>
+        paper-tabs {
+          --paper-tabs-selection-bar-color: var(--paper-blue-500);
+        }
+        paper-tab {
+          --paper-tab-ink: var(--paper-blue-300);
+        }
+      </style>
+      <paper-dialog>
+        <paper-tabs selected="{{selectedTab}}">
+          <paper-tab title="Link to these specific runs, via their IDs">These runs</paper-tab>
+          <paper-tab title="Link to this query, showing the latest matching runs">This query</paper-tab>
+        </paper-tabs>
+        <paper-checkbox checked="{{includePath}}">
+          Include the current path (directory)
+        </paper-checkbox>
+        <br>
+        <paper-checkbox checked="{{includeSearch}}">
+          Include the search query
+        </paper-checkbox>
+
+        <paper-input value="[[url]]"></paper-input>
+
+        <div class="buttons">
+        <paper-button onclick="[[copyToClipboard]]" title="Copy URL to the clipboard" autofocus>Copy link</paper-button>
+        <paper-button dialog-dismiss>Dismiss</paper-button>
+        </div>
+      </paper-dialog>
+      <paper-toast id="toast"></paper-toast>
+`;
+  }
+
+  static get properties() {
+    return {
+      path: String,
+      queryParams: Object,
+      // Path lead-up, instead of '/', e.g. '/results/'.
+      pathPrefix: String,
+      testRuns: Array,
+      includePath: {
+        type: Boolean,
+        value: true,
+      },
+      includeSearch: {
+        type: Boolean,
+        value: true,
+      },
+      selectedTab: {
+        type: Number,
+        value: 0,
+      },
+      url: {
+        type: String,
+        computed: 'computeURL(selectedTab, queryParams, path, includePath, includeSearch, testRuns)',
+      }
+    };
+  }
+
+  constructor() {
+    super();
+    this.copyToClipboard = this.handleCopyToClipboard.bind(this);
+  }
+
+  get dialog() {
+    return this.shadowRoot.querySelector('paper-dialog');
+  }
+
+  get toast() {
+    return this.shadowRoot.querySelector('#toast');
+  }
+
+  open() {
+    this.dialog.open();
+  }
+
+  computeURL(selectedTab, queryParams, path, includePath, includeSearch, testRuns) {
+    let params;
+    if (selectedTab === 0) {
+      params = {};
+      if (testRuns && testRuns.length) {
+        params.run_id = testRuns.map(r => r.id);
+      }
+    } else {
+      params = Object.assign({}, this.queryParams);
+    }
+    if (!includeSearch && 'q' in params) {
+      delete params.q;
+    }
+
+    const url = new URL('/', window.location);
+    if (this.pathPrefix) {
+      url.pathname = this.pathPrefix;
+    }
+    if (includePath && this.path) {
+      url.pathname += this.path.slice(1);
+    }
+    url.search = this.computeQuery(params);
+    return url;
+  }
+
+  async handleCopyToClipboard() {
+    try {
+      const input = this
+        .shadowRoot.querySelector('paper-input')
+        .shadowRoot.querySelector('input');
+      input.select();
+      document.execCommand('copy');
+      this.toast.show({
+        text: 'URL copied to clipboard!',
+        duration: 2000,
+      });
+    } catch (e) {
+      this.toast.show({
+        text: 'Failed to copy URL to clipboard. Copy it manually.',
+        duration: 5000,
+      });
+    }
+
+  }
+}
+
+window.customElements.define(Permalinks.is, Permalinks);
+

--- a/webapp/components/wpt-permalinks.js
+++ b/webapp/components/wpt-permalinks.js
@@ -8,7 +8,7 @@ import '../node_modules/@polymer/paper-checkbox/paper-checkbox.js';
 import '../node_modules/@polymer/paper-dialog/paper-dialog.js';
 import '../node_modules/@polymer/paper-input/paper-input.js';
 import '../node_modules/@polymer/paper-item/paper-item.js';
-import '../node_modules/@polymer/paper-tab/paper-tab.js';
+import '../node_modules/@polymer/paper-tabs/paper-tab.js';
 import '../node_modules/@polymer/paper-tabs/paper-tabs.js';
 import '../node_modules/@polymer/paper-toast/paper-toast.js';
 import { html } from '../node_modules/@polymer/polymer/lib/utils/html-tag.js';

--- a/webapp/components/wpt-results.js
+++ b/webapp/components/wpt-results.js
@@ -33,6 +33,7 @@ import './test-search.js';
 import { WPTColors } from './wpt-colors.js';
 import { WPTFlags } from './wpt-flags.js';
 import './wpt-prs.js';
+import './wpt-permalinks.js';
 
 const TEST_TYPES = ['manual', 'reftest', 'testharness', 'visual', 'wdspec'];
 
@@ -138,6 +139,9 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
         height: 16px;
         width: 16px;
       }
+      .query-actions paper-button {
+        display: inline-block;
+      }
 
       @media (max-width: 800px) {
         table tr td:first-child::after {
@@ -191,6 +195,14 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
       <template is="dom-if" if="[[resultsRangeMessage]]">
         <info-banner>
           [[resultsRangeMessage]]
+          <template is="dom-if" if="[[permalinks]]">
+            <wpt-permalinks path="[[path]]"
+                            path-prefix="/results/"
+                            query-params="[[queryParams]]"
+                            test-runs="[[testRuns]]">
+            </wpt-permalinks>
+            <paper-button onclick="[[togglePermalinks]]" slot="small">Link</paper-button>
+          </template>
           <template is="dom-if" if="[[queryBuilder]]">
             <paper-button onclick="[[toggleQueryEdit]]" slot="small">Edit</paper-button>
           </template>
@@ -488,6 +500,7 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
     this.toggleQueryEdit = () => {
       this.editingQuery = !this.editingQuery;
     };
+    this.togglePermalinks = () => this.shadowRoot.querySelector('wpt-permalinks').open();
     this.toggleDiffFilter = () => {
       this.onlyShowDifferences = !this.onlyShowDifferences;
       this.refreshDisplayedNodes();

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -892,6 +892,27 @@
         "@polymer/polymer": "^3.0.0"
       }
     },
+    "@polymer/paper-dialog": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@polymer/paper-dialog/-/paper-dialog-3.0.1.tgz",
+      "integrity": "sha512-KvglYbEq7AWJvui2j6WKLnOvgVMeGjovAydGrPRj7kVzCiD49Eq/hpYFJTRV5iDcalWH+mORUpw+jrFnG9+Kgw==",
+      "requires": {
+        "@polymer/iron-overlay-behavior": "^3.0.0-pre.27",
+        "@polymer/neon-animation": "^3.0.0-pre.26",
+        "@polymer/paper-dialog-behavior": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/paper-dialog-behavior": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@polymer/paper-dialog-behavior/-/paper-dialog-behavior-3.0.1.tgz",
+      "integrity": "sha512-wbI4kCK8le/9MHT+IXzvHjoatxf3kd3Yn0tgozAiAwfSZ7N4Ubpi5MHrK0m9S9PeIxKokAgBYdTUrezSE5378A==",
+      "requires": {
+        "@polymer/iron-overlay-behavior": "^3.0.0-pre.27",
+        "@polymer/paper-styles": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
     "@polymer/paper-dropdown-menu": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@polymer/paper-dropdown-menu/-/paper-dropdown-menu-3.0.1.tgz",
@@ -2882,6 +2903,16 @@
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
+    "clipboard": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.4.tgz",
+      "integrity": "sha512-Vw26VSLRpJfBofiVaFb/I8PVfdI1OxKcYShe6fm0sP/DtmiWQNCjhM/okTvdCo0G+lMMm1rMYbk4IK4x1X+kgQ==",
+      "requires": {
+        "good-listener": "^1.2.2",
+        "select": "^1.1.2",
+        "tiny-emitter": "^2.0.0"
+      }
+    },
     "clone": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
@@ -3364,6 +3395,11 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
+    },
+    "delegate": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw=="
     },
     "depd": {
       "version": "1.1.2",
@@ -4789,6 +4825,14 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.10.0.tgz",
       "integrity": "sha512-0GZF1RiPKU97IHUO5TORo9w1PwrH/NBPl+fS7oMLdaTRiYmYbwK4NWoZWrAdd0/abG9R2BU+OiwyQpTpE6pdfQ==",
       "dev": true
+    },
+    "good-listener": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
+      "requires": {
+        "delegate": "^3.1.2"
+      }
     },
     "got": {
       "version": "6.7.1",
@@ -7834,6 +7878,11 @@
         }
       }
     },
+    "select": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0="
+    },
     "select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -8843,6 +8892,11 @@
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
       "dev": true
+    },
+    "tiny-emitter": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.0.2.tgz",
+      "integrity": "sha512-2NM0auVBGft5tee/OxP4PI3d8WItkDM+fPnaRAVo6xTDI2knbz9eC5ArWGqtGlYqiH3RU5yMpdyTTO7MguC4ow=="
     },
     "tmp": {
       "version": "0.0.33",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -24,6 +24,7 @@
     "@polymer/paper-button": "^3.0.0",
     "@polymer/paper-card": "^3.0.0",
     "@polymer/paper-checkbox": "^3.0.0",
+    "@polymer/paper-dialog": "^3.0.1",
     "@polymer/paper-dropdown-menu": "^3.0.0",
     "@polymer/paper-input": "^3.0.0",
     "@polymer/paper-item": "^3.0.0",
@@ -37,6 +38,7 @@
     "@polymer/polymer": "^3.0.0",
     "@vaadin/vaadin-date-picker": "^3.3.2",
     "@webcomponents/webcomponentsjs": "^2.2.4",
+    "clipboard": "^2.0.4",
     "pluralize": "^7.0.0"
   }
 }

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -38,7 +38,6 @@
     "@polymer/polymer": "^3.0.0",
     "@vaadin/vaadin-date-picker": "^3.3.2",
     "@webcomponents/webcomponentsjs": "^2.2.4",
-    "clipboard": "^2.0.4",
     "pluralize": "^7.0.0"
   }
 }


### PR DESCRIPTION
## Description
Fixes #645 

Adds a small "Link" button next to "Edit" in the query banner, which opens a dialog allowing the user to tweak the URL a bit and copy to the clipboard with a click (in Chrome/FF, at least).

## Review Information
- Head to /flags, enable the permalink flag
- Visit the homepage, nav to a directory somewhere
- Hit edit, toggle the tickboxes, copy to clipboard