### PR TITLE
Further improve the docs for reftest analyzer

### DIFF
--- a/webapp/components/reftest-analyzer.js
+++ b/webapp/components/reftest-analyzer.js
@@ -11,6 +11,7 @@ import '../node_modules/@polymer/paper-checkbox/paper-checkbox.js';
 import '../node_modules/@polymer/paper-radio-button/paper-radio-button.js';
 import '../node_modules/@polymer/paper-radio-group/paper-radio-group.js';
 import '../node_modules/@polymer/paper-spinner/paper-spinner-lite.js';
+import '../node_modules/@polymer/paper-tooltip/paper-tooltip.js';
 import { LoadingState } from './loading-state.js';
 
 const nsSVG = 'http://www.w3.org/2000/svg';
@@ -28,6 +29,8 @@ class ReftestAnalyzer extends LoadingState(PolymerElement) {
         #zoom svg {
           height: 250px;
           width: 250px;
+          margin: 10px 0;
+          border: 1px solid;
         }
         #zoom #info {
           width: 280px;
@@ -72,6 +75,11 @@ class ReftestAnalyzer extends LoadingState(PolymerElement) {
           <strong>Actual:</strong> [[getRGB(canvasBefore, curX, curY)]] <br>
           <strong>Expected:</strong> [[getRGB(canvasAfter, curX, curY)]] <br>
           <p>
+            The grid above is a zoomed-in view of the 5&times;5 pixels around your cursor.
+            When actual and expected pixels are different, the upper-left half shows the
+            actual and the lower-right half shows the expected.
+          </p>
+          <p>
             Any suggestions?
             <a href="https://github.com/web-platform-tests/wpt.fyi/issues/new?template=screenshots.md&projects=web-platform-tests/wpt.fyi/9" target="_blank">File an issue!</a>
           </p>
@@ -81,10 +89,14 @@ class ReftestAnalyzer extends LoadingState(PolymerElement) {
       <div id="source" class$="[[selectedImage]]">
         <div id="options">
           <paper-radio-group selected="{{selectedImage}}">
-            <paper-radio-button name="before">Image before</paper-radio-button>
-            <paper-radio-button name="after">Image after</paper-radio-button>
+            <paper-radio-button name="before">Actual screenshot</paper-radio-button>
+            <paper-radio-button name="after">Expected screenshot</paper-radio-button>
           </paper-radio-group>
-          <paper-checkbox name="diff" checked="{{showDiff}}">Differences</paper-checkbox>
+          <paper-checkbox id="diff-button" checked="{{showDiff}}">Highlight diff</paper-checkbox>
+          <paper-tooltip for="diff-button">
+            Apply a semi-transparent mask over the selected image, and highlight
+            the areas where two images differ with a solid 1px red border.
+          </paper-tooltip>
           <paper-spinner-lite active="[[isLoading]]" class="blue"></paper-spinner-lite>
         </div>
 

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -600,9 +600,9 @@
       }
     },
     "@google-web-components/google-chart": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@google-web-components/google-chart/-/google-chart-3.0.3.tgz",
-      "integrity": "sha512-r/7qWsFaK+EI3HBKOh7GVBt1VM7Yq/qOntqgdB/cJwKwGHWowX4RkvnTp5y3bbkfM7kXLgENtjtsf9cLE+FQew==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@google-web-components/google-chart/-/google-chart-3.0.4.tgz",
+      "integrity": "sha512-1KSZX4SrWT929tfR8LEpeRdPbBjiieTA8mxn6d/M395zlkwmKfaYOMmYMOA6E00Y3gOhgYEG3SLI+Tm1Ll1oqw==",
       "requires": {
         "@polymer/iron-ajax": "^3.0.0-pre.18",
         "@polymer/polymer": "^3.0.0"
@@ -1092,11 +1092,11 @@
       }
     },
     "@polymer/polymer": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@polymer/polymer/-/polymer-3.1.0.tgz",
