### PR TITLE
Add all/none root queries

### DIFF
--- a/api/query/README.md
+++ b/api/query/README.md
@@ -77,6 +77,18 @@ Combines filters, such that any must apply, e.g.
 > NOTE: Or-conjuction takes less precedence than `and`. Precedence can be modified
 > using parens, e.g. `chrome:pass and (firefox:!pass or safari:!pass)`
 
+### All and None
+
+> BETA: This feature is under development and may change without warning.
+
+    all([query1] [query2])
+
+Combines filters such that they must all apply to all runs.
+
+    none([query1] [query2])
+
+Combines filters such that they must not _all_ apply to _any_ single run.
+
 ### Sequential
 
     seq([query1] [query2] [...])
@@ -133,6 +145,21 @@ that each of its queries is satisfied _by the same run_. This matters for the ca
 that there are multiple runs with the same product.
 
     {"exists": [query1, query2, ...]}
+
+#### all
+
+`all` query objects perform a conjunction of all of the runs, in order to ensure
+that each of its queries is satisfied by all of the runs.
+
+    {"all": [query1, query2, ...]}
+
+#### none
+
+`none` query objects perform a disjunction of all of the runs, in order to ensure
+that no single run satisfies all of its queries. `none` queries are a simplification for
+`{"not": {"exists": [...] }}` queries.
+
+    {"none": [query1, query2, ...]}
 
 #### sequential
 

--- a/api/query/atoms_test.go
+++ b/api/query/atoms_test.go
@@ -279,6 +279,40 @@ func TestStructuredQuery_exists(t *testing.T) {
 	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2}, AbstractQuery: AbstractExists{[]AbstractQuery{TestNamePattern{"cssom"}, TestNamePattern{"html"}}}}, rq)
 }
 
+func TestStructuredQuery_all(t *testing.T) {
+	var rq RunQuery
+	err := json.Unmarshal([]byte(`{
+		"run_ids": [0, 1, 2],
+		"query": {
+			"all": [
+				{"pattern": "cssom"}
+			]
+		}
+	}`), &rq)
+	assert.Nil(t, err)
+	assert.Equal(t, RunQuery{
+		RunIDs: []int64{0, 1, 2},
+		AbstractQuery: AbstractAll{[]AbstractQuery{TestNamePattern{"cssom"}}},
+		}, rq)
+}
+
+func TestStructuredQuery_none(t *testing.T) {
+	var rq RunQuery
+	err := json.Unmarshal([]byte(`{
+		"run_ids": [0, 1, 2],
+		"query": {
+			"none": [
+				{"pattern": "cssom"}
+			]
+		}
+	}`), &rq)
+	assert.Nil(t, err)
+	assert.Equal(t, RunQuery{
+		RunIDs: []int64{0, 1, 2},
+		AbstractQuery: AbstractNone{[]AbstractQuery{TestNamePattern{"cssom"}}},
+		}, rq)
+}
+
 func TestStructuredQuery_sequential(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{

--- a/webapp/components/test-search.js
+++ b/webapp/components/test-search.js
@@ -37,12 +37,18 @@ for (const b of DefaultBrowserNames) {
 /* global ohm */
 const QUERY_GRAMMAR = ohm.grammar(`
   Query {
-    Q = ListOf<RootExp, space*>
+    Q = All
+      | None
+      | Exists
 
     RootExp
       = Sequential
       | Count
       | Exp
+
+    All = "all(" ListOf<Exp, space*> ")"
+
+    None = "none(" ListOf<Exp, space*> ")"
 
     Sequential = "seq(" ListOf<Exp, space*> ")"
 
@@ -53,6 +59,8 @@ const QUERY_GRAMMAR = ohm.grammar(`
       | "three"         -- count3
       | "two"           -- count2
       | "one"           -- count1
+
+    Exists = ListOf<RootExp, space*>
 
     Exp = NonemptyListOf<OrPart, or>
 
@@ -164,12 +172,20 @@ const QUERY_SEMANTICS = QUERY_GRAMMAR.createSemantics().addOperation('eval', {
   NonemptyListOf: function(fst, seps, rest) {
     return [fst.eval()].concat(rest.eval());
   },
-  Q: l => {
+  Exists: l => {
     const ps = l.eval();
     // Separate atoms are each treated as "there exists a run where ...",
     // and the root is grouped by AND of the separated atoms.
     // Nested ands, on the other hand, require all conditions to be met by the same run.
     return ps.length === 0 ? emptyQuery : {exists: ps };
+  },
+  All: (_, l, __) => {
+    const ps = l.eval();
+    return ps.length === 0 ? emptyQuery : {all: ps };
+  },
+  None: (_, l, __) => {
+    const ps = l.eval();
+    return ps.length === 0 ? emptyQuery : {none: ps };
   },
   Sequential: (_, l, __) => {
     const ps = l.eval();

--- a/webapp/components/test/test-search.html
+++ b/webapp/components/test/test-search.html
@@ -230,6 +230,26 @@ suite('<test-search>', () => {
       });
     });
 
+    test('all', () => {
+      assertQueryParse('all(status:!PASS status:!OK)', {
+        all: [
+          {status: {not: 'PASS'} },
+          {status: {not: 'OK'} },
+        ],
+      });
+    });
+
+    test('none', () => {
+      assertQueryParse('none(status:PASS or status:OK)', {
+        none: [{
+          or: [
+            {status: 'PASS'},
+            {status: 'OK'},
+          ]
+        }],
+      });
+    });
+
     test('sequential', () => {
       // Canon: flip-flopping, which is usually flakiness:
       // A pass turning into a fail on the next run, and a non-pass turning to a pass on the next run.


### PR DESCRIPTION
Fixes #1467 
 
## Description
Adds root query options for `all` and `none` (instead of the default, `exists`).

Strangely, `count` and `seq` get wrapped in `exists`. I started to tweak that behaviour, but decided against busying up the PR. Will clean that up another time.