### PR TITLE
Add subtest:pattern support to structured queries

### DIFF
--- a/api/query/atoms.go
+++ b/api/query/atoms.go
@@ -58,6 +58,16 @@ func (tnp TestNamePattern) BindToRuns(runs ...shared.TestRun) ConcreteQuery {
 	return tnp
 }
 
+// SubtestNamePattern is a query atom that matches subtest names to a pattern string.
+type SubtestNamePattern struct {
+	Subtest string
+}
+
+// BindToRuns for SubtestNamePattern is a no-op; it is independent of test runs.
+func (tnp SubtestNamePattern) BindToRuns(runs ...shared.TestRun) ConcreteQuery {
+	return tnp
+}
+
 // TestPath is a query atom that matches exact test path prefixes.
 // It is an inflexible equivalent of TestNamePattern.
 type TestPath struct {
@@ -342,10 +352,31 @@ func (tnp *TestNamePattern) UnmarshalJSON(b []byte) error {
 	}
 	var pattern string
 	if err := json.Unmarshal(*patternMsg, &pattern); err != nil {
-		return errors.New(`Missing test name pattern property "pattern" is not a string`)
+		return errors.New(`test name pattern property "pattern" is not a string`)
 	}
 
 	tnp.Pattern = pattern
+	return nil
+}
+
+// UnmarshalJSON for SubtestNamePattern attempts to interpret a query atom as
+// {"pattern":<test name pattern string>}.
+func (tnp *SubtestNamePattern) UnmarshalJSON(b []byte) error {
+	var data map[string]*json.RawMessage
+	err := json.Unmarshal(b, &data)
+	if err != nil {
+		return err
+	}
+	subtestMsg, ok := data["subtest"]
+	if !ok {
+		return errors.New(`Missing subtest name pattern property: "subtest"`)
+	}
+	var subtest string
+	if err := json.Unmarshal(*subtestMsg, &subtest); err != nil {
+		return errors.New(`Subtest name subtest property "subtest" is not a string`)
+	}
+
+	tnp.Subtest = subtest
 	return nil
 }
 
@@ -630,6 +661,11 @@ func unmarshalQ(b []byte) (AbstractQuery, error) {
 	err := json.Unmarshal(b, &tnp)
 	if err == nil {
 		return tnp, nil
+	}
+	var stnp SubtestNamePattern
+	err = json.Unmarshal(b, &stnp)
+	if err == nil {
+		return stnp, nil
 	}
 	var tp TestPath
 	err = json.Unmarshal(b, &tp)

--- a/api/query/atoms_test.go
+++ b/api/query/atoms_test.go
@@ -136,6 +136,18 @@ func TestStructuredQuery_pattern(t *testing.T) {
 	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2}, AbstractQuery: TestNamePattern{"/2dcontext/"}}, rq)
 }
 
+func TestStructuredQuery_subtest(t *testing.T) {
+	var rq RunQuery
+	err := json.Unmarshal([]byte(`{
+		"run_ids": [0, 1, 2],
+		"query": {
+			"subtest": "Subtest name"
+		}
+	}`), &rq)
+	assert.Nil(t, err)
+	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2}, AbstractQuery: SubtestNamePattern{"Subtest name"}}, rq)
+}
+
 func TestStructuredQuery_path(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{

--- a/api/query/cache/index/filter.go
+++ b/api/query/cache/index/filter.go
@@ -32,6 +32,12 @@ type TestNamePattern struct {
 	q query.TestNamePattern
 }
 
+// SubtestNamePattern is a query.SubtestNamePattern bound to an in-memory index.
+type SubtestNamePattern struct {
+	index
+	q query.SubtestNamePattern
+}
+
 // TestPath is a query.TestPath bound to an in-memory index.
 type TestPath struct {
 	index
@@ -118,6 +124,15 @@ func (tnp TestNamePattern) Filter(t TestID) bool {
 		return false
 	}
 	return strings.Contains(name, tnp.q.Pattern)
+}
+
+// Filter interprets a SubtestNamePattern as a filter function over TestIDs.
+func (tnp SubtestNamePattern) Filter(t TestID) bool {
+	_, subtest, err := tnp.tests.GetName(t)
+	if err != nil || subtest == nil {
+		return false
+	}
+	return strings.Contains(*subtest, tnp.q.Subtest)
 }
 
 // Filter interprets a TestPath as a filter function over TestIDs.
@@ -209,6 +224,8 @@ func newFilter(idx index, q query.ConcreteQuery) (filter, error) {
 		return False{idx}, nil
 	case query.TestNamePattern:
 		return TestNamePattern{idx, v}, nil
+	case query.SubtestNamePattern:
+		return SubtestNamePattern{idx, v}, nil
 	case query.TestPath:
 		return TestPath{idx, v}, nil
 	case query.RunTestStatusEq:

--- a/api/query/concrete_query.go
+++ b/api/query/concrete_query.go
@@ -8,6 +8,9 @@ import (
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
+// Average as of Aug 20, 2019
+const averageNumberOfSubtests = int(1655263 / 34236)
+
 // AggregationOpts are options for the aggregation format used when collecting
 // the results.
 type AggregationOpts struct {
@@ -90,6 +93,10 @@ type Not struct {
 // Size of TestNamePattern has a size of 1: servicing such a query requires a
 // substring match per test.
 func (TestNamePattern) Size() int { return 1 }
+
+// Size of TestNamePattern has a size of 1: servicing such a query requires a
+// substring match per subtest.
+func (SubtestNamePattern) Size() int { return averageNumberOfSubtests }
 
 // Size of TestPath has a size of 1: servicing such a query requires a
 // substring match per test.

--- a/webapp/components/test/test-search.html
+++ b/webapp/components/test/test-search.html
@@ -45,6 +45,14 @@ suite('<test-search>', () => {
       });
     });
 
+    test('subtest', () => {
+      assertQueryParse('subtest:idl_test', {exists: [{subtest: 'idl_test'}]});
+    });
+
+    test('subtest_quoted', () => {
+      assertQueryParse('subtest:"idl_test setup"', {exists: [{subtest: 'idl_test setup'}]});
+    });
+
     test('path', () => {
       assertQueryParse('path:/dom/', {exists: [{path: '/dom/'}]});
     });


### PR DESCRIPTION
## Description
Adds support for substring matching on a subtest name, using a `subtest:"subtest name"` query atom.

## Review Information
- Visit deployed environment
- Search for subtest:"idl_test setup"
- See only results for tests with subtests name `idl_test setup`