### PR TITLE
Include master label for anomalies insight

### DIFF
--- a/webapp/components/wpt-insights.js
+++ b/webapp/components/wpt-insights.js
@@ -182,6 +182,7 @@ class Anomalies extends ProductInfo(PolymerElement) {
 
   computeURL(query, browser, others) {
     const url = new URL('/results/', window.location);
+    url.searchParams.set('labels', 'master');
     url.searchParams.set('q', query);
     const products = [browser, ...others];
     if (DefaultProductSpecs.join(',') !== products.join(',')) {


### PR DESCRIPTION
Avoids showing empty PR results some of the time.