### PR TITLE
Respond to completed CheckSuiteEvent from Taskcluster

### DIFF
--- a/api/azure/api_test.go
+++ b/api/azure/api_test.go
@@ -37,8 +37,8 @@ func TestHandleCheckRunEvent(t *testing.T) {
 	chrome := "chrome"
 	completed := "completed"
 	created := "created"
-	repoName := "wpt"
-	repoOwner := "web-platform-tests"
+	repoName := shared.WPTRepoName
+	repoOwner := shared.WPTRepoOwner
 	sender := "lukebjerring"
 	event := &github.CheckRunEvent{
 		Action: &created,

--- a/api/azure/notify.go
+++ b/api/azure/notify.go
@@ -31,8 +31,8 @@ func notifyHandler(w http.ResponseWriter, r *http.Request) {
 	processed, err := processBuild(
 		aeAPI,
 		azureAPI,
-		"web-platform-tests",
-		"wpt",
+		shared.WPTRepoOwner,
+		shared.WPTRepoName,
 		"", // No sender info.
 		r.FormValue("artifact"), // artifact=foo will only process foo.
 		buildID)

--- a/api/checks/api.go
+++ b/api/checks/api.go
@@ -30,8 +30,6 @@ const (
 	wptRepoStagingInstallationID = int64(449270)
 
 	wptRepoID                = int64(3618133)
-	wptRepoOwner             = "web-platform-tests"
-	wptRepoName              = "wpt"
 	checksForAllUsersFeature = "checksAllUsers"
 )
 
@@ -186,12 +184,12 @@ func (s checksAPIImpl) CreateWPTCheckSuite(appID, installationID int64, sha stri
 	opts := github.CreateCheckSuiteOptions{
 		HeadSHA: sha,
 	}
-	suite, _, err := client.Checks.CreateCheckSuite(s.ctx, wptRepoOwner, wptRepoName, opts)
+	suite, _, err := client.Checks.CreateCheckSuite(s.ctx, shared.WPTRepoOwner, shared.WPTRepoName, opts)
 	if err != nil {
 		log.Errorf("Failed to create GitHub check suite: %s", err.Error())
 	} else if suite != nil {
 		log.Infof("check_suite %v created", suite.GetID())
-		getOrCreateCheckSuite(s.ctx, sha, wptRepoOwner, wptRepoName, appID, installationID, prNumbers...)
+		getOrCreateCheckSuite(s.ctx, sha, shared.WPTRepoOwner, shared.WPTRepoName, appID, installationID, prNumbers...)
 	}
 	return suite != nil, err
 }

--- a/api/checks/webhook.go
+++ b/api/checks/webhook.go
@@ -180,8 +180,7 @@ func handleCheckRunEvent(
 
 	appID := checkRun.GetCheckRun().GetApp().GetID()
 	if !isWPTFYIApp(appID) &&
-		appID != azure.PipelinesAppID &&
-		appID != taskcluster.AppID {
+		appID != azure.PipelinesAppID {
 		log.Infof("Ignoring check_suite App ID %v", appID)
 		return false, nil
 	}
@@ -199,12 +198,6 @@ func handleCheckRunEvent(
 			return azureAPI.HandleCheckRunEvent(checkRun)
 		}
 		log.Infof("Ignoring Azure pipelines event")
-		return false, nil
-	} else if appID == taskcluster.AppID {
-		if aeAPI.IsFeatureEnabled("processTaskclusterCheckRunEvents") {
-			return taskclusterAPI.HandleCheckRunEvent(checkRun)
-		}
-		log.Infof("Ignoring Taskcluster CheckRun event")
 		return false, nil
 	} else if (action == "created" && status != "completed") || action == "rerequested" {
 		shouldSchedule = true

--- a/api/checks/webhook_test.go
+++ b/api/checks/webhook_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/web-platform-tests/wpt.fyi/api/azure/mock_azure"
 	"github.com/web-platform-tests/wpt.fyi/api/checks/mock_checks"
 	"github.com/web-platform-tests/wpt.fyi/api/taskcluster/mock_taskcluster"
+	"github.com/web-platform-tests/wpt.fyi/shared"
 	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
 )
 
@@ -117,8 +118,8 @@ func TestHandleCheckRunEvent_ActionRequested_Ignore(t *testing.T) {
 	requestedAction := "requested_action"
 	pending := "pending"
 	username := "lukebjerring"
-	owner := wptRepoOwner
-	repo := wptRepoName
+	owner := shared.WPTRepoOwner
+	repo := shared.WPTRepoName
 	appID := int64(wptfyiStagingCheckAppID)
 	event := github.CheckRunEvent{
 		Action: &requestedAction,
@@ -167,7 +168,7 @@ func TestHandleCheckRunEvent_ActionRequested_Cancel(t *testing.T) {
 	aeAPI.EXPECT().Context().AnyTimes().Return(sharedtest.NewTestContext())
 	aeAPI.EXPECT().IsFeatureEnabled(checksForAllUsersFeature).Return(false)
 	checksAPI := mock_checks.NewMockAPI(mockCtrl)
-	checksAPI.EXPECT().CancelRun(username, wptRepoOwner, wptRepoName, event.GetCheckRun(), event.GetInstallation())
+	checksAPI.EXPECT().CancelRun(username, shared.WPTRepoOwner, shared.WPTRepoName, event.GetCheckRun(), event.GetInstallation())
 	azureAPI := mock_azure.NewMockAPI(mockCtrl)
 	taskclusterAPI := mock_taskcluster.NewMockAPI(mockCtrl)
 
@@ -180,8 +181,8 @@ func getCheckRunCreatedEvent(status, sender, sha string) github.CheckRunEvent {
 	id := int64(wptfyiStagingCheckAppID)
 	chrome := "chrome"
 	created := "created"
-	repoName := wptRepoName
-	repoOwner := wptRepoOwner
+	repoName := shared.WPTRepoName
+	repoOwner := shared.WPTRepoOwner
 	return github.CheckRunEvent{
 		Action: &created,
 		CheckRun: &github.CheckRun{

--- a/api/manifest/api.go
+++ b/api/manifest/api.go
@@ -60,7 +60,7 @@ func getGitHubReleaseAssetForSHA(aeAPI shared.AppEngineAPI, sha string) (fetched
 	fetchedSHA = sha
 	if shared.IsLatest(sha) {
 		// Use GitHub's API for latest release.
-		release, _, err = client.Repositories.GetLatestRelease(aeAPI.Context(), "web-platform-tests", "wpt")
+		release, _, err = client.Repositories.GetLatestRelease(aeAPI.Context(), shared.WPTRepoOwner, shared.WPTRepoName)
 	} else {
 		q := fmt.Sprintf("SHA:%s user:web-platform-tests repo:wpt", sha)
 		issues, _, err := client.Search.Issues(aeAPI.Context(), q, nil)
@@ -72,7 +72,7 @@ func getGitHubReleaseAssetForSHA(aeAPI shared.AppEngineAPI, sha string) (fetched
 		}
 
 		releaseTag = fmt.Sprintf("merge_pr_%d", issues.Issues[0].GetNumber())
-		release, _, err = client.Repositories.GetReleaseByTag(aeAPI.Context(), "web-platform-tests", "wpt", releaseTag)
+		release, _, err = client.Repositories.GetReleaseByTag(aeAPI.Context(), shared.WPTRepoOwner, shared.WPTRepoName, releaseTag)
 	}
 
 	if err != nil {

--- a/api/taskcluster/api.go
+++ b/api/taskcluster/api.go
@@ -76,6 +76,10 @@ func (a apiImpl) HandleCheckSuiteEvent(event *github.CheckSuiteEvent) (bool, err
 		byGroup.Add(taskGroupID)
 	}
 
+	if byGroup.Cardinality() > 1 {
+		log.Errorf("Encountered multiple (%v) TaskGroup IDs", byGroup.Cardinality())
+	}
+
 	processedSomething := false
 	for _, groupID := range shared.ToStringSlice(byGroup) {
 		processed, err := processTaskclusterBuild(a.aeAPI, groupID, "", sha, shared.ToStringSlice(labels)...)

--- a/api/taskcluster/api.go
+++ b/api/taskcluster/api.go
@@ -23,16 +23,19 @@ const AppID = int64(1317)
 // API is for Azure Taskcluster related requests.
 type API interface {
 	HandleCheckRunEvent(*github.CheckRunEvent) (bool, error)
+	HandleCheckSuiteEvent(*github.CheckSuiteEvent) (bool, error)
 }
 
 type apiImpl struct {
-	ctx context.Context
+	ctx   context.Context
+	aeAPI shared.AppEngineAPI
 }
 
 // NewAPI returns an implementation of taskcluster API
 func NewAPI(ctx context.Context) API {
 	return apiImpl{
-		ctx: ctx,
+		ctx:   ctx,
+		aeAPI: shared.NewAppEngineAPI(ctx),
 	}
 }
 
@@ -59,4 +62,54 @@ func (a apiImpl) HandleCheckRunEvent(event *github.CheckRunEvent) (bool, error) 
 	}
 
 	return processTaskclusterBuild(shared.NewAppEngineAPI(a.ctx), taskGroupID, taskID, sha, shared.ToStringSlice(labels)...)
+}
+
+// HandleCheckSuiteEvent processes a Taskcluster check suite "completed" event.
+func (a apiImpl) HandleCheckSuiteEvent(event *github.CheckSuiteEvent) (bool, error) {
+	log := shared.GetLogger(a.ctx)
+	status := event.GetCheckSuite().GetStatus()
+	if status != "completed" {
+		log.Infof("Ignoring non-completed status %s", status)
+		return false, nil
+	}
+	sha := event.GetCheckSuite().GetHeadSHA()
+
+	labels := mapset.NewSet()
+	sender := event.GetSender().GetLogin()
+	if sender != "" {
+		labels.Add(shared.GetUserLabel(sender))
+	}
+	if event.GetCheckSuite().GetHeadBranch() == shared.MasterLabel {
+		labels.Add(shared.MasterLabel)
+	}
+
+	ghClient, err := a.aeAPI.GetGitHubClient()
+	if err != nil {
+		log.Errorf("Failed to get GitHub client: %s", err.Error())
+		return false, err
+	}
+	runs, _, err := ghClient.Checks.ListCheckRunsCheckSuite(a.ctx, shared.WPTRepoOwner, shared.WPTRepoName, event.GetCheckSuite().GetID(), nil)
+	if err != nil {
+		log.Errorf("Failed to fetch check runs for suite %v: %s", event.GetCheckSuite().GetID(), err.Error())
+		return false, err
+	}
+	byGroup := mapset.NewSet()
+	for _, run := range runs.CheckRuns {
+		taskGroupID, _ := extractTaskGroupID(run.GetDetailsURL())
+		if taskGroupID == "" {
+			return false, fmt.Errorf("unrecognized target_url: %s", run.GetDetailsURL())
+		}
+		byGroup.Add(taskGroupID)
+	}
+
+	processedSomething := false
+	for _, groupID := range shared.ToStringSlice(byGroup) {
+		processed, err := processTaskclusterBuild(a.aeAPI, groupID, "", sha, shared.ToStringSlice(labels)...)
+		if err != nil {
+			log.Errorf("Failed to process %s: %s", groupID, err.Error())
+			continue
+		}
+		processedSomething = processedSomething || processed
+	}
+	return processedSomething, nil
 }

--- a/api/taskcluster/mock_taskcluster/api_mock.go
+++ b/api/taskcluster/mock_taskcluster/api_mock.go
@@ -47,3 +47,18 @@ func (mr *MockAPIMockRecorder) HandleCheckRunEvent(arg0 interface{}) *gomock.Cal
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleCheckRunEvent", reflect.TypeOf((*MockAPI)(nil).HandleCheckRunEvent), arg0)
 }
+
+// HandleCheckSuiteEvent mocks base method
+func (m *MockAPI) HandleCheckSuiteEvent(arg0 *github.CheckSuiteEvent) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HandleCheckSuiteEvent", arg0)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// HandleCheckSuiteEvent indicates an expected call of HandleCheckSuiteEvent
+func (mr *MockAPIMockRecorder) HandleCheckSuiteEvent(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleCheckSuiteEvent", reflect.TypeOf((*MockAPI)(nil).HandleCheckSuiteEvent), arg0)
+}

--- a/api/taskcluster/mock_taskcluster/api_mock.go
+++ b/api/taskcluster/mock_taskcluster/api_mock.go
@@ -33,21 +33,6 @@ func (m *MockAPI) EXPECT() *MockAPIMockRecorder {
 	return m.recorder
 }
 
-// HandleCheckRunEvent mocks base method
-func (m *MockAPI) HandleCheckRunEvent(arg0 *github.CheckRunEvent) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HandleCheckRunEvent", arg0)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// HandleCheckRunEvent indicates an expected call of HandleCheckRunEvent
-func (mr *MockAPIMockRecorder) HandleCheckRunEvent(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleCheckRunEvent", reflect.TypeOf((*MockAPI)(nil).HandleCheckRunEvent), arg0)
-}
-
 // HandleCheckSuiteEvent mocks base method
 func (m *MockAPI) HandleCheckSuiteEvent(arg0 *github.CheckSuiteEvent) (bool, error) {
 	m.ctrl.T.Helper()

--- a/api/taskcluster/webhook.go
+++ b/api/taskcluster/webhook.go
@@ -38,8 +38,7 @@ var (
 var errNoResults = errors.New("no result URLs found in task group")
 
 // tcStatusWebhookHandler reacts to GitHub status webhook events. This is juxtaposed with
-// handleCheckRunEvent below, which is how we react to the (new) CheckRun implementation
-// of Taskcluster.
+// handleCheckSuiteEvent, which is how we react to the (new) CheckRun implementation of Taskcluster.
 func tcStatusWebhookHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Header.Get("Content-Type") != "application/json" ||
 		r.Header.Get("X-GitHub-Event") != "status" {

--- a/api/test_runs.go
+++ b/api/test_runs.go
@@ -141,7 +141,7 @@ func getPRCommits(aeAPI shared.AppEngineAPI, pr int) shared.SHAs {
 		log.Errorf("Failed to get github client: %s", err.Error())
 		return nil
 	}
-	commits, _, err := githubClient.PullRequests.ListCommits(aeAPI.Context(), "web-platform-tests", "wpt", pr, nil)
+	commits, _, err := githubClient.PullRequests.ListCommits(aeAPI.Context(), shared.WPTRepoOwner, shared.WPTRepoName, pr, nil)
 	if err != nil || commits == nil {
 		log.Errorf("Failed to fetch PR #%v: %s", pr, err.Error())
 		return nil

--- a/shared/run_diff.go
+++ b/shared/run_diff.go
@@ -423,7 +423,7 @@ func getDiffRenames(ctx context.Context, shaBefore, shaAfter string) map[string]
 		log.Errorf("Failed to get github client: %s", err.Error())
 		return nil
 	}
-	comparison, _, err := githubClient.Repositories.CompareCommits(ctx, "web-platform-tests", "wpt", shaBefore, shaAfter)
+	comparison, _, err := githubClient.Repositories.CompareCommits(ctx, WPTRepoOwner, WPTRepoName, shaBefore, shaAfter)
 	if err != nil || comparison == nil {
 		log.Errorf("Failed to fetch diff for %s...%s: %s", CropString(shaBefore, 7), CropString(shaAfter, 7), err.Error())
 		return nil

--- a/shared/util.go
+++ b/shared/util.go
@@ -42,6 +42,12 @@ const PRHeadLabel = "pr_head"
 // prefixed because usernames are essentially user input.
 const UserLabelPrefix = "user:"
 
+// WPTRepoOwner is the owner (username) for the GitHub wpt repo.
+const WPTRepoOwner = "web-platform-tests"
+
+// WPTRepoName is the repo name for the GitHub wpt repo.
+const WPTRepoName = "wpt"
+
 // GetUserLabel prefixes the given username with the prefix for using as a label.
 func GetUserLabel(username string) string {
 	return UserLabelPrefix + username


### PR DESCRIPTION
## Description
Handles master-branch cases, where we have multiple shards that need to be grouped (by waiting until all shards are completed).
Fixes one of the many issues in https://github.com/web-platform-tests/wpt.fyi/issues/1240