### PR TITLE
Protect the screenshot upload API

### DIFF
--- a/api/receiver/api_medium_test.go
+++ b/api/receiver/api_medium_test.go
@@ -139,11 +139,18 @@ func TestAuthenticateUploader(t *testing.T) {
 	defer done()
 	a := NewAPI(ctx)
 
-	assert.False(t, a.AuthenticateUploader("user", "123"))
+	req := httptest.NewRequest("", "/api/foo", &bytes.Buffer{})
+	assert.Equal(t, "", AuthenticateUploader(a, req))
 
-	key := datastore.NewKey(ctx, "Uploader", "user", 0, nil)
-	datastore.Put(ctx, key, &shared.Uploader{Username: "user", Password: "123"})
-	assert.True(t, a.AuthenticateUploader("user", "123"))
+	req.SetBasicAuth(InternalUsername, "123")
+	assert.Equal(t, "", AuthenticateUploader(a, req))
+
+	key := datastore.NewKey(ctx, "Uploader", InternalUsername, 0, nil)
+	datastore.Put(ctx, key, &shared.Uploader{Username: InternalUsername, Password: "123"})
+	assert.Equal(t, InternalUsername, AuthenticateUploader(a, req))
+
+	req.SetBasicAuth(InternalUsername, "456")
+	assert.Equal(t, "", AuthenticateUploader(a, req))
 }
 
 func TestFetchWithTimeout_success(t *testing.T) {

--- a/api/receiver/create_run.go
+++ b/api/receiver/create_run.go
@@ -23,12 +23,10 @@ const InternalUsername = "_processor"
 
 // HandleResultsCreate handles the POST requests for creating test runs.
 func HandleResultsCreate(a API, s checks.API, w http.ResponseWriter, r *http.Request) {
-	username, password, ok := r.BasicAuth()
-	if !ok || username != InternalUsername || !a.AuthenticateUploader(username, password) {
-		http.Error(w, "Authentication error", http.StatusUnauthorized)
+	if AuthenticateUploader(a, r) != InternalUsername {
+		http.Error(w, "This is a private API.", http.StatusUnauthorized)
 		return
 	}
-
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/api/receiver/mock_receiver/api_mock.go
+++ b/api/receiver/mock_receiver/api_mock.go
@@ -55,20 +55,6 @@ func (mr *MockAPIMockRecorder) AddTestRun(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddTestRun", reflect.TypeOf((*MockAPI)(nil).AddTestRun), arg0)
 }
 
-// AuthenticateUploader mocks base method
-func (m *MockAPI) AuthenticateUploader(arg0, arg1 string) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AuthenticateUploader", arg0, arg1)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// AuthenticateUploader indicates an expected call of AuthenticateUploader
-func (mr *MockAPIMockRecorder) AuthenticateUploader(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthenticateUploader", reflect.TypeOf((*MockAPI)(nil).AuthenticateUploader), arg0, arg1)
-}
-
 // Context mocks base method
 func (m *MockAPI) Context() context.Context {
 	m.ctrl.T.Helper()

--- a/api/screenshot/cache.go
+++ b/api/screenshot/cache.go
@@ -13,6 +13,7 @@ import (
 
 	"cloud.google.com/go/storage"
 
+	"github.com/web-platform-tests/wpt.fyi/api/receiver"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
@@ -50,6 +51,11 @@ func uploadScreenshotHandler(w http.ResponseWriter, r *http.Request) {
 
 	ctx := shared.NewAppEngineContext(r)
 	aeAPI := shared.NewAppEngineAPI(ctx)
+	if receiver.AuthenticateUploader(aeAPI, r) != receiver.InternalUsername {
+		http.Error(w, "This is a private API.", http.StatusUnauthorized)
+		return
+	}
+
 	// TODO(Hexcles): Abstract and mock the GCS utilities in shared.
 	gcs, err := storage.NewClient(ctx)
 	if err != nil {

--- a/results-processor/wptreport.py
+++ b/results-processor/wptreport.py
@@ -504,7 +504,7 @@ def normalize_product(report):
         return set()
 
 
-def create_test_run(report, run_id, labels_str, uploader, secret,
+def create_test_run(report, run_id, labels_str, uploader, auth,
                     results_url, raw_results_url, callback_url=None):
     """Creates a TestRun on the dashboard.
 
@@ -515,7 +515,7 @@ def create_test_run(report, run_id, labels_str, uploader, secret,
         run_id: The pre-allocated Datastore ID for this run.
         labels_str: A comma-separated string of labels from the uploader.
         uploader: The name of the uploader.
-        secret: A secret token.
+        auth: A (username, password) tuple for HTTP basic auth.
         results_url: URL of the gzipped summary file. (e.g.
             'https://.../wptd/0123456789/chrome-62.0-linux-summary.json.gz')
         raw_results_url: URL of the raw full report. (e.g.
@@ -541,7 +541,7 @@ def create_test_run(report, run_id, labels_str, uploader, secret,
 
     response = requests.post(
         callback_url,
-        auth=('_processor', secret),
+        auth=auth,
         data=json.dumps(payload)
     )
     response.raise_for_status()


### PR DESCRIPTION
Export an authentication function from the receiver package and use it in the screenshot package to guard the private API.

The branch is based on #1222 .