### PR TITLE
Implement logging via a gcloud client in flex contexts

### DIFF
--- a/api/query/cache/index/index.go
+++ b/api/query/cache/index/index.go
@@ -17,10 +17,10 @@ import (
 	"sync"
 
 	mapset "github.com/deckarep/golang-set"
-	"github.com/web-platform-tests/wpt.fyi/shared/metrics"
 	"github.com/web-platform-tests/wpt.fyi/api/query"
 	"github.com/web-platform-tests/wpt.fyi/api/query/cache/lru"
 	"github.com/web-platform-tests/wpt.fyi/shared"
+	"github.com/web-platform-tests/wpt.fyi/shared/metrics"
 
 	log "github.com/Hexcles/logrus"
 )

--- a/api/query/cache/service/main.go
+++ b/api/query/cache/service/main.go
@@ -219,7 +219,7 @@ func searchHandler(w http.ResponseWriter, r *http.Request) {
 		var netClient = &http.Client{
 			Timeout: time.Second * 5,
 		}
-		resp.MetadataResponse = shared.GetMetadataResponse(runs, netClient, log.StandardLogger())
+		resp.MetadataResponse = shared.GetMetadataResponse(runs, netClient, logrus.StandardLogger())
 	}
 
 	data, err = json.Marshal(resp)

--- a/api/query/cache/service/main.go
+++ b/api/query/cache/service/main.go
@@ -219,7 +219,7 @@ func searchHandler(w http.ResponseWriter, r *http.Request) {
 		var netClient = &http.Client{
 			Timeout: time.Second * 5,
 		}
-		resp.MetadataResponse = shared.GetMetadataResponse(runs, netClient, logrus.StandardLogger())
+		resp.MetadataResponse = shared.GetMetadataResponse(runs, netClient, log)
 	}
 
 	data, err = json.Marshal(resp)

