### PR TITLE
Made the reftest comparison wording clearer

### DIFF
--- a/webapp/components/reftest-analyzer.js
+++ b/webapp/components/reftest-analyzer.js
@@ -69,8 +69,8 @@ class ReftestAnalyzer extends LoadingState(PolymerElement) {
 
         <div id="info">
           <strong>Pixel at:</strong> [[curX]], [[curY]] <br>
-          <strong>Image before:</strong> [[getRGB(canvasBefore, curX, curY)]] <br>
-          <strong>Image after:</strong> [[getRGB(canvasAfter, curX, curY)]] <br>
+          <strong>Actual:</strong> [[getRGB(canvasBefore, curX, curY)]] <br>
+          <strong>Expected:</strong> [[getRGB(canvasAfter, curX, curY)]] <br>
           <p>
             Any suggestions?
             <a href="https://github.com/web-platform-tests/wpt.fyi/issues/new?template=screenshots.md&projects=web-platform-tests/wpt.fyi/9" target="_blank">File an issue!</a>


### PR DESCRIPTION
## Description
In the reftest comparison, "Image before" and "Image after" are very unclear to the user. I changed them to the much clearer - "Actual" and "Expected".

## Review Information
https://wpt.fyi/results/css/css-position/position-relative-table-tbody-left-absolute-child.html?run_id=5668853719760896&run_id=5640982771007488&run_id=5907019957534720&run_id=6231803673182208 would do.

## Changes
webapp/components/reftest-analyzer.js - renamed labels.

## Requirements
None.
