### PR TITLE
Improve caching for npm packages and hide SW installer behind a flag

### DIFF
--- a/webapp/app.yaml
+++ b/webapp/app.yaml
@@ -32,6 +32,10 @@ handlers:
   static_files: service-worker-installer.js
   upload: service-worker-installer.js
   secure: always
+- url: /service-worker-uninstaller.js
+  static_files: service-worker-uninstaller.js
+  upload: service-worker-uninstaller.js
+  secure: always
 - url: /favicon.ico
   static_files: static/favicon.ico
   upload: static/favicon.ico

--- a/webapp/app.yaml
+++ b/webapp/app.yaml
@@ -16,19 +16,17 @@ default_expiration: "1d"
 
 # Also refer to dispatch.yaml for higher-priority routing rules.
 handlers:
-  # Special dynamic components:
+# Special dynamic components:
 - url: /components/wpt-env-flags.js
   script: _go_app
   secure: always
-  # Static files:
-- url: /components
-  static_dir: components
+- url: /node_modules/.*
+  script: _go_app
   secure: always
+
+# Static files:
 - url: /static
   static_dir: static
-  secure: always
-- url: /views
-  static_dir: views
   secure: always
 - url: /service-worker-installer.js
   static_files: service-worker-installer.js
@@ -38,12 +36,23 @@ handlers:
   static_files: static/favicon.ico
   upload: static/favicon.ico
   secure: always
-  # Admin-only pages:
+# Static files that change often (i.e. our own code).
+- url: /components
+  static_dir: components
+  expiration: 10m
+  secure: always
+- url: /views
+  static_dir: views
+  expiration: 10m
+  secure: always
+
+# Admin-only pages:
 - url: /admin/.*
   script: _go_app
   secure: always
   login: admin
-  # Everything else (templates & APIs):
+
+# Everything else (templates & APIs):
 - url: /.*
   script: _go_app
   secure: always

--- a/webapp/components_handler.go
+++ b/webapp/components_handler.go
@@ -33,6 +33,8 @@ func componentsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	bytes = packageRegex.ReplaceAll(bytes, []byte(packageRegexReplacement))
-	w.Header().Add("Content-Type", mime.TypeByExtension(filepath.Ext(filePath)))
+	// Cache up to a day (same as the default expiration in app.yaml).
+	w.Header().Set("Cache-Control", "public, max-age=86400")
+	w.Header().Set("Content-Type", mime.TypeByExtension(filepath.Ext(filePath)))
 	w.Write(bytes)
 }

