### PR TITLE
Fix a test broken by DST switch

### DIFF
--- a/shared/test_run_filter_test.go
+++ b/shared/test_run_filter_test.go
@@ -34,7 +34,8 @@ func TestTestRunFilter_NextPage_MaxCount(t *testing.T) {
 }
 
 func TestTestRunFilter_NextPage_From(t *testing.T) {
-	now := time.Now()
+	// Use UTC to avoid DST craziness.
+	now := time.Now().UTC()
 	aWeekAgo := now.AddDate(0, 0, -7)
 	filter := TestRunFilter{
 		From: &aWeekAgo,


### PR DESCRIPTION
```go
// Assume someDate is one day after DST switch.
someDate.Sub(7 * 24 * time.Hour) != someDate.AddDate(0, 0, -7)
```