### PR TITLE
Fix the environment name for GitHub deployments API calls

### DIFF
--- a/util/deploy-comment.sh
+++ b/util/deploy-comment.sh
@@ -3,7 +3,23 @@
 # Helper script for posting a GitHub comment pointing to the deployed environment,
 # from Travis CI. Also see deploy.sh
 
-STAGING_URL="$1"
+usage() {
+  USAGE='Usage: deploy-comment.sh [-e environment-name] [deployed url]
+    -e : Environment name (e.g. webapp)
+    -h : Show (this) help information
+    deployed url: The URL of the deployed environment, e.g. "https://branch-name-dot-wptdashboard-staging.appspot.com"'
+  echo "${USAGE}"
+}
+
+STAGING_URL=${@: -1}
+ENVIRONMENT="staging"
+while getopts ':e:' flag; do
+  case "${flag}" in
+    e) ENVIRONMENT="${OPTARG}" ;;
+    :) echo "Option -$OPTARG requires an argument." && exit 1;;
+    h|*) usage && exit 1;;
+  esac
+done
 
 UTIL_DIR="$(dirname "${BASH_SOURCE[0]}")"
 source "${UTIL_DIR}/logging.sh"
@@ -28,14 +44,14 @@ fi
 set -e
 set -o pipefail
 
-info "Posting deployed enviroment to GitHub..."
+info "Posting deployed environment to GitHub..."
 POST_URL="https://api.github.com/repos/${TRAVIS_REPO_SLUG}/deployments"
 debug "${POST_URL}"
 POST_BODY="{
                 \"ref\": \"${TRAVIS_BRANCH}\",
                 \"task\": \"deploy\",
                 \"auto_merge\": false,
-                \"environment\": \"${APP_PATH}\",
+                \"environment\": \"${ENVIRONMENT}\",
                 \"transient_environment\": true
             }"
 debug "POST body: ${POST_BODY}"

--- a/util/deploy-comment.sh
+++ b/util/deploy-comment.sh
@@ -36,9 +36,9 @@ if [[ -z "${TRAVIS_REPO_SLUG}" ]];
 then fatal "Travis Repo slug (user/repo) is required";
 else debug "Travis Repo slug: ${TRAVIS_REPO_SLUG}";
 fi
-if [[ -z "${TRAVIS_BRANCH}" ]];
-then fatal "Travis branch is required";
-else debug "Travis branch: ${TRAVIS_BRANCH}";
+if [[ -z "${TRAVIS_PULL_REQUEST_BRANCH}" ]];
+then fatal "Travis pull request branch is required";
+else debug "Travis pull request branch: ${TRAVIS_PULL_REQUEST_BRANCH}";
 fi
 
 set -e
@@ -51,7 +51,7 @@ debug "${POST_URL}"
 # By default, all commit statuses need to be "success" to deploy.
 # But travis itself will execute this script, so we don't block on anything.
 POST_BODY="{
-                \"ref\": \"${TRAVIS_BRANCH}\",
+                \"ref\": \"${TRAVIS_PULL_REQUEST_BRANCH}\",
                 \"task\": \"deploy\",
                 \"auto_merge\": false,
                 \"environment\": \"${ENVIRONMENT}\",

--- a/util/deploy-comment.sh
+++ b/util/deploy-comment.sh
@@ -47,12 +47,16 @@ set -o pipefail
 info "Posting deployed environment to GitHub..."
 POST_URL="https://api.github.com/repos/${TRAVIS_REPO_SLUG}/deployments"
 debug "${POST_URL}"
+
+# By default, all commit statuses need to be "success" to deploy.
+# But travis itself will execute this script, so we don't block on anything.
 POST_BODY="{
                 \"ref\": \"${TRAVIS_BRANCH}\",
                 \"task\": \"deploy\",
                 \"auto_merge\": false,
                 \"environment\": \"${ENVIRONMENT}\",
-                \"transient_environment\": true
+                \"transient_environment\": true,
+                \"required_contexts\": []
             }"
 debug "POST body: ${POST_BODY}"
 

--- a/util/deploy-comment.sh
+++ b/util/deploy-comment.sh
@@ -67,10 +67,12 @@ curl -H "Authorization: token ${GITHUB_TOKEN}" \
 if [[ "${EXIT_CODE:=${PIPESTATUS[0]}}" != "0" ]]; then exit ${EXIT_CODE}; fi
 
 DEPLOYMENT_ID=$(jq .id ${TEMP_FILE})
-if [[ "${EXIT_CODE}" == "0" ]]
+if [[ "${DEPLOYMENT_ID}" == "null" ]]
 then
-    debug "Created deployment ${DEPLOYMENT_ID}"
+    fatal "Something went wrong creating the deployment"
 fi
+
+debug "Created deployment ${DEPLOYMENT_ID}"
 
 debug "Setting status to deployed"
 POST_BODY="{

--- a/util/travis-deploy-staging.sh
+++ b/util/travis-deploy-staging.sh
@@ -61,5 +61,5 @@ DEPLOYED_URL=$(tr -d "\r" < ${TEMP_FILE} | sed -ne 's/^Deployed service.*to \[\(
 # Add a GitHub comment to the PR (if there is a PR).
 if [[ -n "${TRAVIS_PULL_REQUEST_BRANCH}" ]];
 then
-  ${UTIL_DIR}/deploy-comment.sh "${DEPLOYED_URL}";
+  ${UTIL_DIR}/deploy-comment.sh -e "${APP_PATH}" "${DEPLOYED_URL}";
 fi


### PR DESCRIPTION
## Description
Fix a couple of problems with #1453 which weren't caught until it hit master.

- `$APP_PATH` wasn't forwarded from the parent script; make it an `$ENVIRONMENT` param on the comment script.
- Fail out when the create POST fails
- Clear out the `required_contexts` so that running from travis isn't blocked by travis being unfinished.