--- a/api/query/cache/service/main.go
+++ b/api/query/cache/service/main.go
@@ -69,18 +69,23 @@ func searchHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	ctx := r.Context()
+	log := shared.GetLogger(ctx)
 	data, err := ioutil.ReadAll(r.Body)
 	if err != nil {
+		log.Errorf("Failed to read request body: %s", err.Error())
 		http.Error(w, "Failed to read request body", http.StatusInternalServerError)
 	}
 	err = r.Body.Close()
 	if err != nil {
+		log.Errorf("Failed to close request body: %s", err.Error())
 		http.Error(w, "Failed to finish reading request body", http.StatusInternalServerError)
 	}
 
 	var rq query.RunQuery
 	err = json.Unmarshal(data, &rq)
 	if err != nil {
+		log.Errorf("Failed to unmarshal RunQuery: %s", err.Error())
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -101,7 +106,7 @@ func searchHandler(w http.ResponseWriter, r *http.Request) {
 	//
 	// `ids` and `runs` tracks run IDs and run metadata for requested runs that
 	// are currently resident in `idx`.
-	store, err := getDatastore()
+	store, err := getDatastore(ctx)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Failed to open datastore: %s", err.Error()), http.StatusInternalServerError)
 		return
@@ -220,8 +225,7 @@ func searchHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write(data)
 }
 
-func getDatastore() (shared.Datastore, error) {
-	ctx := context.Background()
+func getDatastore(ctx context.Context) (shared.Datastore, error) {
 	var client *datastore.Client
 	var err error
 	if gcpCredentialsFile != nil && *gcpCredentialsFile != "" {
@@ -278,7 +282,7 @@ func main() {
 
 	http.HandleFunc("/_ah/liveness_check", livenessCheckHandler)
 	http.HandleFunc("/_ah/readiness_check", readinessCheckHandler)
-	http.HandleFunc("/api/search/cache", searchHandler)
+	http.HandleFunc("/api/search/cache", shared.HandleWithGoogleCloudLogging(searchHandler, *projectID))
 	log.Infof("Listening on port %d", *port)
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", *port), nil))
 }

--- a/api/query/cache/service/main.go
+++ b/api/query/cache/service/main.go
@@ -11,22 +11,22 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"runtime"
 	"time"
-
-	"github.com/web-platform-tests/wpt.fyi/api/query"
-	"github.com/web-platform-tests/wpt.fyi/api/query/cache/backfill"
-	"github.com/web-platform-tests/wpt.fyi/api/query/cache/poll"
-	"github.com/web-platform-tests/wpt.fyi/shared"
-	"google.golang.org/api/option"
-
-	"github.com/web-platform-tests/wpt.fyi/api/query/cache/index"
-	"github.com/web-platform-tests/wpt.fyi/api/query/cache/monitor"
-	cq "github.com/web-platform-tests/wpt.fyi/api/query/cache/query"
 
 	"cloud.google.com/go/compute/metadata"
 	"cloud.google.com/go/datastore"
 	"github.com/Hexcles/logrus"
+	"github.com/web-platform-tests/wpt.fyi/api/query"
+	"github.com/web-platform-tests/wpt.fyi/api/query/cache/backfill"
+	"github.com/web-platform-tests/wpt.fyi/api/query/cache/index"
+	"github.com/web-platform-tests/wpt.fyi/api/query/cache/monitor"
+	"github.com/web-platform-tests/wpt.fyi/api/query/cache/poll"
+	cq "github.com/web-platform-tests/wpt.fyi/api/query/cache/query"
+	"github.com/web-platform-tests/wpt.fyi/shared"
+	"google.golang.org/api/option"
+	mrpb "google.golang.org/genproto/googleapis/api/monitoredres"
 )
 
 var (
@@ -49,6 +49,8 @@ var (
 	idx index.Index
 	mon monitor.Monitor
 )
+
+var monitoredResource mrpb.MonitoredResource
 
 func livenessCheckHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte("Alive"))
@@ -252,9 +254,7 @@ func init() {
 	flag.Parse()
 
 	maxRunsPerRequestMsg = fmt.Sprintf("Too many runs specified; maximum is %d.", *maxRunsPerRequest)
-}
 
-func main() {
 	autoProjectID, err := metadata.ProjectID()
 	if err != nil {
 		logrus.Warningf("Failed to get project ID from metadata service")
@@ -269,10 +269,23 @@ func main() {
 		}
 	}
 
+	monitoredResource = mrpb.MonitoredResource{
+		Type: "gae_app",
+		Labels: map[string]string{
+			"project_id": *projectID,
+			// https://cloud.google.com/appengine/docs/flexible/go/migrating#modules
+			"module_id":  os.Getenv("GAE_SERVICE"),
+			"version_id": os.Getenv("GAE_VERSION"),
+		},
+	}
+}
+
+func main() {
 	logrus.Infof("Serving index with %d shards", *numShards)
 	// TODO: Use different field configurations for index, backfiller, monitor?
 	logger := logrus.StandardLogger()
 
+	var err error
 	idx, err = index.NewShardedWPTIndex(index.HTTPReportLoader{}, *numShards)
 	if err != nil {
 		logrus.Fatalf("Failed to instantiate index: %v", err)
@@ -290,7 +303,7 @@ func main() {
 
 	http.HandleFunc("/_ah/liveness_check", livenessCheckHandler)
 	http.HandleFunc("/_ah/readiness_check", readinessCheckHandler)
-	http.HandleFunc("/api/search/cache", shared.HandleWithGoogleCloudLogging(searchHandler, *projectID))
+	http.HandleFunc("/api/search/cache", shared.HandleWithGoogleCloudLogging(searchHandler, *projectID, &monitoredResource))
 	logrus.Infof("Listening on port %d", *port)
 	logrus.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", *port), nil))
 }

--- a/api/query/cache/service/main.go
+++ b/api/query/cache/service/main.go
@@ -26,7 +26,7 @@ import (
 
 	"cloud.google.com/go/compute/metadata"
 	"cloud.google.com/go/datastore"
-	log "github.com/Hexcles/logrus"
+	"github.com/Hexcles/logrus"
 )
 
 var (
@@ -77,6 +77,7 @@ func searchHandler(w http.ResponseWriter, r *http.Request) {
 		log.Errorf("Failed to read request body: %s", err.Error())
 		http.Error(w, "Failed to read request body", http.StatusInternalServerError)
 	}
+	log.Infof(string(data))
 	err = r.Body.Close()
 	if err != nil {
 		log.Errorf("Failed to close request body: %s", err.Error())
@@ -256,31 +257,31 @@ func init() {
 func main() {
 	autoProjectID, err := metadata.ProjectID()
 	if err != nil {
-		log.Warningf("Failed to get project ID from metadata service")
+		logrus.Warningf("Failed to get project ID from metadata service")
 	} else {
 		if *projectID == "" {
-			log.Infof(`Using project ID from metadata service: "%s"`, *projectID)
+			logrus.Infof(`Using project ID from metadata service: "%s"`, *projectID)
 			*projectID = autoProjectID
 		} else if *projectID != autoProjectID {
-			log.Warningf(`Using project ID from flag: "%s" even though metadata service reports project ID of "%s"`, *projectID, autoProjectID)
+			logrus.Warningf(`Using project ID from flag: "%s" even though metadata service reports project ID of "%s"`, *projectID, autoProjectID)
 		} else {
-			log.Infof(`Using project ID: "%s"`, *projectID)
+			logrus.Infof(`Using project ID: "%s"`, *projectID)
 		}
 	}
 
-	log.Infof("Serving index with %d shards", *numShards)
+	logrus.Infof("Serving index with %d shards", *numShards)
 	// TODO: Use different field configurations for index, backfiller, monitor?
-	logger := log.StandardLogger()
+	logger := logrus.StandardLogger()
 
 	idx, err = index.NewShardedWPTIndex(index.HTTPReportLoader{}, *numShards)
 	if err != nil {
-		log.Fatalf("Failed to instantiate index: %v", err)
+		logrus.Fatalf("Failed to instantiate index: %v", err)
 	}
 
 	fetcher := backfill.NewDatastoreRunFetcher(*projectID, gcpCredentialsFile, logger)
 	mon, err = backfill.FillIndex(fetcher, logger, monitor.GoRuntime{}, *monitorInterval, *monitorMaxIngestedRuns, *maxHeapBytes, *evictRunsPercent, idx)
 	if err != nil {
-		log.Fatalf("Failed to initiate index backkfill: %v", err)
+		logrus.Fatalf("Failed to initiate index backkfill: %v", err)
 	}
 
 	// Index, backfiller, monitor now in place. Start polling to load runs added
@@ -290,6 +291,6 @@ func main() {
 	http.HandleFunc("/_ah/liveness_check", livenessCheckHandler)
 	http.HandleFunc("/_ah/readiness_check", readinessCheckHandler)
 	http.HandleFunc("/api/search/cache", shared.HandleWithGoogleCloudLogging(searchHandler, *projectID))
-	log.Infof("Listening on port %d", *port)
-	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", *port), nil))
+	logrus.Infof("Listening on port %d", *port)
+	logrus.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", *port), nil))
 }

--- a/shared/logger.go
+++ b/shared/logger.go
@@ -152,14 +152,6 @@ func GetLogger(ctx context.Context) Logger {
 	return logger
 }
 
-type cloudLoggingClientKeyType struct{}
-
-var cloudLoggingClientKey = cloudLoggingClientKeyType{}
-
-type traceKeyType struct{}
-
-var traceKey = traceKeyType{}
-
 // HandleWithGoogleCloudLogging handles the request with the given handler, setting the logger
 // on the request's context to be a Google Cloud logging client for the given project.
 //

--- a/shared/logger.go
+++ b/shared/logger.go
@@ -8,6 +8,7 @@ import (
 
 	gclog "cloud.google.com/go/logging"
 	log "github.com/Hexcles/logrus"
+	"google.golang.org/appengine"
 	gaelog "google.golang.org/appengine/log"
 	mrpb "google.golang.org/genproto/googleapis/api/monitoredres"
 )
@@ -21,16 +22,18 @@ type Logger interface {
 	Warningf(format string, args ...interface{})
 }
 
+// NewRequestContext creates a new  context bound to an *http.Request.
+func NewRequestContext(r *http.Request) context.Context {
+	ctx := appengine.NewContext(r)
+	return WithLogger(ctx, log.WithFields(log.Fields{
+		"request": r,
+	}))
+}
+
 // SplitLogger is a logger that sends logging operations to both A and B.
 type loggerMux struct {
 	delegates []Logger
 }
-
-type gaeLogger struct {
-	ctx context.Context
-}
-
-type nilLogger struct{}
 
 // Debugf implements formatted debug logging to both A and B.
 func (lm loggerMux) Debugf(format string, args ...interface{}) {
@@ -60,6 +63,17 @@ func (lm loggerMux) Warningf(format string, args ...interface{}) {
 	}
 }
 
+// NewAppEngineContext creates a new Google App Engine Standard-based
+// context bound to an http.Request.
+func NewAppEngineContext(r *http.Request) context.Context {
+	ctx := appengine.NewContext(r)
+	return WithLogger(ctx, NewGAELogger(ctx))
+}
+
+type gaeLogger struct {
+	ctx context.Context
+}
+
 func (l gaeLogger) Debugf(format string, args ...interface{}) {
 	gaelog.Debugf(l.ctx, format, args...)
 }
@@ -75,6 +89,8 @@ func (l gaeLogger) Infof(format string, args ...interface{}) {
 func (l gaeLogger) Warningf(format string, args ...interface{}) {
 	gaelog.Warningf(l.ctx, format, args...)
 }
+
+type nilLogger struct{}
 
 func (l nilLogger) Debugf(format string, args ...interface{}) {}
 
@@ -169,14 +185,11 @@ func NewAppEngineFlexContext(r *http.Request, project string, commonResource *mr
 	if err != nil {
 		return nil, err
 	}
-	ctx = context.WithValue(ctx, cloudLoggingClientKey, client)
-
+	// See https://cloud.google.com/appengine/docs/flexible/go/writing-application-logs
 	traceID := strings.Split(r.Header.Get("X-Cloud-Trace-Context"), "/")[0]
 	if traceID != "" {
 		traceID = fmt.Sprintf("projects/%s/traces/%s", project, traceID)
 	}
-	ctx = context.WithValue(ctx, traceKey, traceID)
-
 	childLogger := client.Logger("request_log_entries", gclog.CommonResource(commonResource))
 	ctx = WithLogger(ctx, &gcLogger{
 		childLogger: childLogger,
@@ -187,14 +200,10 @@ func NewAppEngineFlexContext(r *http.Request, project string, commonResource *mr
 
 type gcLogger struct {
 	childLogger *gclog.Logger
-	maxSeverity gclog.Severity
 	traceID     string
 }
 
 func (gcl *gcLogger) log(severity gclog.Severity, format string, params ...interface{}) {
-	if severity > gcl.maxSeverity {
-		gcl.maxSeverity = severity
-	}
 	gcl.childLogger.Log(gclog.Entry{
 		Severity: severity,
 		Payload:  fmt.Sprintf(format, params...),

--- a/shared/logger.go
+++ b/shared/logger.go
@@ -154,14 +154,16 @@ func HandleWithGoogleCloudLogging(h http.HandlerFunc, project string) http.Handl
 			parentLogger := client.Logger("request")
 			entry := gclog.Entry{
 				HTTPRequest: &gclog.HTTPRequest{
-					Request: r,
+					Request: withLogger,
 					Latency: time.Now().Sub(began),
 				},
+				Timestamp: began,
 			}
-			if childLogger, ok := ctx.Value(DefaultLoggerCtxKey()).(*gcLogger); ok {
-				entry.Severity = childLogger.maxSeverity
-			}
+			gcLogger, _ := ctx.Value(DefaultLoggerCtxKey()).(*gcLogger)
+			entry.Severity = gcLogger.maxSeverity
 			parentLogger.Log(entry)
+			gcLogger.childLogger.Flush()
+			parentLogger.Flush()
 		}
 	}
 }

--- a/shared/logger.go
+++ b/shared/logger.go
@@ -136,10 +136,13 @@ func GetLogger(ctx context.Context) Logger {
 	return logger
 }
 
-var (
-	cloudLoggingClientKey = "holds a gclog.Client"
-	traceKey              = "holds the trace ID for the request"
-)
+type cloudLoggingClientKeyType struct{}
+
+var cloudLoggingClientKey = cloudLoggingClientKeyType{}
+
+type traceKeyType struct{}
+
+var traceKey = traceKeyType{}
 
 // HandleWithGoogleCloudLogging handles the request with the given handler, setting the logger
 // on the request's context to be a Google Cloud logging client for the given project.

--- a/shared/logger.go
+++ b/shared/logger.go
@@ -1,0 +1,200 @@
+package shared
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	gclog "cloud.google.com/go/logging"
+	log "github.com/Hexcles/logrus"
+	gaelog "google.golang.org/appengine/log"
+)
+
+// Logger is an abstract logging interface that contains an intersection of
+// logrus and GAE logging functionality.
+type Logger interface {
+	Debugf(format string, args ...interface{})
+	Errorf(format string, args ...interface{})
+	Infof(format string, args ...interface{})
+	Warningf(format string, args ...interface{})
+}
+
+// SplitLogger is a logger that sends logging operations to both A and B.
+type loggerMux struct {
+	delegates []Logger
+}
+
+type gaeLogger struct {
+	ctx context.Context
+}
+
+type nilLogger struct{}
+
+// Debugf implements formatted debug logging to both A and B.
+func (lm loggerMux) Debugf(format string, args ...interface{}) {
+	for _, l := range lm.delegates {
+		l.Debugf(format, args...)
+	}
+}
+
+// Errorf implements formatted error logging to both A and B.
+func (lm loggerMux) Errorf(format string, args ...interface{}) {
+	for _, l := range lm.delegates {
+		l.Errorf(format, args...)
+	}
+}
+
+// Infof implements formatted info logging to both A and B.
+func (lm loggerMux) Infof(format string, args ...interface{}) {
+	for _, l := range lm.delegates {
+		l.Infof(format, args...)
+	}
+}
+
+// Warningf implements formatted warning logging to both A and B.
+func (lm loggerMux) Warningf(format string, args ...interface{}) {
+	for _, l := range lm.delegates {
+		l.Warningf(format, args...)
+	}
+}
+
+func (l gaeLogger) Debugf(format string, args ...interface{}) {
+	gaelog.Debugf(l.ctx, format, args...)
+}
+
+func (l gaeLogger) Errorf(format string, args ...interface{}) {
+	gaelog.Errorf(l.ctx, format, args...)
+}
+
+func (l gaeLogger) Infof(format string, args ...interface{}) {
+	gaelog.Infof(l.ctx, format, args...)
+}
+
+func (l gaeLogger) Warningf(format string, args ...interface{}) {
+	gaelog.Warningf(l.ctx, format, args...)
+}
+
+func (l nilLogger) Debugf(format string, args ...interface{}) {}
+
+func (l nilLogger) Errorf(format string, args ...interface{}) {}
+
+func (l nilLogger) Infof(format string, args ...interface{}) {}
+
+func (l nilLogger) Warningf(format string, args ...interface{}) {}
+
+// LoggerCtxKey is a key for attaching a Logger to a context.Context.
+type LoggerCtxKey struct{}
+
+var (
+	gl  = gaeLogger{}
+	nl  = nilLogger{}
+	lck = LoggerCtxKey{}
+)
+
+// NewLoggerMux creates a multiplexing Logger that writes all log operations to
+// all delegates.
+func NewLoggerMux(delegates []Logger) Logger {
+	if len(delegates) == 0 {
+		return NewNilLogger()
+	}
+	return loggerMux{delegates}
+}
+
+// NewGAELogger returns a Google App Engine Standard Environment logger bound to
+// the given context.
+func NewGAELogger(ctx context.Context) Logger {
+	return gaeLogger{ctx}
+}
+
+// NewNilLogger returns a new logger that silently ignores all Logger calls.
+func NewNilLogger() Logger {
+	return nl
+}
+
+// DefaultLoggerCtxKey returns the default key where a logger instance should be
+// stored in a context.Context object.
+func DefaultLoggerCtxKey() LoggerCtxKey {
+	return lck
+}
+
+// GetLogger retrieves a non-nil Logger that is appropriate for use in ctx. If
+// ctx does not provide a logger, then a nil-logger is returned.
+func GetLogger(ctx context.Context) Logger {
+	logger, ok := ctx.Value(DefaultLoggerCtxKey()).(Logger)
+	if !ok || logger == nil {
+		log.Warningf("Context without logger: %v; logs will be dropped", ctx)
+		return NewNilLogger()
+	}
+
+	return logger
+}
+
+type cloudLoggerClientKey struct{}
+
+var (
+	clck = cloudLoggerClientKey{}
+)
+
+// HandleWithGoogleCloudLogging handles the request with the given handler, setting the logger
+// on the request's context to be a Google Cloud logging client for the given project.
+func HandleWithGoogleCloudLogging(h http.HandlerFunc, project string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx, err := NewAppEngineFlexContext(r, project)
+		if err != nil {
+			h(w, r)
+			return
+		}
+		withLogger := r.WithContext(ctx)
+		began := time.Now()
+
+		h(w, withLogger)
+
+		// "Parent" log event that spans the child logger's timestamps.
+		if client, ok := ctx.Value(clck).(*gclog.Client); ok {
+			parentLogger := client.Logger("request")
+			parentLogger.Log(gclog.Entry{
+				HTTPRequest: &gclog.HTTPRequest{
+					Request: r,
+					Latency: time.Now().Sub(began),
+				},
+			})
+		}
+	}
+}
+
+// NewAppEngineFlexContext creates a new Google App Engine Flex-based
+// context, with a Google Cloud logger client bound to an http.Request.
+func NewAppEngineFlexContext(r *http.Request, project string) (ctx context.Context, err error) {
+	ctx = r.Context()
+	client, err := gclog.NewClient(ctx, project)
+	if err != nil {
+		return nil, err
+	}
+	ctx = context.WithValue(ctx, clck, client)
+
+	childLogger := client.Logger("request-events")
+	ctx = context.WithValue(ctx, DefaultLoggerCtxKey(), &gcLogger{
+		childLogger: childLogger,
+	})
+	return ctx, nil
+}
+
+type gcLogger struct {
+	childLogger *gclog.Logger
+}
+
+func (gcl *gcLogger) Debugf(format string, params ...interface{}) {
+	gcl.childLogger.StandardLogger(gclog.Debug).Printf(format, params...)
+}
+
+func (gcl *gcLogger) Infof(format string, params ...interface{}) {
+	gcl.childLogger.StandardLogger(gclog.Info).Printf(format, params...)
+}
+
+func (gcl *gcLogger) Warningf(format string, params ...interface{}) {
+	gcl.childLogger.StandardLogger(gclog.Warning).Printf(format, params...)
+}
+
+func (gcl *gcLogger) Errorf(format string, params ...interface{}) {
+	gcl.childLogger.StandardLogger(gclog.Error).Printf(format, params...)
+}

--- a/shared/util.go
+++ b/shared/util.go
@@ -16,7 +16,6 @@ import (
 	log "github.com/Hexcles/logrus"
 	mapset "github.com/deckarep/golang-set"
 	"google.golang.org/appengine"
-	gaelog "google.golang.org/appengine/log"
 )
 
 // ExperimentalLabel is the implicit label present for runs marked 'experimental'.
@@ -94,125 +93,6 @@ func ToStringSlice(set mapset.Set) []string {
 // of which are treated as looking up the latest run for each browser.
 func IsLatest(sha string) bool {
 	return sha == "" || sha == "latest"
-}
-
-// Logger is an abstract logging interface that contains an intersection of
-// logrus and GAE logging functionality.
-type Logger interface {
-	Debugf(format string, args ...interface{})
-	Errorf(format string, args ...interface{})
-	Infof(format string, args ...interface{})
-	Warningf(format string, args ...interface{})
-}
-
-// SplitLogger is a logger that sends logging operations to both A and B.
-type loggerMux struct {
-	delegates []Logger
-}
-
-type gaeLogger struct {
-	ctx context.Context
-}
-
-type nilLogger struct{}
-
-// Debugf implements formatted debug logging to both A and B.
-func (lm loggerMux) Debugf(format string, args ...interface{}) {
-	for _, l := range lm.delegates {
-		l.Debugf(format, args...)
-	}
-}
-
-// Errorf implements formatted error logging to both A and B.
-func (lm loggerMux) Errorf(format string, args ...interface{}) {
-	for _, l := range lm.delegates {
-		l.Errorf(format, args...)
-	}
-}
-
-// Infof implements formatted info logging to both A and B.
-func (lm loggerMux) Infof(format string, args ...interface{}) {
-	for _, l := range lm.delegates {
-		l.Infof(format, args...)
-	}
-}
-
-// Warningf implements formatted warning logging to both A and B.
-func (lm loggerMux) Warningf(format string, args ...interface{}) {
-	for _, l := range lm.delegates {
-		l.Warningf(format, args...)
-	}
-}
-
-func (l gaeLogger) Debugf(format string, args ...interface{}) {
-	gaelog.Debugf(l.ctx, format, args...)
-}
-
-func (l gaeLogger) Errorf(format string, args ...interface{}) {
-	gaelog.Errorf(l.ctx, format, args...)
-}
-
-func (l gaeLogger) Infof(format string, args ...interface{}) {
-	gaelog.Infof(l.ctx, format, args...)
-}
-
-func (l gaeLogger) Warningf(format string, args ...interface{}) {
-	gaelog.Warningf(l.ctx, format, args...)
-}
-
-func (l nilLogger) Debugf(format string, args ...interface{}) {}
-
-func (l nilLogger) Errorf(format string, args ...interface{}) {}
-
-func (l nilLogger) Infof(format string, args ...interface{}) {}
-
-func (l nilLogger) Warningf(format string, args ...interface{}) {}
-
-// LoggerCtxKey is a key for attaching a Logger to a context.Context.
-type LoggerCtxKey struct{}
-
-var (
-	gl  = gaeLogger{}
-	nl  = nilLogger{}
-	lck = LoggerCtxKey{}
-)
-
-// NewLoggerMux creates a multiplexing Logger that writes all log operations to
-// all delegates.
-func NewLoggerMux(delegates []Logger) Logger {
-	if len(delegates) == 0 {
-		return NewNilLogger()
-	}
-	return loggerMux{delegates}
-}
-
-// NewGAELogger returns a Google App Engine Standard Environment logger bound to
-// the given context.
-func NewGAELogger(ctx context.Context) Logger {
-	return gaeLogger{ctx}
-}
-
-// NewNilLogger returns a new logger that silently ignores all Logger calls.
-func NewNilLogger() Logger {
-	return nl
-}
-
-// DefaultLoggerCtxKey returns the default key where a logger instance should be
-// stored in a context.Context object.
-func DefaultLoggerCtxKey() LoggerCtxKey {
-	return lck
-}
-
-// GetLogger retrieves a non-nil Logger that is appropriate for use in ctx. If
-// ctx does not provide a logger, then a nil-logger is returned.
-func GetLogger(ctx context.Context) Logger {
-	logger, ok := ctx.Value(DefaultLoggerCtxKey()).(Logger)
-	if !ok || logger == nil {
-		log.Warningf("Context without logger: %v; logs will be dropped", ctx)
-		return NewNilLogger()
-	}
-
-	return logger
 }
 
 // NewAppEngineContext creates a new Google App Engine Standard-based

--- a/shared/util.go
+++ b/shared/util.go
@@ -5,17 +5,13 @@
 package shared
 
 import (
-	"context"
 	"errors"
 	"fmt"
-	"net/http"
 	"reflect"
 	"regexp"
 	"strings"
 
-	log "github.com/Hexcles/logrus"
 	mapset "github.com/deckarep/golang-set"
-	"google.golang.org/appengine"
 )
 
 // ExperimentalLabel is the implicit label present for runs marked 'experimental'.
@@ -93,23 +89,6 @@ func ToStringSlice(set mapset.Set) []string {
 // of which are treated as looking up the latest run for each browser.
 func IsLatest(sha string) bool {
 	return sha == "" || sha == "latest"
-}
-
-// NewAppEngineContext creates a new Google App Engine Standard-based
-// context bound to an http.Request.
-func NewAppEngineContext(r *http.Request) context.Context {
-	ctx := appengine.NewContext(r)
-	ctx = context.WithValue(ctx, DefaultLoggerCtxKey(), NewGAELogger(ctx))
-	return ctx
-}
-
-// NewRequestContext creates a new  context bound to an *http.Request.
-func NewRequestContext(r *http.Request) context.Context {
-	ctx := appengine.NewContext(r)
-	ctx = context.WithValue(ctx, DefaultLoggerCtxKey(), log.WithFields(log.Fields{
-		"request": r,
-	}))
-	return ctx
 }
 
 // NewSetFromStringSlice is a helper for the inability to cast []string to []interface{}


### PR DESCRIPTION
We already have an nginx "parent" request log spanning the request's duration.

This PR creates a gcloud logging client, for which all entries are aggregated by the request that they belong to (by replicating its traceId).

To verify:
- Visit appengine logs for `GAE application > searchcache > logging`
- Run a request that will be logged, e.g. `curl -X POST -d '{"run_ids":[5418908555149312,6317650003099648,5797013731934208,6197500226568192],"query":{"exists":[{"contains":"shadowRoot"}]}}' https://logging-dot-searchcache-dot-wptdashboard-staging.appspot.com/api/search/cache`
- See the log, expand, see child logs including the error.

Caveat: If we use the existing "parent" log from nginx, we are not able to set an overarching status (of the most severe log level from the "child" logs).
The alternative, of producing a parent log too, was tried but causes a double-entry (nginx vs request_log), which isn't more desirable.