### PR TITLE
Trivial npm upgrade

### DIFF
--- a/webapp/components/test/interop.html
+++ b/webapp/components/test/interop.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
+  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
   <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
 
   <script type="module" src="../interop.js"></script>

--- a/webapp/components/test/loading-state.html
+++ b/webapp/components/test/loading-state.html
@@ -1,12 +1,12 @@
 <!doctype html>
 <html>
-
 <head>
   <meta charset="utf-8">
-  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
+  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
   <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
 </head>
 
+<body>
 <dom-module id="loading-state-concrete">
   <script type="module">
 import { PolymerElement } from '../../node_modules/@polymer/polymer/polymer-element.js';
@@ -24,7 +24,6 @@ window.customElements.define('loading-state-concrete', ConcreteType);
   </template>
 </test-fixture>
 
-<body>
   <script type="module">
 import '../../node_modules/@polymer/polymer/polymer-element.js';
 import '../loading-state.js';

--- a/webapp/components/test/path-part.html
+++ b/webapp/components/test/path-part.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
+  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
   <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
 
   <script type="module" src="../path-part.js"></script>

--- a/webapp/components/test/reftest-analyzer.html
+++ b/webapp/components/test/reftest-analyzer.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
+  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
   <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
 
   <script type="module" src="../reftest-analyzer.js"></script>

--- a/webapp/components/test/test-file-results-table-terse.html
+++ b/webapp/components/test/test-file-results-table-terse.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
+  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
   <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
 
   <script type="module" src="../test-file-results-table-terse.js"></script>

--- a/webapp/components/test/test-file-results.html
+++ b/webapp/components/test/test-file-results.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
+  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
   <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
 
   <script type="module" src="../test-runs.js"></script>

--- a/webapp/components/test/test-run.html
+++ b/webapp/components/test/test-run.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
+  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
   <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
 
   <script type="module" src="../test-run.js"></script>

--- a/webapp/components/test/test-runs-query-builder.html
+++ b/webapp/components/test/test-runs-query-builder.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
+  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
   <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
 </head>
 <body>

--- a/webapp/components/test/test-runs-query.html
+++ b/webapp/components/test/test-runs-query.html
@@ -2,10 +2,11 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
+  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
   <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
 </head>
 
+<body>
 <dom-module id="test-runs-query-concrete">
   <script type="module">
 import { PolymerElement } from '../../node_modules/@polymer/polymer/polymer-element.js';
@@ -31,7 +32,6 @@ window.customElements.define('test-runs-ui-query-concrete', ConcreteUIType);
   </template>
 </test-fixture>
 
-<body>
   <script type="module">
 import { PolymerElement } from '../../node_modules/@polymer/polymer/polymer-element.js';
 import '../test-runs-query.js';

--- a/webapp/components/test/test-runs.html
+++ b/webapp/components/test/test-runs.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
+  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
   <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
 
   <script type="module" src="../test-runs.js"></script>

--- a/webapp/components/test/test-search.html
+++ b/webapp/components/test/test-search.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
+  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
   <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
 
   <script type="module" src="../test-search.js"></script>

--- a/webapp/components/test/wpt-flags.html
+++ b/webapp/components/test/wpt-flags.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
+  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
   <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
 
   <script type="module" src="../wpt-flags.js"></script>

--- a/webapp/components/test/wpt-permalinks.html
+++ b/webapp/components/test/wpt-permalinks.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
+  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
   <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
 </head>
 <body>

--- a/webapp/components/test/wpt-results.html
+++ b/webapp/components/test/wpt-results.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8">
-  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
+  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
   <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
 
   <script type="module" src="../wpt-results.js"></script>

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -600,9 +600,9 @@
       }
     },
     "@google-web-components/google-chart": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@google-web-components/google-chart/-/google-chart-3.0.0.tgz",
-      "integrity": "sha512-nSUeyoIOfqJcaqLMQlCvtcLZcC9FhLW1hmLHtRSr6YOjzq6HshB+7Ss+TxkAiVts4E0ywIOl7GFxEM7+tmyPQA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@google-web-components/google-chart/-/google-chart-3.0.3.tgz",
+      "integrity": "sha512-r/7qWsFaK+EI3HBKOh7GVBt1VM7Yq/qOntqgdB/cJwKwGHWowX4RkvnTp5y3bbkfM7kXLgENtjtsf9cLE+FQew==",
       "requires": {
         "@polymer/iron-ajax": "^3.0.0-pre.18",
         "@polymer/polymer": "^3.0.0"
@@ -1025,9 +1025,9 @@
       }
     },
     "@polymer/paper-spinner": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@polymer/paper-spinner/-/paper-spinner-3.0.1.tgz",
-      "integrity": "sha512-MYIU6qWZnhZ5yNFOBzROPgBteGfxKEnDZ6bCgjrvUtJkBuQEz0MQZzSE/zmZc0oaJ9u5QK5xAFuYdudsGv7+sQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@polymer/paper-spinner/-/paper-spinner-3.0.2.tgz",
+      "integrity": "sha512-XUzu8/4NH+pnNZUTI2MxtOKFAr0EOsW7eGhTg3VBhTh7DDW/q3ewzwYRWnqNJokX9BEnxKMiXXaIeTEBq4k2dw==",
       "requires": {
         "@polymer/paper-styles": "^3.0.0-pre.26",
         "@polymer/polymer": "^3.0.0"
@@ -1630,9 +1630,9 @@
       "integrity": "sha512-bx0TzeZ11VqYDGLuXfznen8+4u0hADk2dD5RNMFxWL9MM4c5NXCDCgNXgssb4i2zQOos/GGe4tl5AuE0LzJkLA=="
     },
     "@webcomponents/webcomponentsjs": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.2.4.tgz",
