### PR TITLE
No longer use projection in the screenshot API

### DIFF
--- a/api/screenshot/model.go
+++ b/api/screenshot/model.go
@@ -131,7 +131,6 @@ func RecentScreenshotHashes(ds shared.Datastore, browser, browserVersion, os, os
 		for _, l := range labels {
 			query = query.Filter("Labels =", l)
 		}
-		query = query.Project("HashDigest", "HashMethod")
 		query = query.Order("-LastUsed").Limit(totalLimit)
 
 		var hits []Screenshot


### PR DESCRIPTION
We would only save retrieving one field (labels) with projection, but it
requires two additional composite indexes (with and without labels), so
it is not really worthwhile.
