### PR TITLE
Add (beginnings of) ReftestAnalyzer component

### DIFF
--- a/webapp/components/reftest-analyzer.js
+++ b/webapp/components/reftest-analyzer.js
@@ -10,16 +10,48 @@ import '../node_modules/@polymer/polymer/lib/elements/dom-repeat.js';
 import '../node_modules/@polymer/paper-radio-button/paper-radio-button.js';
 import '../node_modules/@polymer/paper-radio-group/paper-radio-group.js';
 
+const nsSVG = 'http://www.w3.org/2000/svg';
+const blankFill = 'white';
+
 class ReftestAnalyzer extends PolymerElement {
   static get template() {
     return html`
-      <paper-radio-group selected="{{selectedImage}}">
-        <template is="dom-repeat" items="[[images]]" as="image" index-as="i">
-          <paper-radio-button name="[[i]]">Image [[i]]</paper-radio-button>
-        </template>
-      </paper-radio-group>
+      <style>
+        :host {
+          display: flex;
+          flex-direction: row;
+        }
+        #zoom svg {
+          height: 250px;
+          width: 250px;
+        }
+        #source #overlay {
+          height: 800px;
+          width: 1000px;
+        }
+      </style>
 
-      <img src="[[selectedImageSrc]]" />
+      <div id='zoom'>
+
+        <svg xmlns="http://www.w3.org/2000/svg" shape-rendering="optimizeSpeed">
+          <g id="zoomed">
+            <rect width="250" height="250" fill="white"/>
+          </g>
+        </svg>
+
+      </div>
+
+      <div id='source'>
+        <paper-radio-group selected="{{selectedImage}}">
+          <template is="dom-repeat" items="[[images]]" as="image" index-as="i">
+            <paper-radio-button name="[[i]]">Image [[i]]</paper-radio-button>
+          </template>
+        </paper-radio-group>
+
+        <div id="overlay">
+          <img onmousemove="[[zoom]]" />
+        </div>
+      </div>
 `;
   }
 
@@ -37,12 +69,77 @@ class ReftestAnalyzer extends PolymerElement {
       selectedImageSrc: {
         type: String,
         computed: '_computeSelectedImageSrc(images, selectedImage)',
+        observer: 'selectedImageSrcChanged',
       },
+      zoomedSVGPaths: Array, // 2D array of the paths.
+      canvas: Object,
     };
+  }
+
+  constructor() {
+    super();
+    this.zoom = this.handleZoom.bind(this);
+  }
+
+  ready() {
+    super.ready();
+    this.setupZoomSVG();
   }
 
   _computeSelectedImageSrc(images, selectedImage) {
     return images && images[selectedImage];
+  }
+
+  selectedImageSrcChanged(src) {
+    var img = this.shadowRoot.querySelector('#overlay img');
+    img.onload = () => {
+      var canvas = document.createElement('canvas');
+      canvas.width = img.width;
+      canvas.height = img.height;
+      canvas.getContext('2d').drawImage(img, 0, 0, img.width, img.height);
+      this.canvas = canvas;
+    };
+    img.src = src;
+  }
+
+  get sourceImage() {
+    return this.shadowRoot && this.shadowRoot.querySelector('#source svg image');
+  }
+
+  setupZoomSVG() {
+    const zoomed = this.shadowRoot.querySelector('#zoomed');
+    const paths = [];
+    for (let x = 0; x < 5; x++) {
+      paths.push([]);
+      for (let y = 0; y < 5; y++) {
+        const path = document.createElementNS(nsSVG, 'path');
+        const offsetX = x * 50 + 1;
+        const offsetY = y * 50 + 1;
+        path.setAttribute('d', `M${offsetX},${offsetY} H${offsetX + 48} V${offsetY + 48} H${offsetX} V${offsetY}`);
+        path.setAttribute('fill', blankFill);
+        paths[x].push(zoomed.appendChild(path));
+      }
+    }
+    this.paths = paths;
+  }
+
+  handleZoom(e) {
+    const ctx = this.canvas.getContext('2d');
+    const c = e.target.getBoundingClientRect();
+    const x = e.clientX - c.left - 2;
+    const y = e.clientY - c.top - 2;
+    for (let i = 0; i < 5; i++) {
+      for (let j = 0; j < 5; j++) {
+        if (x + i < 0 || x + i >= this.canvas.width || y + j < 0 || y + j >= this.canvas.height) {
+          this.paths[i][j].fill = blankFill;
+        } else {
+          const p = ctx.getImageData(x+i, y+j, 1, 1).data;
+          const [r,g,b] = p;
+          const a = p[3]/255;
+          this.paths[i][j].setAttribute('fill', `rgba(${r},${g},${b},${a}`);
+        }
+      }
+    }
   }
 }
 window.customElements.define(ReftestAnalyzer.is, ReftestAnalyzer);

