### PR TITLE
Add Metadata structs to wpt.fyi/shared

### DIFF
--- a/shared/metadata.go
+++ b/shared/metadata.go
@@ -4,12 +4,17 @@
 
 package shared
 
+// Metadata represents a wpt-metadata META.yml file.
 type Metadata struct {
 	Links MetadataLinks
 }
 
+// MetadataLinks is a helper type for a MetadataLink slice.
 type MetadataLinks []MetadataLink
 
+// MetadataLink is an item in the `links` node of a wpt-metadata
+// META.yml file, which lists an external reference, optionally
+// filtered by product and a specific test.
 type MetadataLink struct {
 	Product  ProductSpec
 	TestPath string `yaml:"test"`

--- a/shared/metadata.go
+++ b/shared/metadata.go
@@ -1,0 +1,17 @@
+// Copyright 2019 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package shared
+
+type Metadata struct {
+	Links MetadataLinks
+}
+
+type MetadataLinks []MetadataLink
+
+type MetadataLink struct {
+	Product  ProductSpec
+	TestPath string `yaml:"test"`
+	URL      string
+}

--- a/shared/metadata_test.go
+++ b/shared/metadata_test.go
@@ -1,0 +1,28 @@
+// +build small
+
+// Copyright 2019 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package shared
+
+import (
+	"testing"
+
+	"github.com/go-yaml/yaml"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParse(t *testing.T) {
+	var metadata Metadata
+	err := yaml.Unmarshal([]byte(`
+links:
+  - product: chrome-64
+    test: a.html
+    url: https://external.com/item`), &metadata)
+	assert.Nil(t, err)
+	assert.Equal(t, "chrome", metadata.Links[0].Product.BrowserName)
+	assert.Equal(t, "64", metadata.Links[0].Product.BrowserVersion)
+	assert.Equal(t, "a.html", metadata.Links[0].TestPath)
+	assert.Equal(t, "https://external.com/item", metadata.Links[0].URL)
+}

--- a/shared/product_spec.go
+++ b/shared/product_spec.go
@@ -131,3 +131,13 @@ func (p *ProductSpec) UnmarshalJSON(data []byte) (err error) {
 	*p, err = ParseProductSpec(s)
 	return err
 }
+
+// UnmarshalYAML parses an array so that ProductSpec can be unmarshalled.
+func (p *ProductSpec) UnmarshalYAML(unmarshal func(interface{}) error) (err error) {
+	var s string
+	if err := unmarshal(&s); err != nil {
+		return err
+	}
+	*p, err = ParseProductSpec(s)
+	return err
+}


### PR DESCRIPTION
## Description
Early stab at a strongly-typed interpretation of the wpt-metadata yml format.