### PR TITLE
Add endpoint for fetching pending test runs

### DIFF
--- a/api/pending_test_runs.go
+++ b/api/pending_test_runs.go
@@ -1,0 +1,33 @@
+// Copyright 2019 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/web-platform-tests/wpt.fyi/shared"
+)
+
+// apiPendingTestRunsHandler is responsible for emitting JSON for
+// all the pending test runs.
+func apiPendingTestRunsHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := shared.NewAppEngineContext(r)
+	store := shared.NewAppEngineDatastore(ctx, true)
+
+	q := store.NewQuery("PendingTestRun")
+	var runs []shared.PendingTestRun
+	if _, err := store.GetAll(q, &runs); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	testRunsBytes, err := json.Marshal(runs)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Write(testRunsBytes)
+}

--- a/api/pending_test_runs.go
+++ b/api/pending_test_runs.go
@@ -15,7 +15,7 @@ import (
 // all the pending test runs.
 func apiPendingTestRunsHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := shared.NewAppEngineContext(r)
-	store := shared.NewAppEngineDatastore(ctx, true)
+	store := shared.NewAppEngineDatastore(ctx, false)
 
 	q := store.NewQuery("PendingTestRun")
 	var runs []shared.PendingTestRun

--- a/api/pending_test_runs.go
+++ b/api/pending_test_runs.go
@@ -19,13 +19,13 @@ func apiPendingTestRunsHandler(w http.ResponseWriter, r *http.Request) {
 
 	q := store.NewQuery("PendingTestRun").Order("-Updated")
 	var runs []shared.PendingTestRun
-	if keys, err := store.GetAll(q, &runs); err != nil {
+	keys, err := store.GetAll(q, &runs)
+	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
-	} else {
-		for i, key := range keys {
-			runs[i].ID = key.IntID()
-		}
+	}
+	for i, key := range keys {
+		runs[i].ID = key.IntID()
 	}
 
 	testRunsBytes, err := json.Marshal(runs)

--- a/api/pending_test_runs.go
+++ b/api/pending_test_runs.go
@@ -19,9 +19,13 @@ func apiPendingTestRunsHandler(w http.ResponseWriter, r *http.Request) {
 
 	q := store.NewQuery("PendingTestRun").Order("-Updated")
 	var runs []shared.PendingTestRun
-	if _, err := store.GetAll(q, &runs); err != nil {
+	if keys, err := store.GetAll(q, &runs); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
+	} else {
+		for i, key := range keys {
+			runs[i].ID = key.IntID()
+		}
 	}
 
 	testRunsBytes, err := json.Marshal(runs)

--- a/api/pending_test_runs.go
+++ b/api/pending_test_runs.go
@@ -17,7 +17,7 @@ func apiPendingTestRunsHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := shared.NewAppEngineContext(r)
 	store := shared.NewAppEngineDatastore(ctx, false)
 
-	q := store.NewQuery("PendingTestRun")
+	q := store.NewQuery("PendingTestRun").Order("-Updated")
 	var runs []shared.PendingTestRun
 	if _, err := store.GetAll(q, &runs); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/api/pending_test_runs_medium_test.go
+++ b/api/pending_test_runs_medium_test.go
@@ -41,6 +41,7 @@ func TestAPIPendingTestHandler(t *testing.T) {
 	var results []shared.PendingTestRun
 	json.Unmarshal(body, &results)
 	assert.Len(t, results, 1)
+	assert.Equal(t, results[0].ID, key.IntID())
 	assert.Equal(
 		t,
 		created.Truncate(time.Second).In(time.UTC),

--- a/api/pending_test_runs_medium_test.go
+++ b/api/pending_test_runs_medium_test.go
@@ -1,0 +1,45 @@
+// +build medium
+
+package api
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/web-platform-tests/wpt.fyi/shared"
+	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/appengine/datastore"
+)
+
+func TestAPIPendingTestHandler(t *testing.T) {
+	i, err := sharedtest.NewAEInstance(true)
+	assert.Nil(t, err)
+	defer i.Close()
+	r, err := i.NewRequest("GET", "/api/status", nil)
+	assert.Nil(t, err)
+
+	created := time.Now()
+	testRun := shared.PendingTestRun{}
+	testRun.Created = created
+
+	ctx := shared.NewAppEngineContext(r)
+	key := datastore.NewIncompleteKey(ctx, "PendingTestRun", nil)
+	key, err = datastore.Put(ctx, key, &testRun)
+	assert.Nil(t, err)
+
+	r, _ = i.NewRequest("GET", "/api/status", nil)
+	resp := httptest.NewRecorder()
+	apiPendingTestRunsHandler(resp, r)
+	body, _ := ioutil.ReadAll(resp.Result().Body)
+	assert.Equal(t, http.StatusOK, resp.Code, string(body))
+	var results []shared.PendingTestRun
+	json.Unmarshal(body, &results)
+	assert.Len(t, results, 1)
+	assert.Equal(t, created.Truncate(time.Second), results[0].Created.Truncate(time.Second))
+}

--- a/api/pending_test_runs_medium_test.go
+++ b/api/pending_test_runs_medium_test.go
@@ -41,5 +41,8 @@ func TestAPIPendingTestHandler(t *testing.T) {
 	var results []shared.PendingTestRun
 	json.Unmarshal(body, &results)
 	assert.Len(t, results, 1)
-	assert.Equal(t, created.Truncate(time.Second), results[0].Created.Truncate(time.Second))
+	assert.Equal(
+		t,
+		created.Truncate(time.Second).In(time.UTC),
+		results[0].Created.Truncate(time.Second).In(time.UTC))
 }

--- a/api/routes.go
+++ b/api/routes.go
@@ -58,6 +58,11 @@ func RegisterRoutes() {
 		shared.WrapApplicationJSON(
 			shared.WrapPermissiveCORS(apiTestRunHandler)))
 
+	// API endpoint for listing pending test runs
+	shared.AddRoute("/api/status", "api-pending-test-runs",
+		shared.WrapApplicationJSON(
+			shared.WrapPermissiveCORS(apiPendingTestRunsHandler)))
+
 	// API endpoint for redirecting to a run's summary JSON blob.
 	shared.AddRoute("/api/results", "api-results", shared.WrapPermissiveCORS(apiResultsRedirectHandler))
 

--- a/webapp/routes_test.go
+++ b/webapp/routes_test.go
@@ -73,6 +73,10 @@ func TestApiRunBound(t *testing.T) {
 	assertHandlerIs(t, "/api/runs/123", "api-test-run")
 }
 
+func TestApiStautsBound(t *testing.T) {
+	assertHandlerIs(t, "/api/status", "api-pending-test-runs")
+}
+
 func TestApiResultsBoundCORS(t *testing.T) {
 	assertHandlerIs(t, "/api/results", "api-results")
 	assertHSTS(t, "/api/results/upload")


### PR DESCRIPTION
Adds api endpoint for `/api/status` to fetch all pending runs.

### Review
See https://api-pending-runs-dot-wptdashboard-staging.appspot.com/api/status