### PR TITLE
Only fetch diff when requested.

### DIFF
--- a/webapp/components/wpt-results.js
+++ b/webapp/components/wpt-results.js
@@ -676,7 +676,7 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
       if (q) {
         body.query = q;
       }
-      if (this.diffFromAPI) {
+      if (this.diff && this.diffFromAPI) {
         url.searchParams.set('diff', true);
         url.searchParams.set('filter', this.diffFilter);
       }


### PR DESCRIPTION
Part of the reason for https://github.com/web-platform-tests/wpt.fyi/issues/1143 is that we're asking for a diff (all the time). We shouldn't do that except when the client wants a diff.