### PR TITLE
Fix `npm install` in Docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,11 +92,10 @@ webdriver_node_deps:
 
 # _go_webdriver_test is not intended to be used directly; use go_firefox_test or
 # go_chrome_test instead.
-_go_webdriver_test: var-BROWSER java go_build_test xvfb node-web-component-tester webserver_deps
+_go_webdriver_test: var-BROWSER java go_build_test xvfb geckodriver webserver_deps
 	# This Go test manages Xvfb itself, so we don't start/stop Xvfb for it.
 	# The following variables are defined here because we don't know the
-	# paths before installing node-web-component-tester as the paths
-	# include version strings.
+	# path before installing geckodriver as it includes version strings.
 	GECKODRIVER_PATH="$(shell find $(NODE_SELENIUM_PATH)geckodriver/ -type f -name '*geckodriver')"; \
 	cd $(WPTD_PATH)webdriver; \
 	go test $(VERBOSE) -timeout=15m -tags=large -args \
@@ -225,7 +224,7 @@ gcloud: python curl gpg
 		gcloud config set disable_usage_reporting false; \
 	fi
 
-eslint: node-babel-eslint node-eslint node-eslint-plugin-html
+eslint: webapp_node_modules_all
 	cd $(WPTD_PATH)webapp; npm run lint
 
 dev_data: FLAGS := -remote_host=staging.wpt.fyi

--- a/Makefile
+++ b/Makefile
@@ -261,10 +261,10 @@ deploy_production: deployment_state
 	rm -rf $(WPTD_PATH)api/query/cache/service/wpt.fyi
 
 webapp_node_modules: node
-	cd $(WPTD_PATH)webapp; npm install --production
+	cd $(WPTD_PATH)webapp; npm install --production --unsafe-perm=true
 
 webapp_node_modules_all: node
-	cd $(WPTD_PATH)webapp; npm install
+	cd $(WPTD_PATH)webapp; npm install --unsafe-perm=true
 
 webapp_node_modules_prune: webapp_node_modules
 	cd $(WPTD_PATH)webapp; npm prune --production
@@ -290,7 +290,7 @@ gcloud-%: gcloud
 node-%: node
 	@ echo "# Installing $*..."
 	# Hack to (more quickly) detect whether a package is already installed (available in node).
-	cd $(WPTD_PATH)webapp; node -p "require('$*/package.json').version" 2>/dev/null || npm install --no-save $*
+	cd $(WPTD_PATH)webapp; node -p "require('$*/package.json').version" 2>/dev/null || npm install --no-save --unsafe-perm=true $*
 
 apt-get-%:
 	if [[ "$$(which $*)" == "" ]]; then sudo apt-get install -qqy --no-install-suggests $*; fi

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,6 @@ web_components_test: xvfb firefox chrome webapp_node_modules_all apt-get-psmisc
 
 sys_update: apt_update | sys_deps
 	gcloud components update
-	sudo npm install -g npm
 
 apt_update:
 	sudo apt-get --quiet update

--- a/Makefile
+++ b/Makefile
@@ -264,7 +264,7 @@ webapp_node_modules: node
 	cd $(WPTD_PATH)webapp; npm install --production --unsafe-perm=true
 
 webapp_node_modules_all: node
-	cd $(WPTD_PATH)webapp; npm install --unsafe-perm=true
+	cd $(WPTD_PATH)webapp; npm install --unsafe-perm=true --verbose
 
 webapp_node_modules_prune: webapp_node_modules
 	cd $(WPTD_PATH)webapp; npm prune --production

--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ package_service: var-APP_PATH
 		rm -rf $${TMP_DIR}; \
 	fi
 
-sys_deps: apt-update
+sys_deps: apt_update
 	make gcloud
 	make git
 	make node

--- a/Makefile
+++ b/Makefile
@@ -264,7 +264,7 @@ webapp_node_modules: node
 	cd $(WPTD_PATH)webapp; npm install --production --unsafe-perm=true
 
 webapp_node_modules_all: node
-	cd $(WPTD_PATH)webapp; npm install --unsafe-perm=true --verbose
+	cd $(WPTD_PATH)webapp; npm install --unsafe-perm=true --verbose --allow-root
 
 webapp_node_modules_prune: webapp_node_modules
 	cd $(WPTD_PATH)webapp; npm prune --production

--- a/Makefile
+++ b/Makefile
@@ -78,11 +78,11 @@ go_large_test:
 	make go_firefox_test
 	make go_chrome_test
 
-go_firefox_test: BROWSER := firefox
-go_firefox_test: firefox geckodriver | _go_webdriver_test
+go_firefox_test: firefox geckodriver
+	make _go_webdriver_test BROWSER=firefox
 
-go_chrome_test: BROWSER := chrome
-go_chrome_test: chrome chromedriver | _go_webdriver_test
+go_chrome_test: chrome chromedriver
+	make _go_webdriver_test BROWSER=chrome
 
 puppeteer_chrome_test: chrome webserver_deps webdriver_node_deps
 	cd webdriver; npm test
@@ -112,12 +112,6 @@ _go_webdriver_test: var-BROWSER java go_build_test xvfb geckodriver webserver_de
 web_components_test: xvfb firefox chrome webapp_node_modules_all apt-get-psmisc
 	util/wct.sh $(USE_FRAME_BUFFER)
 
