### PR TITLE
Rely on AppEngine to authenticate admin/ pages

### DIFF
--- a/webapp/admin_handler.go
+++ b/webapp/admin_handler.go
@@ -22,7 +22,7 @@ func adminUploadHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func showAdminUploadForm(a shared.AppEngineAPI, w http.ResponseWriter, r *http.Request) {
-	assertLoginAndRenderTemplate(a, w, r, "/admin/results/upload", "admin_upload.html", nil)
+	assertAdminAndRenderTemplate(a, w, r, "/admin/results/upload", "admin_upload.html", nil)
 }
 
 func adminFlagsHandler(w http.ResponseWriter, r *http.Request) {
@@ -36,7 +36,7 @@ func adminFlagsHandler(w http.ResponseWriter, r *http.Request) {
 		Host: a.GetHostname(),
 	}
 	if r.Method == "GET" {
-		assertLoginAndRenderTemplate(a, w, r, "/admin/flags", "admin_flags.html", data)
+		assertAdminAndRenderTemplate(a, w, r, "/admin/flags", "admin_flags.html", data)
 	} else if r.Method == "POST" {
 		if !a.IsAdmin() {
 			http.Error(w, "Admin only", http.StatusUnauthorized)
@@ -56,22 +56,13 @@ func adminFlagsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func assertLoginAndRenderTemplate(
+func assertAdminAndRenderTemplate(
 	a shared.AppEngineAPI,
 	w http.ResponseWriter,
 	r *http.Request,
 	redirectPath,
 	template string,
 	data interface{}) {
-	if !a.IsLoggedIn() {
-		loginURL, err := a.LoginURL(redirectPath)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		http.Redirect(w, r, loginURL, http.StatusTemporaryRedirect)
-		return
-	}
 	if !a.IsAdmin() {
 		http.Error(w, "Admin only", http.StatusUnauthorized)
 		return
@@ -87,7 +78,7 @@ func adminCacheFlushHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := shared.NewAppEngineContext(r)
 	a := shared.NewAppEngineAPI(ctx)
 
-	if !a.IsLoggedIn() || !a.IsAdmin() {
+	if !a.IsAdmin() {
 		http.Error(w, "Admin only", http.StatusUnauthorized)
 		return
 	}

--- a/webapp/admin_handler_test.go
+++ b/webapp/admin_handler_test.go
@@ -18,22 +18,6 @@ import (
 	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
 )
 
-func TestShowAdminUploadForm_not_logged_in(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	req := httptest.NewRequest("GET", "/admin/results/upload", new(strings.Reader))
-	resp := httptest.NewRecorder()
-	mockAE := sharedtest.NewMockAppEngineAPI(mockCtrl)
-	mockAE.EXPECT().IsLoggedIn().Return(false)
-	mockAE.EXPECT().LoginURL("/admin/results/upload").Return("/login", nil)
-
-	showAdminUploadForm(mockAE, resp, req)
-
-	assert.Equal(t, resp.Code, http.StatusTemporaryRedirect)
-	assert.Equal(t, resp.Header().Get("Location"), "/login")
-}
-
 func TestShowAdminUploadForm_not_admin(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
@@ -41,7 +25,6 @@ func TestShowAdminUploadForm_not_admin(t *testing.T) {
 	req := httptest.NewRequest("GET", "/admin/results/upload", new(strings.Reader))
 	resp := httptest.NewRecorder()
 	mockAE := sharedtest.NewMockAppEngineAPI(mockCtrl)
-	mockAE.EXPECT().IsLoggedIn().Return(true)
 	mockAE.EXPECT().IsAdmin().Return(false)
 
 	showAdminUploadForm(mockAE, resp, req)
@@ -57,7 +40,6 @@ func TestShowAdminUploadForm_admin(t *testing.T) {
 	req := httptest.NewRequest("GET", "/admin/results/upload", new(strings.Reader))
 	resp := httptest.NewRecorder()
 	mockAE := sharedtest.NewMockAppEngineAPI(mockCtrl)
-	mockAE.EXPECT().IsLoggedIn().Return(true)
 	mockAE.EXPECT().IsAdmin().Return(true)
 
 	showAdminUploadForm(mockAE, resp, req)

--- a/webapp/app.yaml
+++ b/webapp/app.yaml
@@ -36,7 +36,7 @@ handlers:
   upload: static/favicon.ico
   secure: always
   # Admin-only pages:
-- url: /admin
+- url: /admin/.*
   script: _go_app
   secure: always
   login: admin

--- a/webapp/app.yaml
+++ b/webapp/app.yaml
@@ -12,17 +12,20 @@ builtins:
 inbound_services:
 - warmup
 
+default_expiration: "1d"
+
+# Also refer to dispatch.yaml for higher-priority routing rules.
 handlers:
-  # Couple of special-case dynamic components.
+  # Special dynamic components:
 - url: /components/wpt-env-flags.js
   script: _go_app
   secure: always
+  # Static files:
 - url: /components
   static_dir: components
   secure: always
 - url: /static
   static_dir: static
-  expiration: "1d"
   secure: always
 - url: /service-worker-installer.js
   static_files: service-worker-installer.js
@@ -32,17 +35,25 @@ handlers:
   static_files: static/favicon.ico
   upload: static/favicon.ico
   secure: always
+  # Admin-only pages:
+- url: /admin
+  script: _go_app
+  secure: always
+  login: admin
+  # Everything else (templates & APIs):
 - url: /.*
   script: _go_app
   secure: always
 
-# Don't upload mock-data static files to AppEngine
+# Don't upload test data, package config, etc. to AppEngine.
 skip_files:
 - components/test/
 - static/b952881825/
 - static/wptd-metrics/
 - test/
 - .eslintrc.json
-- package.json
 - README.md
+- package-lock.json
+- package.json
+- wct.conf.json
 - .*/artifact_test.zip


### PR DESCRIPTION
instead of implementing the login redirect ourselves in Go. This
simplifies the code as well as avoids future omission of admin
authentication.

## Review Information

A rather trivial change.