### PR TITLE
Rearrange manifest to be test-path centric

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -300,9 +300,9 @@ __Parameters__
 __`sha`__ : SHA of the [WPT](https://github.com/web-platform-tests/wpt) repo PR for which to fetch,
     the manifest, or the keyword `latest`. (Defaults to `latest`.)
 
-NOTE: The full SHA of the fetched manifest is returned in the HTTP response header `x-wpt-sha`, e.g.
+NOTE: The full SHA of the fetched manifest is returned in the HTTP response header `wpt-sha`, e.g.
 
-    x-wpt-sha: abcdef0123456789abcdef0123456789abcdef01
+    wpt-sha: abcdef0123456789abcdef0123456789abcdef01
 
 __Response format__
 

--- a/api/README.md
+++ b/api/README.md
@@ -300,9 +300,9 @@ __Parameters__
 __`sha`__ : SHA of the [WPT](https://github.com/web-platform-tests/wpt) repo PR for which to fetch,
     the manifest, or the keyword `latest`. (Defaults to `latest`.)
 
-NOTE: The full SHA of the fetched manifest is returned in the HTTP response header `wpt-sha`, e.g.
+NOTE: The full SHA of the fetched manifest is returned in the HTTP response header `X-WPT-SHA`, e.g.
 
-    wpt-sha: abcdef0123456789abcdef0123456789abcdef01
+    X-WPT-SHA: abcdef0123456789abcdef0123456789abcdef01
 
 __Response format__
 

--- a/api/manifest.go
+++ b/api/manifest.go
@@ -35,7 +35,7 @@ func apiManifestHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusNotFound)
 		return
 	}
-	w.Header().Add("wpt-sha", sha)
+	w.Header().Add("X-WPT-SHA", sha)
 	w.Header().Add("Content-Type", "application/json")
 	w.Write(manifest)
 }

--- a/webapp/components/wpt-results.js
+++ b/webapp/components/wpt-results.js
@@ -793,7 +793,7 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
                 if (!metadata.file.startsWith('/')) {
                   metadata.file = `/${file}`;
                 }
-                let path = test[0]};
+                let path = test[0];
                 if (!path.startsWith('/')) {
                   path = `/${path}`;
                 }

--- a/webapp/components/wpt-results.js
+++ b/webapp/components/wpt-results.js
@@ -777,7 +777,7 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
           }
           let manifestJSON = await r.json();
           const manifest = new Map();
