### PR TITLE
Update the Azure Pipelines artifact name matching

### DIFF
--- a/api/azure/webhook.go
+++ b/api/azure/webhook.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/url"
+	"regexp"
 	"strconv"
 
 	mapset "github.com/deckarep/golang-set"
@@ -15,6 +16,15 @@ import (
 	"github.com/google/go-github/github"
 	uc "github.com/web-platform-tests/wpt.fyi/api/receiver/client"
 	"github.com/web-platform-tests/wpt.fyi/shared"
+)
+
+// Labels for runs from Azure Pipelines are determined from the artifact names.
+// For master runs, artifact name may be either just "results" or something
+// like "safari-results".
+var (
+	masterRegex = regexp.MustCompile(`[^-]results$`)
+	prHeadRegex = regexp.MustCompile(`[^-]affected-tests$`)
+	prBaseRegex = regexp.MustCompile(`[^-]affected-tests-without-changes$`)
 )
 
 // handleCheckRunEvent processes an Azure Pipelines check run "completed" event.
@@ -74,12 +84,12 @@ func processAzureBuild(aeAPI shared.AppEngineAPI, azureAPI API, sha, owner, repo
 		if sender != "" {
 			labels.Add(shared.GetUserLabel(sender))
 		}
-		switch artifact.Name {
-		case "results":
+
+		if masterRegex.MatchString(artifact.Name) {
 			labels.Add(shared.MasterLabel)
-		case "affected-tests":
+		} else if prHeadRegex.MatchString(artifact.Name) {
 			labels.Add(shared.PRHeadLabel)
-		case "affected-tests-without-changes":
+		} else if prBaseRegex.MatchString(artifact.Name) {
 			labels.Add(shared.PRBaseLabel)
 		}
 

--- a/api/azure/webhook.go
+++ b/api/azure/webhook.go
@@ -22,9 +22,9 @@ import (
 // For master runs, artifact name may be either just "results" or something
 // like "safari-results".
 var (
-	masterRegex = regexp.MustCompile(`[^-]results$`)
-	prHeadRegex = regexp.MustCompile(`[^-]affected-tests$`)
-	prBaseRegex = regexp.MustCompile(`[^-]affected-tests-without-changes$`)
+	masterRegex = regexp.MustCompile(`\bresults$`)
+	prHeadRegex = regexp.MustCompile(`\baffected-tests$`)
+	prBaseRegex = regexp.MustCompile(`\baffected-tests-without-changes$`)
 )
 
 // handleCheckRunEvent processes an Azure Pipelines check run "completed" event.

--- a/api/azure/webhook_test.go
+++ b/api/azure/webhook_test.go
@@ -143,3 +143,25 @@ func TestParses(t *testing.T) {
 		assert.NotEmpty(t, artifact.Resource.DownloadURL)
 	}
 }
+
+func TestArtifactRegexes(t *testing.T) {
+	// Names before https://github.com/web-platform-tests/wpt/pull/15110
+	assert.True(t, masterRegex.MatchString("results"))
+	assert.True(t, prHeadRegex.MatchString("affected-tests"))
+	assert.True(t, prBaseRegex.MatchString("affected-tests-without-changes"))
+
+	// Names after https://github.com/web-platform-tests/wpt/pull/15110
+	assert.True(t, masterRegex.MatchString("edge-results"))
+	assert.True(t, prHeadRegex.MatchString("safari-preview-affected-tests"))
+	assert.True(t, prBaseRegex.MatchString("safari-preview-affected-tests-without-changes"))
+
+	// Don't accept the other order
+	assert.False(t, masterRegex.MatchString("results-edge"))
+
+	// Don't accept any string ending with the right pattern
+	assert.False(t, masterRegex.MatchString("nodashresults"))
+
+	// Base and Head could be confused with substring matching
+	assert.False(t, prBaseRegex.MatchString("affected-tests"))
+	assert.False(t, prHeadRegex.MatchString("affected-tests-without-changes"))
+}


### PR DESCRIPTION
## Description
Follows https://github.com/web-platform-tests/wpt/pull/15110, and also allows for the old names.

## Review Information
Can this be tested in webhook_test.go?