### PR TITLE
Add an API and UI for showing invalid runs

### DIFF
--- a/api/pending_test_runs.go
+++ b/api/pending_test_runs.go
@@ -26,7 +26,7 @@ func apiPendingTestRunsHandler(w http.ResponseWriter, r *http.Request) {
 	case "pending":
 		q = q.Order("-Stage").Filter("Stage < ", shared.StageValid)
 	case "invalid":
-		q = q.Order("Stage").Filter("Stage > ", shared.StageValid)
+		q = q.Order("-Stage").Filter("Stage > ", shared.StageValid)
 	case "":
 		// No-op
 	default:

--- a/api/pending_test_runs.go
+++ b/api/pending_test_runs.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"sort"
+	"strings"
 
 	"github.com/gorilla/mux"
 	"github.com/web-platform-tests/wpt.fyi/shared"
@@ -19,10 +20,18 @@ func apiPendingTestRunsHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := shared.NewAppEngineContext(r)
 	store := shared.NewAppEngineDatastore(ctx, false)
 
-	filter := mux.Vars(r)["filter"]
+	filter := strings.ToLower(mux.Vars(r)["filter"])
 	q := store.NewQuery("PendingTestRun")
-	if filter == "pending" {
+	switch filter {
+	case "pending":
 		q = q.Order("-Stage").Filter("Stage < ", shared.StageValid)
+	case "invalid":
+		q = q.Order("Stage").Filter("Stage > ", shared.StageValid)
+	case "":
+		// No-op
+	default:
+		http.Error(w, "Invalid filter: "+filter, http.StatusBadRequest)
+		return
 	}
 	q = q.Order("-Updated")
 

--- a/api/pending_test_runs_medium_test.go
+++ b/api/pending_test_runs_medium_test.go
@@ -73,4 +73,17 @@ func TestAPIPendingTestHandler(t *testing.T) {
 		assert.Len(t, results, 1)
 		assert.Equal(t, results[0].ID, running.ID)
 	})
+
+	t.Run("/api/status/invalid", func(t *testing.T) {
+		r, _ = i.NewRequest("GET", "/api/status/invalid", nil)
+		r = mux.SetURLVars(r, map[string]string{"filter": "invalid"})
+		resp := httptest.NewRecorder()
+		apiPendingTestRunsHandler(resp, r)
+		body, _ := ioutil.ReadAll(resp.Result().Body)
+		assert.Equal(t, http.StatusOK, resp.Code, string(body))
+		var results []shared.PendingTestRun
+		json.Unmarshal(body, &results)
+		assert.Len(t, results, 1)
+		assert.Equal(t, results[0].ID, invalid.ID)
+	})
 }