--- a/webapp/components/reftest-analyzer.js
+++ b/webapp/components/reftest-analyzer.js
@@ -4,8 +4,7 @@
  * found in the LICENSE file.
  */
 
-import { PolymerElement } from '../node_modules/@polymer/polymer/polymer-element.js';
-import { html } from '../../node_modules/@polymer/polymer/lib/utils/html-tag.js';
+import { PolymerElement, html } from '../node_modules/@polymer/polymer/polymer-element.js';
 import '../node_modules/@polymer/polymer/lib/elements/dom-repeat.js';
 import '../node_modules/@polymer/paper-radio-button/paper-radio-button.js';
 import '../node_modules/@polymer/paper-radio-group/paper-radio-group.js';

--- a/webapp/components/reftest-analyzer.js
+++ b/webapp/components/reftest-analyzer.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2018 The WPT Dashboard Project. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+import { PolymerElement } from '../node_modules/@polymer/polymer/polymer-element.js';
+import { html } from '../../node_modules/@polymer/polymer/lib/utils/html-tag.js';
+import '../node_modules/@polymer/polymer/lib/elements/dom-repeat.js';
+import '../node_modules/@polymer/paper-radio-button/paper-radio-button.js';
+import '../node_modules/@polymer/paper-radio-group/paper-radio-group.js';
+
+class ReftestAnalyzer extends PolymerElement {
+  static get template() {
+    return html`
+      <paper-radio-group selected="{{selectedImage}}">
+        <template is="dom-repeat" items="[[images]]" as="image" index-as="i">
+          <paper-radio-button name="[[i]]">Image [[i]]</paper-radio-button>
+        </template>
+      </paper-radio-group>
+
+      <img src="[[selectedImageSrc]]" />
+`;
+  }
+
+  static get is() {
+    return 'reftest-analyzer';
+  }
+
+  static get properties() {
+    return {
+      images: Array,
+      selectedImage: {
+        type: Number,
+        value: 0,
+      },
+      selectedImageSrc: {
+        type: String,
+        computed: '_computeSelectedImageSrc(images, selectedImage)',
+      },
+    };
+  }
+
+  _computeSelectedImageSrc(images, selectedImage) {
+    return images && images[selectedImage];
+  }
+}
+window.customElements.define(ReftestAnalyzer.is, ReftestAnalyzer);

--- a/webapp/components/test/reftest-analyzer.html
+++ b/webapp/components/test/reftest-analyzer.html
@@ -4,6 +4,8 @@
   <meta charset="utf-8">
   <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
   <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
+
+  <script type="module" src="../reftest-analyzer.js"></script>
 </head>
 <body>
   <reftest-analyzer></reftest-analyzer>
@@ -15,7 +17,6 @@
   </test-fixture>
 
   <script type="module">
-import '../reftest-analyzer.js';
 import { PolymerElement } from '../../node_modules/@polymer/polymer/polymer-element.js';
 
 // Playground:

--- a/webapp/components/test/reftest-analyzer.html
+++ b/webapp/components/test/reftest-analyzer.html
@@ -21,10 +21,8 @@ import { PolymerElement } from '../../node_modules/@polymer/polymer/polymer-elem
 
 // Playground:
 const analyzer = document.querySelector('reftest-analyzer');
