### PR TITLE
Set diff results path to deepest shared dir

### DIFF
--- a/api/checks/update.go
+++ b/api/checks/update.go
@@ -199,9 +199,20 @@ func getDiffSummary(aeAPI shared.AppEngineAPI, diffAPI shared.DiffAPI, suite sha
 	}
 
 	regressions := diff.Differences.Regressions()
+	hasRegressions := regressions.Cardinality() > 0
 	neutral := "neutral"
 	checkState.Conclusion = &neutral
 	checksCanBeNonNeutral := aeAPI.IsFeatureEnabled(failChecksOnRegressionFeature)
+
+	// Set URL path to deepest shared dir.
+	var tests []string
+	if hasRegressions {
+		tests, _ = shared.MapStringKeys(diff.AfterSummary)
+	} else {
+		tests = shared.ToStringSlice(regressions)
+	}
+	sharedPath := "/results" + shared.GetSharedPath(tests...)
+	diffURL.Path = sharedPath
 
 	var summary summaries.Summary
 
@@ -214,10 +225,11 @@ func getDiffSummary(aeAPI shared.AppEngineAPI, diffAPI shared.DiffAPI, suite sha
 	if headRun.LabelsSet().Contains(shared.PRHeadLabel) {
 		// Deletions are meaningless and abundant comparing to master; ignore them.
 		masterDiffFilter := shared.DiffFilterParam{Added: true, Changed: true, Unchanged: true}
-		resultsComparison.MasterDiffURL = diffAPI.GetMasterDiffURL(headRun, &masterDiffFilter).String()
+		masterDiffURL := diffAPI.GetMasterDiffURL(headRun, &masterDiffFilter)
+		masterDiffURL.Path = sharedPath
+		resultsComparison.MasterDiffURL = masterDiffURL.String()
 	}
 
-	hasRegressions := regressions.Cardinality() > 0
 	if !hasRegressions {
 		collapsed := collapseSummary(diff.AfterSummary, 10)
 		data := summaries.Completed{

--- a/api/checks/update.go
+++ b/api/checks/update.go
@@ -207,9 +207,9 @@ func getDiffSummary(aeAPI shared.AppEngineAPI, diffAPI shared.DiffAPI, suite sha
 	// Set URL path to deepest shared dir.
 	var tests []string
 	if hasRegressions {
-		tests, _ = shared.MapStringKeys(diff.AfterSummary)
-	} else {
 		tests = shared.ToStringSlice(regressions)
+	} else {
+		tests, _ = shared.MapStringKeys(diff.AfterSummary)
 	}
 	sharedPath := "/results" + shared.GetSharedPath(tests...)
 	diffURL.Path = sharedPath

--- a/shared/util.go
+++ b/shared/util.go
@@ -307,6 +307,8 @@ func GetSharedPath(paths ...string) string {
 				if part == otherParts[i] {
 					continue
 				}
+				// Crop to the matching parts, append empty last-part
+				// so that we have a trailing slash.
 				parts = append(parts[:i], "")
 				break
 			}

--- a/shared/util.go
+++ b/shared/util.go
@@ -294,3 +294,23 @@ func CropString(s string, i int) string {
 	}
 	return s[:i]
 }
+
+// GetSharedPath gets the longest path shared between the given paths.
+func GetSharedPath(paths ...string) string {
+	var parts []string
+	for _, path := range paths {
+		if parts == nil {
+			parts = strings.Split(path, "/")
+		} else {
+			otherParts := strings.Split(path, "/")
+			for i, part := range parts {
+				if part == otherParts[i] {
+					continue
+				}
+				parts = append(parts[:i], "")
+				break
+			}
+		}
+	}
+	return strings.Join(parts, "/")
+}

--- a/shared/util_test.go
+++ b/shared/util_test.go
@@ -83,3 +83,10 @@ func checkResult(t *testing.T, testRun TestRun, testFile string, expected string
 		t.Errorf("\nGot:\n%q\nExpected:\n%q", got, expected)
 	}
 }
+
+func TestGetSharedPath(t *testing.T) {
+	assert.Equal(t, "/a/b/c.html", GetSharedPath("/a/b/c.html"))
+	assert.Equal(t, "/a/b/", GetSharedPath("/a/b/c.html", "/a/b/d.html"))
+	assert.Equal(t, "/", GetSharedPath("/a/b/c.html", "/d/e/f.html"))
+	assert.Equal(t, "/a/", GetSharedPath("/a/z.html", "/a/b/x.html", "/a/b/y.html"))
+}


### PR DESCRIPTION
## Description
Resolves https://github.com/web-platform-tests/wpt.fyi/issues/1070

Finds the deepest shared path, and set that as the URL's path.

## Review
To test this change, we'll need an [example](https://github.com/web-platform-tests/wpt/pull/15067/checks?check_run_id=54652355) that does a poor job.
Once the enviroment is deployed, we can POST to /api/checks/[SHA]?product=chrome (example is b842c84)
That will recompute the links, with this PR's changes.