### PR TITLE
Populate diff summaries from SearchResults

### DIFF
--- a/shared/run_diff.go
+++ b/shared/run_diff.go
@@ -414,14 +414,22 @@ func (d diffAPIImpl) getRunsDiffFromSearchCache(before, after TestRun, filter Di
 
 func runDiffFromSearchResponse(before, after TestRun, scDiff SearchResponse) (RunDiff, error) {
 	differences := make(map[string]TestDiff)
+	beforeSummary := make(ResultsSummary)
+	afterSummary := make(ResultsSummary)
 	for _, t := range scDiff.Results {
 		differences[t.Test] = t.Diff
+		if len(t.LegacyStatus) > 1 {
+			beforeSummary[t.Test] = TestSummary{t.LegacyStatus[0].Passes, t.LegacyStatus[0].Total}
+			afterSummary[t.Test] = TestSummary{t.LegacyStatus[1].Passes, t.LegacyStatus[1].Total}
+		}
 	}
 
 	return RunDiff{
-		Before:      before,
-		After:       after,
-		Differences: differences,
+		Before:        before,
+		BeforeSummary: beforeSummary,
+		After:         after,
+		AfterSummary:  afterSummary,
+		Differences:   differences,
 	}, nil
 }
 

--- a/shared/run_diff_test.go
+++ b/shared/run_diff_test.go
@@ -233,4 +233,8 @@ func TestRunDiffFromSearchResponse(t *testing.T) {
 	diff, err := runDiffFromSearchResponse(TestRun{}, TestRun{}, scDiff)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, diff.Differences.Regressions().Cardinality())
+	assert.Equal(t, 4, diff.BeforeSummary["/pointerevents/idlharness.window.html"][0])
+	assert.Equal(t, 5, diff.BeforeSummary["/pointerevents/idlharness.window.html"][1])
+	assert.Equal(t, 76, diff.AfterSummary["/pointerevents/idlharness.window.html"][0])
+	assert.Equal(t, 84, diff.AfterSummary["/pointerevents/idlharness.window.html"][1])
 }


### PR DESCRIPTION
## Description
Fixes a bug from #1302 - the summaries weren't populated from the `SearchResults` format, which produces an empty CheckRun report.