### PR TITLE
Allow recompute on success

### DIFF
--- a/api/checks/summaries/completed.go
+++ b/api/checks/summaries/completed.go
@@ -40,5 +40,7 @@ func (c Completed) GetSummary() (string, error) {
 
 // GetActions returns the actions that can be taken by the user.
 func (c Completed) GetActions() []*github.CheckRunAction {
-	return nil
+	return []*github.CheckRunAction{
+		RecomputeAction(),
+	}
 }


### PR DESCRIPTION
## Description
Add the recompute action to success outcomes. 

Occassionally we will have false-positive bugs, or bugs in the reporting for a positive outcome, and this allows us to trivially check the fixes.