### PR TITLE
Add structured search atom for filtering by results that differ

### DIFF
--- a/api/query/README.md
+++ b/api/query/README.md
@@ -55,7 +55,7 @@ Filters the results to values which possess/exhibit a given quality.
 
 #### `is:different`
 
-Filters to rows where more there is more than one resulting status for a test
+Filters to rows where there is more than one resulting status for a test
 across the runs.
 
 ### And-conjuction

--- a/api/query/README.md
+++ b/api/query/README.md
@@ -45,6 +45,19 @@ or, negation,
 
 Where `[product]` is a product specification (e.g. `safari`, `chrome-69`).
 
+### Meta qualities
+
+> BETA: This feature is under development and may change without warning.
+
+Filters the results to values which possess/exhibit a given quality.
+
+    is:[quality]
+
+#### `is:different`
+
+Filters to rows where more there is more than one resulting status for a test
+across the runs.
+
 ### And-conjuction
 
     [query1] and [query2] [and ...]
@@ -173,3 +186,14 @@ Search untriaged issues -
 Search triaged issues -
 
     chrome:pass and link:bugs.chromium.org
+
+#### is
+
+`is` query atoms perform a search for tests that possess some meta quality.
+
+    {"is": "different"}
+
+
+
+See [#meta-qualities](Meta qualities) above for more information on other
+meta qualities than `"different"`.

--- a/api/query/atoms_test.go
+++ b/api/query/atoms_test.go
@@ -358,6 +358,25 @@ func TestStructuredQuery_link(t *testing.T) {
 		}}, rq)
 }
 
