### PR TITLE
Fix empty query behaviour

### DIFF
--- a/api/query/search.go
+++ b/api/query/search.go
@@ -134,12 +134,13 @@ func (sh structuredSearchHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	// Check if the query is a simple (empty, or test name only) query
+	// Check if the query is a simple (empty/just True, or test name only) query
 	var simpleQ TestNamePattern
 	var isSimpleQ bool
 	{
-		exists, ok := rq.AbstractQuery.(AbstractExists)
-		if ok && len(exists.Args) == 1 {
+		if _, isTrueQ := rq.AbstractQuery.(True); isTrueQ {
+			isSimpleQ = true
+		} else if exists, isExists := rq.AbstractQuery.(AbstractExists); isExists && len(exists.Args) == 1 {
 			simpleQ, isSimpleQ = exists.Args[0].(TestNamePattern)
 		}
 		q := r.URL.Query()

--- a/webapp/components/wpt-results.js
+++ b/webapp/components/wpt-results.js
@@ -609,12 +609,15 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
     let url = new URL('/api/search', window.location);
     let fetchOpts;
     if (this.structuredQueries) {
+      const body = {
+        run_ids: this.testRuns.map(r => r.id),
+      };
+      if (q) {
+        body.query = q;
+      }
       fetchOpts = {
         method: 'POST',
-        body: JSON.stringify({
-          run_ids: this.testRuns.map(r => r.id),
-          query: q,
-        }),
+        body: JSON.stringify(body),
       };
     } else {
       url.searchParams.set(


### PR DESCRIPTION
## Description
Omits the `q` param when posting if it's not truthy.
Chrome omits the `undefined` value from the JSON.stringify, but FF doesn't.
Also ensures that the server-side handling of an empty query is considered trivial.

Fixes https://github.com/web-platform-tests/wpt.fyi/issues/1122