### PR TITLE
Restore the test counts message when viewing results

### DIFF
--- a/webapp/components/test/wpt-app.html
+++ b/webapp/components/test/wpt-app.html
@@ -15,6 +15,7 @@
   </test-fixture>
 
   <script type="module">
+import '../../views/wpt-app.js';
 import { TEST_RUNS_DATA } from './util/helpers.js';
 
 suite('<wpt-app>', () => {

--- a/webapp/components/test/wpt-app.html
+++ b/webapp/components/test/wpt-app.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+  <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
+</head>
+
+<body>
+  <test-fixture id="wpt-app-fixture">
+    <template>
+      <wpt-app></wpt-app>
+    </template>
+  </test-fixture>
+
+  <script type="module">
+import { TEST_RUNS_DATA } from './util/helpers.js';
+
+suite('<wpt-app>', () => {
+  let appFixture = null;
+
+  setup(() => {
+    appFixture = fixture('wpt-app-fixture');
+    appFixture.path = '/';
+  });
+
+  suite('WPTApp.prototype.*', () => {
+    setup(() => {
+      appFixture.testRuns = Array.from(TEST_RUNS_DATA);
+    });
+
+    suite('computeResultsTotalsRangeMessage', () => {
+      test('absent/zero', () => {
+        appFixture.searchResults = null;
+        expect(appFixture.resultsTotalsRangeMessage).to.not.contain('0 tests');
+        appFixture.searchResults = [];
+        expect(appFixture.resultsTotalsRangeMessage).to.not.contain('0 tests');
+        appFixture.page = 'results';
+        expect(appFixture.resultsTotalsRangeMessage).to.contain('0 tests');
+      });
+
+      test('some sum', () => {
+        appFixture.searchResults = [
+          {test: '/abc.html', legacy_status: [{total: 1}, {total: 5}]},
+          {test: '/def.html', legacy_status: [{total: 2}, {total: 1}]},
+        ];
+        appFixture.page = 'results';
+        expect(appFixture.resultsTotalsRangeMessage).to.contain('2 tests');
+        expect(appFixture.resultsTotalsRangeMessage).to.contain('7 subtests');
+      });
+    });
+  });
+});
+</script>
+</body>
+
+</html>

--- a/webapp/components/test/wpt-results.html
+++ b/webapp/components/test/wpt-results.html
@@ -165,23 +165,6 @@ suite('<wpt-results>', () => {
         expect(trf.resultsRangeMessage).to.contain(`revisions ${sha.substr(0, 7)}, ${sha2.substr(0, 7)}`);
       });
     });
-
-    suite('computeResultsTotalsRangeMessage', () => {
-      test('absent/zero', () => {
-        trf.searchResults = null;
-        expect(trf.resultsTotalsRangeMessage).to.not.contain('0 tests');
-        trf.searchResults = [];
-        expect(trf.resultsTotalsRangeMessage).to.contain('0 tests');
-      });
-      test('some sum', () => {
-        trf.searchResults = [
-          {test: '/abc.html', legacy_status: [{total: 1}, {total: 5}]},
-          {test: '/def.html', legacy_status: [{total: 2}, {total: 1}]},
-        ];
-        expect(trf.resultsTotalsRangeMessage).to.contain('2 tests');
-        expect(trf.resultsTotalsRangeMessage).to.contain('7 subtests');
-      });
-    });
   });
 
   teardown(() => {

--- a/webapp/views/wpt-app.js
+++ b/webapp/views/wpt-app.js
@@ -219,12 +219,16 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
   queryChanged(query) {
     // app-location don't support repeated params.
     this.shadowRoot.querySelector('app-location').__query = query;
-    this.activeView.query = query;
+    if (this.activeView) {
+      this.activeView.query = query;
+    }
   }
 
   _routeChanged(routeData) {
     this.page = routeData.page || 'results';
-    this.activeView.query = this.query;
+    if (this.activeView) {
+      this.activeView.query = this.query;
+    }
   }
 
   _subrouteChanged(subrouteData) {
@@ -302,3 +306,5 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
   }
 }
 customElements.define(WPTApp.is, WPTApp);
+
+export { WPTApp };

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -337,10 +337,7 @@ class WPTResults extends WPTColors(WPTFlags(PathInfo(LoadingState(TestRunsUIBase
       searchResults: {
         type: Array,
         value: [],
-      },
-      resultsTotalsRangeMessage: {
-        type: String,
-        computed: 'computeResultsTotalsRangeMessage(searchResults, shas, productSpecs, to, from, maxCount, labels, master)',
+        notify: true,
       },
       testPaths: {
         type: Set,
@@ -951,23 +948,6 @@ class WPTResults extends WPTColors(WPTFlags(PathInfo(LoadingState(TestRunsUIBase
     }
     this._fetchedQuery = query; // Debounce.
     this.reloadData();
-  }
-
-  computeResultsTotalsRangeMessage(searchResults, shas, productSpecs, from, to, maxCount, labels, master) {
-    const msg = super.computeResultsRangeMessage(shas, productSpecs, from, to, maxCount, labels, master);
-    if (searchResults) {
-      let subtests = 0, tests = 0;
-      for (const r of searchResults) {
-        if (r.test.startsWith(this.path)) {
-          tests++;
-          subtests += Math.max(...r.legacy_status.map(s => s.total));
-        }
-      }
-      return msg.replace(
-        'Showing ',
-        `Showing ${tests} tests (${subtests} subtests) from `);
-    }
-    return msg;
   }
 }
 


### PR DESCRIPTION
## Description
It got dropped in the migration to `wpt-app`. The `N tests (M subtests) from` message is being computed, but on the nest `wpt-results` class, which is not what we're using to populate the banner.