### PR TITLE
Add a query param for including interop summary from /api/search

### DIFF
--- a/api/query/atoms.go
+++ b/api/query/atoms.go
@@ -103,7 +103,7 @@ func (e AbstractSequential) BindToRuns(runs ...shared.TestRun) ConcreteQuery {
 // to a specific browser name.
 type TestStatusEq struct {
 	Product *shared.ProductSpec
-	Status  int64
+	Status  shared.TestStatus
 }
 
 // TestStatusNeq is a query atom that matches tests where the test status/result
@@ -111,7 +111,7 @@ type TestStatusEq struct {
 // filtered to a specific browser name.
 type TestStatusNeq struct {
 	Product *shared.ProductSpec
-	Status  int64
+	Status  shared.TestStatus
 }
 
 // BindToRuns for TestStatusEq expands to a disjunction of RunTestStatusEq

--- a/api/query/atoms.go
+++ b/api/query/atoms.go
@@ -29,13 +29,28 @@ type RunQuery struct {
 	AbstractQuery
 }
 
+// True is a true-valued ConcreteQuery.
+type True struct{}
+
+// BindToRuns for True is a no-op; it is independent of test runs.
+func (t True) BindToRuns(runs ...shared.TestRun) ConcreteQuery {
+	return t
+}
+
+// False is a false-valued ConcreteQuery.
+type False struct{}
+
+// BindToRuns for False is a no-op; it is independent of test runs.
+func (f False) BindToRuns(runs ...shared.TestRun) ConcreteQuery {
+	return f
+}
+
 // TestNamePattern is a query atom that matches test names to a pattern string.
 type TestNamePattern struct {
 	Pattern string
 }
 
-// BindToRuns for TestNamePattern is a no-op: TestNamePattern implements both
-// AbstractQuery and ConcreteQuery because it is independent of test runs.
+// BindToRuns for TestNamePattern is a no-op; it is independent of test runs.
 func (tnp TestNamePattern) BindToRuns(runs ...shared.TestRun) ConcreteQuery {
 	return tnp
 }
@@ -242,17 +257,17 @@ func (rq *RunQuery) UnmarshalJSON(b []byte) error {
 	if len(data.RunIDs) == 0 {
 		return errors.New(`Missing run query property: "run_ids"`)
 	}
-	if len(data.Query) == 0 {
-		return errors.New(`Missing run query property: "query"`)
-	}
-
-	q, err := unmarshalQ(data.Query)
-	if err != nil {
-		return err
-	}
-
 	rq.RunIDs = data.RunIDs
-	rq.AbstractQuery = q
+
+	if len(data.Query) > 0 {
+		q, err := unmarshalQ(data.Query)
+		if err != nil {
+			return err
+		}
+		rq.AbstractQuery = q
+	} else {
+		rq.AbstractQuery = True{}
+	}
 	return nil
 }
 

--- a/api/query/atoms_test.go
+++ b/api/query/atoms_test.go
@@ -35,7 +35,8 @@ func TestStructuredQuery_missingQuery(t *testing.T) {
 	err := json.Unmarshal([]byte(`{
 		"run_ids": [0, 1, 2]
 	}`), &rq)
-	assert.NotNil(t, err)
+	assert.Nil(t, err)
+	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2}, AbstractQuery: True{}}, rq)
 }
 
 func TestStructuredQuery_emptyRunIDs(t *testing.T) {

--- a/api/query/cache/index/aggregator.go
+++ b/api/query/cache/index/aggregator.go
@@ -17,7 +17,7 @@ type aggregator interface {
 type indexAggregator struct {
 	index
 
-	rus             []RunID
+	runIDs          []RunID
 	agg             map[uint64]query.SearchResult
 	includeSubtests bool
 	interopFormat   bool
@@ -42,12 +42,11 @@ func (a *indexAggregator) Add(t TestID) error {
 
 	if a.interopFormat {
 		if r.Interop == nil {
-			r.Interop = make([]int, len(a.rus)+1)
+			r.Interop = make([]int, len(a.runIDs)+1)
 		}
 		passing := 0
-		for _, ru := range a.rus {
-			res := shared.TestStatus(a.runResults[ru].GetResult(t))
-			// Only include tests with non-UNKNOWN status for this run's total.
+		for _, id := range a.runIDs {
+			res := shared.TestStatus(a.runResults[id].GetResult(t))
 			if res.IsPassOrOK() {
 				passing++
 			}
@@ -57,10 +56,10 @@ func (a *indexAggregator) Add(t TestID) error {
 
 	rus := r.LegacyStatus
 	if rus == nil {
-		rus = make([]query.LegacySearchRunResult, len(a.rus))
+		rus = make([]query.LegacySearchRunResult, len(a.runIDs))
 	}
 
-	for i, ru := range a.rus {
+	for i, ru := range a.runIDs {
 		res := shared.TestStatus(a.runResults[ru].GetResult(t))
 		// TODO: Switch to a consistent value for Total across all runs.
 		//
@@ -92,10 +91,10 @@ func (a *indexAggregator) Done() []query.SearchResult {
 	return res
 }
 
-func newIndexAggregator(idx index, rus []RunID, opts query.AggregationOpts) aggregator {
+func newIndexAggregator(idx index, runIDs []RunID, opts query.AggregationOpts) aggregator {
 	return &indexAggregator{
 		index:           idx,
-		rus:             rus,
+		runIDs:          runIDs,
 		agg:             make(map[uint64]query.SearchResult),
 		includeSubtests: opts.IncludeSubtests,
 		interopFormat:   opts.InteropFormat,

--- a/api/query/cache/index/aggregator.go
+++ b/api/query/cache/index/aggregator.go
@@ -54,11 +54,11 @@ func (a *indexAggregator) Add(t TestID) error {
 				rus[i].Passes++
 			}
 		}
-	}
-	if a.includeSubtests {
-		if _, subtest, err := ts.GetName(t); err == nil && subtest != nil {
-			name := *subtest
-			r.Subtests = append(r.Subtests, name)
+
+		if a.includeSubtests {
+			if _, name, err := ts.GetName(t); err == nil && name != nil {
+				r.Subtests.Add(*name)
+			}
 		}
 	}
 	r.LegacyStatus = rus

--- a/api/query/cache/index/aggregator.go
+++ b/api/query/cache/index/aggregator.go
@@ -54,20 +54,20 @@ func (a *indexAggregator) Add(t TestID) error {
 		r.Interop[passing]++
 	}
 
-	rus := r.LegacyStatus
-	if rus == nil {
-		rus = make([]query.LegacySearchRunResult, len(a.runIDs))
+	results := r.LegacyStatus
+	if results == nil {
+		results = make([]query.LegacySearchRunResult, len(a.runIDs))
 	}
 
-	for i, ru := range a.runIDs {
-		res := shared.TestStatus(a.runResults[ru].GetResult(t))
+	for i, id := range a.runIDs {
+		res := shared.TestStatus(a.runResults[id].GetResult(t))
 		// TODO: Switch to a consistent value for Total across all runs.
 		//
 		// Only include tests with non-UNKNOWN status for this run's total.
 		if res != shared.TestStatusUnknown {
-			rus[i].Total++
+			results[i].Total++
 			if res.IsPassOrOK() {
-				rus[i].Passes++
+				results[i].Passes++
 			}
 		}
 	}
@@ -77,7 +77,7 @@ func (a *indexAggregator) Add(t TestID) error {
 			r.Subtests = append(r.Subtests, name)
 		}
 	}
-	r.LegacyStatus = rus
+	r.LegacyStatus = results
 	a.agg[id] = r
 
 	return nil

--- a/api/query/cache/index/aggregator.go
+++ b/api/query/cache/index/aggregator.go
@@ -5,7 +5,6 @@
 package index
 
 import (
-	mapset "github.com/deckarep/golang-set"
 	"github.com/web-platform-tests/wpt.fyi/api/query"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
@@ -37,9 +36,6 @@ func (a *indexAggregator) Add(t TestID) error {
 			Test:         name,
 			LegacyStatus: nil,
 		}
-		if a.includeSubtests {
-			r.Subtests = mapset.NewSet()
-		}
 	}
 
 	rus := r.LegacyStatus
@@ -58,11 +54,11 @@ func (a *indexAggregator) Add(t TestID) error {
 				rus[i].Passes++
 			}
 		}
-
-		if a.includeSubtests {
-			if _, name, err := ts.GetName(t); err == nil && name != nil {
-				r.Subtests.Add(*name)
-			}
+	}
+	if a.includeSubtests {
+		if _, subtest, err := ts.GetName(t); err == nil && subtest != nil {
+			name := *subtest
+			r.Subtests = append(r.Subtests, name)
 		}
 	}
 	r.LegacyStatus = rus

--- a/api/query/cache/index/aggregator.go
+++ b/api/query/cache/index/aggregator.go
@@ -5,6 +5,7 @@
 package index
 
 import (
+	mapset "github.com/deckarep/golang-set"
 	"github.com/web-platform-tests/wpt.fyi/api/query"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
@@ -35,6 +36,9 @@ func (a *indexAggregator) Add(t TestID) error {
 		r = query.SearchResult{
 			Test:         name,
 			LegacyStatus: nil,
+		}
+		if a.includeSubtests {
+			r.Subtests = mapset.NewSet()
 		}
 	}
 

--- a/api/query/cache/index/index_test.go
+++ b/api/query/cache/index/index_test.go
@@ -249,7 +249,7 @@ func TestSync(t *testing.T) {
 	// Populate data with predictable set of two results for each run.
 	loader.EXPECT().Load(gomock.Any()).DoAndReturn(func(run shared.TestRun) (*metrics.TestResultsReport, error) {
 		strID := strconv.FormatInt(run.ID, 10)
-		strStatus := shared.TestStatusStringFromValue(run.ID % 7)
+		strStatus := shared.TestStatusStringFromValue(shared.TestStatus(run.ID % 7))
 		return &metrics.TestResultsReport{
 			Results: []*metrics.TestResults{
 				&metrics.TestResults{

--- a/api/query/cache/service/main.go
+++ b/api/query/cache/service/main.go
@@ -144,8 +144,10 @@ func searchHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Configure format, from request params.
 	_, subtests := r.URL.Query()["subtests"]
+	_, interop := r.URL.Query()["interop"]
 	opts := query.AggregationOpts{
 		IncludeSubtests: subtests,
+		InteropFormat:   interop,
 	}
 	plan, err := idx.Bind(runs, q)
 	if err != nil {

--- a/api/query/concrete_query.go
+++ b/api/query/concrete_query.go
@@ -71,12 +71,6 @@ type Not struct {
 	Arg ConcreteQuery
 }
 
-// True is a true-valued ConcreteQuery.
-type True struct{}
-
-// False is a false-valued ConcreteQuery.
-type False struct{}
-
 // Size of TestNamePattern has a size of 1: servicing such a query requires a
 // substring match per test.
 func (TestNamePattern) Size() int { return 1 }

--- a/api/query/concrete_query.go
+++ b/api/query/concrete_query.go
@@ -12,6 +12,7 @@ import (
 // the results.
 type AggregationOpts struct {
 	IncludeSubtests bool
+	InteropFormat   bool
 }
 
 // Binder is a mechanism for binding a query over a slice of test runs to
@@ -43,7 +44,7 @@ type ConcreteQuery interface {
 // Status IDs are those codified in shared.TestStatus* symbols.
 type RunTestStatusEq struct {
 	Run    int64
-	Status int64
+	Status shared.TestStatus
 }
 
 // RunTestStatusNeq constrains search results to include only test results from a
@@ -52,7 +53,7 @@ type RunTestStatusEq struct {
 // Status IDs are those codified in shared.TestStatus* symbols.
 type RunTestStatusNeq struct {
 	Run    int64
-	Status int64
+	Status shared.TestStatus
 }
 
 // Or is a logical disjunction of ConcreteQuery instances.

--- a/api/query/search.go
+++ b/api/query/search.go
@@ -43,12 +43,12 @@ type SearchResult struct {
 	// summaries contain a "pass count" and a "total count", where the test itself
 	// counts as 1, and each subtest counts as 1. The "pass count" contains any
 	// status values that are "PASS" or "OK".
-	LegacyStatus []LegacySearchRunResult `json:"legacy_status"`
+	LegacyStatus []LegacySearchRunResult `json:"legacy_status,omitempty"`
 
 	// Interoperability scores. For N browsers, we have an array of
 	// N+1 items, where the index X is the number of items passing in exactly
 	// X of the N browsers. e.g. for 4 browsers, [0/4, 1/4, 2/4, 3/4, 4/4].
-	Interop []int `json:"interop"`
+	Interop []int `json:"interop,omitempty"`
 
 	// Subtests (names) which are included in the LegacyStatus summary.
 	Subtests []string `json:"subtests,omitempty"`
@@ -142,6 +142,10 @@ func (sh structuredSearchHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 		if ok && len(exists.Args) == 1 {
 			simpleQ, isSimpleQ = exists.Args[0].(TestNamePattern)
 		}
+		q := r.URL.Query()
+		_, interop := q["interop"]
+		_, subtests := q["subtests"]
+		isSimpleQ = isSimpleQ && !interop && !subtests
 	}
 
 	if !isSimpleQ {

--- a/api/query/search.go
+++ b/api/query/search.go
@@ -18,7 +18,6 @@ import (
 	"strings"
 	time "time"
 
-	mapset "github.com/deckarep/golang-set"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
@@ -47,22 +46,7 @@ type SearchResult struct {
 	LegacyStatus []LegacySearchRunResult `json:"legacy_status"`
 
 	// Subtests (names) which are included in the LegacyStatus summary.
-	Subtests mapset.Set `json:"-"`
-}
-
-type searchResultNoCustomMarshalling SearchResult
-type marshallableSearchResult struct {
-	searchResultNoCustomMarshalling
 	Subtests []string `json:"subtests,omitempty"`
-}
-
-// MarshalJSON treats the set as an array so it can be marshalled.
-func (filter SearchResult) MarshalJSON() ([]byte, error) {
-	m := marshallableSearchResult{
-		searchResultNoCustomMarshalling: searchResultNoCustomMarshalling(filter),
-	}
-	m.Subtests = shared.ToStringSlice(filter.Subtests)
-	return json.Marshal(m)
 }
 
 // SearchResponse contains a response to search API calls, including specific

--- a/api/query/search.go
+++ b/api/query/search.go
@@ -47,13 +47,13 @@ type SearchResult struct {
 	LegacyStatus []LegacySearchRunResult `json:"legacy_status"`
 
 	// Subtests (names) which are included in the LegacyStatus summary.
-	Subtests mapset.Set `json:"subtests,omitempty"`
+	Subtests mapset.Set `json:"-"`
 }
 
 type searchResultNoCustomMarshalling SearchResult
 type marshallableSearchResult struct {
 	searchResultNoCustomMarshalling
-	Subtests []string `json:"labels,omitempty"`
+	Subtests []string `json:"subtests,omitempty"`
 }
 
 // MarshalJSON treats the set as an array so it can be marshalled.

--- a/api/query/search.go
+++ b/api/query/search.go
@@ -45,6 +45,11 @@ type SearchResult struct {
 	// status values that are "PASS" or "OK".
 	LegacyStatus []LegacySearchRunResult `json:"legacy_status"`
 
+	// Interoperability scores. For N browsers, we have an array of
+	// N+1 items, where the index X is the number of items passing in exactly
+	// X of the N browsers. e.g. for 4 browsers, [0/4, 1/4, 2/4, 3/4, 4/4].
+	Interop []int `json:"interop"`
+
 	// Subtests (names) which are included in the LegacyStatus summary.
 	Subtests []string `json:"subtests,omitempty"`
 }

--- a/shared/statuses.go
+++ b/shared/statuses.go
@@ -8,39 +8,42 @@ package shared
 // Shared data types used for string WPT test results in query cache.
 //
 
+// TestStatus represents the possible test result statuses.
+type TestStatus int64
+
 const (
 	// TestStatusUnknown is an uninitialized TestStatus and should
 	// not be used.
-	TestStatusUnknown int64 = 0
+	TestStatusUnknown TestStatus = 0
 
 	// TestStatusPass indicates that all tests completed successfully and passed.
-	TestStatusPass int64 = 1
+	TestStatusPass TestStatus = 1
 
 	// TestStatusOK indicates that all tests completed successfully.
-	TestStatusOK int64 = 2
+	TestStatusOK TestStatus = 2
 
 	// TestStatusError indicates that some tests did not complete
 	// successfully.
-	TestStatusError int64 = 3
+	TestStatusError TestStatus = 3
 
 	// TestStatusTimeout indicates that some tests timed out.
-	TestStatusTimeout int64 = 4
+	TestStatusTimeout TestStatus = 4
 
 	// TestStatusNotRun indicates that a test was not run.
-	TestStatusNotRun int64 = 5
+	TestStatusNotRun TestStatus = 5
 
 	// TestStatusFail indicates that a test failed.
-	TestStatusFail int64 = 6
+	TestStatusFail TestStatus = 6
 
 	// TestStatusCrash indicates that the WPT test runner crashed attempting to run the test.
-	TestStatusCrash int64 = 7
+	TestStatusCrash TestStatus = 7
 
 	// TestStatusSkip indicates that the test was disabled for this test run.
-	TestStatusSkip int64 = 8
+	TestStatusSkip TestStatus = 8
 
 	// TestStatusAssert indicates that a non-fatal assertion failed. This test
 	// status is supported by, at least, Mozilla.
-	TestStatusAssert int64 = 9
+	TestStatusAssert TestStatus = 9
 
 	// TestStatusNameUnknown is the string representation for an uninitialized
 	// TestStatus and should not be used.
@@ -86,14 +89,14 @@ const (
 
 	// TestStatusDefault is the default value used when a status string cannot be
 	// interpreted.
-	TestStatusDefault int64 = TestStatusUnknown
+	TestStatusDefault TestStatus = TestStatusUnknown
 
 	// TestStatusNameDefault is the default string used when a status value cannot
 	// be interpreted.
 	TestStatusNameDefault string = TestStatusNameUnknown
 )
 
-var testStatusValues = map[string]int64{
+var testStatusValues = map[string]TestStatus{
 	TestStatusNameUnknown: TestStatusUnknown,
 	TestStatusNamePass:    TestStatusPass,
 	TestStatusNameOK:      TestStatusOK,
@@ -106,7 +109,7 @@ var testStatusValues = map[string]int64{
 	TestStatusNameAssert:  TestStatusAssert,
 }
 
-var testStatusNames = map[int64]string{
+var testStatusNames = map[TestStatus]string{
 	TestStatusUnknown: TestStatusNameUnknown,
 	TestStatusPass:    TestStatusNamePass,
 	TestStatusOK:      TestStatusNameOK,
@@ -119,9 +122,14 @@ var testStatusNames = map[int64]string{
 	TestStatusAssert:  TestStatusNameAssert,
 }
 
+// IsPassOrOK is true if the value is TestStatusPass or TestStatusOK
+func (s TestStatus) IsPassOrOK() bool {
+	return s == TestStatusOK || s == TestStatusPass
+}
+
 // TestStatusValueFromString returns the enum value associated with str (if
 // any), or else TestStatusDefault.
-func TestStatusValueFromString(str string) int64 {
+func TestStatusValueFromString(str string) TestStatus {
 	v, ok := testStatusValues[str]
 	if !ok {
 		return TestStatusDefault
@@ -131,7 +139,7 @@ func TestStatusValueFromString(str string) int64 {
 
 // TestStatusStringFromValue returns the string associated with s (if any), or
 // else TestStatusStringDefault.
-func TestStatusStringFromValue(s int64) string {
+func TestStatusStringFromValue(s TestStatus) string {
 	str, ok := testStatusNames[s]
 	if !ok {
 		return TestStatusNameDefault


### PR DESCRIPTION
## Description
This will allow us to deprecate the results-analysis pipeline, and compute interop on the fly, including filtering to particular searches, e.g. what's the interoperability of things that Chrome is passing?
And, including custom product sets (see #655)

This PR builds off of #1103, so if you're reviewing, do so with 5599a4e...7a36891

## Review
- Grab a specific view that we have precomputed interop for
- Extract the run_id, and POST to /api/search?interop
  - `{"run_ids":[6347092704362496,4879930668089344,5070059928027136,6495293554032640],"query":{"exists":[{"pattern":"/2dcontext/"}]}}`

Hopefully, see some interop scores.