--- a/webapp/interop_handler.go
+++ b/webapp/interop_handler.go
@@ -11,13 +11,13 @@ import (
 // interopHandler handles the view of test results broken down by the
 // number of browsers for which the test passes.
 func interopHandler(w http.ResponseWriter, r *http.Request) {
-	filter, err := parseTestResultsUIFilter(r)
+	data, err := populateTemplateData(r)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	if err := templates.ExecuteTemplate(w, "index.html", filter); err != nil {
+	if err := templates.ExecuteTemplate(w, "index.html", data); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 }

--- a/webapp/service-worker-uninstaller.js
+++ b/webapp/service-worker-uninstaller.js
@@ -1,0 +1,8 @@
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.getRegistrations().then(registrations => {
+    for (const reg of registrations) {
+      reg.unregister();
+      console.log('Service worker uninstalled');
+    }
+  });
+}

--- a/webapp/templates/_head_common.html
+++ b/webapp/templates/_head_common.html
@@ -2,4 +2,8 @@
 <link rel="stylesheet" href="/static/common.css">
 <script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 <script type="module" src="/components/wpt-header.js"></script>
-{{if .EnableServiceWorker}}<script src="/service-worker-installer.js"></script>{{end}}
+{{if .EnableServiceWorker}}
+<script src="/service-worker-installer.js"></script>
+{{else}}
+<script src="/service-worker-uninstaller.js"></script>
+{{end}}

--- a/webapp/templates/_head_common.html
+++ b/webapp/templates/_head_common.html
@@ -2,4 +2,4 @@
 <link rel="stylesheet" href="/static/common.css">
 <script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 <script type="module" src="/components/wpt-header.js"></script>
-<script src="/service-worker-installer.js"></script>
+{{if .EnableServiceWorker}}<script src="/service-worker-installer.js"></script>{{end}}

--- a/webapp/test_results_handler.go
+++ b/webapp/test_results_handler.go
@@ -32,10 +32,11 @@ type testRunUIFilter struct {
 	TestRuns string
 }
 
-type testResultsUIFilter struct {
+type templateData struct {
 	testRunUIFilter
-	Diff       bool
-	DiffFilter string
+	Diff                bool
+	DiffFilter          string
+	EnableServiceWorker bool
 }
 
 // This handler is responsible for all pages that display test results.
@@ -63,24 +64,25 @@ func testResultsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	filter, err := parseTestResultsUIFilter(r)
+	data, err := populateTemplateData(r)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	if err := templates.ExecuteTemplate(w, "index.html", filter); err != nil {
+	if err := templates.ExecuteTemplate(w, "index.html", data); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 }
 
-// parseTestResultsUIFilter parses the standard TestRunFilter, as well as the extra
-// diff params (diff, before, after).
-func parseTestResultsUIFilter(r *http.Request) (filter testResultsUIFilter, err error) {
+// populateTemplateData parses the standard TestRunFilter from the incoming
+// request, as well as the extra diff params (diff, before, after) & flags, to
+// populate the template data used for rendering.
+func populateTemplateData(r *http.Request) (data templateData, err error) {
 	q := r.URL.Query()
 	testRunFilter, err := shared.ParseTestRunFilterParams(q)
 	if err != nil {
-		return filter, err
+		return data, err
 	}
 	ctx := shared.NewAppEngineContext(r)
 	aeAPI := shared.NewAppEngineAPI(ctx)
@@ -88,20 +90,20 @@ func parseTestResultsUIFilter(r *http.Request) (filter testResultsUIFilter, err 
 	var pr *int
 	pr, err = shared.ParsePRParam(q)
 	if err != nil {
-		return filter, err
+		return data, err
 	}
 
 	runIDs, err := shared.ParseRunIDsParam(q)
 	if err != nil {
-		return filter, err
+		return data, err
 	}
 
 	if len(runIDs) > 0 {
 		marshalled, err := json.Marshal(runIDs)
 		if err != nil {
-			return filter, err
+			return data, err
 		}
-		filter.TestRunIDs = string(marshalled)
+		data.TestRunIDs = string(marshalled)
 	} else {
 		if pr == nil && testRunFilter.IsDefaultQuery() {
 			experimentalByDefault := aeAPI.IsFeatureEnabled("experimentalByDefault")
@@ -118,38 +120,40 @@ func parseTestResultsUIFilter(r *http.Request) (filter testResultsUIFilter, err 
 			testRunFilter = testRunFilter.MasterOnly()
 		}
 
-		filter.testRunUIFilter = convertTestRunUIFilter(testRunFilter)
-		filter.PR = pr
+		data.testRunUIFilter = convertTestRunUIFilter(testRunFilter)
+		data.PR = pr
 	}
 
 	diff, err := shared.ParseBooleanParam(q, "diff")
 	if err != nil {
-		return filter, err
+		return data, err
 	}
-	filter.Diff = diff != nil && *diff
-	if filter.Diff {
+	data.Diff = diff != nil && *diff
+	if data.Diff {
 		diffFilter, _, err := shared.ParseDiffFilterParams(q)
 		if err != nil {
-			return filter, err
+			return data, err
 		}
-		filter.DiffFilter = diffFilter.String()
+		data.DiffFilter = diffFilter.String()
 	}
 
 	var beforeAndAfter shared.ProductSpecs
 	if beforeAndAfter, err = shared.ParseBeforeAndAfterParams(q); err != nil {
-		return filter, err
+		return data, err
 	} else if len(beforeAndAfter) > 0 {
 		var bytes []byte
 		if bytes, err = json.Marshal(beforeAndAfter.Strings()); err != nil {
-			return filter, err
+			return data, err
 		}
-		filter.Products = string(bytes)
-		filter.Diff = true
+		data.Products = string(bytes)
+		data.Diff = true
 	}
 
-	filter.Search = r.URL.Query().Get("q")
+	data.Search = r.URL.Query().Get("q")
 
-	return filter, nil
+	data.EnableServiceWorker = aeAPI.IsFeatureEnabled("serviceWorker")
+
+	return data, nil
 }
 
 func convertTestRunUIFilter(testRunFilter shared.TestRunFilter) (filter testRunUIFilter) {

--- a/webapp/test_results_handler_medium_test.go
+++ b/webapp/test_results_handler_medium_test.go
@@ -14,43 +14,43 @@ import (
 	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
 )
 
-func TestParseTestResultsUIFilter(t *testing.T) {
+func TestPopulateTemplateData(t *testing.T) {
 	i, err := sharedtest.NewAEInstance(true)
 	assert.Nil(t, err)
 	defer i.Close()
 	r, _ := i.NewRequest("GET", "/results/?max-count=3", nil)
 	assert.Nil(t, err)
 
-	f, err := parseTestResultsUIFilter(r)
+	f, err := populateTemplateData(r)
 	assert.Nil(t, err)
 	assert.True(t, f.MaxCount != nil && *f.MaxCount == 3)
 
 	r, _ = i.NewRequest("GET", "/results/?products=chrome,safari&diff", nil)
-	f, err = parseTestResultsUIFilter(r)
+	f, err = populateTemplateData(r)
 	assert.Nil(t, err)
 	assert.Equal(t, "[\"chrome\",\"safari\"]", f.Products)
 	assert.Equal(t, true, f.Diff)
 
 	r, _ = i.NewRequest("GET", "/results/?before=chrome&after=chrome[experimental]", nil)
-	f, err = parseTestResultsUIFilter(r)
+	f, err = populateTemplateData(r)
 	assert.Nil(t, err)
 	assert.Equal(t, "[\"chrome\",\"chrome[experimental]\"]", f.Products)
 	assert.Equal(t, true, f.Diff)
 
 	r, _ = i.NewRequest("GET", "/results/?after=chrome&before=edge", nil)
-	f, err = parseTestResultsUIFilter(r)
+	f, err = populateTemplateData(r)
 	assert.Nil(t, err)
 	assert.Equal(t, "[\"edge\",\"chrome\"]", f.Products)
 	assert.Equal(t, true, f.Diff)
 
 	// MasterOnly default query.
 	r, _ = i.NewRequest("GET", "/results/", nil)
-	f, err = parseTestResultsUIFilter(r)
+	f, err = populateTemplateData(r)
 	assert.Nil(t, err)
 	assert.Contains(t, f.Labels, shared.MasterLabel)
 
 	r, _ = i.NewRequest("GET", "/results/?sha=0123456789", nil)
-	f, err = parseTestResultsUIFilter(r)
+	f, err = populateTemplateData(r)
 	assert.Nil(t, err)
 	assert.NotContains(t, f.Labels, shared.MasterLabel)
 }


### PR DESCRIPTION
## Description

The main purpose of this PR is to improve the page load speed without (re)enabling the service worker (since we still have some cache invalidation bugs in our SW).

This is done via two approaches:
* Enable caching for `node_modules`.
* Do not load `service-worker-installer.js` if service worker isn't enabled (this saves both two unnecessary script loads and a console error).

## Review Information

Review the two commits separately. The second commit contains a refactor (renaming) of a private struct (as well as the function that populates it) to better reflect its meaning.

Open the staging instance. You shouldn't see any network errors in the console.