### PR TITLE
Add script for extracting summary numbers

### DIFF
--- a/webdriver/trend.js
+++ b/webdriver/trend.js
@@ -9,8 +9,8 @@ const puppeteer = require('puppeteer');
 
 const flags = require('flags');
 const browserFlag = flags.defineString('products', 'chrome,firefox,safari', 'Browsers to compare/analyze');
-const mode = flags.defineString('mode', 'failures', 'Analysis type. "failures", "passes", or "flakes"');
-const date = flags.defineString('date', '2019-08-01', 'First date to scrape');
+const mode = flags.defineString('mode', 'failures', 'Analysis type. "stats", "failures", "passes", or "flakes"');
+const date = flags.defineString('date', (new Date()).toISOString().split('T')[0], 'First date to scrape');
 const weeks = flags.defineInteger('weeks', 52, 'Number of weeks to scrape');
 const step = flags.defineInteger('step', 1, 'Number of weeks to step');
 const backward = flags.defineBoolean('backward', true, 'Whether to move backward in time for each week');
@@ -102,12 +102,17 @@ async function main() {
             }
           }
           nextUrl.searchParams.set('q', q);
-        } else {
+        } else if (mode.get() === 'flakes') {
           nextUrl.searchParams.set('products', browser);
           nextUrl.searchParams.set('max-count', 10);
           nextUrl.searchParams.set(
             'q',
             'seq((status:PASS|status:OK) (status:!PASS&status:!OK&status:!unknown)) seq((status:!PASS&status:!OK&status:!unknown) (status:PASS|status:OK))');
+        } else {
+          nextUrl.searchParams.set(
+            'q',
+            `${browser}:ok or ${browser}:pass`
+          );
         }
 
         const {sha, tests, subtests} = await scrape(nextUrl);

--- a/webdriver/trend.js
+++ b/webdriver/trend.js
@@ -10,6 +10,9 @@ const puppeteer = require('puppeteer');
 const flags = require('flags');
 const browserFlag = flags.defineString('products', 'chrome,firefox,safari', 'Browsers to compare');
 const passes = flags.defineBoolean('passes', false, 'Count browser-specific passes, not failures');
+const date = flags.defineString('date', '2019-08-01', 'First date to scrape');
+const weeks = flags.defineInteger('weeks', 52, 'Number of weeks to scrape');
+const backward = flags.defineBoolean('backward', true, 'Whether to move backward in time for each week');
 flags.parse();
 
 const browsers = browserFlag.get().split(',').map(b => b.trim());
@@ -52,10 +55,11 @@ async function main() {
       };
     };
 
