### PR TITLE
Sort results when they arrive

### DIFF
--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -582,7 +582,7 @@ class WPTResults extends WPTColors(WPTFlags(PathInfo(LoadingState(TestRunsUIBase
         5000
       ).then(
         json => {
-          this.searchResults = json.results;
+          this.searchResults = json.results.sort((a, b) => a.test.localeCompare(b.test));
           this.refreshDisplayedNodes();
         },
         (e) => {


### PR DESCRIPTION
## Description
Fixes https://github.com/web-platform-tests/wpt.fyi/issues/1461 which relies on sorted results.

## Review Information
- Visit the deployed environment
- view /results/?diff&filter=ADC&run_id=257090008&run_id=231180012
- Smash the n key many times