### PR TITLE
Filter the matching subtests for individual tests pages

### DIFF
--- a/api/query/cache/index/aggregator.go
+++ b/api/query/cache/index/aggregator.go
@@ -5,6 +5,7 @@
 package index
 
 import (
+	mapset "github.com/deckarep/golang-set"
 	"github.com/web-platform-tests/wpt.fyi/api/query"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
@@ -32,7 +33,13 @@ func (a *indexAggregator) Add(t TestID) error {
 			return err
 		}
 
-		r = query.SearchResult{Test: name, LegacyStatus: nil}
+		r = query.SearchResult{
+			Test:         name,
+			LegacyStatus: nil,
+		}
+		if a.includeSubtests {
+			r.Subtests = mapset.NewSet()
+		}
 	}
 
 	rus := r.LegacyStatus

--- a/api/query/cache/index/aggregator.go
+++ b/api/query/cache/index/aggregator.go
@@ -5,7 +5,6 @@
 package index
 
 import (
-	mapset "github.com/deckarep/golang-set"
 	"github.com/web-platform-tests/wpt.fyi/api/query"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
@@ -37,9 +36,6 @@ func (a *indexAggregator) Add(t TestID) error {
 			Test:         name,
 			LegacyStatus: nil,
 		}
-		if a.includeSubtests {
-			r.Subtests = mapset.NewSet()
-		}
 	}
 
 	rus := r.LegacyStatus
@@ -58,11 +54,11 @@ func (a *indexAggregator) Add(t TestID) error {
 				rus[i].Passes++
 			}
 		}
-
-		if a.includeSubtests {
-			if _, name, err := ts.GetName(t); err == nil && name != nil {
-				r.Subtests.Add(*name)
-			}
+	}
+	if a.includeSubtests {
+		if _, subtest, err := ts.GetName(t); err == nil && subtest != nil {
+			name := *subtest
+			r.Subtests = append(r.Subtests, name)
 		}
 	}
 	r.LegacyStatus = rus

--- a/api/query/cache/index/aggregator.go
+++ b/api/query/cache/index/aggregator.go
@@ -54,7 +54,7 @@ func (a *indexAggregator) Add(t TestID) error {
 
 		if a.includeSubtests {
 			if _, name, err := ts.GetName(t); err == nil && name != nil {
-				r.Subtests = append(r.Subtests, *name)
+				r.Subtests.Add(*name)
 			}
 		}
 	}

--- a/api/query/cache/index/aggregator.go
+++ b/api/query/cache/index/aggregator.go
@@ -72,10 +72,11 @@ func (a *indexAggregator) Done() []query.SearchResult {
 	return res
 }
 
