### PR TITLE
[processor] Strip whitespaces from test names

### DIFF
--- a/results-processor/wptreport.py
+++ b/results-processor/wptreport.py
@@ -300,7 +300,7 @@ class WPTReport(object):
             return self._summary
 
         for result in self.results:
-            test_file = result['test']
+            test_file = result['test'].strip()
 
             if test_file in self._summary:
                 raise ConflictingDataError(test_file)
@@ -342,7 +342,7 @@ class WPTReport(object):
         if directory.endswith('/'):
             directory = directory[:-1]
         for result in self.each_result():
-            test_file = result['test']
+            test_file = result['test'].strip()
             assert test_file.startswith('/')
             filepath = directory + test_file
             self.write_gzip_json(filepath, result)

--- a/results-processor/wptreport_test.py
+++ b/results-processor/wptreport_test.py
@@ -272,6 +272,27 @@ class WPTReportTest(unittest.TestCase):
         with self.assertRaises(ConflictingDataError):
             r.summarize()
 
+    def test_summarize_whitespaces(self):
+        r = WPTReport()
+        r._report = {'results': [
+            {
+                'test': ' /ref/reftest.html',
+                'status': 'PASS',
+                'message': None,
+                'subtests': []
+            },
+            {
+                'test': '/ref/reftest-fail.html\n',
+                'status': 'FAIL',
+                'message': None,
+                'subtests': []
+            }
+        ]}
+        self.assertEqual(r.summarize(), {
+            '/ref/reftest.html': [1, 1],
+            '/ref/reftest-fail.html': [0, 1]
+        })
+
     def test_each_result(self):
         expected_results = [
             {
@@ -328,12 +349,21 @@ class WPTReportTest(unittest.TestCase):
         revision = '0bdaaf9c1622ca49eb140381af1ece6d8001c934'
         r = WPTReport()
         r._report = {
-            'results': [{
-                'test': '/foo/bar.html',
-                'status': 'PASS',
-                'message': None,
-                'subtests': []
-            }],
+            'results': [
+                {
+                    'test': '/foo/bar.html',
+                    'status': 'PASS',
+                    'message': None,
+                    'subtests': []
+                },
+                # Whitespaces need to be trimmed from the test name.
+                {
+                    'test': ' /foo/fail.html\n',
+                    'status': 'FAIL',
+                    'message': None,
+                    'subtests': []
+                }
+            ],
             'run_info': {
                 'revision': revision,
                 'product': 'firefox',
@@ -351,6 +381,10 @@ class WPTReportTest(unittest.TestCase):
         self.assertTrue(os.path.isfile(os.path.join(
             self.tmp_dir, revision,
             'firefox-59.0-linux-0123456789', 'foo', 'bar.html'
+        )))
+        self.assertTrue(os.path.isfile(os.path.join(
+            self.tmp_dir, revision,
+            'firefox-59.0-linux-0123456789', 'foo', 'fail.html'
         )))
 
     def test_update_metadata(self):


### PR DESCRIPTION
Related to https://github.com/web-platform-tests/wpt/issues/16187

We still don't know the root cause of the WPT issue, but we can work
around it from the wpt.fyi side.

## Review Information

I will temporarily promote the staging deployment as the default processor and see if it's able to process the broken Edge runs in our backlog.