### PR TITLE
Fix cleanup script by forcing an unshallow fetch

### DIFF
--- a/util/cleanup-versions.sh
+++ b/util/cleanup-versions.sh
@@ -23,9 +23,6 @@ function cleanup() {
   local FILTER_ARG="traffic_split=0.0 last_deployed_time.datetime<$CUTOFF"
   local versions_to_delete=()
 
-  # Ensure remote branches are fetched.
-  git fetch origin
-
   for version in $( gcloud app versions list $PROJECT_ARG $SERVICE_ARG --filter="$FILTER_ARG" --format="value(id)" ); do
     if ! git show-ref --quiet --verify refs/remotes/origin/$version; then
       debug "'$version' is not a branch in upstream and will be deleted."
@@ -47,6 +44,9 @@ REMOTE_URL=$(git remote get-url origin)
 if [[ $REMOTE_URL != *web-platform-tests/wpt.fyi* ]]; then
   fatal "origin isn't web-platform-tests/wpt.fyi" 1
 fi
+
+# Ensure ALL remote branches are fetched.
+git fetch --unshallow origin
 
 cleanup "default"
 cleanup "processor"


### PR DESCRIPTION
Travis by default uses `git clone --depth=50` which will affect all
future `git fetch` in this checkout. We need to explicitly add
`--unshallow` to make sure branches older than 50 commits ago can also
be fetched.

e.g. https://travis-ci.com/web-platform-tests/wpt.fyi/jobs/195992237#L417
This job will later go on deleting `smaller` incorrectly.