-    const dates = [new Date('2019-07-01')];
-    for (var i = 1; i < 52; i++) {
+    const dates = [new Date(date.get())];
+    for (var i = 1; i < weeks.get(); i++) {
       const next = new Date(dates[dates.length-1]);
-      next.setDate(next.getDate() - 7);
+      const multiplier = backward.get() ? -1 : 1;
+      next.setDate(next.getDate() + 7 * multiplier);
       dates.push(next);
     }
 

--- a/webdriver/trend.js
+++ b/webdriver/trend.js
@@ -7,33 +7,79 @@
 const log = require('debug')('wpt.fyi');
 const puppeteer = require('puppeteer');
 
+const flags = require('flags');
+const browserFlag = flags.defineString('browser', 'chrome', 'Browser which is the only one with failures');
+flags.parse();
+
 async function main() {
   log('Launching puppeteer');
   const browser = await puppeteer.launch({
     headless: process.env.HEADLESS !== 'false',
   });
 
-  /** @type {Page} */
-  const page = await browser.newPage();
-  const url = new URL(`https://wpt.fyi/`);
-  url.searchParams.set('label', 'master');
-  url.searchParams.set('products', 'chrome,firefox,safari');
-  url.searchParams.set('q', '(chrome:!pass&chrome:!ok) (firefox:pass|firefox:ok) (safari:pass|safari:ok)');
-  await page.goto(url);
+  try {
+    const scrape = async function(date) {
+      const dateParam = new Date(date).toISOString().split('T')[0];
+      /** @type {Page} */
+      const page = await browser.newPage();
+      const url = new URL(`https://wpt.fyi/`);
+      url.searchParams.set('labels', 'master,stable');
+      url.searchParams.set('products', 'chrome,firefox,safari');
+      const mainProduct = browserFlag.get();
+      let q = `(${mainProduct}:!pass&${mainProduct}:!ok)`;
+      for (const other of ['chrome','firefox','safari'].filter(b => b != mainProduct)) {
+        q += ` (${other}:pass|${other}:ok)`;
+      }
+      url.searchParams.set('q', q);
+      url.searchParams.set('aligned', true);
+      url.searchParams.set('to', dateParam);
+      await page.goto(url);
 
-  log('Waiting for wpt-results...');
-  const app = await page.$('wpt-app');
-  const results = await page.waitFor(
-    app => app && app.shadowRoot && app.shadowRoot.querySelector(`wpt-results`),
-    {},
-    app
-  );
+      log('Loading homepage...');
+      log(`${url}`);
+      const app = await page.$('wpt-app');
+      const results = await page.waitFor(
+        app => app && app.shadowRoot && app.shadowRoot.querySelector(`wpt-results`),
+        {},
+        app
+      );
 
-  log('Extracting summary...');
-  await page.waitFor(results => !results.isLoading, {}, results);
-  const msg = await page.evaluate(app => app.resultsTotalsRangeMessage, app);
-  log(msg);
+      log('Waiting for searchcache...');
+      await page.waitFor(results => !results.isLoading, {}, results);
+      log('Extracting summary...');
+      const runs = await page.evaluate(results => results.testRuns, results);
+      const msg = await page.evaluate(app => app.resultsTotalsRangeMessage, app);
+      [_, tests, subtests] = /Showing (\d+) tests \((\d+) subtests\)/.exec(msg);
+      tests = parseInt(tests);
+      subtests = parseInt(subtests);
+      log('%s tests (%s subtests)', tests, subtests);
+      return {
+        date: runs[0].created_at,
+        sha: runs[0].revision,
+        tests,
+        subtests
+      };
+    };
 
-  browser.close();
+    const dates = [new Date('2019-07-01')];
+    for (var i = 0; i < 11; i++) {
+      const next = new Date(dates[dates.length-1]);
+      next.setMonth(next.getMonth() - 1);
+      dates.push(next);
+    }
+
+    console.log(['date', 'sha', 'tests', 'subtests'].map(s => s.padEnd(10)).join('\t'));
+    for (const date of dates) {
+      const {sha, tests, subtests} = await scrape(date);
+      console.log([
+        date.toISOString().split('T')[0],
+        sha,
+        tests,
+        subtests
+      ].map(s => `${s}`.padEnd(10)).join('\t'));
+    }
+  } finally {
+    browser.close();
+  }
 };
 main().catch(log);

--- a/webdriver/trend.js
+++ b/webdriver/trend.js
@@ -9,6 +9,12 @@ const puppeteer = require('puppeteer');
 
 const flags = require('flags');
 const browserFlag = flags.defineString('products', 'chrome,firefox,safari', 'Browsers to compare/analyze');
+/**
+ * stats: Basic total pass/ok counts per product
+ * failures: Counts of tests by product that are only failing for that one product.
+ * passes: Counts of tests by product that are only passing for that one product.
+ * flakes: Counts of tests by product that are flaky in the most recent 10 runs for each date.
+ */
 const mode = flags.defineString('mode', 'failures', 'Analysis type. "stats", "failures", "passes", or "flakes"');
 const date = flags.defineString('date', (new Date()).toISOString().split('T')[0], 'First date to scrape');
 const weeks = flags.defineInteger('weeks', 52, 'Number of weeks to scrape');

--- a/webdriver/trend.js
+++ b/webdriver/trend.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2019 The WPT Dashboard Project. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+const log = require('debug')('wpt.fyi');
+const puppeteer = require('puppeteer');
+
+async function main() {
+  log('Launching puppeteer');
+  const browser = await puppeteer.launch({
+    headless: process.env.HEADLESS !== 'false',
+  });
+
+  /** @type {Page} */
+  const page = await browser.newPage();
+  const url = new URL(`https://wpt.fyi/`);
+  url.searchParams.set('label', 'master');
+  url.searchParams.set('products', 'chrome,firefox,safari');
+  url.searchParams.set('q', '(chrome:!pass&chrome:!ok) (firefox:pass|firefox:ok) (safari:pass|safari:ok)');
+  await page.goto(url);
+
+  log('Waiting for wpt-results...');
+  const app = await page.$('wpt-app');
+  const results = await page.waitFor(
+    app => app && app.shadowRoot && app.shadowRoot.querySelector(`wpt-results`),
+    {},
+    app
+  );
+
+  log('Extracting summary...');
+  await page.waitFor(results => !results.isLoading, {}, results);
+  const msg = await page.evaluate(app => app.resultsTotalsRangeMessage, app);
+  log(msg);
+
+  browser.close();
+};
+main().catch(log);


### PR DESCRIPTION
## Description
Adds a puppeteer helper script for scraping the test counts for a query, by leveraging the UI's 422-and-retry behaviour to keep the script simple.