-sys_update: apt_update | sys_deps
-	gcloud components update
-
-apt_update:
-	sudo apt-get --quiet update
-
 # Dependencies for running dev_appserver.py.
 webserver_deps: webapp_deps dev_appserver_deps
 
@@ -129,9 +123,9 @@ chrome: wget
 	if [[ -z "$$(which google-chrome)" ]]; then \
 		ARCHIVE=google-chrome-stable_current_amd64.deb; \
 		wget -q https://dl.google.com/linux/direct/$${ARCHIVE}; \
-		sudo dpkg --install $${ARCHIVE} || true; \
+		sudo dpkg --install $${ARCHIVE} 2>/dev/null || true; \
 		sudo apt-get install --fix-broken -qqy; \
-		sudo dpkg --install $${ARCHIVE}; \
+		sudo dpkg --install $${ARCHIVE} 2>/dev/null; \
 	fi
 
 # https://sites.google.com/a/chromium.org/chromedriver/downloads/version-selection
@@ -185,7 +179,13 @@ package_service: var-APP_PATH
 		rm -rf $${TMP_DIR}; \
 	fi
 
-sys_deps: curl gpg node gcloud git
+sys_deps: apt-update
+	make gcloud
+	make git
+	make node
+
+apt_update:
+	sudo apt-get -qq update
 
 curl: apt-get-curl
 git: apt-get-git

--- a/util/docker-dev/run.sh
+++ b/util/docker-dev/run.sh
@@ -106,9 +106,7 @@ if [[ "${INSPECT_STATUS}" != 0 ]] || [[ "${PR}" == "r" ]]; then
       -p "${WPTD_HOST_API_WEB_PORT}:9999" \
       --name "${DOCKER_INSTANCE}" wptd-dev
   info "Setting up local user"
-  echo "On host: `id`"
   wptd_useradd
-  wptd_exec id
 
   info "Ensuring the home directory is owned by the user..."
   wptd_chown "/home/user"

--- a/util/docker-dev/run.sh
+++ b/util/docker-dev/run.sh
@@ -112,7 +112,6 @@ if [[ "${INSPECT_STATUS}" != 0 ]] || [[ "${PR}" == "r" ]]; then
 
   info "Ensuring the home directory is owned by the user..."
   wptd_chown "/home/user"
-  wptd_exec ls -l /home/user/.npm
 
   info "Instance ${DOCKER_INSTANCE} started."
 elif [[ "${RUNNING_STATUS}" != "0" ]]; then
@@ -126,6 +125,7 @@ fi
 
 info "Updating system/packages..."
 wptd_exec make sys_update
+wptd_exec ls -l /home/user/.npm
 
 if [[ "${DAEMON}" == "true" ]]; then
   exit 0

--- a/util/docker-dev/run.sh
+++ b/util/docker-dev/run.sh
@@ -124,8 +124,7 @@ else
 fi
 
 info "Updating system/packages..."
-wptd_exec make sys_update
-wptd_exec ls -l /home/user/.npm
+wptd_exec make sys_deps
 
 if [[ "${DAEMON}" == "true" ]]; then
   exit 0

--- a/util/docker-dev/run.sh
+++ b/util/docker-dev/run.sh
@@ -106,10 +106,13 @@ if [[ "${INSPECT_STATUS}" != 0 ]] || [[ "${PR}" == "r" ]]; then
       -p "${WPTD_HOST_API_WEB_PORT}:9999" \
       --name "${DOCKER_INSTANCE}" wptd-dev
   info "Setting up local user"
+  echo "On host: `id`"
   wptd_useradd
+  wptd_exec id
 
   info "Ensuring the home directory is owned by the user..."
   wptd_chown "/home/user"
+  wptd_exec ls -l /home/user/.npm
 
   info "Instance ${DOCKER_INSTANCE} started."
 elif [[ "${RUNNING_STATUS}" != "0" ]]; then

--- a/webapp/views/wpt-app.js
+++ b/webapp/views/wpt-app.js
@@ -1,3 +1,4 @@
+// DO NOT MERGE
 import '../components/test-runs-query-builder.js';
 import { TestRunsUIQuery } from '../components/test-runs-query.js';
 import '../components/test-search.js';

--- a/webapp/views/wpt-app.js
+++ b/webapp/views/wpt-app.js
@@ -1,4 +1,3 @@
-// DO NOT MERGE
 import '../components/test-runs-query-builder.js';
 import { TestRunsUIQuery } from '../components/test-runs-query.js';
 import '../components/test-search.js';


### PR DESCRIPTION
Fixes #1330. The root cause is described in details at https://github.com/web-platform-tests/wpt.fyi/issues/1330#issuecomment-497486923

This PR removes `sys_update` altogether, which is causing too much trouble. Moving forward, we do NOT support updating the dev Docker instance in place.

Along the way, I also found out some other hidden bugs in our `Makefile` that may cause trouble in the future:

1. Apparently, we misunderstood [*order-only prerequisites*](https://www.gnu.org/software/make/manual/html_node/Prerequisite-Types.html) in `Makefile`. They don't actually guarantee the execution order (to be before or after the other prerequisites). We need to use sub-make to ensure the order.
2. We have a silent name collision between `gcloud-login` and `gcloud-%` whose behaviour depends on the order of definition (and perhaps the implementation).

They are fixed in this PR, too.