### PR TITLE
Start running mypy on results-processor

### DIFF
--- a/results-processor/.gitignore
+++ b/results-processor/.gitignore
@@ -1,3 +1,4 @@
 env/
 .tox/
 __pycache__/
+.mypy_cache/

--- a/results-processor/config.py
+++ b/results-processor/config.py
@@ -1,25 +1,25 @@
 import os
 
 
-def _is_prod():
+def _is_prod() -> bool:
     return os.getenv('GOOGLE_CLOUD_PROJECT') == 'wptdashboard'
 
 
-def raw_results_bucket():
+def raw_results_bucket() -> str:
     """Returns the bucket name for storing raw, full results."""
     if _is_prod():
         return 'wptd-results'
     return 'wptd-results-staging'
 
 
-def results_bucket():
+def results_bucket() -> str:
     """Returns the bucket name for storing split results."""
     if _is_prod():
         return 'wptd'
     return 'wptd-staging'
 
 
-def project_baseurl():
+def project_baseurl() -> str:
     """Returns the base URL of the current project."""
     # Defaults to staging to prevent accidental access of prod.
     # TODO(Hexcles): Support local dev_appserver.

--- a/results-processor/mypy.ini
+++ b/results-processor/mypy.ini
@@ -1,4 +1,9 @@
 [mypy]
 warn_redundant_casts = True
-warn_unused_configs = True
 warn_unused_ignores = True
+
+[mypy-filelock]
+ignore_missing_imports = True
+
+[mypy-google.cloud]
+ignore_missing_imports = True

--- a/results-processor/mypy.ini
+++ b/results-processor/mypy.ini
@@ -1,0 +1,4 @@
+[mypy]
+warn_redundant_casts = True
+warn_unused_configs = True
+warn_unused_ignores = True

--- a/results-processor/mypy.ini
+++ b/results-processor/mypy.ini
@@ -1,6 +1,15 @@
 [mypy]
+disallow_subclassing_any = True
+#disallow_any_generics = True
+disallow_untyped_calls = True
+#disallow_untyped_defs = True
+disallow_incomplete_defs = True
+#check_untyped_defs = True
+disallow_untyped_decorators = True
+no_implicit_optional = True
 warn_redundant_casts = True
 warn_unused_ignores = True
+warn_return_any = True
 
 [mypy-filelock]
 ignore_missing_imports = True

--- a/results-processor/requirements-top_level.txt
+++ b/results-processor/requirements-top_level.txt
@@ -4,4 +4,5 @@ flake8
 google-cloud-datastore
 google-cloud-storage
 gunicorn
+mypy
 requests

--- a/results-processor/requirements.txt
+++ b/results-processor/requirements.txt
@@ -20,6 +20,8 @@ itsdangerous==1.1.0
 Jinja2==2.10.1
 MarkupSafe==1.1.1
 mccabe==0.6.1
+mypy==0.701
+mypy-extensions==0.4.1
 protobuf==3.7.1
 pyasn1==0.4.5
 pyasn1-modules==0.2.4
@@ -29,5 +31,6 @@ pytz==2019.1
 requests==2.21.0
 rsa==4.0
 six==1.12.0
+typed-ast==1.3.1
 urllib3==1.24.1
 Werkzeug==0.15.2

