### PR TITLE
Preserve diff filter better

### DIFF
--- a/webapp/components/test-runs-query.js
+++ b/webapp/components/test-runs-query.js
@@ -256,6 +256,10 @@ const TestRunsUIQuery = (superClass, opt_queryCompute) => class extends TestRuns
         value: false,
         notify: true,
       },
+      diffFilter: {
+        type: String,
+        value: 'ADC', // Added, Deleted, Changed
+      },
       pr: {
         type: Number,
         notify: true,
@@ -269,6 +273,9 @@ const TestRunsUIQuery = (superClass, opt_queryCompute) => class extends TestRuns
     const params = this.computeTestRunQueryParams(shas, aligned, master, labels, productSpecs, to, from, maxCount);
     if (diff || this.diff) {
       params.diff = true;
+      if (this.diffFilter) {
+        params.filter = this.diffFilter;
+      }
     }
     if (search) {
       params.q = search;
@@ -284,12 +291,17 @@ const TestRunsUIQuery = (superClass, opt_queryCompute) => class extends TestRuns
 
   updateQueryParams(params) {
     super.updateQueryParams(params);
-    this.pr = params.pr;
-    this.search = params.q;
-    this.diff = params.diff;
-    if ('run_id' in params) {
-      this.runIds = Array.from(params['run_id']);
+    let batchUpdate = {};
+    batchUpdate.pr = params.pr;
+    batchUpdate.search = params.q;
+    batchUpdate.diff = params.diff;
+    if (batchUpdate.diff) {
+      batchUpdate.diffFilter = params.filter;
     }
+    if ('run_id' in params) {
+      batchUpdate.runIds = Array.from(params['run_id']);
+    }
+    this.setProperties(batchUpdate);
   }
 };
 // TODO(lukebjerring): Support to & from in the builder.

--- a/webapp/components/wpt-permalinks.js
+++ b/webapp/components/wpt-permalinks.js
@@ -106,6 +106,9 @@ class Permalinks extends QueryBuilder(PolymerElement) {
       }
       if (queryParams.diff) {
         params.diff = queryParams.diff;
+        if (queryParams.filter) {
+          params.filter = queryParams.filter;
+        }
       }
     } else {
       params = Object.assign({}, this.queryParams);

--- a/webapp/components/wpt-results.js
+++ b/webapp/components/wpt-results.js
@@ -396,10 +396,6 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
         type: String,
         computed: 'computeDiffURL(testRuns)',
       },
-      diffFilter: {
-        type: String,
-        value: 'ADC', // Added, Deleted, Changed
-      },
       showHistory: {
         type: Boolean,
         value: false,


### PR DESCRIPTION
## Description
The filter is dropped when we first land on a page and virtual-navigate to push onto the navigation stack.
This fixes that, and also preserves the param when grabbing a permalink.