### PR TITLE
Show before and after in non-regressing check summaries

### DIFF
--- a/api/checks/summaries/_pr_and_master_specs.md
+++ b/api/checks/summaries/_pr_and_master_specs.md
@@ -1,4 +1,4 @@
 Run | Spec
 --- | ---
-`{{ printf "%.7s" .BaseRun.FullRevisionHash }}` | {{ .BaseRun.String }}
+`master` | {{ .BaseRun.String }}
 `{{ printf "%.7s" .HeadRun.FullRevisionHash }}` | {{ .HeadRun.String }}

--- a/api/checks/summaries/compile_test.go
+++ b/api/checks/summaries/compile_test.go
@@ -36,8 +36,13 @@ func TestGetSummary_Completed(t *testing.T) {
 	foo.HostName = "foo.com"
 	foo.HostURL = "https://foo.com/"
 	testName := "/foo.html?exclude=(Document|window|HTML.*)"
-	foo.Results = map[string][]int{
-		testName: []int{2, 3},
+	foo.Results = BeforeAndAfter{
+		testName: TestBeforeAndAfter{
+			PassingBefore: 2,
+			TotalBefore:   3,
+			PassingAfter:  2,
+			TotalAfter:    2,
+		},
 	}
 	foo.More = 1
 
@@ -105,8 +110,8 @@ func TestGetSummary_Regressed(t *testing.T) {
 	foo.HostURL = "https://foo.com/"
 	foo.DiffURL = "https://foo.com/?products=chrome@0000000000,chrome@0123456789&diff"
 	testName := "/foo.html?exclude=(Document|window|HTML.*)"
-	foo.Regressions = map[string]BeforeAndAfter{
-		testName: BeforeAndAfter{
+	foo.Regressions = BeforeAndAfter{
+		testName: TestBeforeAndAfter{
 			PassingBefore: 1,
 			TotalBefore:   1,
 			PassingAfter:  0,

--- a/api/checks/summaries/completed.go
+++ b/api/checks/summaries/completed.go
@@ -24,7 +24,7 @@ type Completed struct {
 	CheckState
 	ResultsComparison
 
-	Results map[string][]int
+	Results BeforeAndAfter
 	More    int
 }
 

--- a/api/checks/summaries/completed.md
+++ b/api/checks/summaries/completed.md
@@ -6,10 +6,10 @@ There were no regressions detected in the results.
 
 ### Results
 
-Test | `{{ printf "%.7s" .HeadRun.FullRevisionHash }}`
+Test | `master` | `{{ printf "%.7s" .HeadRun.FullRevisionHash }}`
 --- | ---
 {{ range $test, $results := .Results -}}
-{{ escapeMD $test }} | {{ index $results 0 }} / {{ index $results 1 }}
+{{ escapeMD $test }} | {{ $results.PassingBefore }} / {{ $results.TotalBefore }} | {{ $results.PassingAfter }} / {{ $results.TotalAfter }}
 {{end}}
 {{ if gt .More 0 -}}
 And {{ .More }} others...
@@ -23,6 +23,6 @@ Other links that might be useful:
 {{- if .MasterDiffURL }}
 - [`{{ printf "%.7s" .HeadRun.FullRevisionHash }}` vs latest master]({{ .MasterDiffURL }})
 {{- end }}
-- [Latest results for `{{ printf "%.7s" .HeadRun.FullRevisionHash }}`]({{.HostURL}}?sha={{.HeadRun.Revision}})
+- [Latest results for `{{ printf "%.7s" .HeadRun.FullRevisionHash }}`]({{.HostURL}}?sha={{.HeadRun.Revision}}&label=pr_head)
 
 {{ template "_file_an_issue.md" . }}

--- a/api/checks/summaries/regressed.go
+++ b/api/checks/summaries/regressed.go
@@ -4,10 +4,34 @@
 
 package summaries
 
-import "github.com/google/go-github/github"
+import (
+	"github.com/google/go-github/github"
+	"github.com/web-platform-tests/wpt.fyi/shared"
+)
 
-// BeforeAndAfter is a struct summarizing pass rates before and after in a diff.
-type BeforeAndAfter struct {
+// BeforeAndAfter summarizes counts for pass/total before and after, across a
+// particular path (could be a folder, could be a test).
+type BeforeAndAfter map[string]TestBeforeAndAfter
+
+// Add the given before/after counts to the totals.
+func (bna BeforeAndAfter) Add(p string, before, after shared.TestSummary) {
+	sum := TestBeforeAndAfter{}
+	if existing, ok := bna[p]; ok {
+		sum = existing
+	}
+	if before != nil {
+		sum.PassingBefore += before[0]
+		sum.TotalBefore += before[1]
+	}
+	if after != nil {
+		sum.PassingAfter += after[0]
+		sum.TotalAfter += after[1]
+	}
+	bna[p] = sum
+}
+
+// TestBeforeAndAfter is a struct summarizing pass rates before and after in a diff.
+type TestBeforeAndAfter struct {
 	PassingBefore int
 	PassingAfter  int
 	TotalBefore   int
@@ -19,7 +43,7 @@ type Regressed struct {
 	CheckState
 	ResultsComparison
 
-	Regressions map[string]BeforeAndAfter
+	Regressions BeforeAndAfter
 	More        int
 }
 

--- a/api/checks/summaries/regressed.md
+++ b/api/checks/summaries/regressed.md
@@ -24,6 +24,6 @@ Other links that might be useful:
 {{- if .MasterDiffURL }}
 - [`{{ printf "%.7s" .HeadRun.FullRevisionHash }}` vs latest master]({{ .MasterDiffURL }})
 {{- end }}
-- [Latest results for `{{ printf "%.7s" .HeadRun.FullRevisionHash }}`]({{.HostURL}}results/?sha={{.HeadRun.Revision}})
+- [Latest results for `{{ printf "%.7s" .HeadRun.FullRevisionHash }}`]({{.HostURL}}results/?sha={{.HeadRun.Revision}}&label=pr_head)
 
 {{ template "_file_an_issue.md" . }}


### PR DESCRIPTION
Currently we only show the "After", which is based on the premise that newly-failing tests would be considered regressing. Now, however, only existing passes that change to failure are considered regressions, so we should show before and after in all cases (in case new tests exist).