### PR TITLE
Add feature for changes-only regression detection

### DIFF
--- a/api/checks/update.go
+++ b/api/checks/update.go
@@ -24,6 +24,7 @@ import (
 const CheckProcessingQueue = "check-processing"
 
 const failChecksOnRegressionFeature = "failChecksOnRegression"
+const onlyChangesAsRegressionsFeature = "onlyChangesAsRegressions"
 
 // updateCheckHandler handles /api/checks/[commit] POST requests.
 func updateCheckHandler(w http.ResponseWriter, r *http.Request) {

--- a/api/checks/update.go
+++ b/api/checks/update.go
@@ -201,11 +201,14 @@ func getDiffSummary(aeAPI shared.AppEngineAPI, diffAPI shared.DiffAPI, suite sha
 		PRNumbers:  suite.PRNumbers,
 	}
 
-	var regressions mapset.NewSet()
+	var regressions mapset.Set
 	if aeAPI.IsFeatureEnabled("onlyChangesAsRegressions") {
 		regressionFilter := shared.DiffFilterParam{Changed: true} // Only changed items
-		regressionDiffs = diffAPI.GetRunsDiff(baseRun, headRun, regressionFilter, nil)
-		regressions = regressionDiffs.Differences.Regressions()
+		changeOnlyDiff, err := diffAPI.GetRunsDiff(baseRun, headRun, regressionFilter, nil)
+		if err != nil {
+			return nil, err
+		}
+		regressions = changeOnlyDiff.Differences.Regressions()
 	} else {
 		regressions = diff.Differences.Regressions()
 	}

--- a/api/checks/update.go
+++ b/api/checks/update.go
@@ -201,7 +201,14 @@ func getDiffSummary(aeAPI shared.AppEngineAPI, diffAPI shared.DiffAPI, suite sha
 		PRNumbers:  suite.PRNumbers,
 	}
 
-	regressions := diff.Differences.Regressions()
+	var regressions mapset.NewSet()
+	if aeAPI.IsFeatureEnabled("onlyChangesAsRegressions") {
+		regressionFilter := shared.DiffFilterParam{Changed: true} // Only changed items
+		regressionDiffs = diffAPI.GetRunsDiff(baseRun, headRun, regressionFilter, nil)
+		regressions = regressionDiffs.Differences.Regressions()
+	} else {
+		regressions = diff.Differences.Regressions()
+	}
 	hasRegressions := regressions.Cardinality() > 0
 	neutral := "neutral"
 	checkState.Conclusion = &neutral

--- a/webapp/components/wpt-flags.js
+++ b/webapp/components/wpt-flags.js
@@ -54,6 +54,7 @@ Object.defineProperty(wpt, 'ServerSideFeatures', {
       'diffRenames',
       'failChecksOnRegression',
       'ignoreHarnessInTotal',
+      'onlyChangesAsRegressions',
       'paginationTokens',
       'pendingChecks',
       'processTaskclusterCheckRunEvents',
@@ -152,7 +153,7 @@ class WPTFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ false) {
         Query Builder component
       </paper-checkbox>
     </paper-item>
-    <paper-item sub-item="">
+    <paper-item sub-item>
       <paper-checkbox checked="{{queryBuilderSHA}}">
         SHA input
       </paper-checkbox>
@@ -254,7 +255,7 @@ class WPTEnvironmentFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ tr
         Fetch experimental runs as the default (homepage) query
       </paper-checkbox>
     </paper-item>
-    <paper-item sub-item="">
+    <paper-item sub-item>
       <paper-checkbox checked="{{experimentalAlignedExceptEdge}}">
         All experimental, except edge, and aligned
       </paper-checkbox>
@@ -289,30 +290,36 @@ class WPTEnvironmentFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ tr
         Ignore "OK" harness status in test summary numbers.
       </paper-checkbox>
     </paper-item>
-    <h5>GitHub Status Checks</h5>
-    <paper-item sub-item="">
+    <h4>GitHub Status Checks</h4>
+    <paper-item>
+      <paper-checkbox checked="{{searchcacheDiffs}}">
+        Use searchcache (not summaries) to compute diffs when processing check run events.
+      </paper-checkbox>
+    </paper-item>
+    <paper-item sub-item>
+      <paper-checkbox checked="{{onlyChangesAsRegressions}}">
+        Only treat C (changed) differences as possible regressions.
+        (<a href="https://github.com/web-platform-tests/wpt.fyi/blob/master/api/README.md#apidiff">See docs for definition</a>)
+      </paper-checkbox>
+    </paper-item>
+    <paper-item>
       <paper-checkbox checked="{{failChecksOnRegression}}">
         Set the wpt.fyi GitHub status check to action_required if regressions are found.
       </paper-checkbox>
     </paper-item>
-    <paper-item sub-item="">
+    <paper-item>
       <paper-checkbox checked="{{checksAllUsers}}">
         Run the wpt.fyi GitHub status check for all users, not just whitelisted ones.
       </paper-checkbox>
     </paper-item>
-    <paper-item sub-item="">
+    <paper-item>
       <paper-checkbox checked="{{pendingChecks}}">
         Create pending GitHub status check when results first arrive, and are being processed.
       </paper-checkbox>
     </paper-item>
-    <paper-item sub-item="">
+    <paper-item>
       <paper-checkbox checked="{{processTaskclusterCheckRunEvents}}">
         Process check run events from Taskcluster (needs to be enabled if Taskcluster is using Checks API).
-      </paper-checkbox>
-    </paper-item>
-    <paper-item sub-item="">
-      <paper-checkbox checked="{{searchcacheDiffs}}">
-        Use searchcache to compute diffs when processing check run events.
       </paper-checkbox>
     </paper-item>
 `;


### PR DESCRIPTION
## Description
Should help with https://github.com/web-platform-tests/wpt.fyi/issues/1300

Changes the checks API to fetch the diff twice, with only `filter=C` the second time. The latter fetch is used when counting regressions, while the full diff is used for the summary text.