### PR TITLE
Improve buttons for reftest-analzyer

### DIFF
--- a/webapp/components/abstract-test-file-results-table.js
+++ b/webapp/components/abstract-test-file-results-table.js
@@ -31,7 +31,7 @@ class AbstractTestFileResultsTable extends WPTColors(TestRunsBase) {
     top: 0;
     z-index: 1;
   }
-  td {
+  td, .ref-button {
     padding: 0;
     height: 1.5em;
   }
@@ -82,7 +82,7 @@ class AbstractTestFileResultsTable extends WPTColors(TestRunsBase) {
             <template is="dom-if" if="[[result.screenshots]]">
               <a class="ref-button" href="[[ computeAnalyzerURL(result.screenshots) ]]">
                 <iron-icon icon="image:compare"></iron-icon>
-                <span>COMPARE</span>
+                COMPARE
               </a>
             </template>
           </td>

--- a/webapp/components/abstract-test-file-results-table.js
+++ b/webapp/components/abstract-test-file-results-table.js
@@ -138,10 +138,10 @@ class AbstractTestFileResultsTable extends WPTColors(TestRunsBase) {
 
   computeAnalyzerURL(screenshots) {
     if (!screenshots) {
-      throw "empty screenshots";
+      throw 'empty screenshots';
     }
     const url = new URL('/analyzer', window.location);
-    for (const [_, sha] of screenshots) {
+    for (const sha of screenshots.values()) {
       url.searchParams.append('screenshot', sha);
     }
     return url.href;

--- a/webapp/components/abstract-test-file-results-table.js
+++ b/webapp/components/abstract-test-file-results-table.js
@@ -6,7 +6,6 @@
 
 import '../node_modules/@polymer/polymer/lib/elements/dom-if.js';
 import '../node_modules/@polymer/polymer/lib/elements/dom-repeat.js';
-import '../node_modules/@polymer/paper-button/paper-button.js';
 import '../node_modules/@polymer/iron-icon/iron-icon.js';
 import '../node_modules/@polymer/iron-icons/image-icons.js';
 import { html } from '../node_modules/@polymer/polymer/polymer-element.js';
@@ -39,11 +38,11 @@ class AbstractTestFileResultsTable extends WPTColors(TestRunsBase) {
   td code {
     white-space: pre-wrap;
   }
-  td code, td paper-button {
+  td code, .ref-button {
     line-height: 1.6em;
     padding: 0 0.25em;
   }
-  td.sub-test-name {
+  td.sub-test-name, .ref-button {
     font-family: monospace;
   }
   td.result {
@@ -53,7 +52,10 @@ class AbstractTestFileResultsTable extends WPTColors(TestRunsBase) {
     border-bottom: 8px solid white;
     padding: 8px;
   }
-  paper-button {
+  .ref-button {
+    color: #333;
+    text-decoration: none;
+    display: block;
     float: right;
   }
 </style>
@@ -78,10 +80,10 @@ class AbstractTestFileResultsTable extends WPTColors(TestRunsBase) {
           <td class$="[[ colorClass(result.status) ]]">
             <code>[[ subtestMessage(result) ]]</code>
             <template is="dom-if" if="[[result.screenshots]]">
-              <paper-button onclick="[[compareReferences(result)]]">
+              <a class="ref-button" href="[[ computeAnalyzerURL(result.screenshots) ]]">
                 <iron-icon icon="image:compare"></iron-icon>
-                Compare
-              </paper-button>
+                <span>COMPARE</span>
+              </a>
             </template>
           </td>
         </template>
@@ -102,15 +104,6 @@ class AbstractTestFileResultsTable extends WPTColors(TestRunsBase) {
         type: Array,
         value: [],
       },
-    };
-  }
-
-  constructor() {
-    super();
-    this.compareReferences = (result) => {
-      return () => this.onReftestCompare && this.onReftestCompare(
-        // Clone the result first.
-        JSON.parse(JSON.stringify(result)));
     };
   }
 
@@ -141,6 +134,17 @@ class AbstractTestFileResultsTable extends WPTColors(TestRunsBase) {
       return this.passRateClass(0, 1);
     }
     return 'result';
+  }
+
+  computeAnalyzerURL(screenshots) {
+    if (!screenshots) {
+      throw "empty screenshots";
+    }
+    const url = new URL('/analyzer', window.location);
+    for (const [_, sha] of screenshots) {
+      url.searchParams.append('screenshot', sha);
+    }
+    return url.href;
   }
 }
 

--- a/webapp/components/reftest-analyzer.js
+++ b/webapp/components/reftest-analyzer.js
@@ -86,6 +86,7 @@ class ReftestAnalyzer extends LoadingState(PolymerElement) {
             Any suggestions?
             <a href="https://github.com/web-platform-tests/wpt.fyi/issues/new?template=screenshots.md&projects=web-platform-tests/wpt.fyi/9" target="_blank">File an issue!</a>
           </p>
+          <button onclick="window.history.back()">Go back</button>
         </div>
       </div>
 

--- a/webapp/components/test-file-results-table-terse.js
+++ b/webapp/components/test-file-results-table-terse.js
@@ -19,7 +19,7 @@ class TestFileResultsTableTerse extends AbstractTestFileResultsTable {
         font-family: monospace;
         background-color: white;
       }
-      td code {
+      td.sub-test-name code {
         box-sizing: border-box;
         height: 100%;
         left: 0;
@@ -30,7 +30,7 @@ class TestFileResultsTableTerse extends AbstractTestFileResultsTable {
         white-space: nowrap;
         width: 100%;
       }
-      td code:hover {
+      td.sub-test-name code:hover {
         z-index: 1;
         text-overflow: initial;
         background-color: inherit;

--- a/webapp/components/test-file-results.js
+++ b/webapp/components/test-file-results.js
@@ -162,16 +162,7 @@ class TestFileResults extends WPTFlags(LoadingState(PathInfo(
           message: data && data.message,
         };
         if (this.reftestAnalyzer && data && data.screenshots) {
-          // Clone the data because we might modify it.
-          const screenshots = Object.assign({}, data.screenshots);
-          // Make sure the test itself appears first in the Map to follow the
-          // convention of reftest-analyzer (actual, expected).
-          const firstScreenshot = [];
-          if (this.path in screenshots) {
-            firstScreenshot.push([this.path, screenshots[this.path]]);
-            delete screenshots[this.path];
-          }
-          result.screenshots = new Map([...firstScreenshot, ...Object.entries(screenshots)]);
+          result.screenshots = this.shuffleScreenshots(this.path, data.screenshots);
         }
         return result;
       }),
@@ -258,6 +249,19 @@ class TestFileResults extends WPTFlags(LoadingState(PathInfo(
 
   statusName(numSubtests) {
     return numSubtests > 0 ? 'Harness status' : 'Test status';
+  }
+
+  shuffleScreenshots(path, rawScreenshots) {
+    // Clone the data because we might modify it.
+    const screenshots = Object.assign({}, rawScreenshots);
+    // Make sure the test itself appears first in the Map to follow the
+    // convention of reftest-analyzer (actual, expected).
+    const firstScreenshot = [];
+    if (path in screenshots) {
+      firstScreenshot.push([path, screenshots[path]]);
+      delete screenshots[path];
+    }
+    return new Map([...firstScreenshot, ...Object.entries(screenshots)]);
   }
 }
 

--- a/webapp/components/test-file-results.js
+++ b/webapp/components/test-file-results.js
@@ -163,7 +163,7 @@ class TestFileResults extends WPTFlags(LoadingState(PathInfo(
         };
         if (this.reftestAnalyzer && data && data.screenshots) {
           // Clone the data because we might modify it.
-          const screenshots = JSON.parse(JSON.stringify(data.screenshots));
+          const screenshots = Object.assign({}, data.screenshots);
           // Make sure the test itself appears first in the Map to follow the
           // convention of reftest-analyzer (actual, expected).
           const firstScreenshot = [];

--- a/webapp/components/test/test-file-results.html
+++ b/webapp/components/test/test-file-results.html
@@ -80,6 +80,45 @@ suite('TestFileResults', () => {
         expect(result).to.deep.equal(['a', 'x', 'b', 'y', 'z']);
       });
     });
+
+    suite('statusName', () => {
+      test('path in screenshots - first', () => {
+        const rawScreenshots = {
+          '/foo/bar/baz.html': 'sha1:060311f9cd4c5b09202a034c4961ca42a3f83ce2',
+          '/foo/bar/baz-ref.html': 'sha1:cf459fa6f04d2c0a18bc30762941289d700224bd',
+        };
+        const screenshots = tfr.shuffleScreenshots('/foo/bar/baz.html', rawScreenshots);
+        assert.lengthOf(Object.keys(rawScreenshots), 2);
+        assert.deepEqual(Array.from(screenshots.entries()), [
+          ['/foo/bar/baz.html', 'sha1:060311f9cd4c5b09202a034c4961ca42a3f83ce2'],
+          ['/foo/bar/baz-ref.html', 'sha1:cf459fa6f04d2c0a18bc30762941289d700224bd'],
+        ]);
+      });
+
+      test('path in screenshots - not first', () => {
+        const rawScreenshots = {
+          '/foo/bar/baz-ref.html': 'sha1:cf459fa6f04d2c0a18bc30762941289d700224bd',
+          '/foo/bar/baz.html': 'sha1:060311f9cd4c5b09202a034c4961ca42a3f83ce2',
+        };
+        const screenshots = tfr.shuffleScreenshots('/foo/bar/baz.html', rawScreenshots);
+        assert.lengthOf(Object.keys(rawScreenshots), 2);
+        assert.deepEqual(Array.from(screenshots.entries()), [
+          ['/foo/bar/baz.html', 'sha1:060311f9cd4c5b09202a034c4961ca42a3f83ce2'],
+          ['/foo/bar/baz-ref.html', 'sha1:cf459fa6f04d2c0a18bc30762941289d700224bd'],
+        ]);
+      });
+
+      test('path not in screenshots', () => {
+        const rawScreenshots = {
+          '/foo/bar/baz.html': 'sha1:060311f9cd4c5b09202a034c4961ca42a3f83ce2',
+          '/foo/bar/baz-ref.html': 'sha1:cf459fa6f04d2c0a18bc30762941289d700224bd',
+          '/foo/bar/baz-ref2.html': 'sha1:cf459fa6f04d2c0a18bc30762941289d700224bd',
+        };
+        const screenshots = tfr.shuffleScreenshots('/not-foo/bar.html', rawScreenshots);
+        assert.lengthOf(Object.keys(rawScreenshots), 3);
+        assert.lengthOf(Array.from(screenshots.entries()), 3);
+      });
+    });
   });
 });
 </script>

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -170,8 +170,7 @@ class WPTResults extends WPTColors(WPTFlags(PathInfo(LoadingState(TestRunsUIBase
                            path="[[path]]"
                            structured-search="[[structuredSearch]]"
                            labels="[[labels]]"
-                           products="[[products]]"
-                           on-reftest-compare="[[showAnalyzer]]">
+                           products="[[products]]">
         </test-file-results>
       </template>
 
@@ -489,7 +488,6 @@ class WPTResults extends WPTColors(WPTFlags(PathInfo(LoadingState(TestRunsUIBase
       this.refreshDisplayedNodes();
     };
     this.dismissToast = e => e.target.closest('paper-toast').close();
-    this.showAnalyzer = this.handleShowAnalyzer.bind(this);
   }
 
   loadData() {
@@ -974,22 +972,6 @@ class WPTResults extends WPTColors(WPTFlags(PathInfo(LoadingState(TestRunsUIBase
         `Showing ${tests} tests (${subtests} subtests) from `);
     }
     return msg;
-  }
-
-  handleShowAnalyzer(result) {
-    if (!result.screenshots) {
-      this.screenshots = null;
-      return;
-    }
-    const url = new URL('/analyzer', window.location);
-    if (this.path in result.screenshots) {
-      url.searchParams.append('screenshot', result.screenshots[this.path]);
-      delete result.screenshots[this.path];
-    }
-    for (const s of Object.values(result.screenshots)) {
-      url.searchParams.append('screenshot', s);
-    }
-    window.location = url;
   }
 }
 


### PR DESCRIPTION
See individual commits -- fixes #1339 and #1340 respectively.

Demo: https://analzyer-button-dot-wptdashboard-staging.appspot.com/results/css/css-fill-stroke/paint-order-001.tentative.html?label=master&label=experimental

Try the new COMPARE button, as well as the "go back" button in the reftest analyzer.