### PR TITLE
Fix treatment of slashes in testname query params

### DIFF
--- a/webapp/components/path.js
+++ b/webapp/components/path.js
@@ -43,9 +43,14 @@ const PathInfo = (superClass) => class extends superClass {
   encodeTestPath(path) {
     path = path || '/';
     console.assert(path.startsWith('/'));
-    let parts = path.split('/').slice(1);
-    parts.push(encodeURIComponent(parts.pop()));
-    return '/' + parts.join('/');
+    const pathAndQuery = path.split('?');
+    let parts = pathAndQuery[0].split('/');
+    let lastPart = parts.pop();
+    if (pathAndQuery.length > 1) {
+      lastPart += '?' + pathAndQuery[1];
+    }
+    parts.push(encodeURIComponent(lastPart));
+    return parts.join('/');
   }
 
   computeTestScheme(path) {
@@ -57,20 +62,40 @@ const PathInfo = (superClass) => class extends superClass {
   }
 
   computePathIsASubfolder(path) {
-    return !this.computePathIsATestFile(path)
-      && path && path.split('/').filter(p => p).length > 0;
+    if (!path || this.computePathIsATestFile(path)) {
+      return false;
+    }
+    return new URL(path, window.location).pathname.split('/').filter(p => p).length > 0;
   }
 
   computePathIsATestFile(path) {
-    return /(\.(html|htm|py|svg|xhtml|xht|xml)(\?.*)?$)/.test(path);
+    return /(\.(html|htm|py|svg|xhtml|xht|xml)(\?.*)?$)/.test(new URL(path, window.location).pathname);
   }
 
   computePathIsRootDir(path) {
     return path && path === '/';
   }
+
+  splitPathIntoLinkedParts(inputPath) {
+    const encoded = this.encodeTestPath(inputPath);
+    const parts = encoded.split('/').slice(1);
+    let path = '';
+    const linkedParts = parts.map(part => {
+      path += `/${part}`;
+      return {
+        name: part,
+        path: path,
+      };
+    });
+    // Decode the last part's name (in case it was escaped).
+    let last = linkedParts.pop();
+    last.name = decodeURIComponent(last.name);
+    linkedParts.push(last);
+    return linkedParts;
+  }
 };
 
-class PathPart extends PolymerElement {
+class PathPart extends PathInfo(PolymerElement) {
   static get template() {
     return html`
     <style>
@@ -100,10 +125,6 @@ class PathPart extends PolymerElement {
 
   static get properties() {
     return {
-      path: {
-        type: String,
-        notify: true,
-      },
       query: {
         type: String
       },
@@ -120,7 +141,7 @@ class PathPart extends PolymerElement {
       },
       relativePath: {
         type: String,
-        computed: 'computedDisplayableRelativePath(path)'
+        computed: 'computeDisplayableRelativePath(path)'
       },
       href: {
         type: Location,
@@ -134,19 +155,19 @@ class PathPart extends PolymerElement {
   }
 
   computeHref(prefix, path, query) {
-    let parts = path.split('/');
-    parts.push(encodeURIComponent(parts.pop()));
+    const encodedPath = this.encodeTestPath(path);
     const href = new URL(window.location);
-    href.pathname = `${prefix || ''}${parts.join('/')}`;
+    href.pathname = `${prefix || ''}${encodedPath}`;
     if (query) {
       href.search = query;
     }
     return href;
   }
 
-  computedDisplayableRelativePath(path) {
+  computeDisplayableRelativePath(path) {
     if (!this.isDir) {
-      return path.substr(path.lastIndexOf('/') + 1);
+      path = this.encodeTestPath(path || '');
+      return decodeURIComponent(path.substr(path.lastIndexOf('/') + 1));
     }
     const windowPath = window.location.pathname.replace(`${this.prefix || ''}`, '');
     const pathPrefix = new RegExp(`^${windowPath}${windowPath.endsWith('/') ? '' : '/'}`);

--- a/webapp/components/path.js
+++ b/webapp/components/path.js
@@ -43,12 +43,10 @@ const PathInfo = (superClass) => class extends superClass {
   encodeTestPath(path) {
     path = path || '/';
     console.assert(path.startsWith('/'));
-    const pathAndQuery = path.split('?');
-    let parts = pathAndQuery[0].split('/');
-    let lastPart = parts.pop();
-    if (pathAndQuery.length > 1) {
-      lastPart += '?' + pathAndQuery[1];
-    }
+    const url = new URL(path || '/', window.location);
+    let parts = url.pathname.split('/');
+    parts.pop();
+    let lastPart = path.substr(parts.join('/').length + 1);
     parts.push(encodeURIComponent(lastPart));
     return parts.join('/');
   }
@@ -65,11 +63,15 @@ const PathInfo = (superClass) => class extends superClass {
     if (!path || this.computePathIsATestFile(path)) {
       return false;
     }
-    return new URL(path, window.location).pathname.split('/').filter(p => p).length > 0;
+    // Strip out query params/anchors.
+    path = new URL(path, window.location).pathname;
+    return path.split('/').filter(p => p).length > 0;
   }
 
   computePathIsATestFile(path) {
-    return /(\.(html|htm|py|svg|xhtml|xht|xml)(\?.*)?$)/.test(new URL(path, window.location).pathname);
+    // Strip out query params/anchors.
+    path = new URL(path || '', window.location).pathname;
+    return /(\.(html|htm|py|svg|xhtml|xht|xml)(\?.*)?$)/.test(path);
   }
 
   computePathIsRootDir(path) {

--- a/webapp/components/test/path.html
+++ b/webapp/components/test/path.html
@@ -62,6 +62,8 @@ suite('PathInfo', () => {
     expect(pathInfo.pathIsATestFile).to.be.true;
     pathInfo.path = '/a/b.html?x=1';
     expect(pathInfo.pathIsATestFile).to.be.true;
+    pathInfo.path = '/a/b.html?x=:a/b/:';
+    expect(pathInfo.pathIsATestFile).to.be.true;
     pathInfo.path = '/a/b/';
     expect(pathInfo.pathIsATestFile).to.be.false;
   });

--- a/webapp/components/test/path.html
+++ b/webapp/components/test/path.html
@@ -62,6 +62,10 @@ suite('PathInfo', () => {
     expect(pathInfo.pathIsATestFile).to.be.true;
     pathInfo.path = '/a/b.html?x=1';
     expect(pathInfo.pathIsATestFile).to.be.true;
+    pathInfo.path = '/a/b.html#x=1';
+    expect(pathInfo.pathIsATestFile).to.be.true;
+    pathInfo.path = '/a/b.html?x=1#y=2';
+    expect(pathInfo.pathIsATestFile).to.be.true;
     pathInfo.path = '/a/b.html?x=:a/b/:';
     expect(pathInfo.pathIsATestFile).to.be.true;
     pathInfo.path = '/a/b/';
@@ -72,6 +76,8 @@ suite('PathInfo', () => {
     expect(pathInfo.encodeTestPath('/a/b.html')).to.equal('/a/b.html');
     expect(pathInfo.encodeTestPath('/a/b/')).to.equal('/a/b/');
     expect(pathInfo.encodeTestPath('/a/b/?c=d')).to.equal('/a/b/%3Fc%3Dd');
+    expect(pathInfo.encodeTestPath('/a/b/#c=d')).to.equal('/a/b/%23c%3Dd');
+    expect(pathInfo.encodeTestPath('/a/b/?c=d#e=f')).to.equal('/a/b/%3Fc%3Dd%23e%3Df');
 
     // Specific example.
     expect(pathInfo.encodeTestPath('/webgpu/cts.html?q=cts:command_buffer/basic:'))
@@ -88,6 +94,17 @@ suite('PathInfo', () => {
       .to.deep.equal([
         {name: 'webgpu', path: '/webgpu'},
         {name: 'cts.html?q=cts:command_buffer/basic:', path: '/webgpu/cts.html%3Fq%3Dcts%3Acommand_buffer%2Fbasic%3A'},
+      ]);
+
+    expect(pathInfo.splitPathIntoLinkedParts('/a/b.html?x=1#y=2'))
+      .to.deep.equal([
+        {name: 'a', path: '/a'},
+        {name: 'b.html?x=1#y=2', path: '/a/b.html%3Fx%3D1%23y%3D2'},
+      ]);
+
+    expect(pathInfo.splitPathIntoLinkedParts('/a.html#x=1'))
+      .to.deep.equal([
+        {name: 'a.html#x=1', path: '/a.html%23x%3D1'},
       ]);
   });
 });
@@ -123,8 +140,8 @@ suite('PathPart', () => {
     suite('href: computeHref(prefix, path)', () => {
       test('computeHref()', () => {
         assert.equal(typeof PathPart.prototype.computeHref, 'function');
-        assert.equal(ppdir.computeHref('x/', 'y').pathname, '/x/y');
-        assert.equal(ppdir.computeHref('', 'y').pathname, '/y');
+        assert.equal(ppdir.computeHref('x', '/y').pathname, '/x/y');
+        assert.equal(ppdir.computeHref('', '/y').pathname, '/y');
         assert.equal(ppdir.computeHref('x', '').pathname, '/x/');
         assert.equal(ppdir.computeHref(undefined, '').pathname, '/');
       });

--- a/webapp/components/test/path.html
+++ b/webapp/components/test/path.html
@@ -4,10 +4,24 @@
   <meta charset="utf-8">
   <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
   <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
-
-  <script type="module" src="../path.js"></script>
 </head>
 <body>
+  <dom-module id="path-info-concrete">
+    <script type="module">
+      import { PolymerElement } from '../../node_modules/@polymer/polymer/polymer-element.js';
+      import { PathInfo } from '../path.js';
+
+      class ConcreteType extends PathInfo(PolymerElement) {}
+      window.customElements.define('path-info-concrete', ConcreteType);
+    </script>
+  </dom-module>
+
+  <test-fixture id="path-info-fixture">
+    <template>
+      <path-info-concrete></path-info-concrete>
+    </template>
+  </test-fixture>
+
   <test-fixture id="path-part-dir-prefixed-fixture">
     <template>
       <path-part path="/a/b" is-dir="true" prefix="/foo" navigate="navigate"></path-part>
@@ -31,9 +45,50 @@
       <path-part path="/a/b/c.html" is-dir="false" navigate="navigate"></path-part>
     </template>
   </test-fixture>
+
   <script type="module">
 import { PathPart } from '../path.js';
 import { PolymerElement } from '../../node_modules/@polymer/polymer/polymer-element.js';
+
+suite('PathInfo', () => {
+  let pathInfo;
+
+  setup(() => {
+    pathInfo = fixture('path-info-fixture');
+  });
+
+  test('pathIsATestPath', () => {
+    pathInfo.path = '/a/b.html';
+    expect(pathInfo.pathIsATestFile).to.be.true;
+    pathInfo.path = '/a/b.html?x=1';
+    expect(pathInfo.pathIsATestFile).to.be.true;
+    pathInfo.path = '/a/b/';
+    expect(pathInfo.pathIsATestFile).to.be.false;
+  });
+
+  test('encodeTestPath', () => {
+    expect(pathInfo.encodeTestPath('/a/b.html')).to.equal('/a/b.html');
+    expect(pathInfo.encodeTestPath('/a/b/')).to.equal('/a/b/');
+    expect(pathInfo.encodeTestPath('/a/b/?c=d')).to.equal('/a/b/%3Fc%3Dd');
+
+    // Specific example.
+    expect(pathInfo.encodeTestPath('/webgpu/cts.html?q=cts:command_buffer/basic:'))
+      .to.equal('/webgpu/cts.html%3Fq%3Dcts%3Acommand_buffer%2Fbasic%3A');
+  });
+
+  test('splitPathIntoLinkedParts', () => {
+    expect(pathInfo.splitPathIntoLinkedParts('/a/b.html')).to.deep.equal([
+      {name: 'a', path: '/a'},
+      {name: 'b.html', path: '/a/b.html'},
+    ]);
+
+    expect(pathInfo.splitPathIntoLinkedParts('/webgpu/cts.html?q=cts:command_buffer/basic:'))
+      .to.deep.equal([
+        {name: 'webgpu', path: '/webgpu'},
+        {name: 'cts.html?q=cts:command_buffer/basic:', path: '/webgpu/cts.html%3Fq%3Dcts%3Acommand_buffer%2Fbasic%3A'},
+      ]);
+  });
+});
 
 suite('PathPart', () => {
   let sandbox, ppdir, ppfile, ppdirprefixed, ppfileprefixed;
@@ -68,7 +123,7 @@ suite('PathPart', () => {
         assert.equal(typeof PathPart.prototype.computeHref, 'function');
         assert.equal(ppdir.computeHref('x/', 'y').pathname, '/x/y');
         assert.equal(ppdir.computeHref('', 'y').pathname, '/y');
-        assert.equal(ppdir.computeHref('x', '').pathname, '/x');
+        assert.equal(ppdir.computeHref('x', '').pathname, '/x/');
         assert.equal(ppdir.computeHref(undefined, '').pathname, '/');
       });
       test('computeHref([default], path)', () => {
@@ -90,17 +145,17 @@ suite('PathPart', () => {
         assert.equal(ppfile.href.pathname, '/bar/a/b/c.html');
       });
     });
-    suite('relativePath: computedDisplayableRelativePath(path)', () => {
-      test('computedDisplayableRelativePath()', () => {
-        assert.equal(typeof PathPart.prototype.computedDisplayableRelativePath, 'function');
-        assert.equal(ppdir.computedDisplayableRelativePath(''), '/');
-        assert.equal(ppdir.computedDisplayableRelativePath('foo'), 'foo/');
+    suite('relativePath: computeDisplayableRelativePath(path)', () => {
+      test('computeDisplayableRelativePath()', () => {
+        assert.equal(typeof PathPart.prototype.computeDisplayableRelativePath, 'function');
+        assert.equal(ppdir.computeDisplayableRelativePath(''), '/');
+        assert.equal(ppdir.computeDisplayableRelativePath('foo'), 'foo/');
       });
 
-      test('computedDisplayableRelativePath(...)', () => {
+      test('computeDisplayableRelativePath(...)', () => {
         assert.equal(ppdir.relativePath, '/a/b/');
       });
-      test('computedDisplayableRelativePath(...) (has prefix, is removed)', () => {
+      test('computeDisplayableRelativePath(...) (has prefix, is removed)', () => {
         assert.equal(ppdirprefixed.relativePath, '/a/b/');
       });
     });

--- a/webapp/views/wpt-app.js
+++ b/webapp/views/wpt-app.js
@@ -260,21 +260,6 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
     return subroutePath || '/';
   }
 
-  splitPathIntoLinkedParts(inputPath) {
-    const parts = (inputPath || '').split('/').slice(1);
-    const lastPart = parts.pop();
-    let path = '';
-    const linkedParts = parts.map(name => {
-      path += `/${name}`;
-      return {
-        name, path
-      };
-    });
-    path += `/${encodeURIComponent(lastPart)}`;
-    linkedParts.push({ name: lastPart, path: path });
-    return linkedParts;
-  }
-
   handleKeyDown(e) {
     // Ignore when something other than body has focus.
     if (!e.path.length || e.path[0] !== document.body) {

--- a/webapp/views/wpt-interop.js
+++ b/webapp/views/wpt-interop.js
@@ -445,9 +445,9 @@ class WPTInterop extends WPTColors(WPTFlags(LoadingState(PathInfo(
         return (acc, t) => {
           // Compute dir/file name that is direct descendant of this.path.
           const suffix = t.test.substring(pLen);
-          const slashIdx = suffix.indexOf('/');
+          const slashIdx = suffix.split('?')[0].indexOf('/');
           const isDir = slashIdx !== -1;
-          const name = isDir ? suffix.substring(0, slashIdx): suffix;
+          const name = isDir ? suffix.substring(0, slashIdx) : suffix;
 
           // Either add new node to acc, or add data to an existing node.
           if (!nodes.hasOwnProperty(name)) {

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -690,7 +690,7 @@ class WPTResults extends WPTColors(WPTFlags(PathInfo(LoadingState(TestRunsUIBase
     const prefix = this.path === '/' ? '/' : `${this.path}/`;
     const collapsePathOnto = (testPath, nodes) => {
       const suffix = testPath.substring(prefix.length);
-      const slashIdx = suffix.indexOf('/');
+      const slashIdx = suffix.split('?')[0].indexOf('/');
       const isDir = slashIdx !== -1;
       const name = isDir ? suffix.substring(0, slashIdx): suffix;
       // Either add new node to acc, or add passes, total to an


### PR DESCRIPTION
## Description
Fixes #1430 

We were naively splitting on slashes, and in the case that a slash appears (unencoded) in a URI's query params (for tests using `variant` metadata), we see the UI behave badly.

## Review Information
- Visit the auto-deployed environment
- Navigate to the webgpu test folder
- You should see some valid test names. cts.html has these variants:
  - ?q=cts:buffers/create_mapped:
  - ?q=cts:buffers/map:
  - ?q=cts:buffers/map_detach:
  - ?q=cts:buffers/map_oom:
  - ?q=cts:canvas/context_creation:
  - ?q=cts:command_buffer/basic:
  - ?q=cts:command_buffer/compute/basic:
  - ?q=cts:command_buffer/copies:
  - ?q=cts:command_buffer/render/basic:
  - ?q=cts:command_buffer/render/rendering:
  - ?q=cts:examples:
  - ?q=cts:fences:
