### PR TITLE
Add support for diffs using searchcache

### DIFF
--- a/api/query/atoms.go
+++ b/api/query/atoms.go
@@ -322,7 +322,7 @@ func (tse *TestStatusEq) UnmarshalJSON(b []byte) error {
 
 	statusStr := strings.ToUpper(data.Status)
 	status := shared.TestStatusValueFromString(statusStr)
-	statusStr2 := shared.TestStatusStringFromValue(status)
+	statusStr2 := status.String()
 	if statusStr != statusStr2 {
 		return fmt.Errorf(`Invalid test status: "%s"`, data.Status)
 	}
@@ -364,7 +364,7 @@ func (tsn *TestStatusNeq) UnmarshalJSON(b []byte) error {
 
 	statusStr := strings.ToUpper(data.Status.Not)
 	status := shared.TestStatusValueFromString(statusStr)
-	statusStr2 := shared.TestStatusStringFromValue(status)
+	statusStr2 := status.String()
 	if statusStr != statusStr2 {
 		return fmt.Errorf(`Invalid test status: "%s"`, data.Status)
 	}

--- a/api/query/cache/index/index_test.go
+++ b/api/query/cache/index/index_test.go
@@ -249,7 +249,7 @@ func TestSync(t *testing.T) {
 	// Populate data with predictable set of two results for each run.
 	loader.EXPECT().Load(gomock.Any()).DoAndReturn(func(run shared.TestRun) (*metrics.TestResultsReport, error) {
 		strID := strconv.FormatInt(run.ID, 10)
-		strStatus := shared.TestStatusStringFromValue(shared.TestStatus(run.ID % 7))
+		strStatus := shared.TestStatus(run.ID % 7).String()
 		return &metrics.TestResultsReport{
 			Results: []*metrics.TestResults{
 				&metrics.TestResults{

--- a/api/query/cache/service/main.go
+++ b/api/query/cache/service/main.go
@@ -143,11 +143,20 @@ func searchHandler(w http.ResponseWriter, r *http.Request) {
 	q := cq.PrepareUserQuery(ids, rq.AbstractQuery.BindToRuns(runs...))
 
 	// Configure format, from request params.
-	_, subtests := r.URL.Query()["subtests"]
-	_, interop := r.URL.Query()["interop"]
+	urlQuery := r.URL.Query()
+	_, subtests := urlQuery["subtests"]
+	_, interop := urlQuery["interop"]
+	_, diff := urlQuery["diff"]
+	diffFilter, _, err := shared.ParseDiffFilterParams(urlQuery)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 	opts := query.AggregationOpts{
 		IncludeSubtests: subtests,
 		InteropFormat:   interop,
+		IncludeDiff:     diff,
+		DiffFilter:      diffFilter,
 	}
 	plan, err := idx.Bind(runs, q)
 	if err != nil {

--- a/api/query/cache/service/main.go
+++ b/api/query/cache/service/main.go
@@ -171,6 +171,15 @@ func searchHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Cull unchanged diffs, if applicable.
+	if opts.IncludeDiff && !opts.DiffFilter.Unchanged {
+		for _, r := range res {
+			if r.Diff.IsEmpty() {
+				r.Diff = nil
+			}
+		}
+	}
+
 	// Response always contains Runs and Results. If some runs are missing, then:
 	// - Add missing runs to IgnoredRuns;
 	// - (If no other error occurs) return `http.StatusUnprocessableEntity` to

--- a/api/query/concrete_query.go
+++ b/api/query/concrete_query.go
@@ -13,6 +13,8 @@ import (
 type AggregationOpts struct {
 	IncludeSubtests bool
 	InteropFormat   bool
+	IncludeDiff     bool
+	DiffFilter      shared.DiffFilterParam
 }
 
 // Binder is a mechanism for binding a query over a slice of test runs to

--- a/api/query/search.go
+++ b/api/query/search.go
@@ -149,7 +149,8 @@ func (sh structuredSearchHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 		q := r.URL.Query()
 		_, interop := q["interop"]
 		_, subtests := q["subtests"]
-		isSimpleQ = isSimpleQ && !interop && !subtests
+		_, diff := q["diff"]
+		isSimpleQ = isSimpleQ && !interop && !subtests && !diff
 	}
 
 	if !isSimpleQ {

--- a/api/query/search.go
+++ b/api/query/search.go
@@ -52,6 +52,9 @@ type SearchResult struct {
 
 	// Subtests (names) which are included in the LegacyStatus summary.
 	Subtests []string `json:"subtests,omitempty"`
+
+	// Diff count of subtests which are included in the LegacyStatus summary.
+	Diff shared.TestDiff `json:"diff,omitempty"`
 }
 
 // SearchResponse contains a response to search API calls, including specific

--- a/shared/run_diff.go
+++ b/shared/run_diff.go
@@ -112,26 +112,62 @@ func (s ResultsSummary) Add(k string, other TestSummary) {
 // TestDiff is an array of differences between 2 tests.
 type TestDiff []int
 
+const (
+	newlyPassingIndex = 0
+	newlyFailingIndex = 1
+	totalDeltaIndex   = 2
+)
+
 // NewlyPassing is the delta/increase in the number of passing tests when comparing before/after.
 func (d TestDiff) NewlyPassing() int {
-	return d[0]
+	return d[newlyPassingIndex]
 }
 
 // Regressions is the delta/increase in the number of failing tests when comparing before/after.
 func (d TestDiff) Regressions() int {
-	return d[1]
+	return d[newlyFailingIndex]
 }
 
 // TotalDelta is the delta in the number of total subtests when comparing before/after.
 func (d TestDiff) TotalDelta() int {
-	return d[2]
+	return d[totalDeltaIndex]
 }
 
 // Add adds the given other TestDiff to this TestDiff's value. Used for summing.
 func (d TestDiff) Add(other TestDiff) {
-	d[0] += other[0]
-	d[1] += other[1]
-	d[2] += other[2]
+	d[newlyPassingIndex] += other[newlyPassingIndex]
+	d[newlyFailingIndex] += other[newlyFailingIndex]
+	d[totalDeltaIndex] += other[totalDeltaIndex]
+}
+
+func (d TestDiff) Append(before, after TestStatus, filter *DiffFilterParam) {
+	if before == TestStatusUnknown {
+		if after == TestStatusUnknown || !filter.Added {
+			return
+		}
+		if after.IsPassOrOK() {
+			d[newlyPassingIndex]++
+		} else {
+			d[newlyFailingIndex]++
+		}
+		return
+	}
+	if after == TestStatusUnknown {
+		if filter.Deleted {
+			d[totalDeltaIndex]--
+		}
+		return
+	}
+	wasPassing, isPassing := before.IsPassOrOK(), after.IsPassOrOK()
+	changed := wasPassing != isPassing
+	if !changed || !filter.Changed {
+		return
+	}
+	if wasPassing {
+		d[newlyFailingIndex]++
+	} else {
+		d[newlyPassingIndex]++
+	}
 }
 
 // NewTestDiff computes the differences between two test-run pass-count summaries,

--- a/shared/run_diff.go
+++ b/shared/run_diff.go
@@ -150,7 +150,7 @@ func (d TestDiff) Add(other TestDiff) {
 	d[totalDeltaIndex] += other[totalDeltaIndex]
 }
 
-// Append appends the difference between the two given statuses, if any.
+// Appends the difference between the two given statuses, if any.
 func (d TestDiff) Append(before, after TestStatus, filter *DiffFilterParam) {
 	if before == TestStatusUnknown {
 		if after == TestStatusUnknown || !filter.Added {

--- a/shared/run_diff.go
+++ b/shared/run_diff.go
@@ -112,6 +112,16 @@ func (s ResultsSummary) Add(k string, other TestSummary) {
 // TestDiff is an array of differences between 2 tests.
 type TestDiff []int
 
+// IsEmpty returns true if the diff is empty (all zeroes)
+func (d TestDiff) IsEmpty() bool {
+	for _, x := range d {
+		if x > 0 {
+			return false
+		}
+	}
+	return true
+}
+
 const (
 	newlyPassingIndex = 0
 	newlyFailingIndex = 1

--- a/shared/run_diff.go
+++ b/shared/run_diff.go
@@ -140,6 +140,7 @@ func (d TestDiff) Add(other TestDiff) {
 	d[totalDeltaIndex] += other[totalDeltaIndex]
 }
 
+// Append appends the difference between the two given statuses, if any.
 func (d TestDiff) Append(before, after TestStatus, filter *DiffFilterParam) {
 	if before == TestStatusUnknown {
 		if after == TestStatusUnknown || !filter.Added {

--- a/shared/statuses.go
+++ b/shared/statuses.go
@@ -137,9 +137,8 @@ func TestStatusValueFromString(str string) TestStatus {
 	return v
 }
 
-// TestStatusStringFromValue returns the string associated with s (if any), or
-// else TestStatusStringDefault.
-func TestStatusStringFromValue(s TestStatus) string {
+// String returns the string associated with s (if any), or else TestStatusStringDefault.
+func (s TestStatus) String() string {
 	str, ok := testStatusNames[s]
 	if !ok {
 		return TestStatusNameDefault

--- a/shared/statuses_test.go
+++ b/shared/statuses_test.go
@@ -28,10 +28,10 @@ func TestDefaults(t *testing.T) {
 
 func TestPass(t *testing.T) {
 	assert.Equal(t, TestStatusPass, TestStatusValueFromString("PASS"))
-	assert.Equal(t, "PASS", TestStatusStringFromValue(TestStatusPass))
+	assert.Equal(t, "PASS", TestStatusPass.String())
 }
 
 func TestDefaultsFromAPI(t *testing.T) {
 	assert.Equal(t, TestStatusDefault, TestStatusValueFromString("NOT_A_TEST_VALUE_STRING"))
-	assert.Equal(t, TestStatusNameDefault, TestStatusStringFromValue(7919))
+	assert.Equal(t, TestStatusNameDefault, TestStatus(7919).String())
 }

--- a/webapp/components/wpt-results.js
+++ b/webapp/components/wpt-results.js
@@ -585,7 +585,9 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
             revision: 'diff',
             browser_name: 'diff',
           };
-          this.fetchDiff();
+          if (!this.structuredQueries) {
+            this.fetchDiff();
+          }
         }
 
         // Load a manifest.
@@ -614,6 +616,10 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
       };
       if (q) {
         body.query = q;
+      }
+      if (this.diffFromAPI) {
+        url.searchParams.set('diff', true);
+        url.searchParams.set('filter', this.diffFilter);
       }
       fetchOpts = {
         method: 'POST',

--- a/webapp/components/wpt-results.js
+++ b/webapp/components/wpt-results.js
@@ -818,6 +818,8 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
           let diff;
           if (this.diffResults) {
             diff = this.diffResults.diff[r.test];
+          } else if (r.diff) {
+            diff = r.diff;
           } else {
             const [before, after] = rs;
             diff = this.computeDifferences(before, after);


### PR DESCRIPTION
## Description
Adds diff param support to /api/search, computing differences for the subtests directly (instead of via summary numbers, which can cause things to cancel each other out).

This is a step towards https://github.com/web-platform-tests/wpt.fyi/issues/1071
We'll need to compute the regression diffs via the same API