### PR TITLE
Fix simple (empty) queries

### DIFF
--- a/api/query/search.go
+++ b/api/query/search.go
@@ -126,8 +126,17 @@ func (sh structuredSearchHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	simpleQ, ok := rq.AbstractQuery.(TestNamePattern)
-	if !ok {
+	// Check if the query is a simple (empty, or test name only) query
+	var simpleQ TestNamePattern
+	var isSimpleQ bool
+	{
+		exists, ok := rq.AbstractQuery.(AbstractExists)
+		if ok && len(exists.Args) == 1 {
+			simpleQ, isSimpleQ = exists.Args[0].(TestNamePattern)
+		}
+	}
+
+	if !isSimpleQ {
 		ctx := sh.api.Context()
 		hostname := sh.api.GetServiceHostname("searchcache")
 		// TODO: This will not work when hostname is localhost (http scheme needed).

--- a/api/query/search_medium_test.go
+++ b/api/query/search_medium_test.go
@@ -227,9 +227,7 @@ func TestStructuredSearchHandler_equivalentToUnstructured(t *testing.T) {
 	url := "/api/search"
 	r, err := i.NewRequest("POST", url, bytes.NewBuffer([]byte(fmt.Sprintf(`{
 		"run_ids": [%d, %d],
-		"query": {
-			"pattern": %s
-		}
+		"query": {"exists": [{"pattern": %s}] }
 	}`, testRuns[0].ID, testRuns[1].ID, string(q)))))
 	assert.Nil(t, err)
 	ctx := shared.NewAppEngineContext(r)
@@ -256,7 +254,7 @@ func TestStructuredSearchHandler_equivalentToUnstructured(t *testing.T) {
 	assert.Nil(t, err)
 	var data SearchResponse
 	err = json.Unmarshal(bytes, &data)
-	assert.Nil(t, err)
+	assert.Nil(t, err, "Error unmarshalling \"%s\"", string(bytes))
 
 	// Same result as TestGetRunsAndFilters_specificRunIDs.
 	assert.Equal(t, SearchResponse{
@@ -456,9 +454,7 @@ func TestStructuredSearchHandler_doNotCacheEmptyResult(t *testing.T) {
 	url := "/api/search"
 	r, err := i.NewRequest("POST", url, bytes.NewBuffer([]byte(fmt.Sprintf(`{
 		"run_ids": [%d, %d],
-		"query": {
-			"pattern": %s
-		}
+		"query": {"exists": [{"pattern": %s}] }
 	}`, testRuns[0].ID, testRuns[1].ID, string(q)))))
 	assert.Nil(t, err)
 	ctx := shared.NewAppEngineContext(r)


### PR DESCRIPTION
## Description
#1057 broke the check for a "simple" query, causing simple queries to bypass the summaries, causing a regression in performance (particularly for uncommon data), which in turn is timing out some integration tests.