### PR TITLE
add prs back

### DIFF
--- a/webapp/views/wpt-app.js
+++ b/webapp/views/wpt-app.js
@@ -71,6 +71,12 @@ class WPTApp extends WPTFlags(TestRunsUIQuery(PolymerElement)) {
           </template>
         </div>
 
+      <template is="dom-if" if="[[searchPRsForDirectories]]">
+        <template is="dom-if" if="[[pathIsASubfolder]]">
+          <wpt-prs path="[[path]]"></wpt-prs>
+        </template>
+      </template>
+
         <paper-spinner-lite active="[[isLoading]]" class="blue"></paper-spinner-lite>
 
         <test-search query="[[search]]"

--- a/webapp/views/wpt-app.js
+++ b/webapp/views/wpt-app.js
@@ -71,11 +71,11 @@ class WPTApp extends WPTFlags(TestRunsUIQuery(PolymerElement)) {
           </template>
         </div>
 
-      <template is="dom-if" if="[[searchPRsForDirectories]]">
-        <template is="dom-if" if="[[pathIsASubfolder]]">
-          <wpt-prs path="[[path]]"></wpt-prs>
+        <template is="dom-if" if="[[searchPRsForDirectories]]">
+          <template is="dom-if" if="[[pathIsASubfolder]]">
+            <wpt-prs path="[[path]]"></wpt-prs>
+          </template>
         </template>
-      </template>
 
         <paper-spinner-lite active="[[isLoading]]" class="blue"></paper-spinner-lite>
 


### PR DESCRIPTION
Restore accidentally deleted PRs list feature. 

## Description
PRs list feature is accidentally deleted in PR,  #1295 

## Review Information

- Visit https://pr-list-dot-wptdashboard-staging.appspot.com/flags
- Enable the feature for listing PRs in directories
- Go to a test folder with open PRs, e.g.  /screen-capture
