### PR TITLE
Bug 1574668 - use the Taskcluster client and taskcluster-lib-urls

### DIFF
--- a/api/taskcluster/webhook.go
+++ b/api/taskcluster/webhook.go
@@ -8,14 +8,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"regexp"
 	"strings"
 	"sync"
 
 	mapset "github.com/deckarep/golang-set"
 	"github.com/google/go-github/github"
+	tcurls "github.com/taskcluster/taskcluster-lib-urls"
+	"github.com/taskcluster/taskcluster/clients/client-go/tcqueue"
 	uc "github.com/web-platform-tests/wpt.fyi/api/receiver/client"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
@@ -167,18 +169,19 @@ func (b branchInfos) GetNames() []string {
 func processTaskclusterBuild(aeAPI shared.AppEngineAPI, taskGroupID, taskID string, sha string, labels ...string) (bool, error) {
 	ctx := aeAPI.Context()
 	log := shared.GetLogger(ctx)
+	rootURL := os.Getenv("TASKCLUSTER_ROOT_URL")
+
 	log.Debugf("Taskcluster task group %s", taskGroupID)
 	if taskID != "" {
 		log.Debugf("Taskcluster task %s", taskID)
 	}
 
-	client := aeAPI.GetHTTPClient()
-	taskGroup, err := getTaskGroupInfo(client, taskGroupID)
+	taskGroup, err := getTaskGroupInfo(rootURL, taskGroupID)
 	if err != nil {
 		return false, err
 	}
 
-	urlsByProduct, err := extractArtifactURLs(log, taskGroup, taskID)
+	urlsByProduct, err := extractArtifactURLs(rootURL, log, taskGroup, taskID)
 	if err != nil {
 		return false, err
 	}
@@ -228,39 +231,31 @@ func extractTaskGroupID(targetURL string) (string, string) {
 	return "", ""
 }
 
-// https://docs.taskcluster.net/docs/reference/platform/taskcluster-queue/references/api#response-2
 type taskGroupInfo struct {
-	TaskGroupID string     `json:"taskGroupId"`
-	Tasks       []taskInfo `json:"tasks"`
+	TaskGroupID string
+	Tasks       []tcqueue.TaskDefinitionAndStatus
 }
 
-type taskInfo struct {
-	Status struct {
-		TaskID string `json:"taskId"`
-		State  string `json:"state"`
-	} `json:"status"`
-	Task struct {
-		Metadata struct {
-			Name string `json:"name"`
-		} `json:"metadata"`
-	} `json:"task"`
-}
+func getTaskGroupInfo(rootURL string, groupID string) (*taskGroupInfo, error) {
+	queue := tcqueue.New(nil, rootURL)
 
-func getTaskGroupInfo(client *http.Client, groupID string) (*taskGroupInfo, error) {
-	// https://docs.taskcluster.net/docs/reference/platform/taskcluster-queue/references/api#list-task-group
-	taskgroupURL := fmt.Sprintf("https://queue.taskcluster.net/v1/task-group/%s/list", groupID)
-	resp, err := client.Get(taskgroupURL)
-	if err != nil {
-		return nil, err
+	group := taskGroupInfo{
+		TaskGroupID: groupID,
 	}
-	payload, err := ioutil.ReadAll(resp.Body)
-	resp.Body.Close()
-	if err != nil {
-		return nil, err
-	}
-	var group taskGroupInfo
-	if err := json.Unmarshal(payload, &group); err != nil {
-		return nil, err
+	continuationToken := ""
+
+	for {
+		ltgr, err := queue.ListTaskGroup(groupID, continuationToken, "1000")
+		if err != nil {
+			return nil, err
+		}
+
+		group.Tasks = append(group.Tasks, ltgr.Tasks...)
+
+		continuationToken = ltgr.ContinuationToken
+		if continuationToken == "" {
+			break
+		}
 	}
 	return &group, nil
 }
@@ -270,7 +265,7 @@ type artifactURLs struct {
 	Screenshots []string
 }
 
-func extractArtifactURLs(log shared.Logger, group *taskGroupInfo, taskID string) (
+func extractArtifactURLs(rootURL string, log shared.Logger, group *taskGroupInfo, taskID string) (
 	urlsByProduct map[string]artifactURLs, err error) {
 	urlsByProduct = make(map[string]artifactURLs)
 	failures := mapset.NewSet()
@@ -304,16 +299,17 @@ func extractArtifactURLs(log shared.Logger, group *taskGroupInfo, taskID string)
 		}
 
 		urls := urlsByProduct[product]
-		// https://docs.taskcluster.net/docs/reference/platform/taskcluster-queue/references/api#get-artifact-from-latest-run
+		// Generate some URLs that point directly to
+		// https://docs.taskcluster.net/docs/reference/platform/queue/api#get-artifact-from-latest-run
 		urls.Results = append(urls.Results,
-			fmt.Sprintf(
-				"https://queue.taskcluster.net/v1/task/%s/artifacts/public/results/wpt_report.json.gz", id,
-			))
+			tcurls.API(
+				rootURL, "queue", "v1",
+				fmt.Sprintf("/task/%s/artifacts/public/results/wpt_report.json.gz", id)))
 		// wpt_screenshot.txt.gz might not exist, which is NOT a fatal error in the receiver.
 		urls.Screenshots = append(urls.Screenshots,
-			fmt.Sprintf(
-				"https://queue.taskcluster.net/v1/task/%s/artifacts/public/results/wpt_screenshot.txt.gz", id,
-			))
+			tcurls.API(
+				rootURL, "queue", "v1",
+				fmt.Sprintf("/task/%s/artifacts/public/results/wpt_screenshot.txt.gz", id)))
 		// urls is a *copy* of the value so we must store it back to the map.
 		urlsByProduct[product] = urls
 	}

--- a/api/taskcluster/webhook_test.go
+++ b/api/taskcluster/webhook_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-github/github"
 	"github.com/stretchr/testify/assert"
+	"github.com/taskcluster/taskcluster/clients/client-go/tcqueue"
 	uc "github.com/web-platform-tests/wpt.fyi/api/receiver/client"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
@@ -90,19 +91,19 @@ func TestIsOnMaster(t *testing.T) {
 
 func TestExtractTaskGroupID(t *testing.T) {
 	t.Run("Status", func(t *testing.T) {
-		group, task := extractTaskGroupID("https://tools.taskcluster.net/task-group-inspector/#/Y4rnZeqDRXGiRNiqxT5Qeg")
+		group, task := extractTaskGroupID("https://tc.example.com/task-group-inspector/#/Y4rnZeqDRXGiRNiqxT5Qeg")
 		assert.Equal(t, "Y4rnZeqDRXGiRNiqxT5Qeg", group)
 		assert.Equal(t, "", task)
 	})
 	t.Run("CheckRun", func(t *testing.T) {
-		group, task := extractTaskGroupID("https://tools.taskcluster.net/groups/IWlO7NuxRnO0_8PKMuHFkw/tasks/NOToWHr0T-u62B9yGQnD5w/details")
+		group, task := extractTaskGroupID("https://tc.example.com/groups/IWlO7NuxRnO0_8PKMuHFkw/tasks/NOToWHr0T-u62B9yGQnD5w/details")
 		assert.Equal(t, "IWlO7NuxRnO0_8PKMuHFkw", group)
 		assert.Equal(t, "NOToWHr0T-u62B9yGQnD5w", task)
 	})
 }
 
 func TestExtractArtifactURLs_all_success_master(t *testing.T) {
-	group := &taskGroupInfo{Tasks: make([]taskInfo, 4)}
+	group := &taskGroupInfo{Tasks: make([]tcqueue.TaskDefinitionAndStatus, 4)}
 	group.Tasks[0].Task.Metadata.Name = "wpt-firefox-nightly-testharness-1"
 	group.Tasks[1].Task.Metadata.Name = "wpt-firefox-nightly-testharness-2"
 	group.Tasks[2].Task.Metadata.Name = "wpt-chrome-dev-testharness-1"
@@ -113,42 +114,42 @@ func TestExtractArtifactURLs_all_success_master(t *testing.T) {
 	}
 
 	t.Run("All", func(t *testing.T) {
-		urls, err := extractArtifactURLs(shared.NewNilLogger(), group, "")
+		urls, err := extractArtifactURLs("https://tc.example.com", shared.NewNilLogger(), group, "")
 		assert.Nil(t, err)
 		assert.Equal(t, map[string]artifactURLs{
 			"firefox-nightly": {
 				Results: []string{
-					"https://queue.taskcluster.net/v1/task/0/artifacts/public/results/wpt_report.json.gz",
-					"https://queue.taskcluster.net/v1/task/1/artifacts/public/results/wpt_report.json.gz",
+					"https://tc.example.com/api/queue/v1/task/0/artifacts/public/results/wpt_report.json.gz",
+					"https://tc.example.com/api/queue/v1/task/1/artifacts/public/results/wpt_report.json.gz",
 				},
 				Screenshots: []string{
-					"https://queue.taskcluster.net/v1/task/0/artifacts/public/results/wpt_screenshot.txt.gz",
-					"https://queue.taskcluster.net/v1/task/1/artifacts/public/results/wpt_screenshot.txt.gz",
+					"https://tc.example.com/api/queue/v1/task/0/artifacts/public/results/wpt_screenshot.txt.gz",
+					"https://tc.example.com/api/queue/v1/task/1/artifacts/public/results/wpt_screenshot.txt.gz",
 				},
 			},
 			"chrome-dev": {
 				Results: []string{
-					"https://queue.taskcluster.net/v1/task/2/artifacts/public/results/wpt_report.json.gz",
-					"https://queue.taskcluster.net/v1/task/3/artifacts/public/results/wpt_report.json.gz",
+					"https://tc.example.com/api/queue/v1/task/2/artifacts/public/results/wpt_report.json.gz",
+					"https://tc.example.com/api/queue/v1/task/3/artifacts/public/results/wpt_report.json.gz",
 				},
 				Screenshots: []string{
-					"https://queue.taskcluster.net/v1/task/2/artifacts/public/results/wpt_screenshot.txt.gz",
-					"https://queue.taskcluster.net/v1/task/3/artifacts/public/results/wpt_screenshot.txt.gz",
+					"https://tc.example.com/api/queue/v1/task/2/artifacts/public/results/wpt_screenshot.txt.gz",
+					"https://tc.example.com/api/queue/v1/task/3/artifacts/public/results/wpt_screenshot.txt.gz",
 				},
 			},
 		}, urls)
 	})
 
 	t.Run("Filtered", func(t *testing.T) {
-		urls, err := extractArtifactURLs(shared.NewNilLogger(), group, "0")
+		urls, err := extractArtifactURLs("https://tc.example.com", shared.NewNilLogger(), group, "0")
 		assert.Nil(t, err)
 		assert.Equal(t, map[string]artifactURLs{
 			"firefox-nightly": {
 				Results: []string{
-					"https://queue.taskcluster.net/v1/task/0/artifacts/public/results/wpt_report.json.gz",
+					"https://tc.example.com/api/queue/v1/task/0/artifacts/public/results/wpt_report.json.gz",
 				},
 				Screenshots: []string{
-					"https://queue.taskcluster.net/v1/task/0/artifacts/public/results/wpt_screenshot.txt.gz",
+					"https://tc.example.com/api/queue/v1/task/0/artifacts/public/results/wpt_screenshot.txt.gz",
 				},
 			},
 		}, urls)
@@ -156,7 +157,7 @@ func TestExtractArtifactURLs_all_success_master(t *testing.T) {
 }
 
 func TestExtractArtifactURLs_all_success_pr(t *testing.T) {
-	group := &taskGroupInfo{Tasks: make([]taskInfo, 3)}
+	group := &taskGroupInfo{Tasks: make([]tcqueue.TaskDefinitionAndStatus, 3)}
 	group.Tasks[0].Task.Metadata.Name = "wpt-chrome-dev-results"
 	group.Tasks[1].Task.Metadata.Name = "wpt-chrome-dev-stability"
 	group.Tasks[2].Task.Metadata.Name = "wpt-chrome-dev-results-without-changes"
@@ -166,38 +167,38 @@ func TestExtractArtifactURLs_all_success_pr(t *testing.T) {
 	}
 
 	t.Run("All", func(t *testing.T) {
-		urls, err := extractArtifactURLs(shared.NewNilLogger(), group, "")
+		urls, err := extractArtifactURLs("https://tc.example.com", shared.NewNilLogger(), group, "")
 		assert.Nil(t, err)
 		assert.Equal(t, map[string]artifactURLs{
 			"chrome-dev-pr_head": {
 				Results: []string{
-					"https://queue.taskcluster.net/v1/task/0/artifacts/public/results/wpt_report.json.gz",
+					"https://tc.example.com/api/queue/v1/task/0/artifacts/public/results/wpt_report.json.gz",
 				},
 				Screenshots: []string{
-					"https://queue.taskcluster.net/v1/task/0/artifacts/public/results/wpt_screenshot.txt.gz",
+					"https://tc.example.com/api/queue/v1/task/0/artifacts/public/results/wpt_screenshot.txt.gz",
 				},
 			},
 			"chrome-dev-pr_base": {
 				Results: []string{
-					"https://queue.taskcluster.net/v1/task/2/artifacts/public/results/wpt_report.json.gz",
+					"https://tc.example.com/api/queue/v1/task/2/artifacts/public/results/wpt_report.json.gz",
 				},
 				Screenshots: []string{
-					"https://queue.taskcluster.net/v1/task/2/artifacts/public/results/wpt_screenshot.txt.gz",
+					"https://tc.example.com/api/queue/v1/task/2/artifacts/public/results/wpt_screenshot.txt.gz",
 				},
 			},
 		}, urls)
 	})
 
 	t.Run("Filtered", func(t *testing.T) {
-		urls, err := extractArtifactURLs(shared.NewNilLogger(), group, "2")
+		urls, err := extractArtifactURLs("https://tc.example.com", shared.NewNilLogger(), group, "2")
 		assert.Nil(t, err)
 		assert.Equal(t, map[string]artifactURLs{
 			"chrome-dev-pr_base": {
 				Results: []string{
-					"https://queue.taskcluster.net/v1/task/2/artifacts/public/results/wpt_report.json.gz",
+					"https://tc.example.com/api/queue/v1/task/2/artifacts/public/results/wpt_report.json.gz",
 				},
 				Screenshots: []string{
-					"https://queue.taskcluster.net/v1/task/2/artifacts/public/results/wpt_screenshot.txt.gz",
+					"https://tc.example.com/api/queue/v1/task/2/artifacts/public/results/wpt_screenshot.txt.gz",
 				},
 			},
 		}, urls)
@@ -205,7 +206,7 @@ func TestExtractArtifactURLs_all_success_pr(t *testing.T) {
 }
 
 func TestExtractArtifactURLs_with_failures(t *testing.T) {
-	group := &taskGroupInfo{Tasks: make([]taskInfo, 3)}
+	group := &taskGroupInfo{Tasks: make([]tcqueue.TaskDefinitionAndStatus, 3)}
 	group.Tasks[0].Status.State = "failed"
 	group.Tasks[0].Status.TaskID = "foo"
 	group.Tasks[0].Task.Metadata.Name = "wpt-firefox-nightly-testharness-1"
@@ -216,7 +217,7 @@ func TestExtractArtifactURLs_with_failures(t *testing.T) {
 	group.Tasks[2].Status.TaskID = "baz"
 	group.Tasks[2].Task.Metadata.Name = "wpt-chrome-dev-testharness-1"
 
-	urls, err := extractArtifactURLs(shared.NewNilLogger(), group, "")
+	urls, err := extractArtifactURLs("https://tc.example.com", shared.NewNilLogger(), group, "")
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(urls))
 	assert.Contains(t, urls, "chrome-dev")

--- a/webapp/app.yaml
+++ b/webapp/app.yaml
@@ -61,6 +61,9 @@ handlers:
   script: _go_app
   secure: always
 
+env_variables:
+  TASKCLUSTER_ROOT_URL: https://taskcluster.net
+
 # Don't upload test data, package config, etc. to AppEngine.
 skip_files:
 - components/test/


### PR DESCRIPTION
## Description
As part of [bug 1574668](https://bugzilla.mozilla.org/show_bug.cgi?id=1574668) we will need the ability to easily switch from one TC deployment to another.  

## Review Information
I modified the existing tests to suit, but nothing tests `getTaskGroupInfo`.  In fact, in its existing incarnation it was incorrect and would under-report tasks in large task groups since it did not use continuation tokens.  I think "large" means over 1000 tasks, but depending on the details of the Azure tables backend, could be smaller than that.

## Changes
Deployments are identified by TASKCLUSTER_ROOT_URL.  So this PR modifies the TC webhook listener to use the TC client and taskcluster-lib-urls to query task groups and generate URLs, based on this env var.

## Requirements
Note that with this change, the API server must be run with `TASKCLUSTER_ROOT_URL` set to an appropriate value (`https://taskcluster.net` for now)
