### PR TITLE
Include a link to the ref for reftests

### DIFF
--- a/webapp/components/wpt-flags.js
+++ b/webapp/components/wpt-flags.js
@@ -37,6 +37,7 @@ Object.defineProperty(wpt, 'ClientSideFeatures', {
       'githubCommitLinks',
       'insightsTab',
       'showTestType',
+      'showTestRefURL',
       'searchPRsForDirectories',
       'permalinks',
     ];
@@ -172,6 +173,11 @@ class WPTFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ false) {
     <paper-item sub-item>
       <paper-checkbox checked="{{showTestType}}">
         Display test types
+      </paper-checkbox>
+    </paper-item>
+    <paper-item sub-item>
+      <paper-checkbox checked="{{showTestRefURL}}">
+        Display link to ref (for reftests)
       </paper-checkbox>
     </paper-item>
     <paper-item>

--- a/webapp/components/wpt-results.js
+++ b/webapp/components/wpt-results.js
@@ -464,6 +464,7 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
     const item = Object.values(manifest.items['reftest']).find(v => v.find(i => i[0] === path));
     // In item[0], the 2nd item is the refs array, and we take the first ref (0).
     // Then, the ref's 1st item is the url (0). (2nd is the condition, e.g. "==".)
+    // See https://github.com/web-platform-tests/wpt/blob/master/tools/manifest/item.py#L141
     const refPath = item && item[0][1][0][0];
     return this.computeTestW3CURL(testType, refPath);
   }


### PR DESCRIPTION
## Description
Resolves https://github.com/web-platform-tests/wpt.fyi/issues/149

Adds a feature for including a link to the ref, in addition to the test itself. This is implemented by leveraging the manifest.

Naively assumes a single ref, with an `==`. Other cases (rare) will be added in the future.