### PR TITLE
Upgrade results-processor to Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ services:
   - docker
 
 language: python
-python: "3.6"
+python: "3.7"
 cache:
   directories:
     - webapp/node_modules

--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ curl: apt-get-curl
 gcc: apt-get-gcc
 git: apt-get-git
 psmisc: apt-get-psmisc
-python3: apt-get-python3.6
+python3: apt-get-python3.7
 python: apt-get-python
 tox: apt-get-tox
 unzip: apt-get-unzip

--- a/results-processor/Dockerfile
+++ b/results-processor/Dockerfile
@@ -19,7 +19,7 @@ RUN gcloud config set disable_usage_reporting false
 RUN rm -f $HOME/.config/gcloud/gce
 
 # Setup and activate virtualenv.
-RUN virtualenv --no-download /env -p python3.6
+RUN virtualenv --no-download /env -p python3.7
 ENV VIRTUAL_ENV /env
 ENV PATH /env/bin:$PATH
 

--- a/results-processor/README.md
+++ b/results-processor/README.md
@@ -1,6 +1,6 @@
 ## Basics
 
-The results processor runs on Python 3.6. The entry point is a Flask web server
+The results processor runs on Python 3.7. The entry point is a Flask web server
 (`main.py`). In production, gunicorn is used as the WSGI (see `Dockerfile`) and
 the container runs as a custom AppEnging Flex instance (see `app.yaml`).
 
@@ -10,7 +10,7 @@ We can create a virtualenv to recreate a setup close to production for daily
 development.
 
 ```bash
-virtualenv env -p python3.6
+virtualenv env -p python3.7
 . env/bin/activate
 pip install -r requirements.txt
 ```

--- a/results-processor/tox.ini
+++ b/results-processor/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36
+envlist = py37
 # We don't have or need setup.py for now.
 skipsdist=True
 


### PR DESCRIPTION
Python 3.7 is the current stable version of Python 3 and is included in
Debian Stable, i.e. almost everywhere including our workstations and
Docker images.

3.7 is backward compatible with 3.6 and everything should just work.

## Review

If tests pass and staging is deployed, then we should be good.