### PR TITLE
Use a forked logrus to fix AppEngine build

### DIFF
--- a/api/azure/api_test.go
+++ b/api/azure/api_test.go
@@ -15,9 +15,9 @@ import (
 	"strings"
 	"testing"
 
+	logrustest "github.com/Hexcles/logrus/hooks/test"
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-github/github"
-	logrustest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/web-platform-tests/wpt.fyi/api/azure"

--- a/api/query/cache/backfill/backfill.go
+++ b/api/query/cache/backfill/backfill.go
@@ -14,7 +14,7 @@ import (
 	"google.golang.org/api/option"
 
 	"cloud.google.com/go/datastore"
-	log "github.com/sirupsen/logrus"
+	log "github.com/Hexcles/logrus"
 	"github.com/web-platform-tests/wpt.fyi/api/query"
 	"github.com/web-platform-tests/wpt.fyi/api/query/cache/index"
 	"github.com/web-platform-tests/wpt.fyi/api/query/cache/monitor"

--- a/api/query/cache/index/filter.go
+++ b/api/query/cache/index/filter.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"sync"
 
-	log "github.com/sirupsen/logrus"
+	log "github.com/Hexcles/logrus"
 	"github.com/web-platform-tests/wpt.fyi/api/query"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )

--- a/api/query/cache/index/index.go
+++ b/api/query/cache/index/index.go
@@ -22,7 +22,7 @@ import (
 	"github.com/web-platform-tests/wpt.fyi/api/query/cache/lru"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 
-	log "github.com/sirupsen/logrus"
+	log "github.com/Hexcles/logrus"
 )
 
 var (

--- a/api/query/cache/service/main.go
+++ b/api/query/cache/service/main.go
@@ -26,7 +26,7 @@ import (
 
 	"cloud.google.com/go/compute/metadata"
 	"cloud.google.com/go/datastore"
-	log "github.com/sirupsen/logrus"
+	log "github.com/Hexcles/logrus"
 )
 
 var (

--- a/shared/util.go
+++ b/shared/util.go
@@ -13,8 +13,8 @@ import (
 	"regexp"
 	"strings"
 
+	log "github.com/Hexcles/logrus"
 	mapset "github.com/deckarep/golang-set"
-	log "github.com/sirupsen/logrus"
 	"google.golang.org/appengine"
 	gaelog "google.golang.org/appengine/log"
 )


### PR DESCRIPTION
Fixes #1254

My fork includes the fix that hasn't been merged upstream: https://github.com/Hexcles/logrus/commit/a0dcfa32eb0aa18d477bfe11a13b29d516085798