### PR TITLE
Add feature for showing iframes for reftests

### DIFF
--- a/webapp/components/product-info.js
+++ b/webapp/components/product-info.js
@@ -94,6 +94,10 @@ function parseProduct(name) {
 const ProductInfo = (superClass) => class extends superClass {
   static get properties() {
     return {
+      activeBrowser: {
+        type: Object,
+        value: getActiveBrowser(),
+      }
     };
   }
 
@@ -159,6 +163,30 @@ const ProductInfo = (superClass) => class extends superClass {
   }
 };
 
+// https://stackoverflow.com/questions/5916900/how-can-you-detect-the-version-of-a-browser
+function getActiveBrowser() {
+  const ua = navigator.userAgent;
+  let tem, M = ua.match(/(opera|chrome|safari|firefox|msie|trident(?=\/))\/?\s*(\d+)/i) || [];
+  if(/trident/i.test(M[1])){
+    tem = /\brv[ :]+(\d+)/g.exec(ua) || [];
+    return { name:'IE', version: tem[1] || '' };
+  }
+  if (M[1] === 'Chrome') {
+    tem = ua.match(/\bOPR|Edge\/(\d+)/);
+    if (tem !== null) {
+      return { name: 'Opera', version: tem[1] };
+    }
+  }
+  M = M[2] ? [M[1], M[2]] : [navigator.appName, navigator.appVersion, '-?'];
+  if ((tem=ua.match(/version\/(\d+)/i)) !== null) {
+    M.splice(1, 1, tem[1]);
+  }
+  return {
+    name: M[0],
+    version: M[1]
+  };
+}
+
 export {
   DisplayNames,
   DefaultBrowserNames,
@@ -171,4 +199,5 @@ export {
   ProductInfo,
   parseProductSpec,
   parseProduct,
+  getActiveBrowser,
 };

--- a/webapp/components/product-info.js
+++ b/webapp/components/product-info.js
@@ -94,10 +94,6 @@ function parseProduct(name) {
 const ProductInfo = (superClass) => class extends superClass {
   static get properties() {
     return {
-      activeBrowser: {
-        type: Object,
-        value: getActiveBrowser(),
-      }
     };
   }
 
@@ -163,30 +159,6 @@ const ProductInfo = (superClass) => class extends superClass {
   }
 };
 
-// https://stackoverflow.com/questions/5916900/how-can-you-detect-the-version-of-a-browser
-function getActiveBrowser() {
-  const ua = navigator.userAgent;
-  let tem, M = ua.match(/(opera|chrome|safari|firefox|msie|trident(?=\/))\/?\s*(\d+)/i) || [];
-  if(/trident/i.test(M[1])){
-    tem = /\brv[ :]+(\d+)/g.exec(ua) || [];
-    return { name:'IE', version: tem[1] || '' };
-  }
-  if (M[1] === 'Chrome') {
-    tem = ua.match(/\bOPR|Edge\/(\d+)/);
-    if (tem !== null) {
-      return { name: 'Opera', version: tem[1] };
-    }
-  }
-  M = M[2] ? [M[1], M[2]] : [navigator.appName, navigator.appVersion, '-?'];
-  if ((tem=ua.match(/version\/(\d+)/i)) !== null) {
-    M.splice(1, 1, tem[1]);
-  }
-  return {
-    name: M[0],
-    version: M[1]
-  };
-}
-
 export {
   DisplayNames,
   DefaultBrowserNames,
@@ -199,5 +171,4 @@ export {
   ProductInfo,
   parseProductSpec,
   parseProduct,
-  getActiveBrowser,
 };

--- a/webapp/components/wpt-flags.js
+++ b/webapp/components/wpt-flags.js
@@ -36,6 +36,7 @@ Object.defineProperty(wpt, 'ClientSideFeatures', {
       'permalinks',
       'queryBuilder',
       'queryBuilderSHA',
+      'reftestIframes',
       'searchCacheInterop',
       'showTestType',
       'showTestRefURL',
@@ -184,6 +185,11 @@ class WPTFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ false) {
     <paper-item sub-item>
       <paper-checkbox checked="{{showTestRefURL}}">
         Display link to ref (for reftests)
+      </paper-checkbox>
+    </paper-item>
+    <paper-item sub-item>
+      <paper-checkbox checked="{{reftestIframes}}">
+        Display comparitive iframes for reftests
       </paper-checkbox>
     </paper-item>
     <paper-item>

--- a/webapp/components/wpt-results.js
+++ b/webapp/components/wpt-results.js
@@ -362,7 +362,7 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
       <template is="dom-if" if="[[ reftestIframes ]]">
         <div class="separator"></div>
         <section>
-          <h4>[[activeBrowser.name]] [[activeBrowser.version]] - [[path]]</h4>
+          <h4>[[path]] in this browser</h4>
           <div class='compare'>
             <div>
               <h5>Result</h5>

--- a/webapp/components/wpt-results.js
+++ b/webapp/components/wpt-results.js
@@ -47,9 +47,6 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
       }
       section.search {
         position: relative;
-        border-bottom: solid 1px var(--paper-grey-300);
-        padding-bottom: 1em;
-        margin-bottom: 1em;
       }
       section.search .path {
         margin-top: 1em;
@@ -58,6 +55,11 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
         position: absolute;
         top: 0;
         right: 0;
+      }
+      .separator {
+        border-bottom: solid 1px var(--paper-grey-300);
+        padding-bottom: 1em;
+        margin-bottom: 1em;
       }
       table {
         width: 100%;
@@ -147,6 +149,10 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
           min-height: 30px;
         }
       }
+
+      .compare {
+        display: flex;
+      }
     </style>
 
     <results-tabs tab="results" path="[[encodedPath]]" query="[[query]]">
@@ -211,6 +217,8 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
         </info-banner>
       </template>
     </section>
+
+    <div class="separator"></div>
 
     <template is="dom-if" if="[[isInvalidDiffUse(diff, testRuns)]]">
       <paper-toast id="diffInvalid" duration="0" text="'diff' was requested, but is only valid when comparing two runs." opened>
@@ -349,6 +357,29 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
         </template>
       </div>
     </template>
+
+    <template is="dom-if" if="[[isRefTest]]">
+      <template is="dom-if" if="[[ reftestIframes ]]">
+        <div class="separator"></div>
+        <section>
+          <h4>[[activeBrowser.name]] [[activeBrowser.version]] - [[path]]</h4>
+          <div class='compare'>
+            <div>
+              <h5>Result</h5>
+              <template is="dom-if" if="[[testW3CURL]]">
+                <iframe src="[[testW3CURL]]"></iframe>
+              </template>
+            </div>
+            <div>
+              <h5>Reference</h5>
+              <template is="dom-if" if="[[testW3CRefURL]]">
+                <iframe src="[[testW3CRefURL]]"></iframe>
+              </template>
+            </div>
+          </div>
+        </template>
+      </section>
+    </template>
 `;
   }
 
@@ -366,6 +397,10 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
         type: String,
         computed: 'computeTestType(path, manifest)',
         value: '',
+      },
+      isRefTest: {
+        type: Boolean,
+        computed: 'computeIsRefTest(testType)'
       },
       testW3CURL: {
         type: Boolean,
@@ -446,6 +481,10 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
       }
     }
     return null;
+  }
+
+  computeIsRefTest(testType) {
+    return testType === 'reftest';
   }
 
   computeTestW3CURL(testType, path) {

--- a/webapp/components/wpt-results.js
+++ b/webapp/components/wpt-results.js
@@ -367,13 +367,13 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
             <div>
               <h5>Result</h5>
               <template is="dom-if" if="[[testW3CURL]]">
-                <iframe src="[[testW3CURL]]"></iframe>
+                <iframe src="[[https(testW3CURL)]]"></iframe>
               </template>
             </div>
             <div>
               <h5>Reference</h5>
               <template is="dom-if" if="[[testW3CRefURL]]">
-                <iframe src="[[testW3CRefURL]]"></iframe>
+                <iframe src="[[https(testW3CRefURL)]]"></iframe>
               </template>
             </div>
           </div>
@@ -504,6 +504,10 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
     // See https://github.com/web-platform-tests/wpt/blob/master/tools/manifest/item.py#L141
     const refPath = item && item[0][1][0][0];
     return this.computeTestW3CURL(testType, refPath);
+  }
+
+  https(url) {
+    return `${url}`.replace(/^http:/, 'https:');
   }
 
   computeTestType(path, manifest) {


### PR DESCRIPTION
## Description
Inlines a couple of iframes when we load the manifest, and are looking at a `reftest` test type.

## Review Information
- Visit /flags, enable the feature for reftest iframes
- Visit /results, find a reftest, e.g. /2dcontext/drawing-images-to-the-canvas/drawimage_canvas_self.html
- See the iframes when the manifest loads.