### PR TITLE
Fix #1225 - set SVG rect width through attribute rather than CSS

### DIFF
--- a/webapp/components/reftest-analyzer.js
+++ b/webapp/components/reftest-analyzer.js
@@ -44,11 +44,6 @@ class ReftestAnalyzer extends LoadingState(PolymerElement) {
         #source.after #before {
           display: none;
         }
-        #diff-layer filter,
-        #diff-layer rect {
-          height: 100%;
-          width: 100%;
-        }
         #options {
           display: flex;
           justify-content: space-between;
@@ -225,7 +220,10 @@ class ReftestAnalyzer extends LoadingState(PolymerElement) {
       display.setAttribute('width', out.width);
       display.setAttribute('height', out.height);
       display.setAttributeNS(nsXLINK, 'xlink:href', this.diff);
-      const rect = this.shadowRoot.querySelector('#diff-layer');
+      const svg = this.shadowRoot.querySelector('#diff-layer');
+      svg.setAttribute('width', out.width);
+      svg.setAttribute('height', out.height);
+      const rect = this.shadowRoot.querySelector('#diff-layer rect');
       rect.setAttribute('width', out.width);
       rect.setAttribute('height', out.height);
       resolve();


### PR DESCRIPTION
<!--
Thanks for the PR, you probably worked hard on it! Before you submit it for review, please make sure you read our guidelines for contributing to this repository. 

Try to make the job easy for your reviewer! Below is a template you can use as a guide for what context your reviewer might need.  
If you changed any dev procedures, consider also updating the README.
-->

## Description
Fixes #1225 
<!-- A detailed description explaining what your code accomplishes, and why this work is taking place. If this affects an open issue, please make sure to properly reference it. -->

## Review Information
SVG2 requires CSS to be supported for this, but it hasn't historically been supported, and isn't in Firefox, so let's not rely on that.
<!-- Provide detailed instructions for how to run the code. -->
