### PR TITLE
Fix the anomalies query

### DIFF
--- a/webapp/components/wpt-insights.js
+++ b/webapp/components/wpt-insights.js
@@ -167,7 +167,7 @@ class Anomalies extends ProductInfo(PolymerElement) {
       .filter(b => b !== browser)
       .map(o => `(${o}:pass|${o}:ok)`)
       .join(' ');
-    return `!${browser}:pass !${browser}:ok ${othersPassing}`;
+    return `(${browser}:!pass&${browser}:!ok) ${othersPassing}`;
   }
 
   computeURL(query) {


### PR DESCRIPTION
## Description
`!chrome:pass` is "any result that isn't a pass in chrome", which will match all the other browsers.

`chrome:!pass` is "a chrome result that isn't a pass", which is what we want.