### PR TITLE
[processor] Report revisions for invalid runs

### DIFF
--- a/results-processor/processor.py
+++ b/results-processor/processor.py
@@ -257,6 +257,9 @@ class Processor(object):
         payload = {'id': int(run_id), 'stage': stage}
         if error:
             payload['error'] = error
+        revision = self.report.run_info.get('full_revision_hash')
+        if revision:
+            payload['full_revision_hash'] = revision
         try:
             response = requests.patch(api, auth=self.auth, json=payload)
             response.raise_for_status()


### PR DESCRIPTION
Whenever the full revision hash is available, we will report it to
/api/status/{id} to update the pending test run, so pending test runs
will almost always have revisions attached, making it easier to debug
problems.
