### PR TITLE
Upgrade distro on Travis and go version in Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+dist: xenial
+
 notifications:
   email:
     on_success: never # default: change

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/gcp-runtimes/go1-builder:1.11
+FROM gcr.io/gcp-runtimes/go1-builder:1.12
 
 #
 # Dockerfile suitable for development and continuous integration of all wpt.fyi
@@ -9,8 +9,8 @@ FROM gcr.io/gcp-runtimes/go1-builder:1.11
 #
 # Caveats:
 # - AppEngine Standard uses golang 1.9, whereas AppEngine Flex defaults to
-#   golang 1.11. This development environment uses the base image recommended
-#   for AppEngine Flex custom golang runtime, hence golang 1.11 is the default
+#   golang 1.12. This development environment uses the base image recommended
+#   for AppEngine Flex custom golang runtime, hence golang 1.12 is the default
 #   golang toolchain. However, when using the gcloud dev_appserver toolchain,
 #   it will internally use a custom golang 1.9 environment.
 #

--- a/api/query/cache/service/Dockerfile
+++ b/api/query/cache/service/Dockerfile
@@ -1,7 +1,7 @@
 # Production deployment spec for query cache service.
 
-# Base golang 1.11 image.
-FROM gcr.io/gcp-runtimes/go1-builder:1.11 as builder
+# Base golang 1.12 image.
+FROM gcr.io/gcp-runtimes/go1-builder:1.12 as builder
 
 RUN apt-get update
 RUN apt-get install -qy --no-install-suggests git

--- a/revisions/service/Dockerfile
+++ b/revisions/service/Dockerfile
@@ -1,7 +1,7 @@
 # Production deployment spec for revisions announcer service.
 
-# Base golang 1.11 image.
-FROM gcr.io/gcp-runtimes/go1-builder:1.11 as builder
+# Base golang 1.12 image.
+FROM gcr.io/gcp-runtimes/go1-builder:1.12 as builder
 
 RUN apt-get update
 RUN apt-get install -qy --no-install-suggests git


### PR DESCRIPTION
* Xenial is the new default on Travis: https://docs.travis-ci.com/user/reference/overview/#linux
* Upgrade to the latest stable version of go: 1.12 (from 1.11).

Changes are trivial. There shouldn't be any observable changes and tests should continue to pass.