### PR TITLE
Handle EMPTY and DUPLICATE results

### DIFF
--- a/api/receiver/handlers.go
+++ b/api/receiver/handlers.go
@@ -5,13 +5,8 @@
 package receiver
 
 import (
-	"encoding/json"
-	"fmt"
-	"io/ioutil"
 	"net/http"
-	"strconv"
 
-	"github.com/gorilla/mux"
 	"github.com/web-platform-tests/wpt.fyi/api/checks"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
@@ -47,37 +42,5 @@ func apiPendingTestRunUpdateHandler(w http.ResponseWriter, r *http.Request) {
 
 	ctx := shared.NewAppEngineContext(r)
 	a := NewAPI(ctx)
-	if AuthenticateUploader(a, r) != InternalUsername {
-		http.Error(w, "This is a private API.", http.StatusUnauthorized)
-		return
-	}
-
-	body, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	var run shared.PendingTestRun
-	if err := json.Unmarshal(body, &run); err != nil {
-		http.Error(w, "Failed to parse JSON: "+err.Error(), http.StatusBadRequest)
-		return
-	}
-
-	vars := mux.Vars(r)
-	idParam := vars["id"]
-	id, err := strconv.ParseInt(idParam, 10, 0)
-	if err != nil {
-		http.Error(w, "Invalid ID: "+idParam, http.StatusBadRequest)
-		return
-	}
-	if id != run.ID {
-		http.Error(w, fmt.Sprintf("Inconsistent ID: %d != %d", id, run.ID), http.StatusBadRequest)
-		return
-	}
-
-	if err := a.UpdatePendingTestRun(run); err != nil {
-		http.Error(w, "Failed to update run: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-	w.WriteHeader(http.StatusCreated)
+	HandleUpdatePendingTestRun(a, w, r)
 }

--- a/api/receiver/update_pending_run.go
+++ b/api/receiver/update_pending_run.go
@@ -1,0 +1,53 @@
+// Copyright 2019 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package receiver
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+
+	"github.com/gorilla/mux"
+	"github.com/web-platform-tests/wpt.fyi/shared"
+)
+
+// HandleUpdatePendingTestRun handles the PATCH request for updating pending test runs.
+func HandleUpdatePendingTestRun(a API, w http.ResponseWriter, r *http.Request) {
+	if AuthenticateUploader(a, r) != InternalUsername {
+		http.Error(w, "This is a private API.", http.StatusUnauthorized)
+		return
+	}
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	var run shared.PendingTestRun
+	if err := json.Unmarshal(body, &run); err != nil {
+		http.Error(w, "Failed to parse JSON: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	vars := mux.Vars(r)
+	idParam := vars["id"]
+	id, err := strconv.ParseInt(idParam, 10, 0)
+	if err != nil {
+		http.Error(w, "Invalid ID: "+idParam, http.StatusBadRequest)
+		return
+	}
+	if id != run.ID {
+		http.Error(w, fmt.Sprintf("Inconsistent ID: %d != %d", id, run.ID), http.StatusBadRequest)
+		return
+	}
+
+	if err := a.UpdatePendingTestRun(run); err != nil {
+		http.Error(w, "Failed to update run: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
+}

--- a/api/receiver/update_pending_run_test.go
+++ b/api/receiver/update_pending_run_test.go
@@ -1,0 +1,54 @@
+// +build small
+
+// Copyright 2019 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package receiver
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/web-platform-tests/wpt.fyi/api/receiver/mock_receiver"
+	"github.com/web-platform-tests/wpt.fyi/shared"
+	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
+)
+
+func TestApiPendingTestRunUpdateHandler(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	pendingRun := shared.PendingTestRun{
+		ID:    12345,
+		Stage: shared.StageWptFyiProcessing,
+	}
+	payload := map[string]interface{}{
+		"id":    12345,
+		"stage": "WPTFYI_PROCESSING",
+	}
+	body, err := json.Marshal(payload)
+	assert.Nil(t, err)
+	req := httptest.NewRequest("PATCH", "/api/status/12345", strings.NewReader(string(body)))
+	req.SetBasicAuth("_processor", "secret-token")
+	req = mux.SetURLVars(req, map[string]string{"id": "12345"})
+
+	mockAE := mock_receiver.NewMockAPI(mockCtrl)
+	mockAE.EXPECT().Context().AnyTimes().Return(sharedtest.NewTestContext())
+	gomock.InOrder(
+		mockAE.EXPECT().GetUploader("_processor").Return(shared.Uploader{"_processor", "secret-token"}, nil),
+		mockAE.EXPECT().UpdatePendingTestRun(pendingRun).Return(nil),
+	)
+
+	w := httptest.NewRecorder()
+	HandleUpdatePendingTestRun(mockAE, w, req)
+	resp := w.Result()
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+}

--- a/results-processor/processor.py
+++ b/results-processor/processor.py
@@ -305,7 +305,7 @@ def process_report(task_id, params):
 
     response = []
     with Processor() as p:
-        p.update_status(run_id, 'WPTFYI_PROCESSING', callback_url)
+        p.update_status(run_id, 'WPTFYI_PROCESSING', None, callback_url)
         if azure_url:
             _log.info("Downloading Azure results: %s", azure_url)
         else:
@@ -314,6 +314,7 @@ def process_report(task_id, params):
         p.download(results, screenshots, azure_url)
         if len(p.results) == 0:
             _log.error("No results successfully downloaded")
+            p.update_status(run_id, 'EMPTY', None, callback_url)
             return ''
         try:
             p.load_report()
@@ -340,6 +341,7 @@ def process_report(task_id, params):
             _log.warning(
                 'Skipping the task because RawResultsURL already exists: %s',
                 p.raw_results_url)
+            p.update_status(run_id, 'DUPLICATE', None, callback_url)
             return ''
         response.append("{} results loaded from task {}".format(
             len(p.report.results), task_id))
@@ -357,6 +359,7 @@ def process_report(task_id, params):
             _log.warning(
                 'Skipping the task because RawResultsURL already exists: %s',
                 p.raw_results_url)
+            p.update_status(run_id, 'DUPLICATE', None, callback_url)
             return ''
 
         p.create_run(run_id, labels, uploader, callback_url)

--- a/shared/models.go
+++ b/shared/models.go
@@ -154,6 +154,8 @@ const (
 	StageWptFyiProcessing PendingTestRunStage = 700
 	StageValid            PendingTestRunStage = 800
 	StageInvalid          PendingTestRunStage = 850
+	StageEmpty            PendingTestRunStage = 851
+	StageDuplicate        PendingTestRunStage = 852
 )
 
 func (s PendingTestRunStage) String() string {
@@ -178,6 +180,10 @@ func (s PendingTestRunStage) String() string {
 		return "VALID"
 	case StageInvalid:
 		return "INVALID"
+	case StageEmpty:
+		return "EMPTY"
+	case StageDuplicate:
+		return "DUPLICATE"
 	}
 	return ""
 }
@@ -214,6 +220,10 @@ func (s *PendingTestRunStage) UnmarshalJSON(b []byte) error {
 		*s = StageValid
 	case "INVALID":
 		*s = StageInvalid
+	case "EMPTY":
+		*s = StageEmpty
+	case "DUPLICATE":
+		*s = StageDuplicate
 	default:
 		return fmt.Errorf("unknown stage: %s", str)
 	}


### PR DESCRIPTION
Previously in https://github.com/web-platform-tests/wpt.fyi/pull/1437 ,
pending test runs wouldn't be updated if they were empty or duplicate
(i.e. they would remain in WPTFYI_PROCESSING forever). This change
handles the two missed edge cases by adding two stages to the enum and
setting them accordingly.

In addition, a few unit tests are added for better coverage.
