### PR TITLE
Add includeSubtests flag for emitting subtest names

### DIFF
--- a/api/query/cache/index/aggregator.go
+++ b/api/query/cache/index/aggregator.go
@@ -17,8 +17,9 @@ type aggregator interface {
 type indexAggregator struct {
 	index
 
-	rus []RunID
-	agg map[uint64]query.SearchResult
+	rus             []RunID
+	agg             map[uint64]query.SearchResult
+	includeSubtests bool
 }
 
 func (a *indexAggregator) Add(t TestID) error {
@@ -48,6 +49,12 @@ func (a *indexAggregator) Add(t TestID) error {
 			rus[i].Total++
 			if res == shared.TestStatusPass || res == shared.TestStatusOK {
 				rus[i].Passes++
+			}
+		}
+
+		if a.includeSubtests {
+			if _, name, err := ts.GetName(t); err == nil && name != nil {
+				r.Subtests = append(r.Subtests, *name)
 			}
 		}
 	}

--- a/api/query/search.go
+++ b/api/query/search.go
@@ -44,6 +44,9 @@ type SearchResult struct {
 	// counts as 1, and each subtest counts as 1. The "pass count" contains any
 	// status values that are "PASS" or "OK".
 	LegacyStatus []LegacySearchRunResult `json:"legacy_status"`
+
+	// Subtests (names) which are included in the LegacyStatus summary.
+	Subtests []string `json:"subtests,omitempty"`
 }
 
 // SearchResponse contains a response to search API calls, including specific


### PR DESCRIPTION
## Description
Adds a (yet unused) flag to the aggregator, to emit an array of subtest names.
This will be followed by a change to set the flag to true when searching for a specific test-file path.