### PR TITLE
Add sequential query atom

### DIFF
--- a/webapp/components/test/test-search.html
+++ b/webapp/components/test/test-search.html
@@ -170,7 +170,7 @@ suite('<test-search>', () => {
       );
     });
 
-    test('all features', () => {
+    test('or of and of and', () => {
       assertQueryParse('firefox:pass a | chrome:fail and ( b & c )', {
         exists: [
           {product: 'firefox', status: 'PASS'},
@@ -188,6 +188,21 @@ suite('<test-search>', () => {
                   },
                 ],
               },
+            ],
+          },
+        ]
+      });
+    });
+
+    test('sequential', () => {
+      // A pass turning into a fail on the next run.
+      assertQueryParse('seq (status:PASS or status:OK) (status:!PASS and status:!OK)', {
+        sequential: [
+          { or: [{status: 'PASS'}, {status: 'OK'}] },
+          {
+            and: [
+              {status: {not: 'PASS'}},
+              {status: {not: 'OK'}},
             ],
           },
         ]


### PR DESCRIPTION
## Description
Adds an atom for changing the root query from "Exists" to "Sequential".
For exists, each separate query/expression must be resolved by _any_ run.
For sequential, each separate query/expression must by resolved by _the next_ run.

This allows us to look for flip-flopping flakiness, rather than "both failing and not failing", which in turn picks up fixed tests incorrectly.