### PR TITLE
Make the page wider and expand reftest previews

### DIFF
--- a/webapp/components/interop.js
+++ b/webapp/components/interop.js
@@ -115,7 +115,7 @@ class WPTInterop extends WPTColors(WPTFlags(SelfNavigation(LoadingState(
       display: inline-block;
     }
 
-    @media (max-width: 800px) {
+    @media (max-width: 1200px) {
       table tr td:first-child::after {
         content: "";
         display: inline-block;

--- a/webapp/components/wpt-results.js
+++ b/webapp/components/wpt-results.js
@@ -141,7 +141,7 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
         display: inline-block;
       }
 
-      @media (max-width: 800px) {
+      @media (max-width: 1200px) {
         table tr td:first-child::after {
           content: "";
           display: inline-block;

--- a/webapp/components/wpt-results.js
+++ b/webapp/components/wpt-results.js
@@ -153,6 +153,13 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
       .compare {
         display: flex;
       }
+      .compare .column {
+        flex-grow: 1;
+      }
+      .compare .column iframe {
+        width: 100%;
+        height: 600px;
+      }
     </style>
 
     <results-tabs tab="results" path="[[encodedPath]]" query="[[query]]">
@@ -372,14 +379,14 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
         <div class="separator"></div>
         <section>
           <h4>[[path]] in this browser</h4>
-          <div class='compare'>
-            <div>
+          <div class="compare">
+            <div class="column">
               <h5>Result</h5>
               <template is="dom-if" if="[[testW3CURL]]">
                 <iframe src="[[https(testW3CURL)]]"></iframe>
               </template>
             </div>
-            <div>
+            <div class="column">
               <h5>Reference</h5>
               <template is="dom-if" if="[[testW3CRefURL]]">
                 <iframe src="[[https(testW3CRefURL)]]"></iframe>

--- a/webapp/components/wpt-runs.js
+++ b/webapp/components/wpt-runs.js
@@ -81,7 +81,7 @@ class WPTRuns extends WPTFlags(SelfNavigation(LoadingState(TestRunsUIBase))) {
         width: 24px;
       }
 
-      @media (max-width: 800px) {
+      @media (max-width: 1200px) {
         table tr td:first-child::after {
           content: "";
           display: inline-block;

--- a/webapp/static/common.css
+++ b/webapp/static/common.css
@@ -6,6 +6,7 @@ body {
   font-size: 16px;
   font-family: Arial;
   color: #333;
+  padding: 0 16px;
 }
 #content {
   margin: 0 auto;

--- a/webapp/static/common.css
+++ b/webapp/static/common.css
@@ -9,7 +9,7 @@ body {
 }
 #content {
   margin: 0 auto;
-  max-width: 800px;
+  max-width: 1200px;
 }
 a {
   text-decoration: none;


### PR DESCRIPTION
## Description

800px is too crowded when we have more than four runs (which is getting more common now that search is heavily used). And reftest previews can be expanded a bit (also to match the default screenshot size 600x600).

## Review Information

See the staging deployment.