### PR TITLE
Bring back history button

### DIFF
--- a/webapp/components/self-navigator.js
+++ b/webapp/components/self-navigator.js
@@ -5,6 +5,7 @@
  */
 
 import '../node_modules/@polymer/polymer/polymer-element.js';
+import { PathInfo } from './path.js';
 
 const $_documentContainer = document.createElement('template');
 $_documentContainer.innerHTML = `<dom-module id="self-navigator">
@@ -13,21 +14,13 @@ $_documentContainer.innerHTML = `<dom-module id="self-navigator">
 
 document.head.appendChild($_documentContainer.content);
 // eslint-disable-next-line no-unused-vars
-const SelfNavigation = (superClass) => class SelfNavigation extends superClass {
+const SelfNavigation = (superClass) => class SelfNavigation extends PathInfo(superClass) {
   static get properties() {
     return {
       path: {
         type: String,
         value: '/',
         observer: 'pathUpdated',
-      },
-      encodedPath: {
-        type: String,
-        computed: 'encodeTestPath(path)'
-      },
-      isSubfolder: {
-        type: Boolean,
-        computed: 'computeIsSubfolder(path)',
       },
       onLocationUpdated: Function,
     };
@@ -88,10 +81,6 @@ const SelfNavigation = (superClass) => class SelfNavigation extends superClass {
       this.onLocationUpdated(
         path, history.state || this.navigationQueryParams());
     }
-  }
-
-  computeIsSubfolder(path) {
-    return path && path !== '/';
   }
 
   /**

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -239,7 +239,7 @@ class WPTResults extends WPTColors(WPTFlags(PathInfo(LoadingState(TestRunsUIBase
       </template>
     </template>
 
-    <template is="dom-if" if="[[pathIsASubfolder]]">
+    <template is="dom-if" if="[[pathIsASubfolderOrFile]]">
       <div class="history">
         <template is="dom-if" if="[[!showHistory]]">
           <paper-button id="show-history" onclick="[[showHistoryClicked()]]" raised>
@@ -307,6 +307,10 @@ class WPTResults extends WPTColors(WPTFlags(PathInfo(LoadingState(TestRunsUIBase
       path: {
         type: String,
         observer: 'pathUpdated',
+      },
+      pathIsASubfolderOrFile: {
+        type: Boolean,
+        computed: 'computePathIsASubfolderOrFile(pathIsASubfolder, pathIsATestFile)'
       },
       sourcePath: {
         type: String,
@@ -389,6 +393,10 @@ class WPTResults extends WPTColors(WPTFlags(PathInfo(LoadingState(TestRunsUIBase
 
   isInvalidDiffUse(diff, testRuns) {
     return diff && testRuns && testRuns.length !== 2;
+  }
+
+  computePathIsASubfolderOrFile(isSubfolder, isFile) {
+    return isSubfolder || isFile;
   }
 
   computeSourcePath(path, manifest) {

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -239,7 +239,7 @@ class WPTResults extends WPTColors(WPTFlags(PathInfo(LoadingState(TestRunsUIBase
       </template>
     </template>
 
-    <template is="dom-if" if="[[isSubfolder]]">
+    <template is="dom-if" if="[[pathIsASubfolder]]">
       <div class="history">
         <template is="dom-if" if="[[!showHistory]]">
           <paper-button id="show-history" onclick="[[showHistoryClicked()]]" raised>


### PR DESCRIPTION
## Description
Broken in https://github.com/web-platform-tests/wpt.fyi/pull/1295, which highlighted a weird mismatch of the `pathIsASubfolder` property.

This refactors the old `SelfNavigator` (still used) to re-use the `PathInfo` mixin to avoid that issue in future.