### PR TITLE
Alias 'missing' status as its backend representation 'unknown'

### DIFF
--- a/webapp/components/test-search.js
+++ b/webapp/components/test-search.js
@@ -214,12 +214,12 @@ const QUERY_SEMANTICS = QUERY_GRAMMAR.createSemantics().addOperation('eval', {
     };
   },
   statusExp_neq: (l, colonBang, r) => {
-    return { status: {not: r.sourceString.toUpperCase() } };
+    return { status: {not: r.eval() } };
   },
   statusExp_product_neq: (l, colonBang, r) => {
     return {
       product: l.sourceString.toLowerCase(),
-      status: {not: r.sourceString.toUpperCase()},
+      status: {not: r.eval()},
     };
   },
   subtestExp: (l, colon, r) => {

--- a/webapp/components/test/test-search.html
+++ b/webapp/components/test/test-search.html
@@ -67,6 +67,7 @@ suite('<test-search>', () => {
 
     test('test status', () => {
       assertQueryParse('status:missing', {exists: [{status: 'UNKNOWN'}]});
+      assertQueryParse('status:!missing', {exists: [{status: {not: 'UNKNOWN'}}]});
       assertQueryParse('sTaTuS:UnKnOwN', {exists: [{status: 'UNKNOWN'}]});
     });
 


### PR DESCRIPTION
## Description
Fixes #1444 by aliasing the status `MISSING` (which is implied by the wpt.fyi) as `UNKNOWN` (which is the placeholder used on the searchcache backend).