-      "integrity": "sha512-YkLxK9Mbw6QK5bNZ67Rarb/yj0gN+Ziy5+2sLjM0lDb3XafM36gXKZXaIBz4zvLA/cYYTdg+l1LlqXeHEcmeiA=="
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.2.7.tgz",
+      "integrity": "sha512-kPPjzV+5kpoWpTniyvBSPcXS33f3j/C6HvNOJ3YecF3pvz3XwVeU4ammbxtVy/osF3z7hr1DYNptIf4oPEvXZA=="
     },
     "accepts": {
       "version": "1.3.5",
@@ -3505,21 +3505,13 @@
       }
     },
     "dom-serializer": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+      "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
       "dev": true,
       "requires": {
-        "domelementtype": "~1.1.1",
-        "entities": "~1.1.1"
-      },
-      "dependencies": {
-        "domelementtype": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
-          "dev": true
-        }
+        "domelementtype": "^1.3.0",
+        "entities": "^1.1.1"
       }
     },
     "dom-urls": {
@@ -3840,9 +3832,9 @@
       }
     },
     "eslint-plugin-html": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-html/-/eslint-plugin-html-5.0.0.tgz",
-      "integrity": "sha512-f7p/7YQdgQUFVAX3nB4dnMQbrDeTalcA01PDhuvTLk0ZadCwM4Pb+639SRuqEf1zMkIxckLY+ckCr0hVP5zl6A==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-html/-/eslint-plugin-html-5.0.3.tgz",
+      "integrity": "sha512-46ruAnp3jVQP/5Bi5eEIOooscjUTPFU3vxCxHe/OG6ORdM7Xv5c25/Nz9fAbHklzCpiXuIiH4/mV/XBkm7MINw==",
       "dev": true,
       "requires": {
         "htmlparser2": "^3.10.0"
@@ -5091,23 +5083,23 @@
       }
     },
     "htmlparser2": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.0.tgz",
-      "integrity": "sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
       "dev": true,
       "requires": {
-        "domelementtype": "^1.3.0",
+        "domelementtype": "^1.3.1",
         "domhandler": "^2.3.0",
         "domutils": "^1.5.1",
         "entities": "^1.1.1",
         "inherits": "^2.0.1",
-        "readable-stream": "^3.0.6"
+        "readable-stream": "^3.1.1"
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
-          "integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
+          "integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,14 +1,19 @@
 {
   "name": "wptdashboard",
+  "description": "Node packages leveraged by build rules for the wpt.fyi project.",
+  "license": "BSD-3-Clause",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/web-platform-tests/wpt.fyi.git"
+  },
   "devDependencies": {
     "@polymer/test-fixture": "^4.0.2",
     "babel-eslint": "^10.0.1",
     "eslint": "^4.14.0",
-    "eslint-plugin-html": "^5.0.0",
+    "eslint-plugin-html": "^5.0.3",
     "wct-browser-legacy": "^1.0.2",
     "web-component-tester": "^6.9.2"
   },
-  "description": "Node packages leveraged by build rules for the wpt.fyi project.",
   "scripts": {
     "test": "npm run wct",
     "lint": "eslint 'components/*.js' && eslint --plugin html 'components/test/*.html'",
@@ -17,7 +22,7 @@
     "wct": "wct --npm"
   },
   "dependencies": {
-    "@google-web-components/google-chart": "^3.0.0",
+    "@google-web-components/google-chart": "^3.0.3",
     "@polymer/iron-collapse": "^3.0.0",
     "@polymer/iron-form": "^3.0.0",
     "@polymer/iron-icons": "^3.0.0",
@@ -31,7 +36,7 @@
     "@polymer/paper-listbox": "^3.0.0",
     "@polymer/paper-radio-button": "^3.0.1",
     "@polymer/paper-radio-group": "^3.0.1",
-    "@polymer/paper-spinner": "^3.0.0",
+    "@polymer/paper-spinner": "^3.0.2",
     "@polymer/paper-styles": "^3.0.0",
     "@polymer/paper-tabs": "^3.0.0",
     "@polymer/paper-toast": "^3.0.0",
@@ -39,7 +44,7 @@
     "@polymer/paper-tooltip": "^3.0.0",
     "@polymer/polymer": "^3.0.0",
     "@vaadin/vaadin-date-picker": "^3.3.2",
-    "@webcomponents/webcomponentsjs": "^2.2.4",
+    "@webcomponents/webcomponentsjs": "^2.2.7",
     "pluralize": "^7.0.0"
   }
 }


### PR DESCRIPTION
With the following changes by the way:
* Add `license` and `repository` fields to `package.json`
* Switch to `webcomponents-loader` (from `bundle`) in tests to be more
  consistent with the real pages and in the hope of speeding up tests a
  bit (much smaller JS size).
