### PR TITLE
Fix bad decoding of space -> + -> %2B

### DIFF
--- a/webapp/components/results-navigation.js
+++ b/webapp/components/results-navigation.js
@@ -72,7 +72,9 @@ const QueryBuilder = (superClass, opts_queryParamsComputer) => class extends sup
     const afterQ = url.search
       .replace(/=true/g, '')
       .replace(/:00.000Z/g, '')
-      .split('?',);
+      // Work around bug where space => + => %2B is not decoded correctly.
+      .replace(/\+/g, '%20')
+      .split('?');
     return afterQ.length && afterQ[1];
   }
 

--- a/webapp/views/wpt-app.js
+++ b/webapp/views/wpt-app.js
@@ -233,6 +233,7 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
     if (this.activeView) {
       this.activeView.query = query;
     }
+    super.queryChanged(query);
   }
 
   _routeChanged(routeData) {

--- a/webapp/views/wpt-app.js
+++ b/webapp/views/wpt-app.js
@@ -68,10 +68,10 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
 
       <section class="search">
         <div class="path">
-          <a href="/[[page]]/?[[ query ]]" on-click="navigate">wpt</a>
+          <a href="/[[page]]/?[[ query ]]">wpt</a>
           <!-- The next line is intentionally formatted so to avoid whitespaces between elements. -->
           <template is="dom-repeat" items="[[ splitPathIntoLinkedParts(path) ]]" as="part"
-            ><span class="path-separator">/</span><a href="/[[page]][[ part.path ]]?[[ query ]]" on-click="navigate">[[ part.name ]]</a></template>
+            ><span class="path-separator">/</span><a href="/[[page]][[ part.path ]]?[[ query ]]">[[ part.name ]]</a></template>
         </div>
 
         <template is="dom-if" if="[[searchPRsForDirectories]]">


### PR DESCRIPTION
## Description
Fixes https://github.com/web-platform-tests/wpt.fyi/issues/1375
Additionally fixes a bug with the search field not updating when navigating back/forward with the browser.

Our use of URLSearchParams causes spaces to become '+' (unnecessarily), which are further encoded by the `app-location` Polymer component. On the way back out, we don't undo the problem.

The fix in this PR ties into the hack for param cleanup and undo the + conversion, resulting in an unambiguous %20 encoding (which decodes back to a space correctly).

## Review Information
- Visit the deployed environment, run a search containing a space. (e.g. `firefox:pass chrome:fail`)
- Change the query (e.g. `firefox:pass chrome:fail safari:pass`)
- Hit the back button
- See previous query in search box, spaces as were (no unexpected +).
- Reload the current URL
- See query as-was (no unexpected +). 