### PR TITLE
[processor] Handle HTTP errors better

### DIFF
--- a/results-processor/processor_test.py
+++ b/results-processor/processor_test.py
@@ -88,10 +88,12 @@ class ProcessorServerTest(unittest.TestCase):
 
     def test_download(self):
         with Processor() as p:
+            p.TIMEOUT_WAIT = 0.1  # to speed up tests
             url_404 = self.url + '/404'
+            url_timeout = self.url + '/slow'
             with self.assertLogs() as lm:
                 p.download(
-                    [self.url + '/download/test.txt'],
+                    [self.url + '/download/test.txt', url_timeout],
                     [url_404],
                     None)
             self.assertEqual(len(p.results), 1)
@@ -99,7 +101,8 @@ class ProcessorServerTest(unittest.TestCase):
             self.assertEqual(len(p.screenshots), 0)
             self.assertListEqual(
                 lm.output,
-                ['ERROR:processor:Failed to fetch (404): ' + url_404])
+                ['ERROR:processor:Timed out fetching: ' + url_timeout,
+                 'ERROR:processor:Failed to fetch (404): ' + url_404])
 
     def test_download_content_disposition(self):
         with Processor() as p:

--- a/results-processor/test_server.py
+++ b/results-processor/test_server.py
@@ -7,6 +7,7 @@
 import argparse
 import logging
 import sys
+import time
 
 import flask
 
@@ -22,6 +23,12 @@ def screenshots_upload():
     sys.stderr.write('{}\n'.format(num))
     sys.stderr.flush()
     return ('Success', 201)
+
+
+@app.route('/slow', methods=['GET'])
+def slow():
+    time.sleep(30)
+    return 'Done'
 
 
 @app.route('/download/attachment', methods=['GET'])


### PR DESCRIPTION
1. Enforce a timeout when issuing HTTP requests (the default is no
   timeout, which is not good).
2. When a HTTP error occurs (timeout or unsuccessful status), we wait 1
   second and retry again.
3. If no results are downloaded successfully, we abort early.
