### PR TITLE
[processor] Fix an uncaught exception

### DIFF
--- a/results-processor/processor.py
+++ b/results-processor/processor.py
@@ -154,6 +154,8 @@ class Processor(object):
 
     def _download_azure(self, azure_url):
         artifact = self._download_http(azure_url)
+        if artifact is None:
+            return
         with zipfile.ZipFile(artifact, mode='r') as z:
             for f in z.infolist():
                 # ZipInfo.is_dir isn't available in Python 3.5.

--- a/results-processor/processor_test.py
+++ b/results-processor/processor_test.py
@@ -51,12 +51,6 @@ class ProcessorTest(unittest.TestCase):
             p._download_http = self.fake_download(
                 'https://wpt.fyi/artifact.zip', 'artifact_test.zip')
 
-            # Test error handling.
-            with self.assertRaises(AssertionError):
-                p.download(['https://wpt.fyi/test.json.gz'],
-                           [],
-                           'https://wpt.fyi/artifact.zip')
-
             p.download([], [], 'https://wpt.fyi/artifact.zip')
             self.assertEqual(len(p.results), 2)
             self.assertTrue(p.results[0].endswith(
@@ -68,6 +62,22 @@ class ProcessorTest(unittest.TestCase):
                 '/artifact_test/wpt_screenshot_1.txt'))
             self.assertTrue(p.screenshots[1].endswith(
                 '/artifact_test/wpt_screenshot_2.txt'))
+
+    def test_download_azure_errors(self):
+        with Processor() as p:
+            p._download_gcs = self.fake_download(None, None)
+            p._download_http = self.fake_download(
+                'https://wpt.fyi/artifact.zip', None)
+
+            # Incorrect param combinations (both results & azure_url):
+            with self.assertRaises(AssertionError):
+                p.download(['https://wpt.fyi/test.json.gz'],
+                           [],
+                           'https://wpt.fyi/artifact.zip')
+
+            # Download failure: no exceptions should be raised.
+            p.download([], [], 'https://wpt.fyi/artifact.zip')
+            self.assertEqual(len(p.results), 0)
 
 
 class ProcessorServerTest(unittest.TestCase):


### PR DESCRIPTION
when Azure artifact cannot be downloaded.

## Review Information

Simple change with tests without observable changes.