### PR TITLE
Plumb param for including subtests in searchcache response

### DIFF
--- a/api/query/cache/index/aggregator.go
+++ b/api/query/cache/index/aggregator.go
@@ -5,6 +5,7 @@
 package index
 
 import (
+	mapset "github.com/deckarep/golang-set"
 	"github.com/web-platform-tests/wpt.fyi/api/query"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
@@ -32,7 +33,13 @@ func (a *indexAggregator) Add(t TestID) error {
 			return err
 		}
 
-		r = query.SearchResult{Test: name, LegacyStatus: nil}
+		r = query.SearchResult{
+			Test:         name,
+			LegacyStatus: nil,
+		}
+		if a.includeSubtests {
+			r.Subtests = mapset.NewSet()
+		}
 	}
 
 	rus := r.LegacyStatus

--- a/api/query/cache/index/aggregator.go
+++ b/api/query/cache/index/aggregator.go
@@ -54,7 +54,7 @@ func (a *indexAggregator) Add(t TestID) error {
 
 		if a.includeSubtests {
 			if _, name, err := ts.GetName(t); err == nil && name != nil {
-				r.Subtests = append(r.Subtests, *name)
+				r.Subtests.Add(*name)
 			}
 		}
 	}

--- a/api/query/cache/index/aggregator.go
+++ b/api/query/cache/index/aggregator.go
@@ -72,10 +72,11 @@ func (a *indexAggregator) Done() []query.SearchResult {
 	return res
 }
 
-func newIndexAggregator(idx index, rus []RunID) aggregator {
+func newIndexAggregator(idx index, rus []RunID, opts query.AggregationOpts) aggregator {
 	return &indexAggregator{
-		index: idx,
-		rus:   rus,
-		agg:   make(map[uint64]query.SearchResult),
+		index:           idx,
+		rus:             rus,
+		agg:             make(map[uint64]query.SearchResult),
+		includeSubtests: opts.IncludeSubtests,
 	}
 }

--- a/api/query/cache/index/index_filter_test.go
+++ b/api/query/cache/index/index_filter_test.go
@@ -39,7 +39,7 @@ func planAndExecute(t *testing.T, runs []shared.TestRun, idx Index, q query.Abst
 	plan, err := idx.Bind(runs, q.BindToRuns(runs...))
 	assert.Nil(t, err)
 
-	res := plan.Execute(runs)
+	res := plan.Execute(runs, query.AggregationOpts{})
 	srs, ok := res.([]query.SearchResult)
 	assert.True(t, ok)
 

--- a/api/query/cache/index/index_test.go
+++ b/api/query/cache/index/index_test.go
@@ -311,7 +311,7 @@ func TestSync(t *testing.T) {
 				return
 			}
 
-			plan.Execute(runs)
+			plan.Execute(runs, query.AggregationOpts{})
 		}(j)
 	}
 	wg.Wait()

--- a/api/query/cache/monitor/monitor_test.go
+++ b/api/query/cache/monitor/monitor_test.go
@@ -64,6 +64,7 @@ func TestDoubleStart(t *testing.T) {
 		defer wg.Done()
 		err1 = mon.Start()
 	}()
+	time.Sleep(time.Microsecond * 100)
 	go func() {
 		defer wg.Done()
 		err2 = mon.Start()

--- a/api/query/cache/service/main.go
+++ b/api/query/cache/service/main.go
@@ -141,13 +141,19 @@ func searchHandler(w http.ResponseWriter, r *http.Request) {
 	// resident in `idx`. In the unlikely event that a run in `ids`/`runs` is no
 	// longer in `idx`, `idx.Bind()` below will return an error.
 	q := cq.PrepareUserQuery(ids, rq.AbstractQuery.BindToRuns(runs...))
+
+	// Configure format, from request params.
+	_, subtests := r.URL.Query()["subtests"]
+	opts := query.AggregationOpts{
+		IncludeSubtests: subtests,
+	}
 	plan, err := idx.Bind(runs, q)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	results := plan.Execute(runs)
+	results := plan.Execute(runs, opts)
 	res, ok := results.([]query.SearchResult)
 	if !ok {
 		http.Error(w, "Search index returned bad results", http.StatusInternalServerError)

--- a/api/query/concrete_query.go
+++ b/api/query/concrete_query.go
@@ -8,6 +8,8 @@ import (
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
+// AggregationOpts are options for the aggregation format used when collecting
+// the results.
 type AggregationOpts struct {
 	IncludeSubtests bool
 }

--- a/api/query/concrete_query.go
+++ b/api/query/concrete_query.go
@@ -8,6 +8,10 @@ import (
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
+type AggregationOpts struct {
+	IncludeSubtests bool
+}
+
 // Binder is a mechanism for binding a query over a slice of test runs to
 // a particular query service mechanism.
 type Binder interface {
@@ -23,7 +27,7 @@ type Binder interface {
 type Plan interface {
 	// Execute runs the query execution plan. The result set type depends on the
 	// underlying query service mechanism that the Plan was bound with.
-	Execute([]shared.TestRun) interface{}
+	Execute([]shared.TestRun, AggregationOpts) interface{}
 }
 
 // ConcreteQuery is an AbstractQuery that has been bound to specific test runs.

--- a/api/query/search.go
+++ b/api/query/search.go
@@ -47,13 +47,13 @@ type SearchResult struct {
 	LegacyStatus []LegacySearchRunResult `json:"legacy_status"`
 
 	// Subtests (names) which are included in the LegacyStatus summary.
-	Subtests mapset.Set `json:"subtests,omitempty"`
+	Subtests mapset.Set `json:"-"`
 }
 
 type searchResultNoCustomMarshalling SearchResult
 type marshallableSearchResult struct {
 	searchResultNoCustomMarshalling
-	Subtests []string `json:"labels,omitempty"`
+	Subtests []string `json:"subtests,omitempty"`
 }
 
 // MarshalJSON treats the set as an array so it can be marshalled.


### PR DESCRIPTION
## Description
Checks for `?subtests` param and plumbs the option to include subtests in the response.