### PR TITLE
Fix the custom error type MultiError

### DIFF
--- a/shared/browsers_test.go
+++ b/shared/browsers_test.go
@@ -1,4 +1,4 @@
-// +build small medium large
+// +build small
 
 // Copyright 2017 The WPT Dashboard Project. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/shared/errors.go
+++ b/shared/errors.go
@@ -23,7 +23,7 @@ type MultiError struct {
 //
 // Note that it uses `range` over the channel, so users need to close the
 // channel before calling this function or running it in a goroutine.
-func NewMultiErrorFromChan(errors chan error, when string) *MultiError {
+func NewMultiErrorFromChan(errors chan error, when string) error {
 	var multiError MultiError
 	for err := range errors {
 		multiError.errors = append(multiError.errors, err)
@@ -36,14 +36,14 @@ func NewMultiErrorFromChan(errors chan error, when string) *MultiError {
 	return nil
 }
 
-func (e MultiError) Error() string {
+func (e *MultiError) Error() string {
 	if len(e.errors) == 0 {
 		return ""
 	}
-	return fmt.Sprintf("%d error(s) occured when %s:\n%s", len(e.errors), e.when, e.errStr)
+	return fmt.Sprintf("%d error(s) occurred when %s:\n%s", len(e.errors), e.when, e.errStr)
 }
 
 // Count returns the number of errors in this MultiError.
-func (e MultiError) Count() int {
+func (e *MultiError) Count() int {
 	return len(e.errors)
 }

--- a/shared/errors_test.go
+++ b/shared/errors_test.go
@@ -1,0 +1,41 @@
+// +build small
+
+// Copyright 2019 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package shared
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewMultiErrorFromChan_non_empty(t *testing.T) {
+	errs := make(chan error, 2)
+	errs <- errors.New("test1")
+	errs <- errors.New("test2")
+	close(errs)
+	err := NewMultiErrorFromChan(errs, "testing")
+	assert.Equal(t, "2 error(s) occurred when testing:\ntest1\ntest2\n", err.Error())
+	_, ok := err.(*MultiError)
+	assert.True(t, ok)
+}
+
+func TestNewMultiErrorFromChan_nil(t *testing.T) {
+	errs := make(chan error)
+	close(errs)
+	// It is vital to pre-declare the type of err.
+	var err error
+	err = NewMultiErrorFromChan(errs, "testing")
+	// Do NOT use assert.Nil: we use the `nil` literal intentionally here.
+	// This is equivalent to `err == nil`. Since err is declared as error,
+	// so we are comparing err against (error)(nil), which will fail if
+	// NewMultiErrorFromChan incorrectly returns a concrete
+	// (*MultiError)(nil).
+	assert.Equal(t, nil, err)
+	_, ok := err.(*MultiError)
+	assert.False(t, ok)
+}


### PR DESCRIPTION
The New method has to return an error interface instead of a concrete
type. This is not only in accordance with the best practice (errors are
checked by type assertions[1]), but also avoids a weird issue when
assigning the return value to a predeclared variable of type error:
(error)(nil) != (*MultiError)(nil).

Add a test to prevent regressing this subtle intentional behaviour.

Drive-by fix: remove unnecessary tags in browsers_test.go.

[1]: https://blog.golang.org/error-handling-and-go