-      "integrity": "sha512-hwN8IMERsFATz/9dSMxYHL+84J9uBkPuuarxJWlTsppZ4CAYTZKnepBfNrKoyNsafBmA3yXBiiKPPf+fJtza7A==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@polymer/polymer/-/polymer-3.2.0.tgz",
+      "integrity": "sha512-L6uV1oM6T6xbwbVx6t3biG5T2VSSB03LxnIrUd9M2pr6RkHVPFHJ37pC5MUwBAEhkGFJif7eks7fdMMSGZTeEQ==",
       "requires": {
-        "@webcomponents/shadycss": "^1.5.2"
+        "@webcomponents/shadycss": "^1.8.0"
       }
     },
     "@polymer/sinonjs": {
@@ -1511,9 +1511,9 @@
       }
     },
     "@vaadin/vaadin-button": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-button/-/vaadin-button-2.1.2.tgz",
-      "integrity": "sha512-NuetM6kemh6wrIclxh7HBGemfbktcCnSh2SPwZXvSHwqlfz1qXf8MHEa7rNMCDl8Cd2pOBMhAWmsbNWy/up2YQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-button/-/vaadin-button-2.1.4.tgz",
+      "integrity": "sha512-i5s4ZSNH0cpMc5ZDInbJDkhcy0l/SQCLRoLpiHtMMXO8WnuQAy1konygw7OFwewty2EIqYGTzGzaOgXC/Ou55w==",
       "requires": {
         "@polymer/polymer": "^3.0.0",
         "@vaadin/vaadin-control-state-mixin": "^2.1.1",
@@ -1524,27 +1524,27 @@
       }
     },
     "@vaadin/vaadin-control-state-mixin": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-control-state-mixin/-/vaadin-control-state-mixin-2.1.2.tgz",
-      "integrity": "sha512-lvQodFm6c4Fti3lBQ7EoJEekQ2ABEFdFMChLdW364Mseur2xg1Q9MIEXGbrlJPl6oSOic2FK7Eu5rk0U6sgcMg==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-control-state-mixin/-/vaadin-control-state-mixin-2.1.3.tgz",
+      "integrity": "sha512-EtLfMN9i/gwToAEuW6E1OA2Q2i/4a+Il6tKkqE/0i7bgu3Xr1IITMcagQn9QSsp1Xkpr/nLtWWKRq7yZZkbHVg==",
       "requires": {
         "@polymer/polymer": "^3.0.0"
       }
     },
     "@vaadin/vaadin-date-picker": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-date-picker/-/vaadin-date-picker-3.3.2.tgz",
-      "integrity": "sha512-wuWh6W87WKMytvN6tu8DPJByi4Lv45B4OiFCNnogPaiQb/+rnz99HusWnc4SH5woltsbwOTsV/z9h3VyuzBNsQ==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-date-picker/-/vaadin-date-picker-3.3.4.tgz",
+      "integrity": "sha512-tI0Nek5IIvUx4rtbcqmy8N/GLYmV4cMi04z61Zo/Qvw+m4iJoHxyanHyweFM+E59jwvBXeZpXvRk50ihW03ipA==",
       "requires": {
-        "@polymer/iron-a11y-announcer": "^3.0.0-pre.18",
-        "@polymer/iron-a11y-keys-behavior": "^3.0.0-pre.18",
-        "@polymer/iron-media-query": "^3.0.0-pre.18",
-        "@polymer/iron-resizable-behavior": "^3.0.0-pre.18",
+        "@polymer/iron-a11y-announcer": "^3.0.0",
+        "@polymer/iron-a11y-keys-behavior": "^3.0.0",
+        "@polymer/iron-media-query": "^3.0.0",
+        "@polymer/iron-resizable-behavior": "^3.0.0",
         "@polymer/polymer": "^3.0.0",
         "@vaadin/vaadin-button": "^2.1.0",
         "@vaadin/vaadin-control-state-mixin": "^2.1.1",
         "@vaadin/vaadin-element-mixin": "^2.0.0",
-        "@vaadin/vaadin-lumo-styles": "^1.1.1",
+        "@vaadin/vaadin-lumo-styles": "^1.4.1",
         "@vaadin/vaadin-material-styles": "^1.1.2",
         "@vaadin/vaadin-overlay": "^3.2.0",
         "@vaadin/vaadin-text-field": "^2.1.2",
@@ -1557,37 +1557,37 @@
       "integrity": "sha512-pzSaUqn+lJbTL2ZC6NCAfhyMymMYg2p4DzeUXdyInJISwSWmgh9RlRVpAGhi6MIUOKC7kGeKPAiB4vyWsEhzDg=="
     },
     "@vaadin/vaadin-element-mixin": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-element-mixin/-/vaadin-element-mixin-2.1.2.tgz",
