### PR TITLE
Always return a non-nil set for NewSetFromStringSlice

### DIFF
--- a/shared/util.go
+++ b/shared/util.go
@@ -93,10 +93,10 @@ func IsLatest(sha string) bool {
 
 // NewSetFromStringSlice is a helper for the inability to cast []string to []interface{}
 func NewSetFromStringSlice(items []string) mapset.Set {
-	if items == nil {
-		return nil
-	}
 	set := mapset.NewSet()
+	if items == nil {
+		return set
+	}
 	for _, i := range items {
 		set.Add(i)
 	}


### PR DESCRIPTION
The name doesn't imply that it will return nil, and it lead to a nil-pointer bug.