### PR TITLE
Eliminate a potential source of timeout

### DIFF
--- a/api/azure/webhook.go
+++ b/api/azure/webhook.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"regexp"
 	"strconv"
+	"time"
 
 	mapset "github.com/deckarep/golang-set"
 
@@ -55,8 +56,9 @@ func processAzureBuild(aeAPI shared.AppEngineAPI, azureAPI API, sha, owner, repo
 	log := shared.GetLogger(aeAPI.Context())
 	log.Infof("Fetching %s", artifactsURL)
 
-	client := aeAPI.GetHTTPClient()
-	resp, err := client.Get(artifactsURL)
+	slowClient, cancel := aeAPI.GetSlowHTTPClient(time.Minute)
+	defer cancel()
+	resp, err := slowClient.Get(artifactsURL)
 	if err != nil {
 		log.Errorf("Failed to fetch artifacts for %s/%s build %v", owner, repo, buildID)
 		return false, err

--- a/api/receiver/client/client.go
+++ b/api/receiver/client/client.go
@@ -70,9 +70,9 @@ func (c client) CreateRun(
 	}
 	req.SetBasicAuth(username, password)
 
-	client, cancel := c.aeAPI.GetSlowHTTPClient(time.Minute)
+	slowClient, cancel := c.aeAPI.GetSlowHTTPClient(time.Minute)
 	defer cancel()
-	resp, err := client.Do(req)
+	resp, err := slowClient.Do(req)
 	if err != nil {
 		return err
 	}

--- a/api/receiver/client/client.go
+++ b/api/receiver/client/client.go
@@ -17,6 +17,9 @@ import (
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
+// UploadTimeout is the timeout to upload results to the results receiver.
+const UploadTimeout = time.Minute
+
 // Client is the interface for the client.
 type Client interface {
 	CreateRun(
@@ -70,7 +73,7 @@ func (c client) CreateRun(
 	}
 	req.SetBasicAuth(username, password)
 
-	slowClient, cancel := c.aeAPI.GetSlowHTTPClient(time.Minute)
+	slowClient, cancel := c.aeAPI.GetSlowHTTPClient(UploadTimeout)
 	defer cancel()
 	resp, err := slowClient.Do(req)
 	if err != nil {

--- a/api/receiver/receive_results.go
+++ b/api/receiver/receive_results.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -160,7 +161,7 @@ func sendResultsToProcessor(
 
 	var errStr string
 	for err := range errors {
-		errStr += err.Error()
+		errStr += strings.TrimSpace(err.Error()) + "\n"
 	}
 	if errStr != "" {
 		return nil, fmt.Errorf("error(s) occured when transferring results from %s to GCS:\n%s", uploader, errStr)

--- a/webapp/app.yaml
+++ b/webapp/app.yaml
@@ -9,6 +9,9 @@ instance_class: F4_1G
 builtins:
 - remote_api: on
 
+inbound_services:
+- warmup
+
 handlers:
   # Couple of special-case dynamic components.
 - url: /components/wpt-env-flags.js


### PR DESCRIPTION
Fetching artifacts from Azure Pipelines is slow and needs to be done with a slow client.

Related to https://github.com/web-platform-tests/wpt.fyi/issues/1131