### PR TITLE
Always pass non-regressing checks, and use action_required instead of failure

### DIFF
--- a/api/checks/update.go
+++ b/api/checks/update.go
@@ -199,7 +199,7 @@ func getDiffSummary(aeAPI shared.AppEngineAPI, diffAPI shared.DiffAPI, suite sha
 	regressions := diff.Differences.Regressions()
 	neutral := "neutral"
 	checkState.Conclusion = &neutral
-	checksCanFailAndPass := aeAPI.IsFeatureEnabled(failChecksOnRegressionFeature)
+	checksCanBeNonNeutral := aeAPI.IsFeatureEnabled(failChecksOnRegressionFeature)
 
 	var summary summaries.Summary
 	host := aeAPI.GetHostname()
@@ -234,10 +234,8 @@ func getDiffSummary(aeAPI shared.AppEngineAPI, diffAPI shared.DiffAPI, suite sha
 				data.More++
 			}
 		}
-		if checksCanFailAndPass {
-			success := "success"
-			data.CheckState.Conclusion = &success
-		}
+		success := "success"
+		data.CheckState.Conclusion = &success
 		summary = data
 	} else {
 		data := summaries.Regressed{
@@ -263,9 +261,9 @@ func getDiffSummary(aeAPI shared.AppEngineAPI, diffAPI shared.DiffAPI, suite sha
 				data.More++
 			}
 		}
-		if checksCanFailAndPass {
-			failure := "failure"
-			data.CheckState.Conclusion = &failure
+		if checksCanBeNonNeutral {
+			actionRequired := "action_required"
+			data.CheckState.Conclusion = &actionRequired
 		}
 		summary = data
 	}

--- a/webapp/components/wpt-flags.js
+++ b/webapp/components/wpt-flags.js
@@ -238,7 +238,7 @@ class WPTEnvironmentFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ tr
     <h5>GitHub Status Checks</h5>
     <paper-item sub-item="">
       <paper-checkbox checked="{{failChecksOnRegression}}">
-        Fail the wpt.fyi GitHub status check if regressions are found, and pass them if not.
+        Set the wpt.fyi GitHub status check to action_required if regressions are found.
       </paper-checkbox>
     </paper-item>
     <paper-item sub-item="">


### PR DESCRIPTION
## Description
Regardless of whether we use neutral for newly-failing / deleted results, always set a pass status when we don't see anything amiss.

Change the non-neutral status to "action_required" instead of failing - fail is too aggressive and might discourage people adding failing tests.

## Review
Docs for valid "conclusion" field values:
https://developer.github.com/v3/checks/runs/#update-a-check-run

cc @jgraham