### PR TITLE
Parse boolean params, not just presence

### DIFF
--- a/api/query/cache/service/main.go
+++ b/api/query/cache/service/main.go
@@ -166,9 +166,9 @@ func searchHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Configure format, from request params.
 	urlQuery := r.URL.Query()
-	_, subtests := urlQuery["subtests"]
-	_, interop := urlQuery["interop"]
-	_, diff := urlQuery["diff"]
+	subtests := shared.ParseBooleanParam(urlQuery, "subtests")
+	interop := shared.ParseBooleanParam(urlQuery, "interop")
+	diff := shared.ParseBooleanParam(urlQuery, "diff")
 	diffFilter, _, err := shared.ParseDiffFilterParams(urlQuery)
 	if err != nil {
 		log.Errorf("%s", err.Error())

--- a/api/query/cache/service/main.go
+++ b/api/query/cache/service/main.go
@@ -166,9 +166,9 @@ func searchHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Configure format, from request params.
 	urlQuery := r.URL.Query()
-	subtests := shared.ParseBooleanParam(urlQuery, "subtests")
-	interop := shared.ParseBooleanParam(urlQuery, "interop")
-	diff := shared.ParseBooleanParam(urlQuery, "diff")
+	subtests, _ := shared.ParseBooleanParam(urlQuery, "subtests")
+	interop, _ := shared.ParseBooleanParam(urlQuery, "interop")
+	diff, _ := shared.ParseBooleanParam(urlQuery, "diff")
 	diffFilter, _, err := shared.ParseDiffFilterParams(urlQuery)
 	if err != nil {
 		log.Errorf("%s", err.Error())
@@ -176,9 +176,9 @@ func searchHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	opts := query.AggregationOpts{
-		IncludeSubtests:         subtests,
-		InteropFormat:           interop,
-		IncludeDiff:             diff,
+		IncludeSubtests:         subtests != nil && *subtests,
+		InteropFormat:           interop != nil && *interop,
+		IncludeDiff:             diff != nil && *diff,
 		DiffFilter:              diffFilter,
 		IgnoreTestHarnessResult: shared.IsFeatureEnabled(store, "ignoreHarnessInTotal"),
 	}

--- a/api/query/search.go
+++ b/api/query/search.go
@@ -95,9 +95,9 @@ func (sh structuredSearchHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 			simpleQ, isSimpleQ = exists.Args[0].(TestNamePattern)
 		}
 		q := r.URL.Query()
-		_, interop := q["interop"]
-		_, subtests := q["subtests"]
-		_, diff := q["diff"]
+		interop := shared.ParseBooleanParam(q, "interop")
+		subtests := shared.ParseBooleanParam(q, "subtests")
+		diff := shared.ParseBooleanParam(q, "diff")
 		isSimpleQ = isSimpleQ && !interop && !subtests && !diff
 	}
 

--- a/api/query/search.go
+++ b/api/query/search.go
@@ -95,10 +95,10 @@ func (sh structuredSearchHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 			simpleQ, isSimpleQ = exists.Args[0].(TestNamePattern)
 		}
 		q := r.URL.Query()
-		interop := shared.ParseBooleanParam(q, "interop")
-		subtests := shared.ParseBooleanParam(q, "subtests")
-		diff := shared.ParseBooleanParam(q, "diff")
-		isSimpleQ = isSimpleQ && !interop && !subtests && !diff
+		for _, param := range []string{"interop", "subtests", "diff"} {
+			val, _ := shared.ParseBooleanParam(q, param)
+			isSimpleQ = isSimpleQ && (val == nil || !*val)
+		}
 	}
 
 	if !isSimpleQ {


### PR DESCRIPTION
## Description
Switches some trivial code to use a shared library method.

Changes the behaviour for `?diff=false` to correctly match diff not being present at all.