-      "integrity": "sha512-ufYIyiesFoqqEla9CsuMfF1eLXzz0UNVRLTltEuNl01wX+O7Ujqpfp88lmI0VtwfAZ9eobSlXK0eQca1+2IDIg==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-element-mixin/-/vaadin-element-mixin-2.1.3.tgz",
+      "integrity": "sha512-tCEdrS5JMIl9ZsyjnV28XI2AFLC35RUWRF6XPrvm/MpKAxWLk1MlYrkwR26avOuSqvNwCBO56NIDN2k1yYC4eA==",
       "requires": {
         "@polymer/polymer": "^3.0.0",
         "@vaadin/vaadin-development-mode-detector": "^2.0.0",
-        "@vaadin/vaadin-usage-statistics": "^2.0.1"
+        "@vaadin/vaadin-usage-statistics": "^2.0.2"
       }
     },
     "@vaadin/vaadin-lumo-styles": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-1.3.3.tgz",
-      "integrity": "sha512-+FHnffbu/0JJVBjASoDiV+4F4dRFt3W7598kQRuYO8AQtt+gkaWj/AHskJGW9GxeGUsG9tDl/vLwYbiDNil1uw==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-1.4.2.tgz",
+      "integrity": "sha512-6JrmxxQRkDfght5JiViVtd9xoIEwFAHIZjgEwW5ygQw2Zbr++vz6+9oBe6l93nM5JjOMHjR/TXW/+md0FrAZ+w==",
       "requires": {
-        "@polymer/iron-icon": "^3.0.0-pre.18",
-        "@polymer/iron-iconset-svg": "^3.0.0-pre.18",
+        "@polymer/iron-icon": "^3.0.0",
+        "@polymer/iron-iconset-svg": "^3.0.0",
         "@polymer/polymer": "^3.0.0"
       }
     },
     "@vaadin/vaadin-material-styles": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-material-styles/-/vaadin-material-styles-1.2.0.tgz",
-      "integrity": "sha512-H46YlNxrG+pvFqzYdVB+LM5PE4WpW38dwagHA13RNIHO52mpqZvaRz8U7YNJ+zjqoy9btz7jk7m9QSpgcNLy2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-material-styles/-/vaadin-material-styles-1.2.2.tgz",
+      "integrity": "sha512-da4zBLC9e16AjTXh1wG3jdFFV+2/L57NeQez2xj/al689uvts8WpB7NErXhNMUU5m9X2os4XpyEBS+OX/8OUdQ==",
       "requires": {
         "@polymer/polymer": "^3.0.0"
       }
     },
     "@vaadin/vaadin-overlay": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-overlay/-/vaadin-overlay-3.2.4.tgz",
-      "integrity": "sha512-1wuTxy1GHbFmT3gotFXLNFMvgpKQWWf4PAKcHbwJDHxahyqrQNK5oiEsjlDWvCvloEbwNMt3Sn8ChnYQxDMZbQ==",
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-overlay/-/vaadin-overlay-3.2.11.tgz",
+      "integrity": "sha512-y7fE6RAjxnvyl1+N4LY6b1KXUdZEEgcmdiwPzyKbRdNaAAtz79T5ZsyZ8K+gGv2aBV3ROVMIgPULK/lWxIZt/w==",
       "requires": {
         "@polymer/polymer": "^3.0.0",
         "@vaadin/vaadin-lumo-styles": "^1.3.0",
@@ -1596,9 +1596,9 @@
       }
     },
     "@vaadin/vaadin-text-field": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-text-field/-/vaadin-text-field-2.1.5.tgz",
