### PR TITLE
[processor] Improve logging for Azure Pipelines

### DIFF
--- a/results-processor/processor.py
+++ b/results-processor/processor.py
@@ -283,7 +283,11 @@ def process_report(task_id, params):
 
     response = []
     with Processor() as p:
-        _log.info("Downloading results & screenshots")
+        if azure_url:
+            _log.info("Downloading Azure results: %s", azure_url)
+        else:
+            _log.info("Downloading %d results & %d screenshots",
+                      len(results), len(screenshots))
         p.download(results, screenshots, azure_url)
         if len(p.results) == 0:
             _log.error("No results successfully downloaded")
@@ -301,7 +305,7 @@ def process_report(task_id, params):
             p.report.finalize()
         except wptreport.WPTReportError:
             etype, e, tb = sys.exc_info()
-            e.path = str(results)
+            e.path = results
             # This will register an error in Stackdriver.
             traceback.print_exception(etype, e, tb)
             # The input is invalid and there is no point to retry, so we return

--- a/results-processor/wptreport.py
+++ b/results-processor/wptreport.py
@@ -14,7 +14,18 @@ import os
 import re
 import tempfile
 from datetime import datetime, timezone
-from typing import Any, Callable, Dict, Iterator, IO, List, Optional, Set, cast
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    IO,
+    Iterator,
+    List,
+    Optional,
+    Set,
+    Union,
+    cast,
+)
 
 import requests
 from mypy_extensions import TypedDict
@@ -56,7 +67,8 @@ class RawWPTReport(TypedDict, total=False):
 
 class WPTReportError(Exception):
     """Base class for all input-related exceptions."""
-    def __init__(self, message: str, path: Optional[str] = None) -> None:
+    def __init__(self, message: str,
+                 path: Optional[Union[str, List[str]]] = None) -> None:
         self.message = message
         self.path = path
 


### PR DESCRIPTION
Currently when results from Azure Pipelines are abnormal, we will see
empty source URLs in the logs (e.g. "Conflicting 'browser_version' found
in the merged report ([])"). This change fixes the problem.