--- a/results-processor/tox.ini
+++ b/results-processor/tox.ini
@@ -7,5 +7,5 @@ skipsdist=True
 deps = -rrequirements.txt
 commands =
     flake8 {toxinidir}/*.py
-    mypy {toxinidir}/*.py
+    mypy {toxinidir}
     python -m unittest discover {toxinidir} "*_test.py"

--- a/results-processor/tox.ini
+++ b/results-processor/tox.ini
@@ -7,5 +7,5 @@ skipsdist=True
 deps = -rrequirements.txt
 commands =
     flake8 {toxinidir}/*.py
-    mypy {toxinidir}
+    mypy {toxinidir}/wptreport.py
     python -m unittest discover {toxinidir} "*_test.py"

--- a/results-processor/tox.ini
+++ b/results-processor/tox.ini
@@ -7,5 +7,5 @@ skipsdist=True
 deps = -rrequirements.txt
 commands =
     flake8 {toxinidir}/*.py
-    mypy {toxinidir}/wptreport.py
+    mypy {toxinidir}/*.py
     python -m unittest discover {toxinidir} "*_test.py"

--- a/results-processor/tox.ini
+++ b/results-processor/tox.ini
@@ -6,5 +6,6 @@ skipsdist=True
 [testenv]
 deps = -rrequirements.txt
 commands =
-    flake8 *.py
-    python -m unittest discover . "*_test.py"
+    flake8 {toxinidir}/*.py
+    mypy {toxinidir}
+    python -m unittest discover {toxinidir} "*_test.py"

--- a/results-processor/wptreport.py
+++ b/results-processor/wptreport.py
@@ -96,7 +96,7 @@ class BufferedHashsum(object):
     """A simple buffered hash calculator."""
 
     def __init__(self,
-                 hash_ctor: Callable[[], hashlib._Hash] = hashlib.sha1,
+                 hash_ctor: Callable = hashlib.sha1,
                  block_size: int = 1024*1024) -> None:
         assert block_size > 0
         self._hash = hash_ctor()
@@ -122,7 +122,7 @@ class BufferedHashsum(object):
 
     def hashsum(self) -> str:
         """Returns the hexadecimal digest of the current hash."""
-        return self._hash.hexdigest()
+        return cast(str, self._hash.hexdigest())
 
 
 class WPTReport(object):

--- a/results-processor/wptreport.py
+++ b/results-processor/wptreport.py
@@ -96,7 +96,9 @@ class ConflictingDataError(WPTReportError):
 class BufferedHashsum(object):
     """A simple buffered hash calculator."""
 
-    def __init__(self, hash_ctor: Callable = hashlib.sha1, block_size: int = 1024*1024) -> None:
+    def __init__(self,
+                 hash_ctor: Callable = hashlib.sha1,
+                 block_size: int = 1024*1024) -> None:
         assert block_size > 0
         self._hash = hash_ctor()
         self._block_size = block_size
@@ -218,7 +220,8 @@ class WPTReport(object):
         with gzip.GzipFile(fileobj=fileobj, mode='rb') as gzip_file:
             self.load_json(cast(IO[bytes], gzip_file))
 
-    def update_metadata(self, revision: str = '', browser_name: str = '', browser_version: str = '',
+    def update_metadata(self, revision: str = '',
+                        browser_name: str = '', browser_version: str = '',
                         os_name: str = '', os_version: str = '') -> None:
         """Overwrites metadata of the report."""
         # Unfortunately, the names of the keys don't exactly match.
@@ -366,7 +369,8 @@ class WPTReport(object):
 
         return name
 
-    def populate_upload_directory(self, output_dir: Optional[str] = None) -> str:
+    def populate_upload_directory(self,
+                                  output_dir: Optional[str] = None) -> str:
         """Populates a directory suitable for uploading to GCS.
 
         The directory structure is as follows:
@@ -476,7 +480,9 @@ class WPTReport(object):
         self.write_gzip_json(filepath, self._report)
 
 
-def prepare_labels(report: WPTReport, labels_str: str, uploader: str) -> Set[str]:
+def prepare_labels(report: WPTReport,
+                   labels_str: str,
+                   uploader: str) -> Set[str]:
     """Prepares the list of labels for a test run.
 
     The following labels will be automatically added:

--- a/results-processor/wptscreenshot.py
+++ b/results-processor/wptscreenshot.py
@@ -31,7 +31,9 @@ _auth = ('username', 'password')
 _run_info: wptreport.RunInfo = {}
 
 
-def _initialize(api: str, auth: Tuple[str, str], run_info: wptreport.RunInfo):
+def _initialize(api: str,
+                auth: Tuple[str, str],
+                run_info: wptreport.RunInfo) -> None:
     global _api
     global _auth
     global _run_info
@@ -40,7 +42,7 @@ def _initialize(api: str, auth: Tuple[str, str], run_info: wptreport.RunInfo):
     _run_info = run_info
 
 
-def _upload(images: List[str]):
+def _upload(images: List[str]) -> None:
     files = []
     for i in range(len(images)):
         files.append((
@@ -55,9 +57,9 @@ def _upload(images: List[str]):
         time.sleep(1)
         requests.post(_api, auth=_auth, data=data, files=files)
 
+
 # End of worker functions
 ############################
-
 
 T = TypeVar('T', bound='WPTScreenshot')
 

--- a/results-processor/wptscreenshot.py
+++ b/results-processor/wptscreenshot.py
@@ -13,6 +13,7 @@ import time
 import requests
 
 import config
+import wptreport
 
 DATA_URI_PNG_PREFIX = 'data:image/png;base64,'
 
@@ -26,7 +27,7 @@ _log = logging.getLogger(__name__)
 # Global variables to be initialized in workers:
 _api = 'API URL to be initialized'
 _auth = ('username', 'password')
-_run_info = {}
+_run_info: wptreport.RunInfo = {}
 
 
 def _initialize(api, auth, run_info):


### PR DESCRIPTION
This adds mypy to results-processor. This doesn't actually quite work yet, though. `wptreport.py` almost passes; we could maybe just enable it for that first.