### PR TITLE
Add api method for getting versioned service hostname

### DIFF
--- a/api/query/search.go
+++ b/api/query/search.go
@@ -129,7 +129,7 @@ func (sh structuredSearchHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 	simpleQ, ok := rq.AbstractQuery.(TestNamePattern)
 	if !ok {
 		ctx := sh.api.Context()
-		hostname := sh.api.GetHostname()
+		hostname := sh.api.GetServiceHostname("searchcache")
 		// TODO: This will not work when hostname is localhost (http scheme needed).
 		url := fmt.Sprintf("https://%s/api/search/cache", hostname)
 		logger := shared.GetLogger(ctx)

--- a/api/query/search_test.go
+++ b/api/query/search_test.go
@@ -132,7 +132,7 @@ func TestStructuredSearchHandler_success(t *testing.T) {
 	r := httptest.NewRequest("POST", "https://example.com/api/query", bytes.NewBuffer([]byte(`{"run_ids":[1,2,3,4],"query":{"browser_name":"chrome","status":"PASS"}}`)))
 
 	api.EXPECT().Context().Return(r.Context())
-	api.EXPECT().GetHostname().Return(hostname)
+	api.EXPECT().GetServiceHostname("searchcache").Return(hostname)
 	api.EXPECT().GetHTTPClient().Return(server.Client())
 	w := httptest.NewRecorder()
 	structuredSearchHandler{queryHandler{}, api}.ServeHTTP(w, r)
@@ -162,7 +162,7 @@ func TestStructuredSearchHandler_failure(t *testing.T) {
 	r := httptest.NewRequest("POST", "https://example.com/api/query", bytes.NewBuffer([]byte(`{"run_ids":[42],"query":{"browser_name":"chrome","status":"PASS"}}`)))
 
 	api.EXPECT().Context().Return(r.Context())
-	api.EXPECT().GetHostname().Return(hostname)
+	api.EXPECT().GetServiceHostname("searchcache").Return(hostname)
 	api.EXPECT().GetHTTPClient().DoAndReturn(func() *http.Client {
 		return server.Client()
 	})

--- a/api/receiver/appengine_mock.go
+++ b/api/receiver/appengine_mock.go
@@ -43,6 +43,7 @@ func (m *MockAppEngineAPI) EXPECT() *MockAppEngineAPIMockRecorder {
 
 // Context mocks base method
 func (m *MockAppEngineAPI) Context() context.Context {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Context")
 	ret0, _ := ret[0].(context.Context)
 	return ret0
@@ -50,11 +51,13 @@ func (m *MockAppEngineAPI) Context() context.Context {
 
 // Context indicates an expected call of Context
 func (mr *MockAppEngineAPIMockRecorder) Context() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockAppEngineAPI)(nil).Context))
 }
 
 // GetGitHubClient mocks base method
 func (m *MockAppEngineAPI) GetGitHubClient() (*github.Client, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetGitHubClient")
 	ret0, _ := ret[0].(*github.Client)
 	ret1, _ := ret[1].(error)
@@ -63,11 +66,13 @@ func (m *MockAppEngineAPI) GetGitHubClient() (*github.Client, error) {
 
 // GetGitHubClient indicates an expected call of GetGitHubClient
 func (mr *MockAppEngineAPIMockRecorder) GetGitHubClient() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGitHubClient", reflect.TypeOf((*MockAppEngineAPI)(nil).GetGitHubClient))
 }
 
 // GetHTTPClient mocks base method
 func (m *MockAppEngineAPI) GetHTTPClient() *http.Client {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHTTPClient")
 	ret0, _ := ret[0].(*http.Client)
 	return ret0
@@ -75,11 +80,13 @@ func (m *MockAppEngineAPI) GetHTTPClient() *http.Client {
 
 // GetHTTPClient indicates an expected call of GetHTTPClient
 func (mr *MockAppEngineAPIMockRecorder) GetHTTPClient() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHTTPClient", reflect.TypeOf((*MockAppEngineAPI)(nil).GetHTTPClient))
 }
 
 // GetHostname mocks base method
 func (m *MockAppEngineAPI) GetHostname() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHostname")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -87,11 +94,13 @@ func (m *MockAppEngineAPI) GetHostname() string {
 
 // GetHostname indicates an expected call of GetHostname
 func (mr *MockAppEngineAPIMockRecorder) GetHostname() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHostname", reflect.TypeOf((*MockAppEngineAPI)(nil).GetHostname))
 }
 
 // GetResultsURL mocks base method
 func (m *MockAppEngineAPI) GetResultsURL(arg0 shared.TestRunFilter) *url.URL {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetResultsURL", arg0)
 	ret0, _ := ret[0].(*url.URL)
 	return ret0
@@ -99,11 +108,13 @@ func (m *MockAppEngineAPI) GetResultsURL(arg0 shared.TestRunFilter) *url.URL {
 
 // GetResultsURL indicates an expected call of GetResultsURL
 func (mr *MockAppEngineAPIMockRecorder) GetResultsURL(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResultsURL", reflect.TypeOf((*MockAppEngineAPI)(nil).GetResultsURL), arg0)
 }
 
 // GetResultsUploadURL mocks base method
 func (m *MockAppEngineAPI) GetResultsUploadURL() *url.URL {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetResultsUploadURL")
 	ret0, _ := ret[0].(*url.URL)
 	return ret0
@@ -111,11 +122,13 @@ func (m *MockAppEngineAPI) GetResultsUploadURL() *url.URL {
 
 // GetResultsUploadURL indicates an expected call of GetResultsUploadURL
 func (mr *MockAppEngineAPIMockRecorder) GetResultsUploadURL() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResultsUploadURL", reflect.TypeOf((*MockAppEngineAPI)(nil).GetResultsUploadURL))
 }
 
 // GetRunsURL mocks base method
 func (m *MockAppEngineAPI) GetRunsURL(arg0 shared.TestRunFilter) *url.URL {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRunsURL", arg0)
 	ret0, _ := ret[0].(*url.URL)
 	return ret0
@@ -123,11 +136,27 @@ func (m *MockAppEngineAPI) GetRunsURL(arg0 shared.TestRunFilter) *url.URL {
 
 // GetRunsURL indicates an expected call of GetRunsURL
 func (mr *MockAppEngineAPIMockRecorder) GetRunsURL(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRunsURL", reflect.TypeOf((*MockAppEngineAPI)(nil).GetRunsURL), arg0)
+}
+
+// GetServiceHostname mocks base method
+func (m *MockAppEngineAPI) GetServiceHostname(arg0 string) string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetServiceHostname", arg0)
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetServiceHostname indicates an expected call of GetServiceHostname
+func (mr *MockAppEngineAPIMockRecorder) GetServiceHostname(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceHostname", reflect.TypeOf((*MockAppEngineAPI)(nil).GetServiceHostname), arg0)
 }
 
 // GetSlowHTTPClient mocks base method
 func (m *MockAppEngineAPI) GetSlowHTTPClient(arg0 time.Duration) (*http.Client, context.CancelFunc) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSlowHTTPClient", arg0)
 	ret0, _ := ret[0].(*http.Client)
 	ret1, _ := ret[1].(context.CancelFunc)
@@ -136,11 +165,13 @@ func (m *MockAppEngineAPI) GetSlowHTTPClient(arg0 time.Duration) (*http.Client, 
 
 // GetSlowHTTPClient indicates an expected call of GetSlowHTTPClient
 func (mr *MockAppEngineAPIMockRecorder) GetSlowHTTPClient(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSlowHTTPClient", reflect.TypeOf((*MockAppEngineAPI)(nil).GetSlowHTTPClient), arg0)
 }
 
 // GetUploader mocks base method
 func (m *MockAppEngineAPI) GetUploader(arg0 string) (shared.Uploader, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUploader", arg0)
 	ret0, _ := ret[0].(shared.Uploader)
 	ret1, _ := ret[1].(error)
@@ -149,11 +180,13 @@ func (m *MockAppEngineAPI) GetUploader(arg0 string) (shared.Uploader, error) {
 
 // GetUploader indicates an expected call of GetUploader
 func (mr *MockAppEngineAPIMockRecorder) GetUploader(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUploader", reflect.TypeOf((*MockAppEngineAPI)(nil).GetUploader), arg0)
 }
 
 // GetVersion mocks base method
 func (m *MockAppEngineAPI) GetVersion() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetVersion")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -161,11 +194,13 @@ func (m *MockAppEngineAPI) GetVersion() string {
 
 // GetVersion indicates an expected call of GetVersion
 func (mr *MockAppEngineAPIMockRecorder) GetVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVersion", reflect.TypeOf((*MockAppEngineAPI)(nil).GetVersion))
 }
 
 // GetVersionedHostname mocks base method
 func (m *MockAppEngineAPI) GetVersionedHostname() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetVersionedHostname")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -173,11 +208,13 @@ func (m *MockAppEngineAPI) GetVersionedHostname() string {
 
 // GetVersionedHostname indicates an expected call of GetVersionedHostname
 func (mr *MockAppEngineAPIMockRecorder) GetVersionedHostname() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVersionedHostname", reflect.TypeOf((*MockAppEngineAPI)(nil).GetVersionedHostname))
 }
 
 // IsAdmin mocks base method
 func (m *MockAppEngineAPI) IsAdmin() bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsAdmin")
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -185,11 +222,13 @@ func (m *MockAppEngineAPI) IsAdmin() bool {
 
 // IsAdmin indicates an expected call of IsAdmin
 func (mr *MockAppEngineAPIMockRecorder) IsAdmin() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsAdmin", reflect.TypeOf((*MockAppEngineAPI)(nil).IsAdmin))
 }
 
 // IsFeatureEnabled mocks base method
 func (m *MockAppEngineAPI) IsFeatureEnabled(arg0 string) bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsFeatureEnabled", arg0)
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -197,11 +236,13 @@ func (m *MockAppEngineAPI) IsFeatureEnabled(arg0 string) bool {
 
 // IsFeatureEnabled indicates an expected call of IsFeatureEnabled
 func (mr *MockAppEngineAPIMockRecorder) IsFeatureEnabled(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsFeatureEnabled", reflect.TypeOf((*MockAppEngineAPI)(nil).IsFeatureEnabled), arg0)
 }
 
 // IsLoggedIn mocks base method
 func (m *MockAppEngineAPI) IsLoggedIn() bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsLoggedIn")
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -209,11 +250,13 @@ func (m *MockAppEngineAPI) IsLoggedIn() bool {
 
 // IsLoggedIn indicates an expected call of IsLoggedIn
 func (mr *MockAppEngineAPIMockRecorder) IsLoggedIn() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsLoggedIn", reflect.TypeOf((*MockAppEngineAPI)(nil).IsLoggedIn))
 }
 
 // LoginURL mocks base method
 func (m *MockAppEngineAPI) LoginURL(arg0 string) (string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LoginURL", arg0)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
@@ -222,11 +265,13 @@ func (m *MockAppEngineAPI) LoginURL(arg0 string) (string, error) {
 
 // LoginURL indicates an expected call of LoginURL
 func (mr *MockAppEngineAPIMockRecorder) LoginURL(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoginURL", reflect.TypeOf((*MockAppEngineAPI)(nil).LoginURL), arg0)
 }
 
 // addTestRun mocks base method
 func (m *MockAppEngineAPI) addTestRun(arg0 *shared.TestRun) (*DatastoreKey, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "addTestRun", arg0)
 	ret0, _ := ret[0].(*DatastoreKey)
 	ret1, _ := ret[1].(error)
@@ -235,11 +280,13 @@ func (m *MockAppEngineAPI) addTestRun(arg0 *shared.TestRun) (*DatastoreKey, erro
 
 // addTestRun indicates an expected call of addTestRun
 func (mr *MockAppEngineAPIMockRecorder) addTestRun(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "addTestRun", reflect.TypeOf((*MockAppEngineAPI)(nil).addTestRun), arg0)
 }
 
 // authenticateUploader mocks base method
 func (m *MockAppEngineAPI) authenticateUploader(arg0, arg1 string) bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "authenticateUploader", arg0, arg1)
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -247,11 +294,13 @@ func (m *MockAppEngineAPI) authenticateUploader(arg0, arg1 string) bool {
 
 // authenticateUploader indicates an expected call of authenticateUploader
 func (mr *MockAppEngineAPIMockRecorder) authenticateUploader(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "authenticateUploader", reflect.TypeOf((*MockAppEngineAPI)(nil).authenticateUploader), arg0, arg1)
 }
 
 // fetchWithTimeout mocks base method
 func (m *MockAppEngineAPI) fetchWithTimeout(arg0 string, arg1 time.Duration) (io.ReadCloser, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "fetchWithTimeout", arg0, arg1)
 	ret0, _ := ret[0].(io.ReadCloser)
 	ret1, _ := ret[1].(error)
@@ -260,11 +309,13 @@ func (m *MockAppEngineAPI) fetchWithTimeout(arg0 string, arg1 time.Duration) (io
 
 // fetchWithTimeout indicates an expected call of fetchWithTimeout
 func (mr *MockAppEngineAPIMockRecorder) fetchWithTimeout(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "fetchWithTimeout", reflect.TypeOf((*MockAppEngineAPI)(nil).fetchWithTimeout), arg0, arg1)
 }
 
 // scheduleResultsTask mocks base method
 func (m *MockAppEngineAPI) scheduleResultsTask(arg0 string, arg1 []string, arg2 string, arg3 map[string]string) (*taskqueue.Task, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "scheduleResultsTask", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*taskqueue.Task)
 	ret1, _ := ret[1].(error)
@@ -273,11 +324,13 @@ func (m *MockAppEngineAPI) scheduleResultsTask(arg0 string, arg1 []string, arg2 
 
 // scheduleResultsTask indicates an expected call of scheduleResultsTask
 func (mr *MockAppEngineAPIMockRecorder) scheduleResultsTask(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "scheduleResultsTask", reflect.TypeOf((*MockAppEngineAPI)(nil).scheduleResultsTask), arg0, arg1, arg2, arg3)
 }
 
 // uploadToGCS mocks base method
 func (m *MockAppEngineAPI) uploadToGCS(arg0 string, arg1 io.Reader, arg2 bool) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "uploadToGCS", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -285,5 +338,6 @@ func (m *MockAppEngineAPI) uploadToGCS(arg0 string, arg1 io.Reader, arg2 bool) e
 
 // uploadToGCS indicates an expected call of uploadToGCS
 func (mr *MockAppEngineAPIMockRecorder) uploadToGCS(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "uploadToGCS", reflect.TypeOf((*MockAppEngineAPI)(nil).uploadToGCS), arg0, arg1, arg2)
 }

--- a/shared/appengine.go
+++ b/shared/appengine.go
@@ -163,6 +163,7 @@ func (a AppEngineAPIImpl) GetVersionedHostname() string {
 }
 
 // GetServiceHostname returns a versioned canonical hostname for the given service (module).
+// If the service does not have the current version, AppEngine routing will fall back to its default version.
 func (a AppEngineAPIImpl) GetServiceHostname(service string) string {
 	// version and instance (last 2 params) left blank means that the version of the current
 	// instance will be used. This is desirable for branches that push multiple services, and

--- a/shared/sharedtest/appengine_mock.go
+++ b/shared/sharedtest/appengine_mock.go
@@ -41,6 +41,7 @@ func (m *MockAppEngineAPI) EXPECT() *MockAppEngineAPIMockRecorder {
 
 // Context mocks base method
 func (m *MockAppEngineAPI) Context() context.Context {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Context")
 	ret0, _ := ret[0].(context.Context)
 	return ret0
@@ -48,11 +49,13 @@ func (m *MockAppEngineAPI) Context() context.Context {
 
 // Context indicates an expected call of Context
 func (mr *MockAppEngineAPIMockRecorder) Context() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockAppEngineAPI)(nil).Context))
 }
 
 // GetHTTPClient mocks base method
 func (m *MockAppEngineAPI) GetHTTPClient() *http.Client {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHTTPClient")
 	ret0, _ := ret[0].(*http.Client)
 	return ret0
@@ -60,11 +63,13 @@ func (m *MockAppEngineAPI) GetHTTPClient() *http.Client {
 
 // GetHTTPClient indicates an expected call of GetHTTPClient
 func (mr *MockAppEngineAPIMockRecorder) GetHTTPClient() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHTTPClient", reflect.TypeOf((*MockAppEngineAPI)(nil).GetHTTPClient))
 }
 
 // GetSlowHTTPClient mocks base method
 func (m *MockAppEngineAPI) GetSlowHTTPClient(arg0 time.Duration) (*http.Client, context.CancelFunc) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSlowHTTPClient", arg0)
 	ret0, _ := ret[0].(*http.Client)
 	ret1, _ := ret[1].(context.CancelFunc)
@@ -73,11 +78,13 @@ func (m *MockAppEngineAPI) GetSlowHTTPClient(arg0 time.Duration) (*http.Client, 
 
 // GetSlowHTTPClient indicates an expected call of GetSlowHTTPClient
 func (mr *MockAppEngineAPIMockRecorder) GetSlowHTTPClient(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSlowHTTPClient", reflect.TypeOf((*MockAppEngineAPI)(nil).GetSlowHTTPClient), arg0)
 }
 
 // GetGitHubClient mocks base method
 func (m *MockAppEngineAPI) GetGitHubClient() (*github.Client, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetGitHubClient")
 	ret0, _ := ret[0].(*github.Client)
 	ret1, _ := ret[1].(error)
@@ -86,11 +93,13 @@ func (m *MockAppEngineAPI) GetGitHubClient() (*github.Client, error) {
 
 // GetGitHubClient indicates an expected call of GetGitHubClient
 func (mr *MockAppEngineAPIMockRecorder) GetGitHubClient() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGitHubClient", reflect.TypeOf((*MockAppEngineAPI)(nil).GetGitHubClient))
 }
 
 // IsLoggedIn mocks base method
 func (m *MockAppEngineAPI) IsLoggedIn() bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsLoggedIn")
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -98,11 +107,13 @@ func (m *MockAppEngineAPI) IsLoggedIn() bool {
 
 // IsLoggedIn indicates an expected call of IsLoggedIn
 func (mr *MockAppEngineAPIMockRecorder) IsLoggedIn() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsLoggedIn", reflect.TypeOf((*MockAppEngineAPI)(nil).IsLoggedIn))
 }
 
 // IsAdmin mocks base method
 func (m *MockAppEngineAPI) IsAdmin() bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsAdmin")
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -110,11 +121,13 @@ func (m *MockAppEngineAPI) IsAdmin() bool {
 
 // IsAdmin indicates an expected call of IsAdmin
 func (mr *MockAppEngineAPIMockRecorder) IsAdmin() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsAdmin", reflect.TypeOf((*MockAppEngineAPI)(nil).IsAdmin))
 }
 
 // LoginURL mocks base method
 func (m *MockAppEngineAPI) LoginURL(redirect string) (string, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LoginURL", redirect)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
@@ -123,11 +136,13 @@ func (m *MockAppEngineAPI) LoginURL(redirect string) (string, error) {
 
 // LoginURL indicates an expected call of LoginURL
 func (mr *MockAppEngineAPIMockRecorder) LoginURL(redirect interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoginURL", reflect.TypeOf((*MockAppEngineAPI)(nil).LoginURL), redirect)
 }
 
 // IsFeatureEnabled mocks base method
 func (m *MockAppEngineAPI) IsFeatureEnabled(featureName string) bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsFeatureEnabled", featureName)
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -135,11 +150,13 @@ func (m *MockAppEngineAPI) IsFeatureEnabled(featureName string) bool {
 
 // IsFeatureEnabled indicates an expected call of IsFeatureEnabled
 func (mr *MockAppEngineAPIMockRecorder) IsFeatureEnabled(featureName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsFeatureEnabled", reflect.TypeOf((*MockAppEngineAPI)(nil).IsFeatureEnabled), featureName)
 }
 
 // GetUploader mocks base method
 func (m *MockAppEngineAPI) GetUploader(uploader string) (shared.Uploader, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUploader", uploader)
 	ret0, _ := ret[0].(shared.Uploader)
 	ret1, _ := ret[1].(error)
@@ -148,11 +165,13 @@ func (m *MockAppEngineAPI) GetUploader(uploader string) (shared.Uploader, error)
 
 // GetUploader indicates an expected call of GetUploader
 func (mr *MockAppEngineAPIMockRecorder) GetUploader(uploader interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUploader", reflect.TypeOf((*MockAppEngineAPI)(nil).GetUploader), uploader)
 }
 
 // GetVersion mocks base method
 func (m *MockAppEngineAPI) GetVersion() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetVersion")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -160,11 +179,13 @@ func (m *MockAppEngineAPI) GetVersion() string {
 
 // GetVersion indicates an expected call of GetVersion
 func (mr *MockAppEngineAPIMockRecorder) GetVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVersion", reflect.TypeOf((*MockAppEngineAPI)(nil).GetVersion))
 }
 
 // GetHostname mocks base method
 func (m *MockAppEngineAPI) GetHostname() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHostname")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -172,11 +193,13 @@ func (m *MockAppEngineAPI) GetHostname() string {
 
 // GetHostname indicates an expected call of GetHostname
 func (mr *MockAppEngineAPIMockRecorder) GetHostname() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHostname", reflect.TypeOf((*MockAppEngineAPI)(nil).GetHostname))
 }
 
 // GetVersionedHostname mocks base method
 func (m *MockAppEngineAPI) GetVersionedHostname() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetVersionedHostname")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -184,11 +207,27 @@ func (m *MockAppEngineAPI) GetVersionedHostname() string {
 
 // GetVersionedHostname indicates an expected call of GetVersionedHostname
 func (mr *MockAppEngineAPIMockRecorder) GetVersionedHostname() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVersionedHostname", reflect.TypeOf((*MockAppEngineAPI)(nil).GetVersionedHostname))
+}
+
+// GetServiceHostname mocks base method
+func (m *MockAppEngineAPI) GetServiceHostname(service string) string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetServiceHostname", service)
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetServiceHostname indicates an expected call of GetServiceHostname
+func (mr *MockAppEngineAPIMockRecorder) GetServiceHostname(service interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceHostname", reflect.TypeOf((*MockAppEngineAPI)(nil).GetServiceHostname), service)
 }
 
 // GetResultsURL mocks base method
 func (m *MockAppEngineAPI) GetResultsURL(filter shared.TestRunFilter) *url.URL {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetResultsURL", filter)
 	ret0, _ := ret[0].(*url.URL)
 	return ret0
@@ -196,11 +235,13 @@ func (m *MockAppEngineAPI) GetResultsURL(filter shared.TestRunFilter) *url.URL {
 
 // GetResultsURL indicates an expected call of GetResultsURL
 func (mr *MockAppEngineAPIMockRecorder) GetResultsURL(filter interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResultsURL", reflect.TypeOf((*MockAppEngineAPI)(nil).GetResultsURL), filter)
 }
 
 // GetRunsURL mocks base method
 func (m *MockAppEngineAPI) GetRunsURL(filter shared.TestRunFilter) *url.URL {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRunsURL", filter)
 	ret0, _ := ret[0].(*url.URL)
 	return ret0
@@ -208,11 +249,13 @@ func (m *MockAppEngineAPI) GetRunsURL(filter shared.TestRunFilter) *url.URL {
 
 // GetRunsURL indicates an expected call of GetRunsURL
 func (mr *MockAppEngineAPIMockRecorder) GetRunsURL(filter interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRunsURL", reflect.TypeOf((*MockAppEngineAPI)(nil).GetRunsURL), filter)
 }
 
 // GetResultsUploadURL mocks base method
 func (m *MockAppEngineAPI) GetResultsUploadURL() *url.URL {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetResultsUploadURL")
 	ret0, _ := ret[0].(*url.URL)
 	return ret0
@@ -220,5 +263,6 @@ func (m *MockAppEngineAPI) GetResultsUploadURL() *url.URL {
 
 // GetResultsUploadURL indicates an expected call of GetResultsUploadURL
 func (mr *MockAppEngineAPIMockRecorder) GetResultsUploadURL() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResultsUploadURL", reflect.TypeOf((*MockAppEngineAPI)(nil).GetResultsUploadURL))
 }


### PR DESCRIPTION
## Description
Ensures we get a versioned external service hostname, so that branches like https://github.com/web-platform-tests/wpt.fyi/pull/1057 keep the webapp and searchcache in sync, so the changes can be tested in the UI.