### PR TITLE
Add "path" atom to structured queries

### DIFF
--- a/api/query/atoms_test.go
+++ b/api/query/atoms_test.go
@@ -134,6 +134,18 @@ func TestStructuredQuery_pattern(t *testing.T) {
 	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2}, AbstractQuery: TestNamePattern{"/2dcontext/"}}, rq)
 }
 
+func TestStructuredQuery_path(t *testing.T) {
+	var rq RunQuery
+	err := json.Unmarshal([]byte(`{
+		"run_ids": [0, 1, 2],
+		"query": {
+			"path": "/2dcontext/"
+		}
+	}`), &rq)
+	assert.Nil(t, err)
+	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2}, AbstractQuery: TestPath{"/2dcontext/"}}, rq)
+}
+
 func TestStructuredQuery_legacyBrowserName(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{

--- a/api/query/cache/index/index_filter_test.go
+++ b/api/query/cache/index/index_filter_test.go
@@ -140,6 +140,52 @@ func TestBindExecute_TestNamePattern(t *testing.T) {
 	assert.Equal(t, expectedResult, srs[0])
 }
 
+func TestBindExecute_TestPath(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	loader := NewMockReportLoader(ctrl)
+	idx, err := NewShardedWPTIndex(loader, testNumShards)
+	assert.Nil(t, err)
+
+	matchingPath := "/dom/"
+	unmatchingPath := "/html/dom/"
+	runs := mockTestRuns(loader, idx, []testRunData{
+		testRunData{
+			shared.TestRun{ID: 1},
+			&metrics.TestResultsReport{
+				Results: []*metrics.TestResults{
+					&metrics.TestResults{
+						Test:   matchingPath,
+						Status: "PASS",
+					},
+					&metrics.TestResults{
+						Test:   unmatchingPath,
+						Status: "FAIL",
+					},
+				},
+			},
+		},
+	})
+
+	q := query.TestPath{
+		Path: "/dom/",
+	}
+	srs := planAndExecute(t, runs, idx, q)
+
+	assert.Equal(t, 1, len(srs))
+	expectedResult := query.SearchResult{
+		Test: matchingPath,
+		LegacyStatus: []query.LegacySearchRunResult{
+			query.LegacySearchRunResult{
+				// Only matching test passes.
+				Passes: 1,
+				Total:  1,
+			},
+		},
+	}
+	assert.Equal(t, expectedResult, srs[0])
+}
+
 func TestBindExecute_TestStatus(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/api/query/concrete_query.go
+++ b/api/query/concrete_query.go
@@ -77,6 +77,10 @@ type Not struct {
 // substring match per test.
 func (TestNamePattern) Size() int { return 1 }
 
+// Size of TestPath has a size of 1: servicing such a query requires a
+// substring match per test.
+func (TestPath) Size() int { return 1 }
+
 // Size of RunTestStatusEq is 1: servicing such a query requires a single lookup
 // in a test run result mapping per test.
 func (RunTestStatusEq) Size() int { return 1 }

--- a/shared/run_diff.go
+++ b/shared/run_diff.go
@@ -150,7 +150,7 @@ func (d TestDiff) Add(other TestDiff) {
 	d[totalDeltaIndex] += other[totalDeltaIndex]
 }
 
-// Appends the difference between the two given statuses, if any.
+// Append the difference between the two given statuses, if any.
 func (d TestDiff) Append(before, after TestStatus, filter *DiffFilterParam) {
 	if before == TestStatusUnknown {
 		if after == TestStatusUnknown || !filter.Added {

--- a/webapp/components/test-search.js
+++ b/webapp/components/test-search.js
@@ -69,13 +69,19 @@ const QUERY_GRAMMAR = ohm.grammar(`
     Fragment
       = not Fragment -- not
       | statusExp
-      | nameFragment
+      | pathExp
+      | patternExp
 
     statusExp
       = caseInsensitive<"status"> ":" statusLiteral  -- eq
       | caseInsensitive<"status"> ":!" statusLiteral -- neq
       | productSpec ":" statusLiteral                -- product_eq
       | productSpec ":!" statusLiteral               -- product_neq
+
+    pathExp
+      = caseInsensitive<"path"> ":" nameFragment
+
+    patternExp = nameFragment
 
     productSpec = browserName ("-" browserVersion)?
 
@@ -170,11 +176,17 @@ const QUERY_SEMANTICS = QUERY_GRAMMAR.createSemantics().addOperation('eval', {
       status: {not: r.sourceString.toUpperCase()},
     };
   },
-  nameFragment_basic: (basic) => {
-    return {pattern: basic.sourceString};
+  pathExp: (l, colon, r) => {
+    return { path: r.eval() };
+  },
+  patternExp: (p) => {
+    return { pattern: p.eval() };
+  },
+  nameFragment_basic: (p) => {
+    return p.sourceString;
   },
   nameFragment_quoted: (_, chars, __) => {
-    return {pattern: chars.sourceString};
+    return chars.sourceString;
   },
   backslash: (v) => '\\',
   quotemark: (v) => '"',

--- a/webapp/components/test/test-search.html
+++ b/webapp/components/test/test-search.html
@@ -24,7 +24,6 @@ suite('<test-search>', () => {
       const S = TestSearch.QUERY_SEMANTICS;
       const p = G.match(query);
       assert.isTrue(p.succeeded(), p.message);
-      console.log(S(p).eval());
       assert.deepEqual(structuredQuery, S(p).eval());
     };
 

--- a/webapp/components/test/test-search.html
+++ b/webapp/components/test/test-search.html
@@ -24,6 +24,7 @@ suite('<test-search>', () => {
       const S = TestSearch.QUERY_SEMANTICS;
       const p = G.match(query);
       assert.isTrue(p.succeeded(), p.message);
+      console.log(S(p).eval());
       assert.deepEqual(structuredQuery, S(p).eval());
     };
 
@@ -43,6 +44,14 @@ suite('<test-search>', () => {
       test('complex', () => {
         assertQueryParse('"/foo.html?exclude=(Document|window|HTML.*)"', {exists: [{pattern: '/foo.html?exclude=(Document|window|HTML.*)'}]});
       });
+    });
+
+    test('path', () => {
+      assertQueryParse('path:/dom/', {exists: [{path: '/dom/'}]});
+    });
+
+    test('path quoted', () => {
+      assertQueryParse('path:"/foo.html?exclude=(Document|window|HTML.*)"', {exists: [{path: '/foo.html?exclude=(Document|window|HTML.*)'}]});
     });
 
     test('versioned browser', () => {


### PR DESCRIPTION
## Description
Add a `path:[test path]` atom, distinct from the `pattern` atom in that it's a prefix-match, not a case-insensitive search (and whatever else we end up doing to make it even more fuzzy).

Fixes #1132 