### PR TITLE
Change browser_name to product in searchcache

### DIFF
--- a/api/query/cache/index/index_filter_test.go
+++ b/api/query/cache/index/index_filter_test.go
@@ -237,14 +237,14 @@ func TestBindExecute_TestStatus(t *testing.T) {
 	}
 
 	// Set BrowserName imperatively to avoid multi-layer type embedding.
-	data[0].run.BrowserName = "Chrome"
-	data[1].run.BrowserName = "Safari"
+	data[0].run.BrowserName = "chrome"
+	data[1].run.BrowserName = "safari"
 
 	runs := mockTestRuns(loader, idx, data)
 
 	q := query.TestStatusEq{
-		BrowserName: "Chrome",
-		Status:      shared.TestStatusFail,
+		Product: shared.ParseProductSpecUnsafe("Chrome"),
+		Status:  shared.TestStatusFail,
 	}
 	srs := planAndExecute(t, runs, idx, q)
 

--- a/api/query/cache/index/index_test.go
+++ b/api/query/cache/index/index_test.go
@@ -303,8 +303,8 @@ func TestSync(t *testing.T) {
 				makeRun(int64(n - 4)),
 			}
 			plan, err := i.Bind(runs, query.TestStatusEq{
-				BrowserName: "Chrome",
-				Status:      shared.TestStatusPass,
+				Product: shared.ParseProductSpecUnsafe("Chrome"),
+				Status:  shared.TestStatusPass,
 			}.BindToRuns(runs))
 			if err != nil {
 				return

--- a/shared/params.go
+++ b/shared/params.go
@@ -120,6 +120,12 @@ func ParseProductSpec(spec string) (productSpec ProductSpec, err error) {
 	return productSpec, nil
 }
 
+// ParseProductSpecUnsafe ignores any potential error parsing the given product spec.
+func ParseProductSpecUnsafe(s string) ProductSpec {
+	parsed, _ := ParseProductSpec(s)
+	return parsed
+}
+
 // ParseProduct parses the `browser-version-os-version` input as a Product struct.
 func ParseProduct(product string) (result Product, err error) {
 	pieces := strings.Split(product, "-")
@@ -127,7 +133,7 @@ func ParseProduct(product string) (result Product, err error) {
 		return result, fmt.Errorf("invalid product: %s", product)
 	}
 	result = Product{
-		BrowserName: pieces[0],
+		BrowserName: strings.ToLower(pieces[0]),
 	}
 	if !IsBrowserName(result.BrowserName) {
 		return result, fmt.Errorf("invalid browser name: %s", result.BrowserName)

--- a/webapp/components/test-search.js
+++ b/webapp/components/test-search.js
@@ -76,14 +76,18 @@ const QUERY_GRAMMAR = ohm.grammar(`
       | "\\"" -- quote
 
     statusExp
-      = browserName ":!" statusLiteral -- neq
-      | browserName ":" statusLiteral -- eq
+      = productSpec ":!" statusLiteral -- neq
+      | productSpec ":" statusLiteral -- eq
+
+    productSpec = browserName ("-" browserVersion)?
 
     browserName
       = caseInsensitive<"chrome">
       | caseInsensitive<"edge">
       | caseInsensitive<"firefox">
       | caseInsensitive<"safari">
+
+    browserVersion = number ("." number)*
 
     statusLiteral
       = caseInsensitive<"unknown">
@@ -103,6 +107,8 @@ const QUERY_GRAMMAR = ohm.grammar(`
       = "\\x00".."\\x08"
       | "\\x0E".."\\x1F"
       | "\\x21".."\\uFFFF"
+
+    number = digit+
   }
 `);
 /* eslint-disable */
@@ -143,13 +149,13 @@ const QUERY_SEMANTICS = QUERY_GRAMMAR.createSemantics().addOperation('eval', {
   nameLiteralChar_quote: (v) => '"',
   statusExp_eq: (l, colon, r) => {
     return {
-      browser_name: l.sourceString.toLowerCase(),
+      product: l.sourceString.toLowerCase(),
       status: r.sourceString.toUpperCase(),
     };
   },
   statusExp_neq: (l, colonBang, r) => {
     return {
-      browser_name: l.sourceString.toLowerCase(),
+      product: l.sourceString.toLowerCase(),
       status: {not: r.sourceString.toUpperCase()},
     };
   },

--- a/webapp/components/test-search.js
+++ b/webapp/components/test-search.js
@@ -78,8 +78,8 @@ const QUERY_GRAMMAR = ohm.grammar(`
     statusExp
       = caseInsensitive<"status"> ":" statusLiteral  -- eq
       | caseInsensitive<"status"> ":!" statusLiteral -- neq
-      | productSpec ":!" statusLiteral               -- product_eq
-      | productSpec ":" statusLiteral                -- product_neq
+      | productSpec ":" statusLiteral                -- product_eq
+      | productSpec ":!" statusLiteral               -- product_neq
 
     productSpec = browserName ("-" browserVersion)?
 

--- a/webapp/components/test/test-search.html
+++ b/webapp/components/test/test-search.html
@@ -31,19 +31,23 @@ suite('<test-search>', () => {
       assertQueryParse('2dcontext', {pattern: '2dcontext'});
     });
 
+    test('versioned browser', () => {
+      assertQueryParse('chrome-64:fail', {product: 'chrome-64', status: 'FAIL'});
+    });
+
     test('browser test status eq', () => {
-      assertQueryParse('cHrOmE:oK', {browser_name: 'chrome', status: 'OK'});
+      assertQueryParse('cHrOmE:oK', {product: 'chrome', status: 'OK'});
     });
 
     test('browser test status neq', () => {
-      assertQueryParse('sAfArI:!FaIl', {browser_name: 'safari', status: {not: 'FAIL'}});
+      assertQueryParse('sAfArI:!FaIl', {product: 'safari', status: {not: 'FAIL'}});
     });
 
     test('pattern + test status', () => {
       assertQueryParse('cssom firefox:timeout', {
         and: [
           {pattern: 'cssom'},
-          {browser_name: 'firefox', status: 'TIMEOUT'},
+          {product: 'firefox', status: 'TIMEOUT'},
         ],
       });
     });
@@ -52,7 +56,7 @@ suite('<test-search>', () => {
       assertQueryParse('cssom or firefox:timeout', {
         or: [
           {pattern: 'cssom'},
-          {browser_name: 'firefox', status: 'TIMEOUT'},
+          {product: 'firefox', status: 'TIMEOUT'},
         ],
       });
     });
@@ -102,13 +106,13 @@ suite('<test-search>', () => {
     test('all features', () => {
       assertQueryParse('firefox:pass a | chrome:fail and ( b & c )', {
         and: [
-          {browser_name: 'firefox', status: 'PASS'},
+          {product: 'firefox', status: 'PASS'},
           {
             or: [
               {pattern: 'a'},
               {
                 and: [
-                  {browser_name: 'chrome', status: 'FAIL'},
+                  {product: 'chrome', status: 'FAIL'},
                   {
                     and: [
                       {pattern: 'b'},


### PR DESCRIPTION
## Description
Consolidates the product-spec parsing behaviour of `product` query params and "browser_name" in structured queries to use the same parsing logic server-side.

In turn, this facilitates searching for version-specific statuses, which we can use to find potential regressions in major releases, with `chrome-64:fail chrome-63:pass` type of thing.