### PR TITLE
Plumb the offset param

### DIFF
--- a/shared/params.go
+++ b/shared/params.go
@@ -307,6 +307,18 @@ func ParseMaxCountParam(v url.Values) (*int, error) {
 	return nil, nil
 }
 
+// ParseOffsetParam parses the 'offset' parameter as an integer
+func ParseOffsetParam(v url.Values) (*int, error) {
+	if offsetParam := v.Get("offset"); offsetParam != "" {
+		offset, err := strconv.Atoi(offsetParam)
+		if err != nil {
+			return nil, err
+		}
+		return &offset, nil
+	}
+	return nil, nil
+}
+
 // ParseMaxCountParamWithDefault parses the 'max-count' parameter as an integer, or returns the
 // default when no param is present, or on error.
 func ParseMaxCountParamWithDefault(v url.Values, defaultValue int) (count int, err error) {
@@ -561,6 +573,9 @@ func ParseTestRunFilterParams(v url.Values) (filter TestRunFilter, err error) {
 		return filter, err
 	}
 	if filter.MaxCount, err = ParseMaxCountParam(v); err != nil {
+		return filter, err
+	}
+	if filter.Offset, err = ParseOffsetParam(v); err != nil {
 		return filter, err
 	}
 	if filter.From, err = ParseDateTimeParam(v, "from"); err != nil {

--- a/shared/test_run_filter.go
+++ b/shared/test_run_filter.go
@@ -186,6 +186,9 @@ func (filter TestRunFilter) ToQuery() (q url.Values) {
 	if filter.MaxCount != nil {
 		q.Set("max-count", fmt.Sprintf("%v", *filter.MaxCount))
 	}
+	if filter.Offset != nil {
+		q.Set("offset", fmt.Sprintf("%v", *filter.Offset))
+	}
 	if filter.From != nil {
 		q.Set("from", filter.From.Format(time.RFC3339))
 	}

--- a/webapp/components/interop.js
+++ b/webapp/components/interop.js
@@ -31,7 +31,7 @@ import './wpt-permalinks.js';
 class WPTInterop extends WPTColors(WPTFlags(SelfNavigation(LoadingState(
   TestRunsQueryLoader(
     PolymerElement,
-    'interopQueryParams(shas, aligned, master, labels, productSpecs, to, from, maxCount, search)'))))) {
+    'interopQueryParams(shas, aligned, master, labels, productSpecs, to, from, maxCount, offset, search)'))))) {
   static get template() {
     return html`
   <style>
@@ -410,8 +410,8 @@ class WPTInterop extends WPTColors(WPTFlags(SelfNavigation(LoadingState(
     return '/interop';
   }
 
-  interopQueryParams(shas, aligned, master, labels, productSpecs, maxCount, to, from, search) {
-    const params = this.computeTestRunQueryParams(shas, aligned, master, labels, productSpecs, to, from, maxCount);
+  interopQueryParams(shas, aligned, master, labels, productSpecs, maxCount, offset, to, from, search) {
+    const params = this.computeTestRunQueryParams(shas, aligned, master, labels, productSpecs, to, from, maxCount, offset);
     if (search) {
       params.q = search;
     }

--- a/webapp/components/test-results-chart.js
+++ b/webapp/components/test-results-chart.js
@@ -143,9 +143,9 @@ class TestResultsChart extends TestFileResults {
     this.showForNow = false;
   }
 
-  computeTestRunQueryParams(shas, aligned, master, labels, productSpecs, to, from, maxCount) {
+  computeTestRunQueryParams(shas, aligned, master, labels, productSpecs, to, from, maxCount, offset) {
     maxCount = this.chunkSize;
-    return super.computeTestRunQueryParams(shas, aligned, master, labels, productSpecs, to, from, maxCount);
+    return super.computeTestRunQueryParams(shas, aligned, master, labels, productSpecs, to, from, maxCount, offset);
   }
   // eslint-disable-next-line no-unused-vars
   async loadResults(tests, query) {

--- a/webapp/components/test-runs-query.js
+++ b/webapp/components/test-runs-query.js
@@ -8,7 +8,7 @@ import { QueryBuilder } from './results-navigation.js';
 import { pluralize } from './pluralize.js';
 
 const testRunsQueryComputer =
-  'computeTestRunQueryParams(shas, aligned, master, labels, productSpecs, to, from, maxCount)';
+  'computeTestRunQueryParams(shas, aligned, master, labels, productSpecs, to, from, maxCount, offset)';
 
 const TestRunsQuery = (superClass, opt_queryCompute) => class extends QueryBuilder(
   ProductInfo(superClass),
@@ -37,6 +37,7 @@ const TestRunsQuery = (superClass, opt_queryCompute) => class extends QueryBuild
         value: [],
       },
       maxCount: Number,
+      offset: Number,
       shas: Array,
       aligned: Boolean,
       master: Boolean,
@@ -79,7 +80,7 @@ const TestRunsQuery = (superClass, opt_queryCompute) => class extends QueryBuild
   /**
   * Convert the UI property values into their equivalent URI query params.
   */
-  computeTestRunQueryParams(shas, aligned, master, labels, productSpecs, to, from, maxCount) {
+  computeTestRunQueryParams(shas, aligned, master, labels, productSpecs, to, from, maxCount, offset) {
     const params = {};
     if (!this.computeIsLatest(shas)) {
       params.sha = shas;
@@ -95,6 +96,9 @@ const TestRunsQuery = (superClass, opt_queryCompute) => class extends QueryBuild
     maxCount = maxCount || this.defaultMaxCount;
     if (maxCount) {
       params['max-count'] = maxCount;
+    }
+    if (offset) {
+      params['offset'] = offset;
     }
     if (from) {
       params.from = from.toISOString();
@@ -191,6 +195,9 @@ const TestRunsQuery = (superClass, opt_queryCompute) => class extends QueryBuild
     if ('max-count' in params) {
       batchUpdate.maxCount = params['max-count'];
     }
+    if ('offset' in params) {
+      batchUpdate.offset = params['offset'];
+    }
     if ('from' in params) {
       batchUpdate.from = new Date(params['from']);
     }
@@ -269,8 +276,8 @@ const TestRunsUIQuery = (superClass, opt_queryCompute) => class extends TestRuns
     };
   }
 
-  computeTestRunUIQueryParams(shas, aligned, master, labels, productSpecs, to, from, maxCount, diff, search, pr, runIds) {
-    const params = this.computeTestRunQueryParams(shas, aligned, master, labels, productSpecs, to, from, maxCount);
+  computeTestRunUIQueryParams(shas, aligned, master, labels, productSpecs, to, from, maxCount, offset, diff, search, pr, runIds) {
+    const params = this.computeTestRunQueryParams(shas, aligned, master, labels, productSpecs, to, from, maxCount, offset);
     if (diff || this.diff) {
       params.diff = true;
       if (this.diffFilter) {
@@ -306,7 +313,7 @@ const TestRunsUIQuery = (superClass, opt_queryCompute) => class extends TestRuns
 };
 // TODO(lukebjerring): Support to & from in the builder.
 const testRunsUIQueryComputer =
-  'computeTestRunUIQueryParams(shas, aligned, master, labels, productSpecs, to, from, maxCount, diff, search, pr, runIds)';
+  'computeTestRunUIQueryParams(shas, aligned, master, labels, productSpecs, to, from, maxCount, offset, diff, search, pr, runIds)';
 
 TestRunsQuery.Computer = testRunsQueryComputer;
 TestRunsUIQuery.Computer = testRunsUIQueryComputer;

--- a/webapp/templates/_test_run_query_params.html
+++ b/webapp/templates/_test_run_query_params.html
@@ -2,6 +2,7 @@
           {{- if .SHAs}} shas="{{ .SHAs }}" {{end}}
           {{- if .Labels}} labels="{{ .Labels }}"{{end}}
           {{- if .MaxCount}} max-count="{{ .MaxCount }}"{{end}}
+          {{- if .Offset}} offset="{{ .Offset }}"{{end}}
           {{- if .From}} from="{{ .From }}"{{end}}
           {{- if .To}} to="{{ .To }}"{{end}}
           {{- if .Aligned}} aligned{{end}}

--- a/webapp/test_results_handler.go
+++ b/webapp/test_results_handler.go
@@ -24,6 +24,7 @@ type testRunUIFilter struct {
 	SHAs       string
 	Aligned    bool
 	MaxCount   *int
+	Offset     *int
 	From       string
 	To         string
 	Search     string
@@ -165,6 +166,7 @@ func convertTestRunUIFilter(testRunFilter shared.TestRunFilter) (filter testRunU
 		filter.Products = string(data)
 	}
 	filter.MaxCount = testRunFilter.MaxCount
+	filter.Offset = testRunFilter.Offset
 	filter.Aligned = testRunFilter.Aligned != nil && *testRunFilter.Aligned
 	if testRunFilter.From != nil {
 		filter.From = testRunFilter.From.Format(time.RFC3339)


### PR DESCRIPTION
## Description
Handles the `offset` param in TestRun queries.

We already support the param when unmarshalling `next-page-token`, but it can also be typed manually by the user.

## Review
- Load /results?product=chrome[master]&max-count=2&offset=2
- Load /results?product=chrome[master]&max-count=2&offset=4
- See different runs.