### PR TITLE
Add permissive CORS for /api/search

### DIFF
--- a/api/query/routes.go
+++ b/api/query/routes.go
@@ -9,7 +9,10 @@ import "github.com/web-platform-tests/wpt.fyi/shared"
 // RegisterRoutes binds query API handlers to URL routes.
 func RegisterRoutes() {
 	// API endpoint for searching results over given runs.
-	shared.AddRoute("/api/search", "api-search", apiSearchHandler)
+	shared.AddRoute(
+		"/api/search",
+		"api-search",
+		shared.WrapPermissiveCORS(apiSearchHandler))
 	// API endpoint for search autocomplete.
 	shared.AddRoute("/api/autocomplete", "api-autocomplete", apiAutocompleteHandler)
 }

--- a/shared/routing.go
+++ b/shared/routing.go
@@ -41,11 +41,15 @@ func WrapHSTS(h http.Handler) http.HandlerFunc {
 
 // WrapPermissiveCORS wraps the given handler func in one that sets an
 // all-permissive CORS header on the response.
-func WrapPermissiveCORS(h http.HandlerFunc) http.HandlerFunc {
-	cors := handlers.CORS(
+func WrapPermissiveCORS(h http.HandlerFunc, methods ...string) http.HandlerFunc {
+	opts := []handlers.CORSOption{
 		handlers.AllowedOrigins([]string{"*"}),
-	)
-	return cors(h).ServeHTTP
+		handlers.AllowedHeaders([]string{"Content-Type"}),
+	}
+	if len(methods) > 0 {
+		opts = append(opts, handlers.AllowedMethods(methods))
+	}
+	return handlers.CORS(opts...)(h).ServeHTTP
 }
 
 // WrapApplicationJSON wraps the given handler func in one that sets a Content-Type

--- a/shared/routing.go
+++ b/shared/routing.go
@@ -42,8 +42,9 @@ func WrapHSTS(h http.Handler) http.HandlerFunc {
 // WrapPermissiveCORS wraps the given handler func in one that sets an
 // all-permissive CORS header on the response.
 func WrapPermissiveCORS(h http.HandlerFunc) http.HandlerFunc {
-	cors := handlers.CORS().
-		AllowedOrigins([]string{"*"})
+	cors := handlers.CORS(
+		handlers.AllowedOrigins([]string{"*"}),
+	)
 	return cors(h).ServeHTTP
 }
 

--- a/shared/routing.go
+++ b/shared/routing.go
@@ -7,6 +7,7 @@ package shared
 import (
 	"net/http"
 
+	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 )
 
@@ -24,34 +25,33 @@ func Router() *mux.Router {
 
 // AddRoute is a helper for registering a handler for an http path (route).
 // Note that it adds an HSTS header to the response.
-func AddRoute(route, name string, handler func(http.ResponseWriter, *http.Request)) *mux.Route {
-	return Router().HandleFunc(route, WrapHSTS(handler)).Name(name)
+func AddRoute(route, name string, h http.HandlerFunc) *mux.Route {
+	return Router().Handle(route, WrapHSTS(h)).Name(name)
 }
 
 // WrapHSTS wraps the given handler func in one that sets the
 // Strict-Transport-Security header on the response.
-func WrapHSTS(h http.HandlerFunc) http.HandlerFunc {
+func WrapHSTS(h http.Handler) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		value := "max-age=31536000; preload"
 		w.Header().Add("Strict-Transport-Security", value)
-		h(w, r)
+		h.ServeHTTP(w, r)
 	})
 }
 
 // WrapPermissiveCORS wraps the given handler func in one that sets an
 // all-permissive CORS header on the response.
 func WrapPermissiveCORS(h http.HandlerFunc) http.HandlerFunc {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Add("Access-Control-Allow-Origin", "*")
-		h(w, r)
-	})
+	cors := handlers.CORS().
+		AllowedOrigins([]string{"*"})
+	return cors(h).ServeHTTP
 }
 
 // WrapApplicationJSON wraps the given handler func in one that sets a Content-Type
 // header of "text/json" on the response.
-func WrapApplicationJSON(h http.HandlerFunc) http.HandlerFunc {
+func WrapApplicationJSON(h http.Handler) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Content-Type", "application/json")
-		h(w, r)
+		h.ServeHTTP(w, r)
 	})
 }

--- a/webapp/routes_test.go
+++ b/webapp/routes_test.go
@@ -133,6 +133,7 @@ func assertHSTS(t *testing.T, path string) {
 
 func assertCORS(t *testing.T, path string) {
 	req := httptest.NewRequest("OPTIONS", path, nil)
+	req.Header.Set("Access-Control-Request-Headers", "content-type")
 	rr := httptest.NewRecorder()
 	handler, _ := http.DefaultServeMux.Handler(req)
 	handler.ServeHTTP(rr, req)

--- a/webapp/routes_test.go
+++ b/webapp/routes_test.go
@@ -44,7 +44,7 @@ func TestRunsBound(t *testing.T) {
 	assertHandlerIs(t, "/test-runs", "test-runs")
 }
 
-func TestApiDiffBoundCORS(t *testing.T) {
+func TestApiDiffBound(t *testing.T) {
 	assertHandlerIs(t, "/api/diff", "api-diff")
 }
 
@@ -71,6 +71,7 @@ func TestApiRunBound(t *testing.T) {
 
 func TestApiResultsBoundCORS(t *testing.T) {
 	assertHandlerIs(t, "/api/results", "api-results")
+	assertHSTS(t, "/api/results/upload")
 	assertCORS(t, "/api/results")
 }
 
@@ -131,15 +132,22 @@ func assertHSTS(t *testing.T, path string) {
 }
 
 func assertCORS(t *testing.T, path string) {
-	req := httptest.NewRequest("GET", path, nil)
+	req := httptest.NewRequest("OPTIONS", path, nil)
 	rr := httptest.NewRecorder()
 	handler, _ := http.DefaultServeMux.Handler(req)
+	handler.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusOK, rr.Result().StatusCode)
+
+	req = httptest.NewRequest("GET", path, nil)
+	req.Header.Add("Origin", "localhost:8080")
+	rr = httptest.NewRecorder()
+	handler, _ = http.DefaultServeMux.Handler(req)
 	handler.ServeHTTP(rr, req)
 	res := rr.Result()
 	assert.Equal(
 		t,
-		"[*]",
-		fmt.Sprintf("%s", res.Header["Access-Control-Allow-Origin"]))
+		"*",
+		res.Header.Get("Access-Control-Allow-Origin"))
 }
 
 func assertNoCORS(t *testing.T, path string) {


### PR DESCRIPTION
## Description
Mozilla would like to use it externally.