+func TestStructuredQuery_is(t *testing.T) {
+	var rq RunQuery
+	err := json.Unmarshal([]byte(`{
+		"run_ids": [0, 1, 2],
+		"query": {
+			"exists": [{
+				"is": "different"
+			}]
+		}
+	}`), &rq)
+	assert.Nil(t, err)
+	assert.Equal(t, RunQuery{
+		RunIDs: []int64{0, 1, 2},
+		AbstractQuery: AbstractExists{[]AbstractQuery{
+			MetadataQualityDifferent,
+		}},
+	}, rq)
+}
+
 func TestStructuredQuery_combinedlink(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{

--- a/api/query/atoms_test.go
+++ b/api/query/atoms_test.go
@@ -664,8 +664,7 @@ func TestStructuredQuery_bindCount(t *testing.T) {
 		Where: TestStatusEq{Status: 1},
 	}
 
-	runs := shared.TestRuns{}
-	runs = shared.TestRuns{
+	runs := shared.TestRuns{
 		{
 			ID:                int64(0),
 			ProductAtRevision: e.ProductAtRevision,
@@ -696,8 +695,7 @@ func TestStructuredQuery_bindLink(t *testing.T) {
 		Pattern: "bugs.bar",
 	}
 
-	runs := shared.TestRuns{}
-	runs = shared.TestRuns{
+	runs := shared.TestRuns{
 		{
 			ID:                int64(0),
 			ProductAtRevision: e.ProductAtRevision,
@@ -725,6 +723,28 @@ func TestStructuredQuery_bindLink(t *testing.T) {
 		},
 	}
 	assert.Equal(t, expect, q.BindToRuns(runs...))
+}
+
+func TestStructuredQuery_bindIs(t *testing.T) {
+	defer func(url string) {
+		shared.MetadataArchiveURL = url
+	}(shared.MetadataArchiveURL)
+
+	e := shared.ParseProductSpecUnsafe("chrome")
+	f := shared.ParseProductSpecUnsafe("safari")
+	q := MetadataQualityDifferent
+
+	runs := shared.TestRuns{
+		{
+			ID:                int64(0),
+			ProductAtRevision: e.ProductAtRevision,
+		},
+		{
+			ID:                int64(1),
+			ProductAtRevision: f.ProductAtRevision,
+		},
+	}
+	assert.Equal(t, q, q.BindToRuns(runs...))
 }
 
 func TestStructuredQuery_bindAnd(t *testing.T) {

--- a/api/query/cache/index/filter.go
+++ b/api/query/cache/index/filter.go
@@ -202,7 +202,7 @@ func (q MetadataQuality) Filter(t TestID) bool {
 	for _, result := range q.runResults {
 		set.Add(result.GetResult(t))
 	}
-	return set.Cardinality() != 1
+	return set.Cardinality() > 1
 }
 
 // Filter interprets an And as a filter function over TestIDs.

--- a/api/query/cache/index/index_filter_test.go
+++ b/api/query/cache/index/index_filter_test.go
@@ -464,6 +464,66 @@ func TestBindExecute_Link(t *testing.T) {
 	assert.Equal(t, expectedResult, srs[0])
 }
 
+func TestBindExecute_Is(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	loader := NewMockReportLoader(ctrl)
+	idx, err := NewShardedWPTIndex(loader, testNumShards)
+	assert.Nil(t, err)
+
+	runs := mockTestRuns(loader, idx, []testRunData{
+		testRunData{
+			shared.TestRun{ID: 1},
+			&metrics.TestResultsReport{
+				Results: []*metrics.TestResults{
+					&metrics.TestResults{
+						Test:   "/a/b/c",
+						Status: "PASS",
+					},
+					&metrics.TestResults{
+						Test:   "/d/e/f",
+						Status: "FAIL",
+					},
+				},
+			},
+		},
+		testRunData{
+			shared.TestRun{ID: 2},
+			&metrics.TestResultsReport{
+				Results: []*metrics.TestResults{
+					&metrics.TestResults{
+						Test:   "/a/b/c",
+						Status: "PASS",
+					},
+					&metrics.TestResults{
+						Test:   "/d/e/f",
+						Status: "PASS",
+					},
+				},
+			},
+		},
+	})
+
+	quality := query.MetadataQualityDifferent
+	plan, err := idx.Bind(runs, quality)
+	assert.Nil(t, err)
+
+	res := plan.Execute(runs, query.AggregationOpts{})
+	srs, ok := res.([]shared.SearchResult)
+	assert.True(t, ok)
+
+	assert.Equal(t, 1, len(srs))
+	expectedResult := shared.SearchResult{
+		Test: "/d/e/f", // /a/b/c was the same, /d/e/f differed.
+		LegacyStatus: []shared.LegacySearchRunResult{
+			shared.LegacySearchRunResult{Passes: 0, Total: 1},
+			shared.LegacySearchRunResult{Passes: 1, Total: 1},
+		},
+	}
+
+	assert.Equal(t, expectedResult, srs[0])
+}
+
 func TestBindExecute_LinkNoMatchingPattern(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/api/query/concrete_query.go
+++ b/api/query/concrete_query.go
@@ -117,6 +117,15 @@ func (Link) Size() int { return 1 }
 // Size of Count is the sum of the sizes of its constituent ConcretQuery instances.
 func (c Count) Size() int { return size(c.Args) }
 
+// Size of Is depends on the quality.
+func (q MetadataQuality) Size() int {
+	switch q {
+	case MetadataQualityDifferent:
+		return 1
+	}
+	return 1
+}
+
 // Size of Or is the sum of the sizes of its constituent ConcretQuery instances.
 func (o Or) Size() int { return size(o.Args) }
 

--- a/api/query/concrete_query.go
+++ b/api/query/concrete_query.go
@@ -119,10 +119,7 @@ func (c Count) Size() int { return size(c.Args) }
 
 // Size of Is depends on the quality.
 func (q MetadataQuality) Size() int {
-	switch q {
-	case MetadataQualityDifferent:
-		return 1
-	}
+	// Currently only 'Different' supported, which is one set comparison per row.
 	return 1
 }
 

--- a/webapp/components/test-search.js
+++ b/webapp/components/test-search.js
@@ -81,6 +81,7 @@ const QUERY_GRAMMAR = ohm.grammar(`
     Fragment
       = not Fragment -- not
       | linkExp
+      | isExp
       | statusExp
       | subtestExp
       | pathExp
@@ -101,6 +102,9 @@ const QUERY_GRAMMAR = ohm.grammar(`
     linkExp
       = caseInsensitive<"link"> ":" nameFragment
 
+    isExp
+      = caseInsensitive<"is"> ":" metadataQualityLiteral
+
     patternExp = nameFragment
 
     productSpec = browserName ("-" browserVersion)?
@@ -112,6 +116,9 @@ const QUERY_GRAMMAR = ohm.grammar(`
 
     statusLiteral
       = ${statuses.map(s => 'caseInsensitive<"' + s + '">').join('\n      |')}
+
+    metadataQualityLiteral
+      = caseInsensitive<"different">
 
     nameFragment
       = basicNameFragment                       -- basic
@@ -221,6 +228,9 @@ const QUERY_SEMANTICS = QUERY_GRAMMAR.createSemantics().addOperation('eval', {
       product: l.sourceString.toLowerCase(),
       status: {not: r.eval()},
     };
+  },
+  isExp: (l, colon, r) => {
+    return { is: r.eval() };
   },
   subtestExp: (l, colon, r) => {
     return { subtest: r.eval() };

--- a/webapp/components/test/test-search.html
+++ b/webapp/components/test/test-search.html
@@ -269,6 +269,12 @@ suite('<test-search>', () => {
       });
     });
 
+    test('is', () => {
+      assertQueryParse('is:different', {
+        exists: [{ is: 'different' }]
+      });
+    });
+
     test('count', () => {
       assertQueryParse('count:5(status:PASS or status:OK)', {
         exists: [{


### PR DESCRIPTION
Fixes #1460 

## Description
Adds handling of `is:different` atom, which will return true for rows where the size/cardinality of the set of result statuses is not 1.

## Review Information
- Visit the deployed environment
- Search for is:different
- See only rows that have differing values.
- Try queries with 2, 3, and 4 runs, ensure behaves as expected.