### PR TITLE
Show only one pr_head run in checks pr link

### DIFF
--- a/api/checks/summaries/_pr_runs_links.md
+++ b/api/checks/summaries/_pr_runs_links.md
@@ -1,4 +1,4 @@
 {{- range $pr := .CheckState.PRNumbers }}
-- [Latest results for PR #{{ $pr }}]({{ $.HostURL }}results/?pr={{ $pr }}&label=pr_head)
+- [Latest results for PR #{{ $pr }}]({{ $.HostURL }}results/?pr={{ $pr }}&label=pr_head&max-count=1)
 - [All runs for PR #{{ $pr }}]({{ $.HostURL }}runs/?pr={{ $pr }})
 {{- end}}


### PR DESCRIPTION
## Description
Follows up to improvement of #1008 to cap per-product results at just one item.