### PR TITLE
[processor] Support the new "edgechromium" product

### DIFF
--- a/results-processor/wptreport.py
+++ b/results-processor/wptreport.py
@@ -524,10 +524,11 @@ def prepare_labels(report: WPTReport,
     return labels
 
 
-def normalize_product(report):
-    """Normalizes the product identifier.
+def normalize_product(report: WPTReport) -> Set[str]:
+    """Normalizes the product identifier in the report.
 
-    Computes what labels need to be added while normalizing the product.
+    In addition to modifying the 'product' of the report, this function also
+    returns a set of labels that need to be added.
 
     Args:
         report: A WPTReport
@@ -536,10 +537,12 @@ def normalize_product(report):
        A set of strings.
     """
     product = report.run_info['product']
-    if "_" in product:
-        tokens = product.split("_")
-        report.run_info['product'] = tokens[0]
-        return set(tokens)
+    if product == 'edge_webdriver':
+        report.run_info['product'] = 'edge'
+        return {'edge', 'webdriver', 'edge_webdriver'}
+    elif product == 'edgechromium':
+        report.run_info['product'] = 'edge'
+        return {'edge', 'edgechromium'}
     else:
         return set()
 

--- a/results-processor/wptreport_test.py
+++ b/results-processor/wptreport_test.py
@@ -588,7 +588,7 @@ class HelpersTest(unittest.TestCase):
             {'beta', 'blade-runner', 'firefox'}
         )
 
-    def test_normalize_product(self):
+    def test_normalize_product_edge_webdriver(self):
         r = WPTReport()
         r._report = {
             'run_info': {
@@ -597,7 +597,23 @@ class HelpersTest(unittest.TestCase):
         }
         self.assertSetEqual(
             normalize_product(r),
-            {'edge', 'webdriver'}
+            {'edge', 'webdriver', 'edge_webdriver'}
+        )
+        self.assertEqual(
+            r.run_info['product'],
+            'edge'
+        )
+
+    def test_normalize_product_edgechromium(self):
+        r = WPTReport()
+        r._report = {
+            'run_info': {
+                'product': 'edgechromium',
+            }
+        }
+        self.assertSetEqual(
+            normalize_product(r),
+            {'edge', 'edgechromium'}
         )
         self.assertEqual(
             r.run_info['product'],


### PR DESCRIPTION
Treat it similar to "edge_webdriver" (i.e. consider it as Edge).

The product was added to WPT in
https://github.com/web-platform-tests/wpt/pull/16691 .