-      "integrity": "sha512-2zic4pD1iL3MsUeH+BOTRcnxh2SFhXfETl/OUOO5kdk4AXmdNJqQZ8eCzP3kNiJ8PjmL1pzfbRfmmeWdx2IRFg==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-text-field/-/vaadin-text-field-2.3.6.tgz",
+      "integrity": "sha512-hnplcCBQy4XBUyRoS2pTa6eV/XaJhgEEbXr4nDJYpuvQqla3WUSbQHz4OU9aOX5VZYsDYd8OAHUPtSMcrA7Nwg==",
       "requires": {
         "@polymer/polymer": "^3.0.0",
         "@vaadin/vaadin-control-state-mixin": "^2.1.1",
@@ -1609,25 +1609,25 @@
       }
     },
     "@vaadin/vaadin-themable-mixin": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-1.4.0.tgz",
-      "integrity": "sha512-E7iqR0mF06PSNQCsL906DglX/UGJD3mhr4ucAqOfLPynrTRpgsM+pnGTpcitLJNdosoe6xW85pyLPAfiVyazIQ==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-1.4.4.tgz",
+      "integrity": "sha512-S/zN0DvSQ3cy1PdH0Dfa2yQirIFQKWCC3o0YdBzrKVCGvi5QW8+IqBTDFKnIaOfWjYoHsw2eunWcg9pu2jlI1Q==",
       "requires": {
         "@polymer/polymer": "^3.0.0"
       }
     },
     "@vaadin/vaadin-usage-statistics": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-usage-statistics/-/vaadin-usage-statistics-2.0.1.tgz",
-      "integrity": "sha512-8CmbCXZo8Z343jQT3hMVIvdkjzK72r762/UyqjLD54ArjzadneoA+4U6mFGbnbHO7FZpDhc4BKZRb5KAt0ibGg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-usage-statistics/-/vaadin-usage-statistics-2.0.2.tgz",
+      "integrity": "sha512-emu6IttPhlfH7chc3tvvZyztULtrMhNi6SK6BPXe7hN9PvF3XZfLLtVHxQMbJid85yYDcynKSyKznlhDkyrc7Q==",
       "requires": {
         "@vaadin/vaadin-development-mode-detector": "^2.0.0"
       }
     },
     "@webcomponents/shadycss": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.8.0.tgz",
-      "integrity": "sha512-bx0TzeZ11VqYDGLuXfznen8+4u0hADk2dD5RNMFxWL9MM4c5NXCDCgNXgssb4i2zQOos/GGe4tl5AuE0LzJkLA=="
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.9.0.tgz",
+      "integrity": "sha512-g8Xa+6RSEME4g/wLJW4YII0eq15rvXp76RxPAuv7hx+Bdoi7GzZJ/EoZOUfyIbqAsQbII1TcWD4/+Xhs5NcM1w=="
     },
     "@webcomponents/webcomponentsjs": {
       "version": "2.2.7",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -22,7 +22,7 @@
     "wct": "wct --npm"
   },
   "dependencies": {
-    "@google-web-components/google-chart": "^3.0.3",
+    "@google-web-components/google-chart": "^3.0.4",
     "@polymer/iron-collapse": "^3.0.0",
     "@polymer/iron-form": "^3.0.0",
     "@polymer/iron-icons": "^3.0.0",
@@ -42,8 +42,8 @@
     "@polymer/paper-toast": "^3.0.0",
     "@polymer/paper-toggle-button": "^3.0.0",
     "@polymer/paper-tooltip": "^3.0.0",
-    "@polymer/polymer": "^3.0.0",
-    "@vaadin/vaadin-date-picker": "^3.3.2",
+    "@polymer/polymer": "^3.2.0",
+    "@vaadin/vaadin-date-picker": "^3.3.4",
     "@webcomponents/webcomponentsjs": "^2.2.7",
     "pluralize": "^7.0.0"
   }


### PR DESCRIPTION
## Description

#1250 missed another pair of confusing "before"/"after". This PR fixes that. In addition, two more paragraphs of docs are added (one under the zoomed-in view and the other in the tooltip of "highlight diff").

## Review Information

Travis is broken due to #1254 . I've manually deployed the staging instance:
https://reftest-analyzer-dot-wptdashboard-staging.appspot.com/analyzer?screenshot=sha1%3Afcb424b57a939b8fd40803a3a57591fe41bbc25d&screenshot=sha1%3A6ab8cb76ce84ebd802d2e2c7476334652df3d0fe