### PR TITLE
Fix recompute action

### DIFF
--- a/api/checks/webhook.go
+++ b/api/checks/webhook.go
@@ -17,7 +17,7 @@ import (
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
-var runNameRegex = regexp.MustCompile("^(?:(?:staging\\.)?wpt\\.fyi - )(.*)$")
+var runNameRegex = regexp.MustCompile(`^(?:(?:staging\.)?wpt\.fyi - )(.*)$`)
 
 func isWPTFYIApp(appID int64) bool {
 	switch appID {

--- a/api/checks/webhook_test.go
+++ b/api/checks/webhook_test.go
@@ -109,47 +109,99 @@ func TestHandleCheckRunEvent_Created_Pending(t *testing.T) {
 }
 
 func TestHandleCheckRunEvent_ActionRequested_Ignore(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
+	for _, prefix := range []string{"staging.wpt.fyi - ", "wpt.fyi - ", ""} {
+		t.Run(prefix, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
 
-	id := int64(wptfyiStagingCheckAppID)
-	sha := strings.Repeat("0123456789", 4)
-	chrome := "chrome"
-	requestedAction := "requested_action"
-	pending := "pending"
-	username := "lukebjerring"
-	owner := shared.WPTRepoOwner
-	repo := shared.WPTRepoName
-	appID := int64(wptfyiStagingCheckAppID)
-	event := github.CheckRunEvent{
-		Action: &requestedAction,
-		CheckRun: &github.CheckRun{
-			App:     &github.App{ID: &id},
-			Name:    &chrome,
-			Status:  &pending,
-			HeadSHA: &sha,
-		},
-		Repo: &github.Repository{
-			Owner: &github.User{Login: &owner},
-			Name:  &repo,
-		},
-		RequestedAction: &github.RequestedAction{Identifier: "ignore"},
-		Installation:    &github.Installation{AppID: &appID},
-		Sender:          &github.User{Login: &username},
+			id := int64(wptfyiStagingCheckAppID)
+			sha := strings.Repeat("0123456789", 4)
+			name := prefix + "chrome"
+			requestedAction := "requested_action"
+			pending := "pending"
+			username := "lukebjerring"
+			owner := shared.WPTRepoOwner
+			repo := shared.WPTRepoName
+			appID := int64(wptfyiStagingCheckAppID)
+			event := github.CheckRunEvent{
+				Action: &requestedAction,
+				CheckRun: &github.CheckRun{
+					App:     &github.App{ID: &id},
+					Name:    &name,
+					Status:  &pending,
+					HeadSHA: &sha,
+				},
+				Repo: &github.Repository{
+					Owner: &github.User{Login: &owner},
+					Name:  &repo,
+				},
+				RequestedAction: &github.RequestedAction{Identifier: "ignore"},
+				Installation:    &github.Installation{AppID: &appID},
+				Sender:          &github.User{Login: &username},
+			}
+			payload, _ := json.Marshal(event)
+
+			aeAPI := sharedtest.NewMockAppEngineAPI(mockCtrl)
+			aeAPI.EXPECT().Context().AnyTimes().Return(sharedtest.NewTestContext())
+			aeAPI.EXPECT().IsFeatureEnabled(checksForAllUsersFeature).Return(false)
+			checksAPI := mock_checks.NewMockAPI(mockCtrl)
+			checksAPI.EXPECT().IgnoreFailure(username, owner, repo, event.GetCheckRun(), event.GetInstallation())
+			azureAPI := mock_azure.NewMockAPI(mockCtrl)
+			taskclusterAPI := mock_taskcluster.NewMockAPI(mockCtrl)
+
+			processed, err := handleCheckRunEvent(aeAPI, checksAPI, azureAPI, taskclusterAPI, payload)
+			assert.Nil(t, err)
+			assert.True(t, processed)
+		})
 	}
-	payload, _ := json.Marshal(event)
+}
 
-	aeAPI := sharedtest.NewMockAppEngineAPI(mockCtrl)
-	aeAPI.EXPECT().Context().AnyTimes().Return(sharedtest.NewTestContext())
-	aeAPI.EXPECT().IsFeatureEnabled(checksForAllUsersFeature).Return(false)
-	checksAPI := mock_checks.NewMockAPI(mockCtrl)
-	checksAPI.EXPECT().IgnoreFailure(username, owner, repo, event.GetCheckRun(), event.GetInstallation())
-	azureAPI := mock_azure.NewMockAPI(mockCtrl)
-	taskclusterAPI := mock_taskcluster.NewMockAPI(mockCtrl)
+func TestHandleCheckRunEvent_ActionRequested_Recompute(t *testing.T) {
+	for _, prefix := range []string{"staging.wpt.fyi - ", "wpt.fyi - ", ""} {
+		t.Run(prefix, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
 
-	processed, err := handleCheckRunEvent(aeAPI, checksAPI, azureAPI, taskclusterAPI, payload)
-	assert.Nil(t, err)
-	assert.True(t, processed)
+			id := int64(wptfyiStagingCheckAppID)
+			sha := strings.Repeat("0123456789", 4)
+			name := prefix + "chrome[experimental]"
+			requestedAction := "requested_action"
+			pending := "pending"
+			username := "lukebjerring"
+			owner := shared.WPTRepoOwner
+			repo := shared.WPTRepoName
+			appID := int64(wptfyiStagingCheckAppID)
+			event := github.CheckRunEvent{
+				Action: &requestedAction,
+				CheckRun: &github.CheckRun{
+					App:     &github.App{ID: &id},
+					Name:    &name,
+					Status:  &pending,
+					HeadSHA: &sha,
+				},
+				Repo: &github.Repository{
+					Owner: &github.User{Login: &owner},
+					Name:  &repo,
+				},
+				RequestedAction: &github.RequestedAction{Identifier: "recompute"},
+				Installation:    &github.Installation{AppID: &appID},
+				Sender:          &github.User{Login: &username},
+			}
+			payload, _ := json.Marshal(event)
+
+			aeAPI := sharedtest.NewMockAppEngineAPI(mockCtrl)
+			aeAPI.EXPECT().Context().AnyTimes().Return(sharedtest.NewTestContext())
+			aeAPI.EXPECT().IsFeatureEnabled(checksForAllUsersFeature).Return(false)
+			checksAPI := mock_checks.NewMockAPI(mockCtrl)
+			checksAPI.EXPECT().ScheduleResultsProcessing(sha, sharedtest.SameProductSpec("chrome[experimental]"))
+			azureAPI := mock_azure.NewMockAPI(mockCtrl)
+			taskclusterAPI := mock_taskcluster.NewMockAPI(mockCtrl)
+
+			processed, err := handleCheckRunEvent(aeAPI, checksAPI, azureAPI, taskclusterAPI, payload)
+			assert.Nil(t, err)
+			assert.True(t, processed)
+		})
+	}
 }
 
 func TestHandleCheckRunEvent_ActionRequested_Cancel(t *testing.T) {


### PR DESCRIPTION
## Description
Adding a "wpt.fyi - " prefix (https://github.com/web-platform-tests/wpt.fyi/pull/1148, I think?) broke the recompute action.

This PR adds a test for `recompute`, and covers prefixed names for the `ignore` action test too.