### PR TITLE
[lifecycle] Basic data models & WPTFYI_RECEIVED/VALID stages

### DIFF
--- a/api/receiver/api.go
+++ b/api/receiver/api.go
@@ -86,7 +86,7 @@ func (a apiImpl) UpdatePendingTestRun(newRun shared.PendingTestRun) error {
 	key := a.store.NewIDKey("PendingTestRun", newRun.ID)
 	return a.store.Update(key, &buffer, func(obj interface{}) error {
 		run := obj.(*shared.PendingTestRun)
-		if newRun.Stage != "" {
+		if newRun.Stage != 0 {
 			if err := run.Transition(newRun.Stage); err != nil {
 				return err
 			}
@@ -153,7 +153,7 @@ func (a apiImpl) ScheduleResultsTask(
 
 	pendingRun := shared.PendingTestRun{
 		ID:               key.IntID(),
-		Stage:            "WPTFYI_RECEIVED",
+		Stage:            shared.StageWptFyiReceived,
 		Uploader:         uploader,
 		FullRevisionHash: extraParams["revision"],
 	}

--- a/api/receiver/api_medium_test.go
+++ b/api/receiver/api_medium_test.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -107,6 +108,13 @@ func TestScheduleResultsTask(t *testing.T) {
 	stats, err = taskqueue.QueueStats(ctx, []string{""})
 	assert.Nil(t, err)
 	assert.Equal(t, stats[0].Tasks, 1)
+
+	var pendingRun shared.PendingTestRun
+	id, err := strconv.Atoi(task.Name)
+	assert.Nil(t, err)
+	datastore.Get(ctx, datastore.NewKey(ctx, "PendingTestRun", "", int64(id), nil), &pendingRun)
+	assert.Equal(t, "blade-runner", pendingRun.Uploader)
+	assert.Equal(t, "WPTFYI_RECEIVED", string(pendingRun.Stage))
 }
 
 func TestAddTestRun(t *testing.T) {

--- a/api/receiver/api_medium_test.go
+++ b/api/receiver/api_medium_test.go
@@ -114,7 +114,7 @@ func TestScheduleResultsTask(t *testing.T) {
 	assert.Nil(t, err)
 	datastore.Get(ctx, datastore.NewKey(ctx, "PendingTestRun", "", int64(id), nil), &pendingRun)
 	assert.Equal(t, "blade-runner", pendingRun.Uploader)
-	assert.Equal(t, "WPTFYI_RECEIVED", string(pendingRun.Stage))
+	assert.Equal(t, shared.StageWptFyiReceived, pendingRun.Stage)
 }
 
 func TestAddTestRun(t *testing.T) {
@@ -151,7 +151,7 @@ func TestUpdatePendingTestRun(t *testing.T) {
 	run := shared.PendingTestRun{
 		ID:         1,
 		CheckRunID: 100,
-		Stage:      "WPTFYI_RECEIVED",
+		Stage:      shared.StageWptFyiReceived,
 	}
 	assert.Nil(t, a.UpdatePendingTestRun(run))
 	var run2 shared.PendingTestRun
@@ -159,16 +159,16 @@ func TestUpdatePendingTestRun(t *testing.T) {
 
 	// CheckRunID should not be updated; Stage should be transitioned.
 	run.CheckRunID = 0
-	run.Stage = "VALID"
+	run.Stage = shared.StageValid
 	assert.Nil(t, a.UpdatePendingTestRun(run))
 	var run3 shared.PendingTestRun
 	datastore.Get(ctx, key, &run3)
 
 	assert.Equal(t, int64(100), run3.CheckRunID)
-	assert.Equal(t, "VALID", string(run3.Stage))
+	assert.Equal(t, shared.StageValid, run3.Stage)
 	assert.Equal(t, run2.Created, run3.Created)
 
-	run.Stage = "WPTFYI_PROCESSING"
+	run.Stage = shared.StageWptFyiProcessing
 	assert.EqualError(t, a.UpdatePendingTestRun(run),
 		"cannot transition from VALID to WPTFYI_PROCESSING")
 }

--- a/api/receiver/create_run.go
+++ b/api/receiver/create_run.go
@@ -78,7 +78,7 @@ func HandleResultsCreate(a API, s checks.API, w http.ResponseWriter, r *http.Req
 	log := shared.GetLogger(a.Context())
 	pendingRun := shared.PendingTestRun{
 		ID:               testRun.ID,
-		Stage:            "VALID",
+		Stage:            shared.StageValid,
 		FullRevisionHash: testRun.FullRevisionHash,
 	}
 	if err := a.UpdatePendingTestRun(pendingRun); err != nil {

--- a/api/receiver/create_run.go
+++ b/api/receiver/create_run.go
@@ -63,6 +63,9 @@ func HandleResultsCreate(a API, s checks.API, w http.ResponseWriter, r *http.Req
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	// Copy int64 representation of key into TestRun.ID so that clients can
+	// inspect/use key value.
+	testRun.ID = key.IntID()
 
 	// Do not schedule on pr_base to avoid redundancy with pr_head.
 	if !testRun.LabelsSet().Contains(shared.PRBaseLabel) {
@@ -72,16 +75,22 @@ func HandleResultsCreate(a API, s checks.API, w http.ResponseWriter, r *http.Req
 		s.ScheduleResultsProcessing(testRun.FullRevisionHash, spec)
 	}
 
-	// Copy int64 representation of key into TestRun.ID so that clients can
-	// inspect/use key value.
-	testRun.ID = key.IntID()
+	log := shared.GetLogger(a.Context())
+	pendingRun := shared.PendingTestRun{
+		ID:               testRun.ID,
+		Stage:            "VALID",
+		FullRevisionHash: testRun.FullRevisionHash,
+	}
+	if err := a.UpdatePendingTestRun(pendingRun); err != nil {
+		// This is a non-fatal error; don't return.
+		log.Errorf("Failed to update pending test run: %s", err.Error())
+	}
 
 	jsonOutput, err := json.Marshal(testRun)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	log := shared.GetLogger(a.Context())
 	log.Infof("Successfully created run %v (%s)", testRun.ID, testRun.String())
 	w.WriteHeader(http.StatusCreated)
 	w.Write(jsonOutput)

--- a/api/receiver/create_run_test.go
+++ b/api/receiver/create_run_test.go
@@ -62,6 +62,11 @@ func TestHandleResultsCreate(t *testing.T) {
 		},
 	}
 	testKey := &sharedtest.MockKey{TypeName: "TestRun", ID: 12345}
+	pendingRun := shared.PendingTestRun{
+		ID:               12345,
+		Stage:            "VALID",
+		FullRevisionHash: sha,
+	}
 
 	mockAE := mock_receiver.NewMockAPI(mockCtrl)
 	mockAE.EXPECT().Context().AnyTimes().Return(sharedtest.NewTestContext())
@@ -70,6 +75,7 @@ func TestHandleResultsCreate(t *testing.T) {
 		mockAE.EXPECT().GetUploader("_processor").Return(shared.Uploader{"_processor", "secret-token"}, nil),
 		mockAE.EXPECT().AddTestRun(sharedtest.SameProductSpec(testRunIn.String())).Return(testKey, nil),
 		mockS.EXPECT().ScheduleResultsProcessing(sha, sharedtest.SameProductSpec("firefox")).Return(nil),
+		mockAE.EXPECT().UpdatePendingTestRun(pendingRun).Return(nil),
 	)
 
 	w := httptest.NewRecorder()
@@ -105,6 +111,11 @@ func TestHandleResultsCreate_NoTimestamps(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/results/create", strings.NewReader(string(body)))
 	req.SetBasicAuth("_processor", "secret-token")
 	testKey := &sharedtest.MockKey{TypeName: "TestRun", ID: 1}
+	pendingRun := shared.PendingTestRun{
+		ID:               1,
+		Stage:            "VALID",
+		FullRevisionHash: sha,
+	}
 
 	mockAE := mock_receiver.NewMockAPI(mockCtrl)
 	mockAE.EXPECT().Context().AnyTimes().Return(sharedtest.NewTestContext())
@@ -113,6 +124,7 @@ func TestHandleResultsCreate_NoTimestamps(t *testing.T) {
 		mockAE.EXPECT().GetUploader("_processor").Return(shared.Uploader{"_processor", "secret-token"}, nil),
 		mockAE.EXPECT().AddTestRun(gomock.Any()).Return(testKey, nil),
 		mockS.EXPECT().ScheduleResultsProcessing(sha, sharedtest.SameProductSpec("firefox")).Return(nil),
+		mockAE.EXPECT().UpdatePendingTestRun(pendingRun).Return(nil),
 	)
 
 	w := httptest.NewRecorder()

--- a/api/receiver/create_run_test.go
+++ b/api/receiver/create_run_test.go
@@ -64,7 +64,7 @@ func TestHandleResultsCreate(t *testing.T) {
 	testKey := &sharedtest.MockKey{TypeName: "TestRun", ID: 12345}
 	pendingRun := shared.PendingTestRun{
 		ID:               12345,
-		Stage:            "VALID",
+		Stage:            shared.StageValid,
 		FullRevisionHash: sha,
 	}
 
@@ -113,7 +113,7 @@ func TestHandleResultsCreate_NoTimestamps(t *testing.T) {
 	testKey := &sharedtest.MockKey{TypeName: "TestRun", ID: 1}
 	pendingRun := shared.PendingTestRun{
 		ID:               1,
-		Stage:            "VALID",
+		Stage:            shared.StageValid,
 		FullRevisionHash: sha,
 	}
 

--- a/api/receiver/mock_receiver/api_mock.go
+++ b/api/receiver/mock_receiver/api_mock.go
@@ -298,6 +298,20 @@ func (mr *MockAPIMockRecorder) ScheduleResultsTask(arg0, arg1, arg2, arg3 interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScheduleResultsTask", reflect.TypeOf((*MockAPI)(nil).ScheduleResultsTask), arg0, arg1, arg2, arg3)
 }
 
+// UpdatePendingTestRun mocks base method
+func (m *MockAPI) UpdatePendingTestRun(arg0 shared.PendingTestRun) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdatePendingTestRun", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdatePendingTestRun indicates an expected call of UpdatePendingTestRun
+func (mr *MockAPIMockRecorder) UpdatePendingTestRun(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePendingTestRun", reflect.TypeOf((*MockAPI)(nil).UpdatePendingTestRun), arg0)
+}
+
 // UploadToGCS mocks base method
 func (m *MockAPI) UploadToGCS(arg0 string, arg1 io.Reader, arg2 bool) error {
 	m.ctrl.T.Helper()

--- a/shared/models.go
+++ b/shared/models.go
@@ -140,29 +140,51 @@ func (r TestRun) Channel() string {
 }
 
 // PendingTestRunStage represents the stage of a test run in its life cycle.
-type PendingTestRunStage string
+type PendingTestRunStage int
 
-// PendingTestRunLifeCycle is an ordered array of all valid stages in a life cycle.
-var PendingTestRunLifeCycle = [...]PendingTestRunStage{
-	"GITHUB_QUEUED",
-	"GITHUB_IN_PROGRESS",
-	"CI_RUNNING",
-	"CI_FINISHED",
-	"GITHUB_SUCCESS",
-	"GITHUB_FAILURE",
-	"WPTFYI_RECEIVED",
-	"WPTFYI_PROCESSING",
-	"VALID",
-	"INVALID",
+// Constant enums for PendingTestRunStage
+const (
+	StageGitHubQueued     PendingTestRunStage = 100
+	StageGitHubInProgress PendingTestRunStage = 200
+	StageCIRunning        PendingTestRunStage = 300
+	StageCIFinished       PendingTestRunStage = 400
+	StageGitHubSuccess    PendingTestRunStage = 500
+	StageGitHubFailure    PendingTestRunStage = 550
+	StageWptFyiReceived   PendingTestRunStage = 600
+	StageWptFyiProcessing PendingTestRunStage = 700
+	StageValid            PendingTestRunStage = 800
+	StageInvalid          PendingTestRunStage = 850
+)
+
+func (s PendingTestRunStage) String() string {
+	switch s {
+	case StageGitHubQueued:
+		return "GITHUB_QUEUED"
+	case StageGitHubInProgress:
+		return "GITHUB_IN_PROGRESS"
+	case StageCIRunning:
+		return "CI_RUNNING"
+	case StageCIFinished:
+		return "CI_FINISHED"
+	case StageGitHubSuccess:
+		return "GITHUB_SUCCESS"
+	case StageGitHubFailure:
+		return "GITHUB_FAILURE"
+	case StageWptFyiReceived:
+		return "WPTFYI_RECEIVED"
+	case StageWptFyiProcessing:
+		return "WPTFYI_PROCESSING"
+	case StageValid:
+		return "VALID"
+	case StageInvalid:
+		return "INVALID"
+	}
+	return ""
 }
 
-func (s PendingTestRunStage) toInt() int {
-	for i, stage := range PendingTestRunLifeCycle {
-		if stage == s {
-			return i
-		}
-	}
-	return -1
+// MarshalJSON is the custom marshaler for PendingTestRunStage.
+func (s PendingTestRunStage) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.String())
 }
 
 // PendingTestRun represents a TestRun that has started, but is not yet
@@ -182,10 +204,8 @@ type PendingTestRun struct {
 // Transition sets Stage to next if the transition is allowed; otherwise an
 // error is returned.
 func (s *PendingTestRun) Transition(next PendingTestRunStage) error {
-	i := s.Stage.toInt()
-	j := next.toInt()
-	if j < 0 || j <= i {
-		return fmt.Errorf("cannot transition from %s to %s", s.Stage, next)
+	if next == 0 || s.Stage > next {
+		return fmt.Errorf("cannot transition from %s to %s", s.Stage.String(), next.String())
 	}
 	s.Stage = next
 	return nil

--- a/shared/sharedtest/datastore_mock.go
+++ b/shared/sharedtest/datastore_mock.go
@@ -204,3 +204,17 @@ func (mr *MockDatastoreMockRecorder) TestRunQuery() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TestRunQuery", reflect.TypeOf((*MockDatastore)(nil).TestRunQuery))
 }
+
+// Update mocks base method
+func (m *MockDatastore) Update(arg0 shared.Key, arg1 interface{}, arg2 func(interface{}) error) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Update", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Update indicates an expected call of Update
+func (mr *MockDatastoreMockRecorder) Update(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockDatastore)(nil).Update), arg0, arg1, arg2)
+}

--- a/webapp/admin_handler.go
+++ b/webapp/admin_handler.go
@@ -22,7 +22,12 @@ func adminUploadHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func showAdminUploadForm(a shared.AppEngineAPI, w http.ResponseWriter, r *http.Request) {
-	assertAdminAndRenderTemplate(a, w, r, "/admin/results/upload", "admin_upload.html", nil)
+	data := struct {
+		CallbackURL string
+	}{
+		CallbackURL: fmt.Sprintf("https://%s/api/results/create", a.GetVersionedHostname()),
+	}
+	assertAdminAndRenderTemplate(a, w, r, "/admin/results/upload", "admin_upload.html", data)
 }
 
 func adminFlagsHandler(w http.ResponseWriter, r *http.Request) {

--- a/webapp/admin_handler_test.go
+++ b/webapp/admin_handler_test.go
@@ -26,6 +26,7 @@ func TestShowAdminUploadForm_not_admin(t *testing.T) {
 	resp := httptest.NewRecorder()
 	mockAE := sharedtest.NewMockAppEngineAPI(mockCtrl)
 	mockAE.EXPECT().IsAdmin().Return(false)
+	mockAE.EXPECT().GetVersionedHostname().Return("")
 
 	showAdminUploadForm(mockAE, resp, req)
 
@@ -41,6 +42,7 @@ func TestShowAdminUploadForm_admin(t *testing.T) {
 	resp := httptest.NewRecorder()
 	mockAE := sharedtest.NewMockAppEngineAPI(mockCtrl)
 	mockAE.EXPECT().IsAdmin().Return(true)
+	mockAE.EXPECT().GetVersionedHostname().Return("")
 
 	showAdminUploadForm(mockAE, resp, req)
 

--- a/webapp/templates/admin_upload.html
+++ b/webapp/templates/admin_upload.html
@@ -42,6 +42,7 @@
 <div class="column">
   <h2>File payload</h2>
   <form method="POST" action="/api/results/upload" enctype="multipart/form-data">
+    {{if .CallbackURL}}<input type="hidden" name="callback_url" value="{{.CallbackURL}}">{{end}}
     <paper-input-container auto-validate>
       <label slot="label">Uploader</label>
       <iron-input slot="input" required>
@@ -111,6 +112,7 @@
 <div class="column">
   <h2>URL payload</h2>
   <form method="POST" action="/api/results/upload">
+    {{if .CallbackURL}}<input type="hidden" name="callback_url" value="{{.CallbackURL}}">{{end}}
     <paper-input-container auto-validate>
       <label slot="label">Uploader</label>
       <iron-input slot="input" required>


### PR DESCRIPTION
## Description

Design doc: https://docs.google.com/document/d/125dg-NST0xnEVqN7a-LrfGxPueSwXvDukAjOM8n5q50/

## Review Information

You can use https://lifecycle-dot-wptdashboard-staging.appspot.com/api/results/upload to upload a run, and check the `PendingTestRun` table in Datastore to see the new run going through WPTFYI_RECEIVED to VALID. I already did a manual integration test of the flow.

## Changes

See each commit title. Changes are split into logical commits, so it might be easier to review by commits.