### PR TITLE
Surface test-count totals in the message

### DIFF
--- a/webapp/components/test/test-runs-query.html
+++ b/webapp/components/test/test-runs-query.html
@@ -161,33 +161,6 @@ suite('TestRunsQuery', () => {
         expect(testRunsQuery.sha).to.equal('latest');
       });
     });
-
-    suite('computeResultsRangeMessage', () => {
-      test('chrome', () => {
-        testRunsQuery.productSpecs = ['chrome', 'firefox'];
-        expect(testRunsQuery.resultsRangeMessage).to.contain('chrome, firefox');
-      });
-      test('labels', () => {
-        testRunsQuery.labels = ['foo'];
-        expect(testRunsQuery.resultsRangeMessage).to.contain('with label \'foo\'');
-        testRunsQuery.labels = ['foo', 'bar'];
-        expect(testRunsQuery.resultsRangeMessage).to.contain('with labels \'foo\', \'bar\'');
-      });
-      test('master', () => {
-        testRunsQuery.master = true;
-        expect(testRunsQuery.resultsRangeMessage).to.contain('master test runs');
-        expect(testRunsQuery.resultsRangeMessage).to.not.contain('with label');
-      });
-      test('shas', () => {
-        const sha = '1234567890';
-        testRunsQuery.shas = [sha];
-        expect(testRunsQuery.resultsRangeMessage).to.contain(`revision ${sha.substr(0, 7)}`);
-
-        const sha2 = 'abcdef1234abcdef1234abcdef1234abcdef1234';
-        testRunsQuery.shas = [sha, sha2];
-        expect(testRunsQuery.resultsRangeMessage).to.contain(`revisions ${sha.substr(0, 7)}, ${sha2.substr(0, 7)}`);
-      });
-    });
   });
 
   suite('TestRunsUIQuery.prototype.*', () => {

--- a/webapp/components/test/wpt-results.html
+++ b/webapp/components/test/wpt-results.html
@@ -139,6 +139,33 @@ suite('<wpt-results>', () => {
         }
       });
     });
+
+    suite('computeResultsRangeMessage', () => {
+      test('chrome', () => {
+        trf.productSpecs = ['chrome', 'firefox'];
+        expect(trf.resultsRangeMessage).to.contain('chrome, firefox');
+      });
+      test('labels', () => {
+        trf.labels = ['foo'];
+        expect(trf.resultsRangeMessage).to.contain('with label \'foo\'');
+        trf.labels = ['foo', 'bar'];
+        expect(trf.resultsRangeMessage).to.contain('with labels \'foo\', \'bar\'');
+      });
+      test('master', () => {
+        trf.master = true;
+        expect(trf.resultsRangeMessage).to.contain('master test runs');
+        expect(trf.resultsRangeMessage).to.not.contain('with label');
+      });
+      test('shas', () => {
+        const sha = '1234567890';
+        trf.shas = [sha];
+        expect(trf.resultsRangeMessage).to.contain(`revision ${sha.substr(0, 7)}`);
+
+        const sha2 = 'abcdef1234abcdef1234abcdef1234abcdef1234';
+        trf.shas = [sha, sha2];
+        expect(trf.resultsRangeMessage).to.contain(`revisions ${sha.substr(0, 7)}, ${sha2.substr(0, 7)}`);
+      });
+    });
   });
 
   teardown(() => {

--- a/webapp/components/test/wpt-results.html
+++ b/webapp/components/test/wpt-results.html
@@ -166,6 +166,23 @@ suite('<wpt-results>', () => {
         expect(trf.resultsRangeMessage).to.contain(`revisions ${sha.substr(0, 7)}, ${sha2.substr(0, 7)}`);
       });
     });
+
+    suite('computeResultsTotalsRangeMessage', () => {
+      test('absent/zero', () => {
+        trf.searchResults = null;
+        expect(trf.resultsTotalsRangeMessage).to.not.contain('0 tests');
+        trf.searchResults = [];
+        expect(trf.resultsTotalsRangeMessage).to.contain('0 tests');
+      });
+      test('some sum', () => {
+        trf.searchResults = [
+          {test: '/abc.html', legacy_status: [{total: 1}, {total: 5}]},
+          {test: '/def.html', legacy_status: [{total: 2}, {total: 1}]},
+        ];
+        expect(trf.resultsTotalsRangeMessage).to.contain('2 tests');
+        expect(trf.resultsTotalsRangeMessage).to.contain('7 subtests');
+      });
+    });
   });
 
   teardown(() => {

--- a/webapp/components/wpt-results.js
+++ b/webapp/components/wpt-results.js
@@ -207,9 +207,9 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
         </div>
       </template>
 
-      <template is="dom-if" if="[[resultsRangeMessage]]">
+      <template is="dom-if" if="[[resultsTotalsRangeMessage]]">
         <info-banner>
-          [[resultsRangeMessage]]
+          [[resultsTotalsRangeMessage]]
           <template is="dom-if" if="[[permalinks]]">
             <wpt-permalinks path="[[path]]"
                             path-prefix="/results/"
@@ -430,6 +430,10 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
       searchResults: {
         type: Array,
         value: [],
+      },
+      resultsTotalsRangeMessage: {
+        type: String,
+        computed: 'computeResultsTotalsRangeMessage(searchResults, shas, productSpecs, to, from, maxCount, labels, master)',
       },
       testPaths: {
         type: Set,
@@ -1090,6 +1094,23 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
     builder.master = true;
     this.handleSubmitQuery();
     this.dismissToast(e);
+  }
+
+  computeResultsTotalsRangeMessage(searchResults, shas, productSpecs, from, to, maxCount, labels, master) {
+    const msg = super.computeResultsRangeMessage(shas, productSpecs, from, to, maxCount, labels, master);
+    if (searchResults) {
+      let subtests = 0, tests = 0;
+      for (const r of searchResults) {
+        if (r.test.startsWith(this.path)) {
+          tests++;
+          subtests += Math.max(...r.legacy_status.map(s => s.total));
+        }
+      }
+      return msg.replace(
+        'Showing ',
+        `Showing ${tests} tests (${subtests} subtests) from `);
+    }
+    return msg;
   }
 }
 

--- a/webapp/components/wpt-results.js
+++ b/webapp/components/wpt-results.js
@@ -558,8 +558,9 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
   }
 
   computeDisplayedTests(path, searchResults) {
-    return searchResults.map(r => r.test)
-      .filter(name => name.startsWith(path));
+    return searchResults
+      && searchResults.map(r => r.test) .filter(name => name.startsWith(path))
+      || [];
   }
 
   computeDiffURL(testRuns) {


### PR DESCRIPTION
## Description
Tests is the number of entries in the /api/search, subtests is the sum of the maximum 'total' value present across each run.

Resolves https://github.com/web-platform-tests/wpt.fyi/issues/1134