### PR TITLE
Add feature for whether to process azure check_run events

### DIFF
--- a/api/checks/webhook.go
+++ b/api/checks/webhook.go
@@ -175,7 +175,11 @@ func handleCheckRunEvent(aeAPI shared.AppEngineAPI, checksAPI API, azureAPI azur
 	status := checkRun.GetCheckRun().GetStatus()
 	shouldSchedule := false
 	if appID == azure.PipelinesAppID {
-		return azureAPI.HandleCheckRunEvent(checkRun)
+		if aeAPI.IsFeatureEnabled("processAzureCheckRunEvents") {
+			return azureAPI.HandleCheckRunEvent(checkRun)
+		}
+		log.Infof("Ignoring Azure pipelines event")
+		return false, nil
 	} else if (action == "created" && status != "completed") || action == "rerequested" {
 		shouldSchedule = true
 	} else if action == "requested_action" {


### PR DESCRIPTION
## Description
Should fix #1130 

Disables the azure pipelines `CheckRunEvent` processing for GitHub webhooks, unless feature `processAzureCheckRunEvents` is enabled.

This PR should be coupled with a change to the non-sharded (affected-tests) Azure jobs, to fire the completion webhook.