### PR TITLE
Fetch any/all matching product keys in a single datastore lookup

### DIFF
--- a/api/test_runs.go
+++ b/api/test_runs.go
@@ -55,9 +55,9 @@ func apiTestRunsHandler(w http.ResponseWriter, r *http.Request) {
 		if pr != nil && aeAPI.IsFeatureEnabled("runsByPRNumber") {
 			filters.SHAs = getPRCommits(aeAPI, *pr)
 			if len(filters.SHAs) < 1 {
-				log.Warningf("PR %s returned no commits from GitHub", *pr)
+				log.Warningf("PR %v returned no commits from GitHub", *pr)
 			} else {
-				log.Infof("PR %s returned %v commits: %s", *pr, len(filters.SHAs), strings.Join(filters.SHAs.SevenCharSHAs(), ","))
+				log.Infof("PR %v returned %v commits: %s", *pr, len(filters.SHAs), strings.Join(filters.SHAs.SevenCharSHAs(), ","))
 			}
 		}
 		var runsByProduct shared.TestRunsByProduct

--- a/api/test_runs.go
+++ b/api/test_runs.go
@@ -57,7 +57,7 @@ func apiTestRunsHandler(w http.ResponseWriter, r *http.Request) {
 			if len(filters.SHAs) < 1 {
 				log.Warningf("PR %v returned no commits from GitHub", *pr)
 			} else {
-				log.Infof("PR %v returned %v commits: %s", *pr, len(filters.SHAs), strings.Join(filters.SHAs.SevenCharSHAs(), ","))
+				log.Infof("PR %v returned %v commits: %s", *pr, len(filters.SHAs), strings.Join(filters.SHAs.ShortSHAs(), ","))
 			}
 		}
 		var runsByProduct shared.TestRunsByProduct

--- a/shared/product_spec.go
+++ b/shared/product_spec.go
@@ -47,7 +47,9 @@ func (p ProductSpec) MatchesProductAtRevision(productAtRevision ProductAtRevisio
 	if productAtRevision.BrowserName != p.BrowserName {
 		return false
 	}
-	if !IsLatest(p.Revision) && p.Revision != productAtRevision.Revision {
+	if !IsLatest(p.Revision) &&
+		p.Revision != productAtRevision.Revision &&
+		!strings.HasPrefix(productAtRevision.FullRevisionHash, p.Revision) {
 		return false
 	}
 	if p.BrowserVersion != "" {

--- a/shared/test_run_filter.go
+++ b/shared/test_run_filter.go
@@ -33,7 +33,7 @@ func (s SHAs) FirstOrLatest() string {
 }
 
 // Returns an array of the given SHAs' first 7-chars.
-func (s SHAs) SevenCharSHAs() []string {
+func (s SHAs) ShortSHAs() []string {
 	short := make([]string, len(s))
 	for i, long := range s {
 		short[i] = long[:7]

--- a/shared/test_run_filter.go
+++ b/shared/test_run_filter.go
@@ -32,6 +32,15 @@ func (s SHAs) FirstOrLatest() string {
 	return s[0]
 }
 
+// Returns an array of the given SHAs' first 7-chars.
+func (s SHAs) SevenCharSHAs() []string {
+	short := make([]string, len(s))
+	for i, long := range s {
+		short[i] = long[:7]
+	}
+	return short
+}
+
 // TestRunFilter represents the ways TestRun entities can be filtered in
 // the webapp and api.
 type TestRunFilter struct {

--- a/shared/test_run_filter.go
+++ b/shared/test_run_filter.go
@@ -32,7 +32,7 @@ func (s SHAs) FirstOrLatest() string {
 	return s[0]
 }
 
-// Returns an array of the given SHAs' first 7-chars.
+// ShortSHAs returns an array of the given SHAs' first 7-chars.
 func (s SHAs) ShortSHAs() []string {
 	short := make([]string, len(s))
 	for i, long := range s {

--- a/shared/test_run_query.go
+++ b/shared/test_run_query.go
@@ -158,6 +158,7 @@ func (t testRunQueryImpl) LoadTestRunKeys(
 			for _, id := range ids {
 				revKeyFilter.Add(id)
 			}
+			log.Debugf("Found %v keys for %s@%s", revKeyFilter.Cardinality(), product.BrowserName, product.Revision)
 			productKeyFilter = merge(productKeyFilter, revKeyFilter)
 		}
 		if product.BrowserVersion != "" {
@@ -165,6 +166,7 @@ func (t testRunQueryImpl) LoadTestRunKeys(
 			if versionKeys, err = loadKeysForBrowserVersion(t.store, query, product.BrowserVersion); err != nil {
 				return nil, err
 			}
+			log.Debugf("Found %v keys for %s", versionKeys.Cardinality(), product.BrowserVersion)
 			productKeyFilter = merge(productKeyFilter, versionKeys)
 		}
 		// TODO(lukebjerring): Indexes + filtering for OS + version.
@@ -190,6 +192,7 @@ func (t testRunQueryImpl) LoadTestRunKeys(
 			}
 			results = append(results, key)
 		}
+		log.Debugf("Found %v results for %s", len(results), product.String())
 		result[i] = ProductTestRunKeys{
 			Product: product,
 			Keys:    results,

--- a/shared/test_run_query.go
+++ b/shared/test_run_query.go
@@ -140,7 +140,7 @@ func (t testRunQueryImpl) LoadTestRunKeys(
 				globalIDFilter.Add(id)
 			}
 		}
-		log.Debugf("Found %v keys across %v resivions", globalIDFilter.Cardinality(), len(revisions))
+		log.Debugf("Found %d keys across %d revisions", globalIDFilter.Cardinality(), len(revisions))
 	}
 
 	for i, product := range products {

--- a/shared/test_run_query_medium_test.go
+++ b/shared/test_run_query_medium_test.go
@@ -267,6 +267,13 @@ func TestLoadTestRuns_SHAinProductSpec(t *testing.T) {
 	allRuns = loaded.AllRuns()
 	assert.Equal(t, 1, len(allRuns))
 	assert.Equal(t, "1111111111", allRuns[0].Revision)
+
+	// Partial SHA, Exact version
+	products[0].BrowserVersion = "63.1.1.1"
+	loaded, err = store.TestRunQuery().LoadTestRuns(products, nil, nil, nil, nil, nil, nil)
+	allRuns = loaded.AllRuns()
+	assert.Equal(t, 1, len(allRuns))
+	assert.Equal(t, "1111111111", allRuns[0].Revision)
 }
 
 func TestLoadTestRuns_Ordering(t *testing.T) {


### PR DESCRIPTION
## Description
Fixes the underlying cause of datastore timeouts, which in turn fixes https://github.com/web-platform-tests/wpt.fyi/issues/973

Example that is timing out: https://wpt.fyi/api/runs?pr=17560
(And its corresponding fix: https://runs-by-pr-dot-wptdashboard-staging.appspot.com/api/runs?pr=17560)