### PR TITLE
Revert "Disable puppeterr_chrome_test"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,8 @@ matrix:
     - env:
         - MAKE_TEST_TARGET=go_chrome_test
     - env:
+        - MAKE_TEST_TARGET=puppeteer_chrome_test
+    - env:
         - MAKE_TEST_TARGET=lint
     - env:
         - MAKE_TEST_TARGET=go_test


### PR DESCRIPTION
This reverts commit 597415ca0a08313e26226286a326a0d1046898ca.

Turns out it's not related to #1330 .