### PR TITLE
Propagate /runs query params to /results?sha= links

### DIFF
--- a/util/populate_dev_data.go
+++ b/util/populate_dev_data.go
@@ -184,6 +184,11 @@ func main() {
 	filters.Labels = mapset.NewSetWith(shared.BetaLabel)
 	copyProdRuns(ctx, filters)
 
+	log.Print("Adding latest aligned Edge stable and Chrome/Firefox/Safari experimental data...")
+	filters.Labels = nil
+	filters.Products, _ = shared.ParseProductSpecs("chrome[experimental]", "edge", "firefox[experimental]", "safari[experimental]")
+	copyProdRuns(ctx, filters)
+
 	log.Printf("Successfully copied a total of %v distinct TestRuns", seenTestRunIDs.Cardinality())
 }
 

--- a/webapp/components/wpt-runs.js
+++ b/webapp/components/wpt-runs.js
@@ -178,7 +178,7 @@ class WPTRuns extends Pluralizer(WPTFlags(SelfNavigation(LoadingState(TestRunsUI
         <template is="dom-repeat" items="{{ testRunsBySHA }}" as="results">
           <tr>
             <td>
-              <a class="github" href="/?sha={{ results.sha }}">
+              <a class="github" href="{{ revisionLink(results) }}">
                 <template is="dom-if" if="[[results.commitType]]">
                   <img src="/static/[[results.commitType]].svg">
                   {{ githubRevision(results.sha) }}
@@ -387,6 +387,15 @@ class WPTRuns extends Pluralizer(WPTFlags(SelfNavigation(LoadingState(TestRunsUI
       }
     }
     return link.toString();
+  }
+
+  revisionLink(results) {
+    const url = new URL('/results', window.location);
+    url.search = this.query;
+    url.searchParams.set('sha', results.sha);
+    url.searchParams.set('max-count', 1);
+    url.searchParams.delete('from');
+    return url;
   }
 
   computeThWidth(browsers) {


### PR DESCRIPTION
## Description
Fixes https://github.com/web-platform-tests/wpt.fyi/issues/1173

Propagates any query params used to filter the `/runs` view across to the `/results` view for specific SHAs.