### PR TITLE
A small fix to avoid gcloud deprecation warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -267,7 +267,7 @@ results_analysis_symlink:
 	fi
 
 gcloud-%: gcloud
-	gcloud components list --filter="state[name]=Installed AND id=$*" | grep " $* " \
+	gcloud components list --only-local-state --format="value(id)" 2>/dev/null | grep -q "$*" \
 		|| gcloud components install --quiet $*
 
 node-%: node


### PR DESCRIPTION
Finally took the time to read the deprecation warning today:
https://cloud.google.com/sdk/gcloud/reference/topic/filters

We need to use regex (key~^value$) to ensure full-text matching in
gcloud filters in the future. Instead of using regex, this change uses
`gcloud components list --only-local-state` to avoid filters altogther.
