### PR TITLE
fixup! Wrong URL was passed to create test runs

### DIFF
--- a/results-processor/processor.py
+++ b/results-processor/processor.py
@@ -215,7 +215,7 @@ class Processor(object):
             labels,
             uploader,
             self.auth,
-            self.results_gs_url,
+            self.results_url,
             self.raw_results_url,
             callback_url)
         assert self.test_run_id


### PR DESCRIPTION
The bug was introduced in the big refactoring 2b9bd292 by accident.

@foolip TBR to fix a critical issue. I'll follow up with some tests later.