### PR TITLE
Fix permalinks

### DIFF
--- a/webapp/components/test-runs.js
+++ b/webapp/components/test-runs.js
@@ -74,17 +74,12 @@ const TestRunsQueryLoader = (superClass) =>
   };
 
 class TestRunsBase extends TestRunsQueryLoader(TestRunsQuery(PolymerElement, TestRunsQuery.Computer)) {
+  // This is only used in tests, so we don't call window.customElements.define here.
   static get is() {
     return 'wpt-results-base';
   }
 }
-window.customElements.define(TestRunsBase.is, TestRunsBase);
 
-class TestRunsUIBase extends TestRunsQueryLoader(TestRunsUIQuery(PolymerElement, TestRunsUIQuery.Computer)) {
-  static get is() {
-    return 'wpt-results-ui-base';
-  }
-}
-window.customElements.define(TestRunsUIBase.is, TestRunsUIBase);
+class TestRunsUIBase extends TestRunsQueryLoader(TestRunsUIQuery(PolymerElement, TestRunsUIQuery.Computer)) {}
 
 export { TestRunsQueryLoader, TestRunsBase, TestRunsUIBase };

--- a/webapp/components/test/test-run.html
+++ b/webapp/components/test/test-run.html
@@ -38,7 +38,7 @@ suite('<test-run>', () => {
     });
   });
 
-  suite('TestRunsBase.prototype.*', () => {
+  suite('TestRun.prototype.*', () => {
     let sandbox;
 
     setup(() => {

--- a/webapp/components/test/test-runs.html
+++ b/webapp/components/test/test-runs.html
@@ -5,7 +5,10 @@
   <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
   <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
 
-  <script type="module" src="../test-runs.js"></script>
+  <script type="module">
+    import { TestRunsBase } from '../test-runs.js';
+    window.customElements.define(TestRunsBase.is, TestRunsBase);
+  </script>
 </head>
 <body>
   <test-fixture id="wpt-results-base-fixture">

--- a/webapp/components/wpt-permalinks.js
+++ b/webapp/components/wpt-permalinks.js
@@ -77,7 +77,7 @@ class Permalinks extends QueryBuilder(PolymerElement) {
       },
       url: {
         type: String,
-        computed: 'computeURL(selectedTab, queryParams, path, includePath, includeSearch, testRuns)',
+        computed: 'computeURL(selectedTab, queryParams, pathPrefix, path, includePath, includeSearch, testRuns)',
       }
     };
   }
@@ -99,7 +99,7 @@ class Permalinks extends QueryBuilder(PolymerElement) {
     this.dialog.open();
   }
 
-  computeURL(selectedTab, queryParams, path, includePath, includeSearch, testRuns) {
+  computeURL(selectedTab, queryParams, pathPrefix, path, includePath, includeSearch, testRuns) {
     let params;
     if (selectedTab === 0) {
       params = {};
@@ -123,8 +123,8 @@ class Permalinks extends QueryBuilder(PolymerElement) {
     }
 
     const url = new URL('/', window.location);
-    if (this.pathPrefix) {
-      url.pathname = this.pathPrefix;
+    if (pathPrefix) {
+      url.pathname = pathPrefix;
     }
     if (includePath && this.path) {
       url.pathname += this.path.slice(1);

--- a/webapp/views/wpt-app.js
+++ b/webapp/views/wpt-app.js
@@ -1,6 +1,6 @@
 import { PathInfo } from '../components/path.js';
 import '../components/test-runs-query-builder.js';
-import { TestRunsUIQuery } from '../components/test-runs-query.js';
+import { TestRunsUIBase } from '../components/test-runs.js';
 import '../components/test-search.js';
 import '../components/wpt-flags.js';
 import { WPTFlags } from '../components/wpt-flags.js';
@@ -10,12 +10,12 @@ import '../node_modules/@polymer/app-route/app-location.js';
 import '../node_modules/@polymer/app-route/app-route.js';
 import '../node_modules/@polymer/iron-pages/iron-pages.js';
 import '../node_modules/@polymer/polymer/lib/elements/dom-if.js';
-import { html, PolymerElement } from '../node_modules/@polymer/polymer/polymer-element.js';
+import { html } from '../node_modules/@polymer/polymer/polymer-element.js';
 import '../views/wpt-404.js';
 import '../views/wpt-interop.js';
 import '../views/wpt-results.js';
 
-class WPTApp extends PathInfo(WPTFlags(TestRunsUIQuery(PolymerElement))) {
+class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
   static get is() { return 'wpt-app'; }
 
   static get template() {
@@ -85,7 +85,7 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIQuery(PolymerElement))) {
                      test-paths="[[testPaths]]">
         </test-search>
 
-        <template is="dom-if" if="{{ pathIsATestFile }}">
+        <template is="dom-if" if="[[ pathIsATestFile ]]">
           <div class="links">
             <ul>
               <li>
@@ -127,7 +127,8 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIQuery(PolymerElement))) {
         <wpt-results name="results"
                      is-loading="{{resultsLoading}}"
                      structured-search="[[structuredSearch]]"
-                     path="[[subroute.path]]"></wpt-results>
+                     path="[[subroute.path]]"
+                     test-runs="{{testRuns}}"></wpt-results>
 
         <wpt-interop name="interop"
                      is-loading="{{interopLoading}}"


### PR DESCRIPTION
## Description

Fixes #1350 .

## Review Information

Check the staging deployment. Click on the "LINK" button near the top and the pop-up dialog should include run IDs. Then close the dialog and switch to interop. The LINK button should still work. The dialog should show **interop** instead of results, and the run IDs should still be there.

## Changes

The first commit is a no-op cleanup (of tests, mostly), while the second commit is the actual fix.