### PR TITLE
Improve reftest analyzer

### DIFF
--- a/webapp/components/reftest-analyzer.js
+++ b/webapp/components/reftest-analyzer.js
@@ -29,6 +29,9 @@ class ReftestAnalyzer extends LoadingState(PolymerElement) {
           height: 250px;
           width: 250px;
         }
+        #zoom #info {
+          width: 280px;
+        }
         #display {
           position: relative;
           height: 800px;
@@ -60,9 +63,9 @@ class ReftestAnalyzer extends LoadingState(PolymerElement) {
         </svg>
 
         <div id="info">
-          <p><strong>Pixel at:</strong> [[curX]], [[curY]]</p>
-          <p><strong>Image before:</strong> [[getRGB(canvasBefore, curX, curY)]]</p>
-          <p><strong>Image after:</strong> [[getRGB(canvasAfter, curX, curY)]]</p>
+          <strong>Pixel at:</strong> [[curX]], [[curY]] <br>
+          <strong>Image before:</strong> [[getRGB(canvasBefore, curX, curY)]] <br>
+          <strong>Image after:</strong> [[getRGB(canvasAfter, curX, curY)]] <br>
         </div>
       </div>
 

--- a/webapp/components/reftest-analyzer.js
+++ b/webapp/components/reftest-analyzer.js
@@ -52,12 +52,18 @@ class ReftestAnalyzer extends LoadingState(PolymerElement) {
         }
       </style>
 
-      <div id='zoom'>
+      <div id="zoom">
         <svg xmlns="http://www.w3.org/2000/svg" shape-rendering="optimizeSpeed">
           <g id="zoomed">
             <rect width="250" height="250" fill="white"/>
           </g>
         </svg>
+
+        <div id="info">
+          <p><strong>Pixel at:</strong> [[curX]], [[curY]]</p>
+          <p><strong>Image before:</strong> [[getRGB(canvasBefore, curX, curY)]]</p>
+          <p><strong>Image after:</strong> [[getRGB(canvasAfter, curX, curY)]]</p>
+        </div>
       </div>
 
       <div id="source" class$="[[selectedImage]]">
@@ -87,11 +93,8 @@ class ReftestAnalyzer extends LoadingState(PolymerElement) {
                   <feFlood result="red" flood-color="#f00" />
                   <feComposite result="highlight" in="red" in2="border" operator="in" />
 
-                  <feFlood id="shadow" result="shadow" flood-color="#000" flood-opacity="0.2" />
-                  <feMerge>
-                    <feMergeNode in="highlight" />
-                    <feMergeNode in="shadow" />
-                  </feMerge>
+                  <feFlood id="shadow" result="shadow" flood-color="#fff" flood-opacity="0.8" />
+                  <feBlend in="shadow" in2="highlight" mode="multiply" />
                 </filter>
               </defs>
               <rect onmousemove="[[zoom]]" filter="url(#diff-filter)" />
@@ -108,6 +111,8 @@ class ReftestAnalyzer extends LoadingState(PolymerElement) {
 
   static get properties() {
     return {
+      curX: Number,
+      curY: Number,
       before: String,
       after: String,
       selectedImage: {
@@ -185,6 +190,15 @@ class ReftestAnalyzer extends LoadingState(PolymerElement) {
     this.pathsAfter = pathsAfter;
   }
 
+  getRGB(canvas, x, y) {
+    if (!canvas) {
+      return;
+    }
+    const ctx = canvas.getContext('2d');
+    const p = ctx.getImageData(x, y, 1, 1).data;
+    return `RGB(${p[0]}, ${p[1]}, ${p[2]})`;
+  }
+
   computeDiff(canvasBefore, canvasAfter) {
     if (!canvasBefore || !canvasAfter) {
       return;
@@ -234,23 +248,27 @@ class ReftestAnalyzer extends LoadingState(PolymerElement) {
     if (!this.canvasAfter || !this.canvasBefore) {
       return;
     }
+    const c = e.target.getBoundingClientRect();
+    // (x, y) is the current position on the image.
+    this.curX = e.clientX - c.left;
+    this.curY = e.clientY - c.top;
 
     for (const before of [true, false]) {
       const canvas = before ? this.canvasBefore : this.canvasAfter;
       const paths = before ? this.pathsBefore : this.pathsAfter;
       const ctx = canvas.getContext('2d');
-      const c = e.target.getBoundingClientRect();
-      const x = e.clientX - c.left - 2;
-      const y = e.clientY - c.top - 2;
+      // We extract a 5x5 square around (x, y): (x-2, y-2) .. (x+2, y+2).
+      const dx = this.curX - 2;
+      const dy = this.curY - 2;
       for (let i = 0; i < 5; i++) {
         for (let j = 0; j < 5; j++) {
-          if (x + i < 0 || x + i >= canvas.width || y + j < 0 || y + j >= canvas.height) {
+          if (dx + i < 0 || dx + i >= canvas.width || dy + j < 0 || dy + j >= canvas.height) {
             paths[i][j].fill = blankFill;
           } else {
-            const p = ctx.getImageData(x+i, y+j, 1, 1).data;
+            const p = ctx.getImageData(dx+i, dy+j, 1, 1).data;
             const [r,g,b] = p;
             const a = p[3]/255;
-            paths[i][j].setAttribute('fill', `rgba(${r},${g},${b},${a}`);
+            paths[i][j].setAttribute('fill', `rgba(${r},${g},${b},${a})`);
           }
         }
       }

--- a/webapp/components/reftest-analyzer.js
+++ b/webapp/components/reftest-analyzer.js
@@ -194,7 +194,7 @@ class ReftestAnalyzer extends LoadingState(PolymerElement) {
   }
 
   getRGB(canvas, x, y) {
-    if (!canvas) {
+    if (!canvas || x === undefined || y === undefined) {
       return;
     }
     const ctx = canvas.getContext('2d');


### PR DESCRIPTION
## Description

1. Show the pixel position & RGB values of the current position (#1228).
2. Mask same pixels even more to highlight the border of the different areas.

## Review Information

Demo: https://reftest-analyzer2-dot-wptdashboard-staging.appspot.com/analyzer?screenshot=sha1%3A8cfce4c0c8e873c12e613a94e53c8c0a8e44eb3e&screenshot=sha1%3Ac8fbf3067a700b1916632ec1eed6c379a7113efd