### PR TITLE
Remove go.mod, which leads to an old version of logrus

### DIFF
--- a/api/query/cache/index/go.mod
+++ b/api/query/cache/index/go.mod
@@ -1,3 +1,0 @@
-module github.com/web-platform-tests/wpt.fyi/api/query/cache/index
-
-require github.com/dgryski/go-farm v0.0.0-20190323231341-8198c7b169ec // indirect


### PR DESCRIPTION
My visual Studio Code kept parsing go.mod and it leads to an older version of logrus that causes breakage.