### PR TITLE
Use 1+2 keys for toggling before+after on /analyzer

### DIFF
--- a/webapp/components/reftest-analyzer.js
+++ b/webapp/components/reftest-analyzer.js
@@ -51,6 +51,9 @@ class ReftestAnalyzer extends LoadingState(PolymerElement) {
           display: none;
           width: 800px;
         }
+        #source {
+          min-width: 800px;
+        }
         #source.before #after,
         #source.after #before {
           display: none;
@@ -101,9 +104,11 @@ class ReftestAnalyzer extends LoadingState(PolymerElement) {
         </div>
 
 
-        <p id="error-message">Failed to load images. Some historical runs (before 2019-04-01) and
-        some runners did not have complete screenshots. Please file an issue using the link on the
-        left if you think something is wrong.</p>
+        <p id="error-message">
+          Failed to load images. Some historical runs (before 2019-04-01) and
+          some runners did not have complete screenshots. Please file an issue using the link on the
+          left if you think something is wrong.
+        </p>
 
         <div id="display">
           <img id="before" onmousemove="[[zoom]]" crossorigin="anonymous" on-error="showError" />
@@ -320,7 +325,7 @@ class ReftestAnalyzer extends LoadingState(PolymerElement) {
 
   showError() {
     this.shadowRoot.querySelector('#display').style.display = 'none';
-    this.shadowRoot.querySelector('#error-message').style.display = 'unset';
+    this.shadowRoot.querySelector('#error-message').style.display = 'block';
   }
 }
 window.customElements.define(ReftestAnalyzer.is, ReftestAnalyzer);

--- a/webapp/templates/analyzer.html
+++ b/webapp/templates/analyzer.html
@@ -6,9 +6,9 @@
 import '/components/reftest-analyzer.js';
 
 document.body.addEventListener('keydown', e => {
-  if (e.which == 49) {
+  if (e.which == 49) { // The '1' key
     document.querySelector('reftest-analyzer').selectedImage = 'before';
-  } else if (e.which === 50) {
+  } else if (e.which === 50) { // The '2' key
     document.querySelector('reftest-analyzer').selectedImage = 'after';
   }
 });

--- a/webapp/templates/analyzer.html
+++ b/webapp/templates/analyzer.html
@@ -2,11 +2,23 @@
 <html>
 <head>
 {{ template "_head_common.html" }}
-<script type="module" src="/components/reftest-analyzer.js"></script>
+<script type="module">
+import '/components/reftest-analyzer.js';
+
+document.body.addEventListener('keydown', e => {
+  if (e.which == 49) {
+    document.querySelector('reftest-analyzer').selectedImage = 'before';
+  } else if (e.which === 50) {
+    document.querySelector('reftest-analyzer').selectedImage = 'after';
+  }
+});
+</script>
 </head>
 <body>
 <div id="content">
-  <reftest-analyzer before="{{.Before}}" after="{{.After}}"></reftest-analyzer>
+  <reftest-analyzer before="{{.Before}}"
+                    after="{{.After}}">
+  </reftest-analyzer>
 </div>
 {{ template "_ga.html" }}
 </body>


### PR DESCRIPTION
## Description
Fixes #1264 

## Review Information
Also drive-by fixes the width when the error message is shown, and handling the spinner stopping onerror.