### PR TITLE
[processor] Upgrade to Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ branches:
 services:
   - docker
 
+language: python
+python: "3.6"
+
 # ${GITHUB_TOKEN}
 env:
   global:
@@ -76,25 +79,33 @@ before_install: |
   travis_retry docker build -t "${DOCKER_IMAGE}" .
   travis_retry bash ./util/docker-dev/run.sh -d -q
 
-install:
+install: |
   # Retry `go get` to avoid intermittent network issues.
-  # FIXME: not all make targets require building go packages.
-  - travis_retry docker exec -t "${DOCKER_INSTANCE}" make go_build
+  if [[ "${MAKE_TEST_TARGET}" == "python_test" || "DEPLOY_PR_STAGING_TARGET" == "results-processor" ]]; then
+    travis_retry pip install tox;
+  else
+    travis_retry docker exec -t "${DOCKER_INSTANCE}" make go_build;
+  fi
 
 script:
   - |
     # Deploy PR to staging environment (only when Travis secrets are available).
     # Note: Done here (in 'script', not 'deploy') because we need deploy to happen before staging webdriver test.
     set -e
-    if [ -n "${DEPLOY_STAGING_TARGET}" ]; then
+    if [[ -n "${DEPLOY_STAGING_TARGET}" ]]; then
       bash util/travis-deploy-staging.sh -f "${DEPLOY_STAGING_TARGET}";
-    elif [ -n "${DEPLOY_PR_STAGING_TARGET}" ]; then
+    elif [[ -n "${DEPLOY_PR_STAGING_TARGET}" ]]; then
       bash util/travis-deploy-staging.sh "${DEPLOY_PR_STAGING_TARGET}";
     else
       echo "Not on master or a PR. Skipping deployment.";
     fi
   - |
     # Run tests
-    if [ "${MAKE_TEST_TARGET}" != "" ]; then
+    if [[ -n "${MAKE_TEST_TARGET}" && "${MAKE_TEST_TARGET}" != "python_test" ]]; then
       docker exec -t "${DOCKER_INSTANCE}" make "${MAKE_TEST_TARGET}" ${MAKE_TEST_FLAGS};
+    fi
+  - |
+    # Run Python tests
+    if [[ "${MAKE_TEST_TARGET}" == "python_test" ]]; then
+      cd results-processor; tox;
     fi

--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ sys_deps: curl gpg node gcloud git
 
 curl: apt-get-curl
 git: apt-get-git
-python3: apt-get-python3
+python3: apt-get-python3.6
 python: apt-get-python
 tox: apt-get-tox
 wget: apt-get-wget

--- a/results-processor/Dockerfile
+++ b/results-processor/Dockerfile
@@ -19,7 +19,7 @@ RUN gcloud config set disable_usage_reporting false
 RUN rm -f $HOME/.config/gcloud/gce
 
 # Setup and activate virtualenv.
-RUN virtualenv --no-download /env -p python3
+RUN virtualenv --no-download /env -p python3.6
 ENV VIRTUAL_ENV /env
 ENV PATH /env/bin:$PATH
 

--- a/results-processor/README.md
+++ b/results-processor/README.md
@@ -1,0 +1,28 @@
+## Basics
+
+The results processor runs on Python 3.6. The entry point is a Flask web server
+(`main.py`). In production, gunicorn is used as the WSGI (see `Dockerfile`) and
+the container runs as a custom AppEnging Flex instance (see `app.yaml`).
+
+## Getting started
+
+We can create a virtualenv to recreate a setup close to production for daily
+development.
+
+```bash
+virtualenv env -p python3.6
+. env/bin/activate
+pip install -r requirements.txt
+```
+
+## Running tests
+
+We strongly recommend you to run tests **outside of** the virtualenv created
+above to avoid running into issues caused by nested virtualenvs (`tox` manages
+virtualenv itself).
+
+
+```bash
+deactivate  # or in a different shell
+tox
+```

--- a/results-processor/tox.ini
+++ b/results-processor/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3
+envlist = py36
 # We don't have or need setup.py for now.
 skipsdist=True
 


### PR DESCRIPTION
Nothing is changed except our test setup.

Unfortunately, the dev Docker image we use does not have Python 3.6 (it's running Debian stretch). Instead of using debports etc. to get Python 3.6 into stretch, I changed the Travis configuration for the `python_test` target to run tests outside of Docker using Travis' native Python support.