### PR TITLE
Move to next + prev individual test when n + p are pressed

### DIFF
--- a/webapp/components/path.js
+++ b/webapp/components/path.js
@@ -13,7 +13,10 @@ import { html, PolymerElement } from '../node_modules/@polymer/polymer/polymer-e
 const PathInfo = (superClass) => class extends superClass {
   static get properties() {
     return {
-      path: String,
+      path: {
+        type: String,
+        notify: true,
+      },
       encodedPath: {
         type: String,
         computed: 'encodeTestPath(path)'

--- a/webapp/components/path.js
+++ b/webapp/components/path.js
@@ -98,7 +98,8 @@ class PathPart extends PolymerElement {
   static get properties() {
     return {
       path: {
-        type: String
+        type: String,
+        notify: true,
       },
       query: {
         type: String

--- a/webapp/views/wpt-app.js
+++ b/webapp/views/wpt-app.js
@@ -68,10 +68,10 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
 
       <section class="search">
         <div class="path">
-          <a href="/[[page]]/?[[ query ]]" on-click="navigate">wpt</a>
+          <a href="/[[page]]/?[[ query ]]">wpt</a>
           <!-- The next line is intentionally formatted so to avoid whitespaces between elements. -->
           <template is="dom-repeat" items="[[ splitPathIntoLinkedParts(path) ]]" as="part"
-            ><span class="path-separator">/</span><a href="/[[page]][[ part.path ]]?[[ query ]]" on-click="navigate">[[ part.name ]]</a></template>
+            ><span class="path-separator">/</span><a href="/[[page]][[ part.path ]]?[[ query ]]">[[ part.name ]]</a></template>
         </div>
 
         <template is="dom-if" if="[[searchPRsForDirectories]]">
@@ -130,14 +130,14 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
         <wpt-results name="results"
                      is-loading="{{resultsLoading}}"
                      structured-search="[[structuredSearch]]"
-                     path="[[subroute.path]]"
+                     path="{{subroute.path}}"
                      test-runs="{{testRuns}}"
                      search-results="{{searchResults}}"></wpt-results>
 
         <wpt-interop name="interop"
                      is-loading="{{interopLoading}}"
                      structured-search="[[structuredSearch]]"
-                     path="[[subroute.path]]"></wpt-interop>
+                     path="{{subroute.path}}"></wpt-interop>
 
         <wpt-404 name="404" ></wpt-404>
       </iron-pages>
@@ -207,6 +207,7 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
     const testSearch = this.shadowRoot.querySelector('test-search');
     testSearch.addEventListener('commit', this.handleSearchCommit.bind(this));
     testSearch.addEventListener('autocomplete', this.handleSearchAutocomplete.bind(this));
+    document.addEventListener('keydown', this.handleKeyDown.bind(this));
   }
 
   disconnectedCallback() {
@@ -271,6 +272,16 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
     path += `/${encodeURIComponent(lastPart)}`;
     linkedParts.push({ name: lastPart, path: path });
     return linkedParts;
+  }
+
+  handleKeyDown(e) {
+    // Ignore when something other than body has focus.
+    if (!e.path.length || e.path[0] !== document.body) {
+      return;
+    }
+    if (e.key === 'n') {
+      this.activeView.moveToNext();
+    }
   }
 
   handleSubmitQuery() {

--- a/webapp/views/wpt-app.js
+++ b/webapp/views/wpt-app.js
@@ -281,6 +281,8 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
     }
     if (e.key === 'n') {
       this.activeView.moveToNext();
+    } else if (e.key === 'p') {
+      this.activeView.moveToPrev();
     }
   }
 

--- a/webapp/views/wpt-interop.js
+++ b/webapp/views/wpt-interop.js
@@ -522,16 +522,24 @@ class WPTInterop extends WPTColors(WPTFlags(LoadingState(PathInfo(
   }
 
   moveToNext() {
+    this._move(true);
+  }
+
+  moveToPrev() {
+    this._move(false);
+  }
+
+  _move(forward) {
     if (!this.searchResults || !this.searchResults.length) {
       return;
     }
-    let next = this.searchResults.findIndex(r => r.test === this.path);
+    let next = this.searchResults.findIndex(r => r.test.startsWith(this.path));
     if (next < 0) {
-      next = 0;
+      next = (forward ? 0 : -1);
     } else {
-      next = next + 1 % this.searchResults.length;
+      next = next + (forward ? 1 : -1);
     }
-    this.path = this.searchResults[next].test;
+    this.path = this.searchResults[next % this.searchResults.length].test;
   }
 }
 window.customElements.define(WPTInterop.is, WPTInterop);

--- a/webapp/views/wpt-interop.js
+++ b/webapp/views/wpt-interop.js
@@ -530,18 +530,21 @@ class WPTInterop extends WPTColors(WPTFlags(LoadingState(PathInfo(
   }
 
   _move(forward) {
-    if (!this.searchResults || !this.searchResults.length) {
+    if (!this.searchResults
+        || !this.searchResults.results
+        || !this.searchResults.results.length) {
       return;
     }
-    const n = this.searchResults.length;
-    let next = this.searchResults.findIndex(r => r.test.startsWith(this.path));
+    const results = this.searchResults.results.sort((a, b) => a.test.localeCompare(b.test));
+    const n = results.length;
+    let next = results.findIndex(r => r.test.startsWith(this.path));
     if (next < 0) {
       next = (forward ? 0 : -1);
-    } else if (this.searchResults[next].test === this.path) { // Only advance 1 for exact match.
+    } else if (results[next].test === this.path) { // Only advance 1 for exact match.
       next = next + (forward ? 1 : -1);
     }
     // % in js is not modulo, it's remainder. Ensure it's positive.
-    this.path = this.searchResults[(n + next) % n].test;
+    this.path = results[(n + next) % n].test;
   }
 }
 window.customElements.define(WPTInterop.is, WPTInterop);

--- a/webapp/views/wpt-interop.js
+++ b/webapp/views/wpt-interop.js
@@ -533,13 +533,15 @@ class WPTInterop extends WPTColors(WPTFlags(LoadingState(PathInfo(
     if (!this.searchResults || !this.searchResults.length) {
       return;
     }
+    const n = this.searchResults.length;
     let next = this.searchResults.findIndex(r => r.test.startsWith(this.path));
     if (next < 0) {
       next = (forward ? 0 : -1);
-    } else {
+    } else if (this.searchResults[next].test === this.path) { // Only advance 1 for exact match.
       next = next + (forward ? 1 : -1);
     }
-    this.path = this.searchResults[next % this.searchResults.length].test;
+    // % in js is not modulo, it's remainder. Ensure it's positive.
+    this.path = this.searchResults[(n + next) % n].test;
   }
 }
 window.customElements.define(WPTInterop.is, WPTInterop);

--- a/webapp/views/wpt-interop.js
+++ b/webapp/views/wpt-interop.js
@@ -520,6 +520,19 @@ class WPTInterop extends WPTColors(WPTFlags(LoadingState(PathInfo(
     }
     return Math.round(score * 100);
   }
+
+  moveToNext() {
+    if (!this.searchResults || !this.searchResults.length) {
+      return;
+    }
+    let next = this.searchResults.findIndex(r => r.test === this.path);
+    if (next < 0) {
+      next = 0;
+    } else {
+      next = next + 1 % this.searchResults.length;
+    }
+    this.path = this.searchResults[next].test;
+  }
 }
 window.customElements.define(WPTInterop.is, WPTInterop);
 

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -944,16 +944,26 @@ class WPTResults extends WPTColors(WPTFlags(PathInfo(LoadingState(TestRunsUIBase
   }
 
   moveToNext() {
+    this._move(true);
+  }
+
+  moveToPrev() {
+    this._move(false);
+  }
+
+  _move(forward) {
     if (!this.searchResults || !this.searchResults.length) {
       return;
     }
-    let next = this.searchResults.findIndex(r => r.test === this.path);
+    const n = this.searchResults.length;
+    let next = this.searchResults.findIndex(r => r.test.startsWith(this.path));
     if (next < 0) {
-      next = 0;
+      next = (forward ? 0 : -1);
     } else {
-      next = next + 1 % this.searchResults.length;
+      next = next + (forward ? 1 : -1);
     }
-    this.path = this.searchResults[next].test;
+    // % in js is not modulo, it's remainder. Ensure it's positive.
+    this.path = this.searchResults[(n + next) % n].test;
   }
 }
 

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -959,7 +959,7 @@ class WPTResults extends WPTColors(WPTFlags(PathInfo(LoadingState(TestRunsUIBase
     let next = this.searchResults.findIndex(r => r.test.startsWith(this.path));
     if (next < 0) {
       next = (forward ? 0 : -1);
-    } else {
+    } else if (this.searchResults[next].test === this.path) { // Only advance 1 for exact match.
       next = next + (forward ? 1 : -1);
     }
     // % in js is not modulo, it's remainder. Ensure it's positive.

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -307,6 +307,7 @@ class WPTResults extends WPTColors(WPTFlags(PathInfo(LoadingState(TestRunsUIBase
       path: {
         type: String,
         observer: 'pathUpdated',
+        notify: true,
       },
       pathIsASubfolderOrFile: {
         type: Boolean,
@@ -933,11 +934,6 @@ class WPTResults extends WPTColors(WPTFlags(PathInfo(LoadingState(TestRunsUIBase
     };
   }
 
-  handleSearchAutocomplete(e) {
-    this.shadowRoot.querySelector('test-search').clear();
-    this.navigateToPath(e.detail.path);
-  }
-
   queryChanged(query, queryBefore) {
     super.queryChanged(query, queryBefore);
     if (this._fetchedQuery === query) {
@@ -945,6 +941,19 @@ class WPTResults extends WPTColors(WPTFlags(PathInfo(LoadingState(TestRunsUIBase
     }
     this._fetchedQuery = query; // Debounce.
     this.reloadData();
+  }
+
+  moveToNext() {
+    if (!this.searchResults || !this.searchResults.length) {
+      return;
+    }
+    let next = this.searchResults.findIndex(r => r.test === this.path);
+    if (next < 0) {
+      next = 0;
+    } else {
+      next = next + 1 % this.searchResults.length;
+    }
+    this.path = this.searchResults[next].test;
   }
 }
 


### PR DESCRIPTION
### Description
When N is pressed on the document body, finds the next full test path that isn't the current path, or the first test path, and navigates to it.

Feature kinda requested in #1421. We can build off the keycodes and add "expand" shorthands in a follow-up PR.

### Review
Head to the deployed env and try it.
Please make sure to test the interop view's behaviour works too; hard to test locally.
