### PR TITLE
Use variable hostname in check title

### DIFF
--- a/api/azure/api.go
+++ b/api/azure/api.go
@@ -67,7 +67,3 @@ func (a apiImpl) GetAzureArtifactsURL(owner, repo string, buildID int64) string 
 		repo,
 		buildID)
 }
-
-func getCheckTitle(product shared.ProductSpec) string {
-	return fmt.Sprintf("wpt.fyi - %s results", product.DisplayName())
-}

--- a/api/checks/api.go
+++ b/api/checks/api.go
@@ -88,6 +88,7 @@ func (s checksAPIImpl) PendingCheckRun(suite shared.CheckSuite, product shared.P
 
 	pending := summaries.Pending{
 		CheckState: summaries.CheckState{
+			HostName:   aeAPI.GetHostname(),
 			TestRun:    nil, // It's pending, no run exists yet.
 			Product:    product,
 			HeadSHA:    suite.SHA,
@@ -95,8 +96,7 @@ func (s checksAPIImpl) PendingCheckRun(suite shared.CheckSuite, product shared.P
 			Status:     "in_progress",
 			PRNumbers:  suite.PRNumbers,
 		},
-		HostName: aeAPI.GetHostname(),
-		RunsURL:  runsURL.String(),
+		RunsURL: runsURL.String(),
 	}
 	return updateCheckRunSummary(s.ctx, pending, suite)
 }

--- a/api/checks/summaries/compile.go
+++ b/api/checks/summaries/compile.go
@@ -12,7 +12,7 @@ import (
 	"runtime"
 	"text/template"
 
-	"github.com/deckarep/golang-set"
+	mapset "github.com/deckarep/golang-set"
 
 	"github.com/google/go-github/github"
 	"github.com/web-platform-tests/wpt.fyi/shared"
@@ -40,6 +40,7 @@ type Summary interface {
 
 // CheckState represents all the status fields for updating a check.
 type CheckState struct {
+	HostName   string          // The host (e.g. wpt.fyi)
 	TestRun    *shared.TestRun // The (completed) TestRun, if applicable.
 	Product    shared.ProductSpec
 	HeadSHA    string
@@ -62,7 +63,11 @@ func (c CheckState) Name() string {
 
 // Title returns the check run's title, based on the product.
 func (c CheckState) Title() string {
-	return fmt.Sprintf("wpt.fyi - %s results", c.Product.DisplayName())
+	host := c.HostName
+	if host == "" {
+		host = "wpt.fyi"
+	}
+	return fmt.Sprintf("%s - %s results", host, c.Product.DisplayName())
 }
 
 // GetCheckState returns the info in the CheckState struct.

--- a/api/checks/summaries/compile_test.go
+++ b/api/checks/summaries/compile_test.go
@@ -74,9 +74,9 @@ func TestGetSummary_Completed(t *testing.T) {
 
 func TestGetSummary_Pending(t *testing.T) {
 	foo := Pending{
-		HostName: "https://foo.com",
-		RunsURL:  "https://foo.com/runs?products=chrome&sha=0123456789",
+		RunsURL: "https://foo.com/runs?products=chrome&sha=0123456789",
 	}
+	foo.HostName = "https://foo.com"
 	s, err := foo.GetSummary()
 	printOutput(s)
 	if err != nil {

--- a/api/checks/summaries/completed.go
+++ b/api/checks/summaries/completed.go
@@ -16,7 +16,6 @@ type ResultsComparison struct {
 	HeadRun       shared.TestRun
 	MasterDiffURL string
 	DiffURL       string // URL for the diff-view of the results
-	HostName      string // Host environment name, e.g. "wpt.fyi"
 	HostURL       string // Host environment URL, e.g. "https://wpt.fyi"
 }
 

--- a/api/checks/summaries/pending.go
+++ b/api/checks/summaries/pending.go
@@ -10,8 +10,7 @@ import "github.com/google/go-github/github"
 type Pending struct {
 	CheckState
 
-	HostName string // Host environment name
-	RunsURL  string // URL for the list of test runs
+	RunsURL string // URL for the list of test runs
 }
 
 // GetCheckState returns the info needed to update a check.

--- a/api/checks/update.go
+++ b/api/checks/update.go
@@ -187,7 +187,9 @@ func getDiffSummary(aeAPI shared.AppEngineAPI, diffAPI shared.DiffAPI, suite sha
 	}
 
 	diffURL := diffAPI.GetDiffURL(baseRun, headRun, &diffFilter)
+	host := aeAPI.GetHostname()
 	checkState := summaries.CheckState{
+		HostName:   host,
 		TestRun:    &headRun,
 		Product:    checkProduct,
 		HeadSHA:    headRun.FullRevisionHash,
@@ -202,14 +204,12 @@ func getDiffSummary(aeAPI shared.AppEngineAPI, diffAPI shared.DiffAPI, suite sha
 	checksCanFailAndPass := aeAPI.IsFeatureEnabled(failChecksOnRegressionFeature)
 
 	var summary summaries.Summary
-	host := aeAPI.GetHostname()
 
 	resultsComparison := summaries.ResultsComparison{
-		BaseRun:  baseRun,
-		HeadRun:  headRun,
-		HostName: host,
-		HostURL:  fmt.Sprintf("https://%s/", host),
-		DiffURL:  diffURL.String(),
+		BaseRun: baseRun,
+		HeadRun: headRun,
+		HostURL: fmt.Sprintf("https://%s/", host),
+		DiffURL: diffURL.String(),
 	}
 	if headRun.LabelsSet().Contains(shared.PRHeadLabel) {
 		// Deletions are meaningless and abundant comparing to master; ignore them.


### PR DESCRIPTION
## Description
Related to #850 

We have duplicated staging/prod wpt.fyi checks on some whitelisted users, and the title on the landing page is not distinct (both hard-coded to wpt.fyi). This PR changes it to actually grab the hostname and use that, so the staging checks will have staging.wpt.fyi in the title.