-analyzer.images = [
-  '/static/chrome_64x64.png',
-  '/static/chrome-beta_64x64.png',
-];
+analyzer.before = '/static/chrome_64x64.png';
+analyzer.after = '/static/chrome-beta_64x64.png';
 
 suite('ReftestAnalyzer', () => {
   let analyzer, sandbox;

--- a/webapp/components/test/reftest-analyzer.html
+++ b/webapp/components/test/reftest-analyzer.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
+  <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
+</head>
+<body>
+  <reftest-analyzer></reftest-analyzer>
+
+  <test-fixture id="reftest-analyzer-fixture">
+    <template>
+      <reftest-analyzer></reftest-analyzer>
+    </template>
+  </test-fixture>
+
+  <script type="module">
+import '../reftest-analyzer.js';
+import { PolymerElement } from '../../node_modules/@polymer/polymer/polymer-element.js';
+
+// Playground:
+const analyzer = document.querySelector('reftest-analyzer');
+analyzer.images = [
+  '/static/chrome_64x64.png',
+  '/static/chrome-beta_64x64.png',
+];
+
+suite('ReftestAnalyzer', () => {
+  let analyzer, sandbox;
+
+  setup(() => {
+    sandbox = sinon.sandbox.create();
+
+    analyzer = fixture('reftest-analyzer-fixture');
+  });
+
+  teardown(() => {
+    sandbox.restore();
+  });
+
+  test('instanceof Polymer.Element', () => {
+    assert.isTrue(analyzer instanceof PolymerElement);
+  });
+});
+
+</script>
+</body>
+</html>

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -992,6 +992,29 @@
         "@polymer/polymer": "^3.0.0"
       }
     },
+    "@polymer/paper-radio-button": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@polymer/paper-radio-button/-/paper-radio-button-3.0.1.tgz",
+      "integrity": "sha512-ltCdgolOrmTeG3IxHhfMgxRc9AloNpoIwRMInrTI5Nzva4yOzSpP01bfpEwBpTl11o0NYxqfYYCxCjLQGRq9ng==",
+      "requires": {
+        "@polymer/iron-checked-element-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-flex-layout": "^3.0.0-pre.26",
+        "@polymer/paper-behaviors": "^3.0.0-pre.27",
+        "@polymer/paper-styles": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/paper-radio-group": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@polymer/paper-radio-group/-/paper-radio-group-3.0.1.tgz",
+      "integrity": "sha512-VYUWj6Y7/1sJncbtKJ4+aKJ0U98cLPXWu6mTgMREoA2jOKrb41JxtnKNrKMjs+lBHCZj4wvtmHwzeS//HFULfA==",
+      "requires": {
+        "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.26",
+        "@polymer/iron-menu-behavior": "^3.0.0-pre.26",
+        "@polymer/paper-radio-button": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
     "@polymer/paper-ripple": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@polymer/paper-ripple/-/paper-ripple-3.0.1.tgz",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -29,6 +29,8 @@
     "@polymer/paper-input": "^3.0.0",
     "@polymer/paper-item": "^3.0.0",
     "@polymer/paper-listbox": "^3.0.0",
+    "@polymer/paper-radio-button": "^3.0.1",
+    "@polymer/paper-radio-group": "^3.0.1",
     "@polymer/paper-spinner": "^3.0.0",
     "@polymer/paper-styles": "^3.0.0",
     "@polymer/paper-tabs": "^3.0.0",


### PR DESCRIPTION
## Description
Start of a Polymer-based reimplementation of the reftest-analyzer, for wpt.fyi.
So far, only shows a zoomed-in view of the image.

https://github.com/mozilla/gecko-dev/blob/master/layout/tools/reftest/reftest-analyzer.xhtml

## Review Information
- Clone this locally, and run it
- Visit http://localhost:8080/components/test/reftest-analyzer.html
- See zoomed in pixels when you hover over the image