### PR TITLE
Add feature for ignore testharness status (OK) in summary counts

### DIFF
--- a/api/query/cache/index/aggregator.go
+++ b/api/query/cache/index/aggregator.go
@@ -40,6 +40,15 @@ func (a *indexAggregator) Add(t TestID) error {
 		}
 	}
 
+	if a.opts.IgnoreTestHarnessResult {
+		for _, id := range a.runIDs {
+			res := shared.TestStatus(a.runResults[id].GetResult(t))
+			if res.IsHarnessStatus() {
+				return nil
+			}
+		}
+	}
+
 	if a.opts.InteropFormat {
 		if r.Interop == nil {
 			r.Interop = make([]int, len(a.runIDs)+1)

--- a/api/query/concrete_query.go
+++ b/api/query/concrete_query.go
@@ -11,10 +11,11 @@ import (
 // AggregationOpts are options for the aggregation format used when collecting
 // the results.
 type AggregationOpts struct {
-	IncludeSubtests bool
-	InteropFormat   bool
-	IncludeDiff     bool
-	DiffFilter      shared.DiffFilterParam
+	IncludeSubtests         bool
+	InteropFormat           bool
+	IncludeDiff             bool
+	IgnoreTestHarnessResult bool // Don't +1 the "OK" status for testharness tests.
+	DiffFilter              shared.DiffFilterParam
 }
 
 // Binder is a mechanism for binding a query over a slice of test runs to

--- a/shared/statuses.go
+++ b/shared/statuses.go
@@ -127,6 +127,12 @@ func (s TestStatus) IsPassOrOK() bool {
 	return s == TestStatusOK || s == TestStatusPass
 }
 
+// IsHarnessStatus is true if the value is TestStatusPass or TestStatusError,
+// statuses which are used for the harness-level result.
+func (s TestStatus) IsHarnessStatus() bool {
+	return s == TestStatusOK || s == TestStatusError
+}
+
 // TestStatusValueFromString returns the enum value associated with str (if
 // any), or else TestStatusDefault.
 func TestStatusValueFromString(str string) TestStatus {

--- a/shared/statuses.go
+++ b/shared/statuses.go
@@ -130,7 +130,7 @@ func (s TestStatus) IsPassOrOK() bool {
 // IsHarnessStatus is true if the value is TestStatusPass or TestStatusError,
 // statuses which are used for the harness-level result.
 func (s TestStatus) IsHarnessStatus() bool {
-	return s == TestStatusOK || s == TestStatusError
+	return s == TestStatusOK
 }
 
 // TestStatusValueFromString returns the enum value associated with str (if

--- a/webapp/components/wpt-flags.js
+++ b/webapp/components/wpt-flags.js
@@ -49,14 +49,15 @@ Object.defineProperty(wpt, 'ClientSideFeatures', {
 Object.defineProperty(wpt, 'ServerSideFeatures', {
   get: function() {
     return [
-      'diffRenames',
-      'taskclusterAllBranches',
-      'paginationTokens',
-      'runsByPRNumber',
-      'failChecksOnRegression',
       'checksAllUsers',
+      'diffRenames',
+      'failChecksOnRegression',
+      'ignoreHarnessInTotal',
+      'paginationTokens',
       'pendingChecks',
+      'runsByPRNumber',
       'serviceWorker',
+      'taskclusterAllBranches',
     ];
   }
 });
@@ -288,6 +289,11 @@ class WPTEnvironmentFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ tr
     <paper-item>
       <paper-checkbox checked="{{serviceWorker}}">
         Install a service worker to cache all the web components.
+      </paper-checkbox>
+    </paper-item>
+    <paper-item>
+      <paper-checkbox checked="{{ignoreHarnessInTotal}}">
+        Ignore "OK" harness status in test summary numbers.
       </paper-checkbox>
     </paper-item>
 `;


### PR DESCRIPTION
## Description
Hack at https://github.com/web-platform-tests/wpt.fyi/issues/62

Note that this relies on at least one of the runs having a non-ambiguous status (the `OK` status), which should™ usually be the case.