### PR TITLE
[processor] Ignore inconsistent browser_build_id

### DIFF
--- a/results-processor/wptreport.py
+++ b/results-processor/wptreport.py
@@ -135,9 +135,17 @@ class WPTReport(object):
                 target[key] = source[key]
 
         if 'run_info' in chunk:
+            def ignore_conflict(a, b):
+                return a if a == b else None
+
             for key in chunk['run_info']:
                 update_property(
-                    key, chunk['run_info'], self._report['run_info'])
+                    key, chunk['run_info'], self._report['run_info'],
+                    # Ignore inconsistent browser_build_id for now.
+                    # TODO(Hexcles): Remove this exception once the decision
+                    # task is implemented on Taskcluster.
+                    ignore_conflict if key == 'browser_build_id' else None,
+                )
 
         update_property('time_start', chunk, self._report, min)
         update_property('time_end', chunk, self._report, max)

--- a/results-processor/wptreport_test.py
+++ b/results-processor/wptreport_test.py
@@ -162,6 +162,26 @@ class WPTReportTest(unittest.TestCase):
             with self.assertRaises(ConflictingDataError):
                 r.load_json(f)
 
+    def test_load_json_multiple_chunks_ignored_conflicting_data(self):
+        tmp_path = os.path.join(self.tmp_dir, 'test.json')
+        r = WPTReport()
+        with open(tmp_path, 'wt') as f:
+            json.dump({
+                'results': [{'test1': 'foo'}],
+                'run_info': {'browser_build_id': '1'},
+            }, f)
+        with open(tmp_path, 'rb') as f:
+            r.load_json(f)
+
+        with open(tmp_path, 'wt') as f:
+            json.dump({
+                'results': [{'test2': 'bar'}],
+                'run_info': {'browser_build_id': '2'},
+            }, f)
+        with open(tmp_path, 'rb') as f:
+            r.load_json(f)
+        self.assertIsNone(r.run_info['browser_build_id'])
+
     def test_load_gzip_json(self):
         # This case also covers the Unicode testing of load_json().
         obj = {


### PR DESCRIPTION
Firefox started to add browser_build_id (a minor revision number to
run_info), which is different before and after a release cut (for
reference, Nightly is released twice a day), so jobs around release cuts
might be rejected as their chunks may have different build IDs.

In most cases, the minor difference in revisions isn't a big problem,
and having results available is generally more important. Besides, we
had been accepting results with different builds before the introduction
of the build ID field.