--- a/api/routes.go
+++ b/api/routes.go
@@ -62,7 +62,7 @@ func RegisterRoutes() {
 	pendingTestRuns := shared.WrapApplicationJSON(
 		shared.WrapPermissiveCORS(apiPendingTestRunsHandler))
 	shared.AddRoute("/api/status", "api-pending-test-runs", pendingTestRuns)
-	shared.AddRoute("/api/status/{filter:pending}", "api-pending-test-runs", pendingTestRuns)
+	shared.AddRoute("/api/status/{filter:pending|invalid}", "api-pending-test-runs", pendingTestRuns)
 
 	// API endpoint for redirecting to a run's summary JSON blob.
 	shared.AddRoute("/api/results", "api-results", shared.WrapPermissiveCORS(apiResultsRedirectHandler))

--- a/webapp/components/wpt-processor.js
+++ b/webapp/components/wpt-processor.js
@@ -112,11 +112,11 @@ class WPTProcessor extends LoadingState(PolymerElement) {
   _selectedTabChanged(tab) {
     const path = tab === 0 ? '/api/status/pending' : '/api/status/invalid';
     this.load(
-        this.loadPendingRuns(path),
-        () => {
-          this.resultsLoadFailed = true;
-          this.testRuns = [];
-        });
+      this.loadPendingRuns(path),
+      () => {
+        this.resultsLoadFailed = true;
+        this.testRuns = [];
+      });
   }
 
   async loadPendingRuns(path) {

--- a/webapp/components/wpt-processor.js
+++ b/webapp/components/wpt-processor.js
@@ -61,7 +61,7 @@ class WPTProcessor extends LoadingState(PolymerElement) {
         <template is="dom-repeat" items="[[testRuns]]" as="run">
           <tr>
             <td>[[ run.id ]]</td>
-            <td>[[ shortSHA(run.full_revision_hash) ]]</td>
+            <td title="[[run.full_revision_hash]]">[[ shortSHA(run.full_revision_hash) ]]</td>
             <td class="timestamp">[[ timestamp(run.updated) ]]</td>
             <td class="time-ago">[[ timeAgo(run.updated) ]]</td>
             <td class="timestamp">[[ timestamp(run.created) ]]</td>

--- a/webapp/components/wpt-processor.js
+++ b/webapp/components/wpt-processor.js
@@ -1,14 +1,17 @@
+/**
+ * Copyright 2019 The WPT Dashboard Project. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+import '../node_modules/@polymer/paper-styles/color.js';
+import '../node_modules/@polymer/paper-tabs/paper-tabs.js';
 import '../node_modules/@polymer/polymer/lib/elements/dom-if.js';
 import '../node_modules/@polymer/polymer/lib/elements/dom-repeat.js';
 import { html, PolymerElement } from '../node_modules/@polymer/polymer/polymer-element.js';
 import { LoadingState } from './loading-state.js';
 import { timeAgo } from './utils.js';
 
-/**
- * Copyright 2019 The WPT Dashboard Project. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
- */
 class WPTProcessor extends LoadingState(PolymerElement) {
   static get template() {
     return html`
@@ -28,7 +31,19 @@ class WPTProcessor extends LoadingState(PolymerElement) {
         text-align: left;
         color: #ccc;
       }
+      paper-tabs {
+        --paper-tabs-selection-bar-color: var(--paper-blue-500);
+        margin-bottom: 20px;
+      }
+      paper-tab {
+        --paper-tab-ink: var(--paper-blue-300);
+      }
     </style>
+
+    <paper-tabs selected="{{selectedTab}}">
+      <paper-tab>Pending runs</paper-tab>
+      <paper-tab>Invalid runs</paper-tab>
+    </paper-tabs>
 
     <template is="dom-if" if="[[testRuns.length]]">
       <table>
@@ -43,7 +58,7 @@ class WPTProcessor extends LoadingState(PolymerElement) {
           </tr>
         </thead>
         <tbody>
-        <template is="dom-repeat" items="{{ testRuns }}" as="run">
+        <template is="dom-repeat" items="[[testRuns]]" as="run">
           <tr>
             <td>[[ run.id ]]</td>
             <td>[[ shortSHA(run.full_revision_hash) ]]</td>
@@ -56,6 +71,10 @@ class WPTProcessor extends LoadingState(PolymerElement) {
           </tr>
         </template>
       </table>
+    </template>
+
+    <template is="dom-if" if="[[resultsLoadFailed]]">
+      <div>No runs found.</div>
     </template>
 
     <div class="loading">
@@ -74,26 +93,35 @@ class WPTProcessor extends LoadingState(PolymerElement) {
       testRuns: {
         type: Array
       },
+      resultsLoadFailed: {
+        type: Boolean,
+        value: false,
+      },
+      selectedTab: {
+        type: Number,
+        value: 0,
+        observer: '_selectedTabChanged',
+      }
     };
   }
 
-  constructor() {
-    super();
-    this.onLoadingComplete = () => {
-      this.loadingFailed = !this.testRuns;
-    };
-  }
-
-  async ready() {
-    await super.ready();
+  _selectedTabChanged(tab) {
+    const path = tab === 0 ? '/api/status/pending' : '/api/status/invalid';
     this.load(
-      this.loadPendingRuns()
-    );
+        this.loadPendingRuns(path),
+        () => {
+          this.resultsLoadFailed = true;
+          this.testRuns = [];
+        });
   }
 
-  async loadPendingRuns() {
-    const r = await fetch('/api/status/pending');
-    this.testRuns = r.ok && await r.json();
+  async loadPendingRuns(path) {
+    this.resultsLoadFailed = false;
+    const r = await fetch(path);
+    if (!r.ok || r.status !== 200) {
+      throw 'Failed to fetch pending runs.';
+    }
+    this.testRuns = await r.json();
   }
 
   shortSHA(sha) {

--- a/webapp/components/wpt-processor.js
+++ b/webapp/components/wpt-processor.js
@@ -73,8 +73,12 @@ class WPTProcessor extends LoadingState(PolymerElement) {
       </table>
     </template>
 
-    <template is="dom-if" if="[[resultsLoadFailed]]">
+    <template is="dom-if" if="[[!testRuns.length]]">
       <div>No runs found.</div>
+    </template>
+
+    <template is="dom-if" if="[[resultsLoadFailed]]">
+      <div>Failed to load runs.</div>
     </template>
 
     <div class="loading">
@@ -118,7 +122,7 @@ class WPTProcessor extends LoadingState(PolymerElement) {
   async loadPendingRuns(path) {
     this.resultsLoadFailed = false;
     const r = await fetch(path);
-    if (!r.ok || r.status !== 200) {
+    if (!r.ok) {
       throw 'Failed to fetch pending runs.';
     }
     this.testRuns = await r.json();

--- a/webapp/routes_test.go
+++ b/webapp/routes_test.go
@@ -76,6 +76,7 @@ func TestApiRunBound(t *testing.T) {
 func TestApiStatusBound(t *testing.T) {
 	assertHandlerIs(t, "/api/status", "api-pending-test-runs")
 	assertHandlerIs(t, "/api/status/pending", "api-pending-test-runs")
+	assertHandlerIs(t, "/api/status/invalid", "api-pending-test-runs")
 	assertHandlerIs(t, "/api/status/123", "api-pending-test-run-update")
 	assertHandlerIsDefault(t, "/api/status/notavalidfilter")
 }


### PR DESCRIPTION
API /api/status/invalid returns a list of invalid runs.

A tab bar is added to the /status interface to switch between pending
and invalid runs.

## Review Information

Go to the "processor" page (`/status`) of the staging deployment.