### PR TITLE
Support selecting runs in the /runs UI

### DIFF
--- a/webapp/components/pluralize.js
+++ b/webapp/components/pluralize.js
@@ -512,4 +512,10 @@ const pluralize = (function (root, pluralize) {
   return pluralize;
 });
 
-export { pluralize };
+const Pluralizer = (superClass) => class Pluralizer extends superClass {
+  pluralize(word, count) {
+    return pluralize(word, count);
+  }
+};
+
+export { pluralize, Pluralizer };

--- a/webapp/components/test-run.js
+++ b/webapp/components/test-run.js
@@ -30,10 +30,6 @@ class TestRun extends WPTFlags(ProductInfo(PolymerElement)) {
   static get template() {
     return html`
     <style>
-      :host {
-        display: block;
-        font-size: 16px;
-      }
       a {
         text-decoration: none;
         color: #0d5de6;

--- a/webapp/components/wpt-runs.js
+++ b/webapp/components/wpt-runs.js
@@ -4,8 +4,10 @@
  * found in the LICENSE file.
  */
 
+import '../node_modules/@polymer/polymer/lib/elements/dom-if.js';
 import '../node_modules/@polymer/iron-collapse/iron-collapse.js';
 import '../node_modules/@polymer/paper-button/paper-button.js';
+import '../node_modules/@polymer/paper-toast/paper-toast.js';
 import '../node_modules/@polymer/paper-spinner/paper-spinner-lite.js';
 import '../node_modules/@polymer/paper-styles/color.js';
 import '../node_modules/@polymer/polymer/lib/elements/dom-if.js';
@@ -20,8 +22,9 @@ import './test-run.js';
 import './test-runs-query-builder.js';
 import { TestRunsUIBase } from './test-runs.js';
 import { WPTFlags } from './wpt-flags.js';
+import { Pluralizer } from './pluralize.js';
 
-class WPTRuns extends WPTFlags(SelfNavigation(LoadingState(TestRunsUIBase))) {
+class WPTRuns extends Pluralizer(WPTFlags(SelfNavigation(LoadingState(TestRunsUIBase)))) {
   static get template() {
     return html`
     <style>
@@ -80,6 +83,30 @@ class WPTRuns extends WPTFlags(SelfNavigation(LoadingState(TestRunsUIBase))) {
         height: 24px;
         width: 24px;
       }
+      test-run {
+        display: inline-block;
+        pointer: cursor;
+      }
+      test-run[selected] {
+        padding: 4px;
+        background: var(--paper-blue-700);
+        border-radius: 50%;
+      }
+      paper-toast {
+        min-width: 320px;
+      }
+      paper-toast div {
+        display: flex;
+        align-items: center;
+      }
+      paper-toast span {
+        flex-grow: 1;
+      }
+      paper-toast paper-button {
+        display: inline-block;
+        flex-grow: 0;
+        flex-shrink: 0;
+      }
 
       @media (max-width: 1200px) {
         table tr td:first-child::after {
@@ -91,6 +118,16 @@ class WPTRuns extends WPTFlags(SelfNavigation(LoadingState(TestRunsUIBase))) {
       }
     </style>
 
+    <paper-toast id="selected-toast" duration="0">
+      <div style="display: flex;">
+        <span>[[selectedRuns.length]] [[runPlural]] selected</span>
+        <paper-button onclick="[[showRuns]]">View [[runPlural]]</paper-button>
+        <template is="dom-if" if="[[twoRunsSelected]]">
+          <paper-button onclick="[[showDiff]]">View diff</paper-button>
+        </template>
+      </div>
+    </paper-toast>
+
     <template is="dom-if" if="[[resultsRangeMessage]]">
       <info-banner>
         [[resultsRangeMessage]]
@@ -100,7 +137,16 @@ class WPTRuns extends WPTFlags(SelfNavigation(LoadingState(TestRunsUIBase))) {
 
     <template is="dom-if" if="[[queryBuilder]]">
       <iron-collapse opened="[[editingQuery]]">
-        <test-runs-query-builder product-specs="[[productSpecs]]" labels="[[labels]]" master="[[master]]" shas="[[shas]]" aligned="[[aligned]]" on-submit="[[submitQuery]]" from="[[from]]" to="[[to]]" diff="[[diff]]" show-time-range="">
+        <test-runs-query-builder product-specs="[[productSpecs]]"
+                                 labels="[[labels]]"
+                                 master="[[master]]"
+                                 shas="[[shas]]"
+                                 aligned="[[aligned]]"
+                                 on-submit="[[submitQuery]]"
+                                 from="[[from]]"
+                                 to="[[to]]"
+                                 diff="[[diff]]"
+                                 show-time-range>
         </test-runs-query-builder>
       </iron-collapse>
     </template>
@@ -145,9 +191,7 @@ class WPTRuns extends WPTFlags(SelfNavigation(LoadingState(TestRunsUIBase))) {
             <template is="dom-repeat" items="{{ browsers }}" as="browser">
               <td class\$="runs [[ runClass(results.runs, browser) ]]">
                 <template is="dom-repeat" items="[[runList(results.runs, browser)]]" as="run">
-                  <a href="[[runLink(run)]]">
-                    <test-run small="" show-source="" test-run="[[run]]"></test-run>
-                  </a>
+                  <test-run onclick="[[selectRun]]" data-run-id$="[[run.id]]" small show-source test-run="[[run]]"></test-run>
                 </template>
               </td>
             </template>
@@ -202,6 +246,18 @@ class WPTRuns extends WPTFlags(SelfNavigation(LoadingState(TestRunsUIBase))) {
       editingQuery: Boolean,
       toggleBuilder: Function,
       submitQuery: Function,
+      selectedRuns: {
+        type: Array,
+        value: [],
+      },
+      runPlural: {
+        type: String,
+        computed: 'computeRunPlural(selectedRuns)',
+      },
+      twoRunsSelected: {
+        type: Boolean,
+        computed: 'computeTwoRunsSelected(selectedRuns)',
+      }
     };
   }
 
@@ -216,6 +272,15 @@ class WPTRuns extends WPTFlags(SelfNavigation(LoadingState(TestRunsUIBase))) {
     };
     this.submitQuery = this.handleSubmitQuery.bind(this);
     this.loadNextPage = this.handleLoadNextPage.bind(this);
+    this.selectRun = this.handleSelectRun.bind(this);
+    this.showRuns = () => this._showRuns(false);
+    this.showDiff = () => this._showRuns(true);
+  }
+
+  async ready() {
+    super.ready();
+    this.load(this.loadRuns());
+    this._createMethodObserver('testRunsLoaded(testRuns, testRuns.*)');
   }
 
   computeDateDisplay(results) {
@@ -244,12 +309,6 @@ class WPTRuns extends WPTFlags(SelfNavigation(LoadingState(TestRunsUIBase))) {
       minute: '2-digit',
       hour12: false,
     });
-  }
-
-  async ready() {
-    super.ready();
-    this.load(this.loadRuns());
-    this._createMethodObserver('testRunsLoaded(testRuns, testRuns.*)');
   }
 
   testRunsLoaded(testRuns) {
@@ -373,6 +432,42 @@ class WPTRuns extends WPTFlags(SelfNavigation(LoadingState(TestRunsUIBase))) {
         }
       }
     }
+  }
+
+  _showRuns(diff) {
+    const url = new URL('/results', window.location);
+    for (const id of this.selectedRuns) {
+      url.searchParams.append('run_id', id);
+    }
+    if (diff) {
+      url.searchParams.set('diff', true);
+    }
+    window.location = url;
+  }
+
+  handleSelectRun(e) {
+    const id = e.target.getAttribute('data-run-id');
+    if (this.selectedRuns.find(r => r === id)) {
+      this.selectedRuns = this.selectedRuns.filter(r => r !== id);
+      e.target.removeAttribute('selected');
+    } else {
+      this.selectedRuns = [...this.selectedRuns, id];
+      e.target.setAttribute('selected', 'selected');
+    }
+    const toast = this.shadowRoot.querySelector('#selected-toast');
+    if (this.selectedRuns.length) {
+      toast.show();
+    } else {
+      toast.hide();
+    }
+  }
+
+  computeRunPlural(selectedRuns) {
+    return this.pluralize('run', selectedRuns.length);
+  }
+
+  computeTwoRunsSelected(selectedRuns) {
+    return selectedRuns.length === 2;
   }
 }
 


### PR DESCRIPTION
## Description
Fixes #114 and https://github.com/web-platform-tests/wpt.fyi/issues/1138

Clicking a run in the /runs UI selects that run, and triggers a toast, which has a "view runs" button.
Selecting exactly two runs also shows a "view diff" button (which includes the ?diff param).

## Review Information
- Visit https://select-dot-wptdashboard-staging.appspot.com/runs
- Click on runs
- Be amazed