### PR TITLE
Don't list all the tests found in the manifest if searching.

### DIFF
--- a/webapp/components/wpt-results.js
+++ b/webapp/components/wpt-results.js
@@ -731,7 +731,7 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
 
     // Add an empty row for all the tests known from the manifest.
     const knownNodes = {};
-    if (this.manifest) {
+    if (this.manifest && !this.search) {
       for (const type of Object.keys(this.manifest.items)) {
         if (['manual', 'reftest', 'testharness', 'wdspec'].includes(type)) {
           for (const file of Object.keys(this.manifest.items[type])) {


### PR DESCRIPTION
## Description
Fixes #1052 

## Review
- Make sure you enable the manifest (/flags, tick the load a manifest feature)
- Load the homepage
- Load https://manifest-dot-wptdashboard-staging.appspot.com/results/css/css-backgrounds?label=master&label=experimental&max-count=10&product=firefox&q=%28firefox%3Apass%7Cfirefox%3Aok%29+%28firefox%3Atimeout%7Cfirefox%3Aerror%7Cfirefox%3Afail%29

You should see only the flaky results, not 0/0 all over the place.