### PR TITLE
Simplify the flakes query

### DIFF
--- a/webapp/components/wpt-insights.js
+++ b/webapp/components/wpt-insights.js
@@ -82,7 +82,7 @@ class Flakes extends ProductInfo(PolymerElement) {
       },
       query: {
         type: String,
-        computed: 'computeQuery(browser)',
+        computed: 'computeQuery()',
       },
       url: {
         type: URL,
@@ -91,9 +91,10 @@ class Flakes extends ProductInfo(PolymerElement) {
     };
   }
 
-  computeQuery(browser) {
-    const passing = Object.values(TestStatuses).filter(s => s.isPass).map(s => `${browser}:${s}`).join('|');
-    const notPassing = Object.values(TestStatuses).filter(s => !s.isPass).map(s => `${browser}:${s}`).join('|');
+  computeQuery() {
+    const passStatuses =Object.values(TestStatuses).filter(s => s.isPass);
+    const passing = passStatuses.map(s => `status:${s}`).join('|');
+    const notPassing = passStatuses.map(s => `status:!${s}`).join('&');
     return `(${passing}) (${notPassing})`;
   }
 


### PR DESCRIPTION
## Description
After #1057 we can now make "and" combinations for atoms, since the disjunction of the runs is done at the root instead of at the status equality (leaf). And after #1073 we don't need to be product-specific (since the flakes queries load a single product).

So, `(chrome:pass|chrome:ok) (chrome:fail|chrome:error|chrome:timeout|...)` simplifies to `(status:pass|status:ok) (status:!pass&status:!ok)`