### PR TITLE
[processor] Add all tokens of product as labels

### DIFF
--- a/results-processor/wptreport.py
+++ b/results-processor/wptreport.py
@@ -499,7 +499,7 @@ def normalize_product(report):
     if "_" in product:
         tokens = product.split("_")
         report.run_info['product'] = tokens[0]
-        return set(tokens[1:])
+        return set(tokens)
     else:
         return set()
 

--- a/results-processor/wptreport_test.py
+++ b/results-processor/wptreport_test.py
@@ -563,7 +563,7 @@ class HelpersTest(unittest.TestCase):
         }
         self.assertSetEqual(
             normalize_product(r),
-            {'webdriver'}
+            {'edge', 'webdriver'}
         )
         self.assertEqual(
             r.run_info['product'],


### PR DESCRIPTION
When we normalize product names like "edge_webdriver", we want to add
both "edge" and "webdriver" as labels of the test run.

This was an oversight in #1119. Fixes #1176.
