### PR TITLE
[processor] Also ignore inconsistent browser_changeset

### DIFF
--- a/results-processor/wptreport.py
+++ b/results-processor/wptreport.py
@@ -31,6 +31,9 @@ CHANNEL_TO_LABEL = {
     'nightly': 'experimental',
     'preview': 'experimental',
 }
+# Ignore inconsistent browser minor versions for now.
+# TODO(Hexcles): Remove this when the TC decision task is implemented.
+IGNORED_CONFLICTS = {'browser_build_id', 'browser_changeset'}
 
 _log = logging.getLogger(__name__)
 
@@ -141,10 +144,7 @@ class WPTReport(object):
             for key in chunk['run_info']:
                 update_property(
                     key, chunk['run_info'], self._report['run_info'],
-                    # Ignore inconsistent browser_build_id for now.
-                    # TODO(Hexcles): Remove this exception once the decision
-                    # task is implemented on Taskcluster.
-                    ignore_conflict if key == 'browser_build_id' else None,
+                    ignore_conflict if key in IGNORED_CONFLICTS else None,
                 )
 
         update_property('time_start', chunk, self._report, min)

--- a/results-processor/wptreport_test.py
+++ b/results-processor/wptreport_test.py
@@ -168,7 +168,10 @@ class WPTReportTest(unittest.TestCase):
         with open(tmp_path, 'wt') as f:
             json.dump({
                 'results': [{'test1': 'foo'}],
-                'run_info': {'browser_build_id': '1'},
+                'run_info': {
+                    'browser_build_id': '1',
+                    'browser_changeset': 'r1',
+                },
             }, f)
         with open(tmp_path, 'rb') as f:
             r.load_json(f)
@@ -176,11 +179,15 @@ class WPTReportTest(unittest.TestCase):
         with open(tmp_path, 'wt') as f:
             json.dump({
                 'results': [{'test2': 'bar'}],
-                'run_info': {'browser_build_id': '2'},
+                'run_info': {
+                    'browser_build_id': '2',
+                    'browser_changeset': 'r2',
+                },
             }, f)
         with open(tmp_path, 'rb') as f:
             r.load_json(f)
         self.assertIsNone(r.run_info['browser_build_id'])
+        self.assertIsNone(r.run_info['browser_changeset'])
 
     def test_load_gzip_json(self):
         # This case also covers the Unicode testing of load_json().


### PR DESCRIPTION
In ac86e63f4c3badf9c5547edaa6c391950387fe90, we allowed browser_build_id
to be different but forgot browser_changeset.
