### PR TITLE
Fix the `IsMasterBranch()` helper for Azure Pipelines

### DIFF
--- a/api/azure/api.go
+++ b/api/azure/api.go
@@ -58,7 +58,7 @@ type BuildTriggerInfo struct {
 
 // IsMasterBranch returns whether the source branch for the build is the master branch.
 func (a *Build) IsMasterBranch() bool {
-	return a != nil && a.TriggerInfo.SourceBranch == "master"
+	return a != nil && a.SourceBranch == "refs/heads/master"
 }
 
 // API is for Azure Pipelines related requests.


### PR DESCRIPTION
Right fix concluded from the logs, which said:
```
Source branch: refs/heads/master
Trigger PR branch:
Fetching https://dev.azure.com/web-platform-tests/wpt/_apis/build/builds/28411/artifacts
```

Not tested because it would just check that the string being checked
is correct, it wouldn't catch if there's a typo, and wouldn't prevent
a regression if the Azure Pipelines API changes.

Fixes https://github.com/web-platform-tests/wpt.fyi/issues/1439.