-          manifest.sha = sha || r.headers && r.headers['wpt-sha'];
+          manifest.sha = sha || r.headers && r.headers['X-WPT-SHA'];
           for (const [type, items] of Object.entries(manifestJSON.items)) {
             for (const [file, tests] of Object.entries(items)) {
               for (const test of tests) {

--- a/webapp/components/wpt-results.js
+++ b/webapp/components/wpt-results.js
@@ -780,6 +780,9 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
           const manifest = new Map();
           manifest.sha = sha || r.headers && r.headers['X-WPT-SHA'];
           for (const [type, items] of Object.entries(manifestJSON.items)) {
+            if (!TEST_TYPES.includes(type)) {
+              continue;
+            }
             for (const [file, tests] of Object.entries(items)) {
               for (const test of tests) {
                 const metadata = {
@@ -789,7 +792,7 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
                 if (type === 'reftest') {
                   metadata.refPath = test[1][0][0];
                 }
-                // Ensure leading slashes.
+                // Ensure leading slashes (e.g. manual/visual tests don't).
                 if (!metadata.file.startsWith('/')) {
                   metadata.file = `/${file}`;
                 }

--- a/webapp/components/wpt-results.js
+++ b/webapp/components/wpt-results.js
@@ -35,8 +35,6 @@ import { WPTFlags } from './wpt-flags.js';
 import './wpt-permalinks.js';
 import './wpt-prs.js';
 
-const TEST_TYPES = ['manual', 'reftest', 'testharness', 'visual', 'wdspec'];
-
 class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRunsUIBase)))) {
   static get template() {
     return html`
@@ -487,6 +485,7 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
         value: false,
       },
       onlyShowDifferences: Boolean,
+      // path => {type, file[, refPath]} simplification.
       manifest: Object,
       screenshots: Array,
     };
@@ -505,15 +504,10 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
       return path;
     }
     // Filter in case any types are fully missing.
-    const itemSets = TEST_TYPES.map(t => manifest.items[t]).filter(i => i);
-    for (const items of itemSets) {
-      const key = Object.keys(items).find(k => items[k].find(i => i[0] === path));
-      if (key) {
-        // Ensure leading slash.
-        return key.startsWith('/') ? key : `/${key}`;
-      }
+    const metadata = manifest.get(path);
+    if (metadata) {
+      return metadata.file.startsWith('/') ? metadata.file : `/${metadata.file}`;
     }
-    return null;
   }
 
   computeIsRefTest(testType) {
@@ -524,22 +518,7 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
     if (testType === 'wdspec') {
       return;
     }
-    if (this.webPlatformTestsLive) {
-      return new URL(`${this.scheme}://web-platform-tests.live${path}`);
-    }
-    return new URL(`${this.scheme}://w3c-test.org${path}`);
-  }
-
-  computeTestRefURL(testType, path, manifest) {
-    if (!this.showTestRefURL || testType !== 'reftest') {
-      return;
-    }
-    const item = Object.values(manifest.items['reftest']).find(v => v.find(i => i[0] === path));
-    // In item[0], the 2nd item is the refs array, and we take the first ref (0).
-    // Then, the ref's 1st item is the url (0). (2nd is the condition, e.g. "==".)
-    // See https://github.com/web-platform-tests/wpt/blob/master/tools/manifest/item.py#L141
-    const refPath = item && item[0][1][0][0];
-    return this.computeTestURL(testType, refPath);
+    return new URL(`${this.scheme}://${this.liveTestDomain}${path}`);
   }
 
   computeLiveTestDomain() {
@@ -547,6 +526,16 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
       return 'web-platform-tests.live';
     }
     return 'w3c-test.org';
+  }
+
+  computeTestRefURL(testType, path, manifest) {
+    if (!this.showTestRefURL || testType !== 'reftest') {
+      return;
+    }
+    const metadata = manifest.get(path);
+    if (metadata && metadata.refPath) {
+      return this.computeTestURL(testType, metadata.refPath);
+    }
   }
 
   https(url) {
@@ -557,15 +546,8 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
     if (!this.computePathIsATestFile(path) || !manifest) {
       return;
     }
-    for (const type of TEST_TYPES) {
-      const items = manifest.items[type];
-      if (items) {
-        const test = Object.values(items).find(v => v.find(i => i[0] === path));
-        if (test) {
-          return type;
-        }
-      }
-    }
+    const metadata = manifest.get(path);
+    return metadata && metadata.type;
   }
 
   computeTestTypeIcon(testType) {
@@ -793,9 +775,30 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
               && isSpecificSHA
               && this.fetchManifestForSHA('latest');
           }
-          let manifest = await r.json();
-          manifest.sha = sha || r.headers && r.headers['x-wpt-sha'];
+          let manifestJSON = await r.json();
+          const manifest = new Map();
+          manifest.sha = sha || r.headers && r.headers['wpt-sha'];
+          for (const [type, items] of Object.entries(manifestJSON.items)) {
+            for (const [file, tests] of Object.entries(items)) {
+              for (const test of tests) {
+                const metadata = {
+                  file,
+                  type,
+                };
+                if (type === 'reftest') {
+                  metadata.refPath = test[1][0][0];
+                }
+                let path = `${test[0]}`;
+                if (!path.startsWith('/')) {
+                  path = `/${path}`;
+                }
+                manifest.set(path, metadata);
+              }
+            }
+          }
           this.manifest = manifest;
+          // eslint-disable-next-line no-console
+          console.info(`Loaded manifest ${manifest.sha}`);
           this.refreshDisplayedNodes();
         }
       )
@@ -851,14 +854,10 @@ class WPTResults extends WPTColors(WPTFlags(SelfNavigation(LoadingState(TestRuns
     // Add an empty row for all the tests known from the manifest.
     const knownNodes = {};
     if (this.manifest && !this.search) {
-      for (const type of Object.keys(this.manifest.items)) {
+      for (const [path, {type}] of Object.entries(this.manifest)) {
         if (['manual', 'reftest', 'testharness', 'wdspec'].includes(type)) {
-          for (const file of Object.keys(this.manifest.items[type])) {
-            for (const test of this.manifest.items[type][file]) {
-              if (test[0].startsWith(prefix)) {
-                collapsePathOnto(test[0], knownNodes);
-              }
-            }
+          if (path.startsWith(prefix)) {
+            collapsePathOnto(path, knownNodes);
           }
         }
       }


### PR DESCRIPTION
## Description
Otherwise, it's computationally expensive to find a test path (we have to iterate the whole manifest and look up the `manifest.items[type][file][0]` entry).

Fixes #1208