### PR TITLE
Fix path autocomplete in the search bar

### DIFF
--- a/webapp/components/test-search.js
+++ b/webapp/components/test-search.js
@@ -311,7 +311,7 @@ class TestSearch extends WPTFlags(PolymerElement) {
         type: Array,
         notify: true,
       },
-      testPaths: Array,
+      testPaths: Set,
       onKeyUp: Function,
       onChange: Function,
       onFocus: Function,

--- a/webapp/views/wpt-app.js
+++ b/webapp/views/wpt-app.js
@@ -166,10 +166,7 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
         type: String,
         reflectToAttribute: true,
       },
-      path: {
-        type: String,
-        computed: '_computePath(subroute.path)',
-      },
+      path: String,
       testPaths: Set,
       structuredSearch: Object,
       interopLoading: Boolean,
@@ -189,7 +186,7 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
   static get observers() {
     return [
       '_routeChanged(routeData, routeData.*)',
-      '_subrouteChanged(subrouteData, subrouteData.*)',
+      '_subrouteChanged(subroute, subroute.*)',
     ];
   }
 
@@ -246,8 +243,8 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
     }
   }
 
-  _subrouteChanged(subrouteData) {
-    this.path = subrouteData.path || '/';
+  _subrouteChanged(subroute) {
+    this.path = subroute.path || '/';
   }
 
   get activeView() {
@@ -256,10 +253,6 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
 
   _computeIsLoading(interopLoading, resultsLoading) {
     return interopLoading || resultsLoading;
-  }
-
-  _computePath(subroutePath) {
-    return subroutePath || '/';
   }
 
   handleKeyDown(e) {
@@ -290,8 +283,7 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
 
   handleSearchAutocomplete(e) {
     this.shadowRoot.querySelector('test-search').clear();
-    this.subroute.path = e.detail.path;
-    this.notifyPath('subroute.path');
+    this.set('subroute.path', e.detail.path);
   }
 
   handleAddMasterLabel(e) {

--- a/webapp/views/wpt-app.js
+++ b/webapp/views/wpt-app.js
@@ -132,6 +132,7 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
                      structured-search="[[structuredSearch]]"
                      path="{{subroute.path}}"
                      test-runs="{{testRuns}}"
+                     test-paths="{{testPaths}}"
                      search-results="{{searchResults}}"></wpt-results>
 
         <wpt-interop name="interop"
@@ -169,6 +170,7 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
         type: String,
         computed: '_computePath(subroute.path)',
       },
+      testPaths: Set,
       structuredSearch: Object,
       interopLoading: Boolean,
       resultsLoading: Boolean,

--- a/webapp/views/wpt-app.js
+++ b/webapp/views/wpt-app.js
@@ -291,6 +291,7 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
   handleSearchAutocomplete(e) {
     this.shadowRoot.querySelector('test-search').clear();
     this.subroute.path = e.detail.path;
+    this.notifyPath('subroute.path');
   }
 
   handleAddMasterLabel(e) {

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -347,6 +347,7 @@ class WPTResults extends WPTColors(WPTFlags(PathInfo(LoadingState(TestRunsUIBase
       testPaths: {
         type: Set,
         computed: 'computeTestPaths(searchResults)',
+        notify: true,
       },
       displayedNodes: {
         type: Array,


### PR DESCRIPTION
Fixes #1443

## Description

`testPaths` wasn't propagated correctly; and `subroute` wasn't observed correctly.

## Review Information

Go to the staging instance and play with autocomplete.