### PR TITLE
Add a flag to enable web-platform-tests.live instead of w3c-test.org

### DIFF
--- a/webapp/components/interop.js
+++ b/webapp/components/interop.js
@@ -149,8 +149,16 @@ class WPTInterop extends WPTColors(WPTFlags(SelfNavigation(LoadingState(
         <ul>
           <li>
             <a href\$="https://github.com/web-platform-tests/wpt/blob/master[[path]]" target="_blank">View source on GitHub</a></li>
-          <li><a href\$="[[scheme]]://w3c-test.org[[path]]" target="_blank">Run in your
-            browser on w3c-test.org</a></li>
+
+            <template is="dom-if" if="[[ !webPlatformTestsLive ]]">
+              <li><a href\$="[[scheme]]://w3c-test.org[[path]]" target="_blank">Run in your
+               browser on w3c-test.org</a></li>
+            </template>
+
+            <template is="dom-if" if="[[ webPlatformTestsLive ]]">
+              <li><a href\$="[[scheme]]://web-platform-tests.live[[path]]" target="_blank">Run in your
+                browser on web-platform-tests.live</a></li>
+            </template>
         </ul>
       </div>
     </template>

--- a/webapp/components/wpt-flags.js
+++ b/webapp/components/wpt-flags.js
@@ -43,6 +43,7 @@ Object.defineProperty(wpt, 'ClientSideFeatures', {
       'showTestRefURL',
       'structuredQueries',
       'searchPRsForDirectories',
+      'webPlatformTestsLive',
     ];
   }
 });
@@ -217,6 +218,11 @@ class WPTFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ false) {
     <paper-item>
       <paper-checkbox checked="{{permalinks}}">
         Show dialog for copying a permalink (on /results page).
+      </paper-checkbox>
+    </paper-item>
+    <paper-item>
+      <paper-checkbox checked="{{webPlatformTestsLive}}">
+        Use web-platform-tests.live.
       </paper-checkbox>
     </paper-item>
 `;

--- a/webapp/components/wpt-results.js
+++ b/webapp/components/wpt-results.js
@@ -205,20 +205,10 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
           <ul>
             <li><a href\$="https://github.com/web-platform-tests/wpt/blob/master[[sourcePath]]" target="_blank">View source on GitHub</a></li>
             <template is="dom-if" if="[[ showTestURL ]]">
-              <template is="dom-if" if="[[ !webPlatformTestsLive ]]">
-                <li><a href="[[showTestURL]]" target="_blank">Run in your browser on w3c-test.org</a></li>
-              </template>
-              <template is="dom-if" if="[[ webPlatformTestsLive ]]">
-               <li><a href="[[showTestURL]]" target="_blank">Run in your browser on web-platform-tests.live</a></li>
-              </template>
+              <li><a href="[[showTestURL]]" target="_blank">Run in your browser on [[ liveTestDomain ]]</a></li>
             </template>
             <template is="dom-if" if="[[ showTestRefURL ]]">
-              <template is="dom-if" if="[[ !webPlatformTestsLive ]]">
-                <li><a href="[[showTestRefURL]]" target="_blank">View ref in your browser on w3c-test.org</a></li>
-              </template>
-              <template is="dom-if" if="[[ webPlatformTestsLive ]]">
-                <li><a href="[[showTestRefURL]]" target="_blank">View ref in your browser on web-platform-tests.live</a></li>
-            </template>
+              <li><a href="[[showTestRefURL]]" target="_blank">View ref in your browser on [[ liveTestDomain ]]</a></li>
             </template>
           </ul>
         </div>
@@ -444,6 +434,10 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
         type: String,
         computed: 'computeTestRefURL(testType, path, manifest)',
       },
+      liveTestDomain: {
+        type: String,
+        computed: 'computeLiveTestDomain()',
+      },
       structuredSearch: Object,
       searchResults: {
         type: Array,
@@ -546,6 +540,13 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
     // See https://github.com/web-platform-tests/wpt/blob/master/tools/manifest/item.py#L141
     const refPath = item && item[0][1][0][0];
     return this.computeTestURL(testType, refPath);
+  }
+
+  computeLiveTestDomain() {
+    if (this.webPlatformTestsLive) {
+      return 'web-platform-tests.live'
+    }
+    return 'w3c-test.org'
   }
 
   https(url) {

--- a/webapp/components/wpt-results.js
+++ b/webapp/components/wpt-results.js
@@ -204,11 +204,11 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
         <div class="links">
           <ul>
             <li><a href\$="https://github.com/web-platform-tests/wpt/blob/master[[sourcePath]]" target="_blank">View source on GitHub</a></li>
-            <template is="dom-if" if="{{ showTestURL }}">
-              <template is="dom-if" if="{{ !webPlatformTestsLive }}">
+            <template is="dom-if" if="[[ showTestURL ]]">
+              <template is="dom-if" if="[[ !webPlatformTestsLive ]]">
                 <li><a href="[[showTestURL]]" target="_blank">Run in your browser on w3c-test.org</a></li>
               </template>
-              <template is="dom-if" if="{{ webPlatformTestsLive }}">
+              <template is="dom-if" if="[[ webPlatformTestsLive ]]">
                <li><a href="[[showTestURL]]" target="_blank">Run in your browser on web-platform-tests.live</a></li>
               </template>
             </template>

--- a/webapp/components/wpt-results.js
+++ b/webapp/components/wpt-results.js
@@ -544,9 +544,9 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
 
   computeLiveTestDomain() {
     if (this.webPlatformTestsLive) {
-      return 'web-platform-tests.live'
+      return 'web-platform-tests.live';
     }
-    return 'w3c-test.org'
+    return 'w3c-test.org';
   }
 
   https(url) {

--- a/webapp/components/wpt-results.js
+++ b/webapp/components/wpt-results.js
@@ -204,11 +204,21 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
         <div class="links">
           <ul>
             <li><a href\$="https://github.com/web-platform-tests/wpt/blob/master[[sourcePath]]" target="_blank">View source on GitHub</a></li>
-            <template is="dom-if" if="{{ testW3CURL }}">
-              <li><a href="[[testW3CURL]]" target="_blank">Run in your browser on w3c-test.org</a></li>
+            <template is="dom-if" if="{{ showTestURL }}">
+              <template is="dom-if" if="{{ !webPlatformTestsLive }}">
+                <li><a href="[[showTestURL]]" target="_blank">Run in your browser on w3c-test.org</a></li>
+              </template>
+              <template is="dom-if" if="{{ webPlatformTestsLive }}">
+               <li><a href="[[showTestURL]]" target="_blank">Run in your browser on web-platform-tests.live</a></li>
+              </template>
             </template>
-            <template is="dom-if" if="[[ testW3CRefURL ]]">
-              <li><a href="[[testW3CRefURL]]" target="_blank">View ref in your browser on w3c-test.org</a></li>
+            <template is="dom-if" if="[[ showTestRefURL ]]">
+              <template is="dom-if" if="[[ !webPlatformTestsLive ]]">
+                <li><a href="[[showTestRefURL]]" target="_blank">View ref in your browser on w3c-test.org</a></li>
+              </template>
+              <template is="dom-if" if="[[ webPlatformTestsLive ]]">
+                <li><a href="[[showTestRefURL]]" target="_blank">View ref in your browser on web-platform-tests.live</a></li>
+            </template>
             </template>
           </ul>
         </div>
@@ -390,14 +400,14 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
           <div class="compare">
             <div class="column">
               <h5>Result</h5>
-              <template is="dom-if" if="[[testW3CURL]]">
-                <iframe src="[[https(testW3CURL)]]"></iframe>
+              <template is="dom-if" if="[[showTestURL]]">
+                <iframe src="[[https(showTestURL)]]"></iframe>
               </template>
             </div>
             <div class="column">
               <h5>Reference</h5>
-              <template is="dom-if" if="[[testW3CRefURL]]">
-                <iframe src="[[https(testW3CRefURL)]]"></iframe>
+              <template is="dom-if" if="[[showTestRefURL]]">
+                <iframe src="[[https(showTestRefURL)]]"></iframe>
               </template>
             </div>
           </div>
@@ -426,11 +436,11 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
         type: Boolean,
         computed: 'computeIsRefTest(testType)'
       },
-      testW3CURL: {
+      showTestURL: {
         type: Boolean,
-        computed: 'computeTestW3CURL(testType, path)',
+        computed: 'computeTestURL(testType, path)',
       },
-      testW3CRefURL: {
+      showTestRefURL: {
         type: String,
         computed: 'computeTestRefURL(testType, path, manifest)',
       },
@@ -516,9 +526,12 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
     return testType === 'reftest';
   }
 
-  computeTestW3CURL(testType, path) {
+  computeTestURL(testType, path) {
     if (testType === 'wdspec') {
       return;
+    }
+    if (this.webPlatformTestsLive) {
+      return new URL(`${this.scheme}://web-platform-tests.live${path}`);
     }
     return new URL(`${this.scheme}://w3c-test.org${path}`);
   }
@@ -532,7 +545,7 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
     // Then, the ref's 1st item is the url (0). (2nd is the condition, e.g. "==".)
     // See https://github.com/web-platform-tests/wpt/blob/master/tools/manifest/item.py#L141
     const refPath = item && item[0][1][0][0];
-    return this.computeTestW3CURL(testType, refPath);
+    return this.computeTestURL(testType, refPath);
   }
 
   https(url) {


### PR DESCRIPTION
## Description
Fix #380. Add a flag to enable web-platform-tests.live.

## Review Information
- Visit /flags, enable the feature for web-platform-tests.live
- Visit /results, find a test
- Click on Run in your browser on web-platform-tests.live
- See if it directs to a web-platform-tests.live page and the result is shown properly
