### PR TITLE
[receiver] Sleep longer between retries when fetching results

### DIFF
--- a/api/receiver/receive_results.go
+++ b/api/receiver/receive_results.go
@@ -171,7 +171,7 @@ func sendResultsToProcessor(
 
 func fetchFile(a AppEngineAPI, url string) (io.ReadCloser, error) {
 	log := shared.GetLogger(a.Context())
-	sleep := time.Millisecond * 500
+	sleep := time.Second
 	for retry := 0; retry < NumRetries; retry++ {
 		body, err := a.fetchWithTimeout(url, DownloadTimeout)
 		if err == nil {


### PR DESCRIPTION
The two sleeps between three retries are increased from (0.5s, 1s) to
(1s, 2s) to give Taskcluster more time to persist and expose the
artifacts.

This issue was identified in the logs when debugging unrelated Azure timeouts.