-func newIndexAggregator(idx index, rus []RunID) aggregator {
+func newIndexAggregator(idx index, rus []RunID, opts query.AggregationOpts) aggregator {
 	return &indexAggregator{
-		index: idx,
-		rus:   rus,
-		agg:   make(map[uint64]query.SearchResult),
+		index:           idx,
+		rus:             rus,
+		agg:             make(map[uint64]query.SearchResult),
+		includeSubtests: opts.IncludeSubtests,
 	}
 }

--- a/api/query/cache/index/index.go
+++ b/api/query/cache/index/index.go
@@ -222,17 +222,18 @@ func (i *shardedWPTIndex) IngestRun(r shared.TestRun) error {
 
 		// Add each subtests' result to the appropriate shard (same shard as
 		// top-level test).
-		for _, sub := range subs {
-			t, err := computeTestID(res.Test, &sub.Name)
+		for i := range subs {
+			name := subs[i].Name
+			t, err := computeTestID(res.Test, &name)
 			if err != nil {
 				return err
 			}
 
-			re := ResultID(shared.TestStatusValueFromString(sub.Status))
+			re := ResultID(shared.TestStatusValueFromString(subs[i].Status))
 			dataForShard[t] = testData{
 				testName: testName{
 					name:    res.Test,
-					subName: &sub.Name,
+					subName: &name,
 				},
 				ResultID: re,
 			}

--- a/api/query/cache/index/index_filter_test.go
+++ b/api/query/cache/index/index_filter_test.go
@@ -39,7 +39,7 @@ func planAndExecute(t *testing.T, runs []shared.TestRun, idx Index, q query.Abst
 	plan, err := idx.Bind(runs, q.BindToRuns(runs...))
 	assert.Nil(t, err)
 
-	res := plan.Execute(runs)
+	res := plan.Execute(runs, query.AggregationOpts{})
 	srs, ok := res.([]query.SearchResult)
 	assert.True(t, ok)
 

--- a/api/query/cache/index/index_test.go
+++ b/api/query/cache/index/index_test.go
@@ -311,7 +311,7 @@ func TestSync(t *testing.T) {
 				return
 			}
 
-			plan.Execute(runs)
+			plan.Execute(runs, query.AggregationOpts{})
 		}(j)
 	}
 	wg.Wait()

--- a/api/query/cache/monitor/monitor_test.go
+++ b/api/query/cache/monitor/monitor_test.go
@@ -64,6 +64,7 @@ func TestDoubleStart(t *testing.T) {
 		defer wg.Done()
 		err1 = mon.Start()
 	}()
+	time.Sleep(time.Microsecond * 100)
 	go func() {
 		defer wg.Done()
 		err2 = mon.Start()

--- a/api/query/cache/service/main.go
+++ b/api/query/cache/service/main.go
@@ -141,13 +141,19 @@ func searchHandler(w http.ResponseWriter, r *http.Request) {
 	// resident in `idx`. In the unlikely event that a run in `ids`/`runs` is no
 	// longer in `idx`, `idx.Bind()` below will return an error.
 	q := cq.PrepareUserQuery(ids, rq.AbstractQuery.BindToRuns(runs...))
+
+	// Configure format, from request params.
+	_, subtests := r.URL.Query()["subtests"]
+	opts := query.AggregationOpts{
+		IncludeSubtests: subtests,
+	}
 	plan, err := idx.Bind(runs, q)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	results := plan.Execute(runs)
+	results := plan.Execute(runs, opts)
 	res, ok := results.([]query.SearchResult)
 	if !ok {
 		http.Error(w, "Search index returned bad results", http.StatusInternalServerError)

--- a/api/query/concrete_query.go
+++ b/api/query/concrete_query.go
@@ -8,6 +8,8 @@ import (
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
+// AggregationOpts are options for the aggregation format used when collecting
+// the results.
 type AggregationOpts struct {
 	IncludeSubtests bool
 }

--- a/api/query/concrete_query.go
+++ b/api/query/concrete_query.go
@@ -8,6 +8,10 @@ import (
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
+type AggregationOpts struct {
+	IncludeSubtests bool
+}
+
 // Binder is a mechanism for binding a query over a slice of test runs to
 // a particular query service mechanism.
 type Binder interface {
@@ -23,7 +27,7 @@ type Binder interface {
 type Plan interface {
 	// Execute runs the query execution plan. The result set type depends on the
 	// underlying query service mechanism that the Plan was bound with.
-	Execute([]shared.TestRun) interface{}
+	Execute([]shared.TestRun, AggregationOpts) interface{}
 }
 
 // ConcreteQuery is an AbstractQuery that has been bound to specific test runs.

--- a/api/query/search.go
+++ b/api/query/search.go
@@ -18,7 +18,6 @@ import (
 	"strings"
 	time "time"
 
-	mapset "github.com/deckarep/golang-set"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
@@ -47,22 +46,7 @@ type SearchResult struct {
 	LegacyStatus []LegacySearchRunResult `json:"legacy_status"`
 
 	// Subtests (names) which are included in the LegacyStatus summary.
-	Subtests mapset.Set `json:"-"`
-}
-
-type searchResultNoCustomMarshalling SearchResult
-type marshallableSearchResult struct {
-	searchResultNoCustomMarshalling
 	Subtests []string `json:"subtests,omitempty"`
-}
-
-// MarshalJSON treats the set as an array so it can be marshalled.
-func (filter SearchResult) MarshalJSON() ([]byte, error) {
-	m := marshallableSearchResult{
-		searchResultNoCustomMarshalling: searchResultNoCustomMarshalling(filter),
-	}
-	m.Subtests = shared.ToStringSlice(filter.Subtests)
-	return json.Marshal(m)
 }
 
 // SearchResponse contains a response to search API calls, including specific

--- a/api/query/search.go
+++ b/api/query/search.go
@@ -47,13 +47,13 @@ type SearchResult struct {
 	LegacyStatus []LegacySearchRunResult `json:"legacy_status"`
 
 	// Subtests (names) which are included in the LegacyStatus summary.
-	Subtests mapset.Set `json:"subtests,omitempty"`
+	Subtests mapset.Set `json:"-"`
 }
 
 type searchResultNoCustomMarshalling SearchResult
 type marshallableSearchResult struct {
 	searchResultNoCustomMarshalling
-	Subtests []string `json:"labels,omitempty"`
+	Subtests []string `json:"subtests,omitempty"`
 }
 
 // MarshalJSON treats the set as an array so it can be marshalled.

--- a/api/query/search.go
+++ b/api/query/search.go
@@ -159,15 +159,16 @@ func (sh structuredSearchHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 		ctx := sh.api.Context()
 		hostname := sh.api.GetServiceHostname("searchcache")
 		// TODO: This will not work when hostname is localhost (http scheme needed).
-		url := fmt.Sprintf("https://%s/api/search/cache", hostname)
-		logger := shared.GetLogger(ctx)
+		fwdURL, _ := url.Parse(fmt.Sprintf("https://%s/api/search/cache", hostname))
+		fwdURL.RawQuery = r.URL.RawQuery
 
-		logger.Infof("Forwarding structured search request to cache: %s", string(data))
+		logger := shared.GetLogger(ctx)
+		logger.Infof("Forwarding structured search request to %s: %s", hostname, string(data))
 
 		client := sh.api.GetHTTPClient()
-		req, err := http.NewRequest("POST", url, bytes.NewBuffer(data))
+		req, err := http.NewRequest("POST", fwdURL.String(), bytes.NewBuffer(data))
 		if err != nil {
-			logger.Errorf("Failed to create request to POST %s: %v", url, err)
+			logger.Errorf("Failed to create request to POST %s: %v", fwdURL.String(), err)
 			http.Error(w, "Error connecting to search API cache", http.StatusInternalServerError)
 			return
 		}
@@ -181,7 +182,7 @@ func (sh structuredSearchHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 		}
 
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-			msg := fmt.Sprintf("Error from request: POST %s: STATUS %d", url, resp.StatusCode)
+			msg := fmt.Sprintf("Error from request: POST %s: STATUS %d", fwdURL.String(), resp.StatusCode)
 			errBody, err2 := ioutil.ReadAll(resp.Body)
 			if err2 == nil {
 				msg = fmt.Sprintf("%s: %s", msg, string(errBody))

--- a/webapp/components/test-file-results.js
+++ b/webapp/components/test-file-results.js
@@ -93,7 +93,7 @@ class TestFileResults extends WPTFlags(LoadingState(TestRunsUIQuery(
       this.fetchTestFile(path, testRuns),
     ]);
 
-    if (searchResults) {
+    if (resultsTable && searchResults) {
       const test = searchResults.results.find(r => r.test === path);
       if (test) {
         let subtests = new Set(test.subtests);

--- a/webapp/components/test-file-results.js
+++ b/webapp/components/test-file-results.js
@@ -111,17 +111,12 @@ class TestFileResults extends WPTFlags(LoadingState(TestRunsUIQuery(
     }
 
     // Combine the query with " and [path]".
-    const q = Object.assign({}, structuredSearch);
-    if (q.exists) {
-      q.exists = q.exists.map(node => {
-        return {
-          and: [
-            node,
-            {pattern: path}
-          ]
-        };
-      });
-    }
+    let q = {
+      and: [
+        {pattern: path},
+        structuredSearch,
+      ]
+    };
 
     let url = new URL('/api/search', window.location);
     url.searchParams.set('subtests', '');

--- a/webapp/components/test-file-results.js
+++ b/webapp/components/test-file-results.js
@@ -96,8 +96,8 @@ class TestFileResults extends WPTFlags(LoadingState(TestRunsUIQuery(
     if (resultsTable && searchResults) {
       const test = searchResults.results.find(r => r.test === path);
       if (test) {
-        let subtests = new Set(test.subtests);
-        let [first, ...others] = resultsTable;
+        const subtests = new Set(test.subtests);
+        const [first, ...others] = resultsTable;
         const matches = others.filter(t => subtests.has(t.name));
         resultsTable = [first, ...matches];
       }
@@ -111,14 +111,14 @@ class TestFileResults extends WPTFlags(LoadingState(TestRunsUIQuery(
     }
 
     // Combine the query with " and [path]".
-    let q = {
+    const q = {
       and: [
         {pattern: path},
         structuredSearch,
       ]
     };
 
-    let url = new URL('/api/search', window.location);
+    const url = new URL('/api/search', window.location);
     url.searchParams.set('subtests', '');
     const fetchOpts = {
       method: 'POST',

--- a/webapp/components/test-file-results.js
+++ b/webapp/components/test-file-results.js
@@ -98,7 +98,8 @@ class TestFileResults extends WPTFlags(LoadingState(TestRunsUIQuery(
       if (test) {
         let subtests = new Set(test.subtests);
         let [first, ...others] = resultsTable;
-        resultsTable = [first, others.filter(t => subtests.has(t.name))];
+        const matches = others.filter(t => subtests.has(t.name));
+        resultsTable = [first, ...matches];
       }
     }
     this.resultsTable = resultsTable;
@@ -131,7 +132,7 @@ class TestFileResults extends WPTFlags(LoadingState(TestRunsUIQuery(
         query: q,
       }),
     };
-    this.retry(
+    return await this.retry(
       async() => {
         const r = await window.fetch(url, fetchOpts);
         if (!r.ok) {
@@ -145,15 +146,6 @@ class TestFileResults extends WPTFlags(LoadingState(TestRunsUIQuery(
       err => err === 422,
       testRuns.length + 1,
       5000
-    ).then(
-      json => {
-        this.searchResults = json.results;
-        this.refreshDisplayedNodes();
-      },
-      (e) => {
-        // eslint-disable-next-line no-console
-        console.log(`Failed to load: ${e}`);
-      }
     );
   }
 

--- a/webapp/components/test-file-results.js
+++ b/webapp/components/test-file-results.js
@@ -10,10 +10,12 @@ import { html } from '../node_modules/@polymer/polymer/lib/utils/html-tag.js';
 import { PolymerElement } from '../node_modules/@polymer/polymer/polymer-element.js';
 import { TestRunsUIQuery } from './test-runs-query.js';
 import { TestRunsQueryLoader } from './test-runs.js';
+import { LoadingState } from './loading-state.js';
 import './wpt-colors.js';
+import { WPTFlags } from './wpt-flags.js';
 
-class TestFileResults extends TestRunsUIQuery(
-  TestRunsQueryLoader(PolymerElement, TestRunsUIQuery.Computer)) {
+class TestFileResults extends WPTFlags(LoadingState(TestRunsUIQuery(
+  TestRunsQueryLoader(PolymerElement, TestRunsUIQuery.Computer)))) {
   static get template() {
     return html`
     <style include="wpt-colors">
@@ -62,6 +64,7 @@ class TestFileResults extends TestRunsUIQuery(
 
   static get properties() {
     return {
+      structuredSearch: Object,
       resultsTable: {
         type: Array,
         value: [],
@@ -80,7 +83,78 @@ class TestFileResults extends TestRunsUIQuery(
   }
 
   static get observers() {
-    return ['fetchTestFile(path, testRuns)'];
+    return ['loadData(path, testRuns, structuredSearch)'];
+  }
+
+  async loadData(path, testRuns, structuredSearch) {
+    // Run a search query, including subtests, as well as fetching the results file.
+    let [searchResults, resultsTable] = await Promise.all([
+      this.fetchSearchResults(path, testRuns, structuredSearch),
+      this.fetchTestFile(path, testRuns),
+    ]);
+
+    if (searchResults) {
+      const test = searchResults.results.find(r => r.test === path);
+      if (test) {
+        let subtests = new Set(test.subtests);
+        let [first, ...others] = resultsTable;
+        resultsTable = [first, others.filter(t => subtests.has(t.name))];
+      }
+    }
+    this.resultsTable = resultsTable;
+  }
+
+  async fetchSearchResults(path, testRuns, structuredSearch) {
+    if (!testRuns || !testRuns.length || !this.structuredQueries || !structuredSearch) {
+      return;
+    }
+
+    // Combine the query with " and [path]".
+    const q = Object.assign({}, structuredSearch);
+    if (q.exists) {
+      q.exists = q.exists.map(node => {
+        return {
+          and: [
+            node,
+            {pattern: path}
+          ]
+        };
+      });
+    }
+
+    let url = new URL('/api/search', window.location);
+    url.searchParams.set('subtests', '');
+    const fetchOpts = {
+      method: 'POST',
+      body: JSON.stringify({
+        run_ids: testRuns.map(r => r.id),
+        query: q,
+      }),
+    };
+    this.retry(
+      async() => {
+        const r = await window.fetch(url, fetchOpts);
+        if (!r.ok) {
+          if (fetchOpts.method === 'POST' && r.status === 422) {
+            throw r.status;
+          }
+          throw 'Failed to fetch results data.';
+        }
+        return r.json();
+      },
+      err => err === 422,
+      testRuns.length + 1,
+      5000
+    ).then(
+      json => {
+        this.searchResults = json.results;
+        this.refreshDisplayedNodes();
+      },
+      (e) => {
+        // eslint-disable-next-line no-console
+        console.log(`Failed to load: ${e}`);
+      }
+    );
   }
 
   async fetchTestFile(path, testRuns) {
@@ -129,8 +203,7 @@ class TestFileResults extends TestRunsUIQuery(
     // Set name for test-level status entry after subtests discovered.
     // Parameter is number of subtests.
     resultsTable[0].name = this.statusName(resultsTable.length - 1);
-
-    this.resultsTable = resultsTable;
+    return resultsTable;
   }
 
   async loadResultFile(testRun) {

--- a/webapp/components/test-search.js
+++ b/webapp/components/test-search.js
@@ -218,7 +218,10 @@ class TestSearch extends WPTFlags(PolymerElement) {
         notify: true,
         observer: 'queryUpdated',
       },
-      structuredQuery: Object,
+      structuredQuery: {
+        type: Object,
+        notify: true,
+      },
       results: {
         type: Array,
         notify: true,
@@ -254,7 +257,7 @@ class TestSearch extends WPTFlags(PolymerElement) {
     this.queryInput = query;
     if (this.structuredQueries) {
       try {
-        this.structuredQuery = this.parseAndInterpretQuery(query);
+        this.structuredQuery = Object.freeze(this.parseAndInterpretQuery(query));
       } catch (err) {
         // TODO: Handle query parse/interpret error.
       }

--- a/webapp/components/test-search.js
+++ b/webapp/components/test-search.js
@@ -263,10 +263,14 @@ class TestSearch extends WPTFlags(PolymerElement) {
   queryUpdated(query) {
     this.queryInput = query;
     if (this.structuredQueries) {
-      try {
-        this.structuredQuery = Object.freeze(this.parseAndInterpretQuery(query));
-      } catch (err) {
-        // TODO: Handle query parse/interpret error.
+      if (!query) {
+        this.structuredQuery = null;
+      } else {
+        try {
+          this.structuredQuery = Object.freeze(this.parseAndInterpretQuery(query));
+        } catch (err) {
+          // TODO: Handle query parse/interpret error.
+        }
       }
     }
   }

--- a/webapp/components/wpt-results.js
+++ b/webapp/components/wpt-results.js
@@ -243,7 +243,11 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
 
     <template is="dom-if" if="[[testRuns]]">
       <template is="dom-if" if="{{ pathIsATestFile }}">
-        <test-file-results test-runs="[[testRuns]]" path="[[path]]" labels="[[labels]]" products="[[products]]">
+        <test-file-results test-runs="[[testRuns]]"
+                           path="[[path]]"
+                           structured-search="[[structuredSearch]]"
+                           labels="[[labels]]"
+                           products="[[products]]">
         </test-file-results>
       </template>
 

--- a/webapp/components/wpt-results.js
+++ b/webapp/components/wpt-results.js
@@ -59,11 +59,6 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
         top: 0;
         right: 0;
       }
-      /* Direct access to test-search from local shadowRoot prevents using
-       * \`dom-if\` for this. */
-      section.search test-search.search-true {
-        display: none;
-      }
       table {
         width: 100%;
         border-collapse: collapse;
@@ -180,8 +175,10 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
 
       <paper-spinner-lite active="[[isLoading]]" class="blue"></paper-spinner-lite>
 
-      <test-search class\$="search-[[pathIsATestFile]]" query="{{search}}" test-runs="[[testRuns]]" test-paths="[[testPaths]]">
-      </test-search>
+      <test-search query="{{search}}"
+                   structured-query="{{structuredSearch}}"
+                   test-runs="[[testRuns]]"
+                   test-paths="[[testPaths]]"></test-search>
 
       <template is="dom-if" if="{{ pathIsATestFile }}">
         <div class="links">
@@ -374,6 +371,7 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
         type: String,
         computed: 'computeTestRefURL(testType, path, manifest)',
       },
+      structuredSearch: Object,
       searchResults: {
         type: Array,
         value: [],


### PR DESCRIPTION
## Description
Checks for ?subtests param and plumbs the option to include subtests in the response.
Then, leverages the functionality from the client in order to filter the results on an individual test file page.

Fix for #81 (and duplicate #1048)