### PR TITLE
Clear unchanged diffs by ref

### DIFF
--- a/api/query/cache/service/main.go
+++ b/api/query/cache/service/main.go
@@ -173,9 +173,9 @@ func searchHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Cull unchanged diffs, if applicable.
 	if opts.IncludeDiff && !opts.DiffFilter.Unchanged {
-		for _, r := range res {
-			if r.Diff.IsEmpty() {
-				r.Diff = nil
+		for i := range res {
+			if res[i].Diff.IsEmpty() {
+				res[i].Diff = nil
 			}
 		}
 	}

--- a/shared/run_diff.go
+++ b/shared/run_diff.go
@@ -115,7 +115,7 @@ type TestDiff []int
 // IsEmpty returns true if the diff is empty (all zeroes)
 func (d TestDiff) IsEmpty() bool {
 	for _, x := range d {
-		if x > 0 {
+		if x != 0 {
 			return false
 		}
 	}


### PR DESCRIPTION
## Description
Attempt to fix #1146 

The code for detecting empty differences looks correct, so I'm speculating that the struct is being copied out of the array with each loop iteration, and clearing the field only occurs on the local copy?