### PR TITLE
Add android_webview as a browser

### DIFF
--- a/shared/browsers.go
+++ b/shared/browsers.go
@@ -14,7 +14,7 @@ var defaultBrowsers = []string{
 
 // An extra list of known browsers.
 var extraBrowsers = []string{
-	"epiphany", "uc",
+	"android_webview", "epiphany", "uc",
 }
 
 var allBrowsers mapset.Set

--- a/shared/browsers_test.go
+++ b/shared/browsers_test.go
@@ -18,6 +18,7 @@ func TestGetDefaultBrowserNames(t *testing.T) {
 	assert.True(t, sort.StringsAreSorted(names))
 	// Non default browser names:
 	for _, n := range names {
+		assert.NotEqual(t, "android_webview", n)
 		assert.NotEqual(t, "epiphany", n)
 		assert.NotEqual(t, "uc", n)
 	}
@@ -28,6 +29,7 @@ func TestIsBrowserName(t *testing.T) {
 	assert.True(t, IsBrowserName("edge"))
 	assert.True(t, IsBrowserName("firefox"))
 	assert.True(t, IsBrowserName("safari"))
+	assert.True(t, IsBrowserName("android_webview"))
 	assert.True(t, IsBrowserName("epiphany"))
 	assert.True(t, IsBrowserName("uc"))
 	assert.False(t, IsBrowserName("not-a-browser"))


### PR DESCRIPTION
A rather simple change to allow us to use `?product=android_webview`.