### PR TITLE
Add inequality atoms

### DIFF
--- a/api/query/README.md
+++ b/api/query/README.md
@@ -116,6 +116,20 @@ Safari is the only one missing a result:
 
     three(status:!missing) safari:missing
 
+#### Count inequality
+
+> BETA: This feature is under development and may change without warning.
+
+    count[inequality][number]([query1])
+
+Requires that the number of results matching the given query satisfies the given
+inequality comparator.
+
+    count>1(status:PASS)
+    count<3(status:!FAIL)
+    count<=1(status:FAIL)
+    count>=1(status:MISSING)
+
 ## /api/search
 
 The `/api/search` endpoint takes an HTTP `POST` method, where the body is of the format

--- a/api/query/atoms.go
+++ b/api/query/atoms.go
@@ -91,8 +91,12 @@ func (e AbstractExists) BindToRuns(runs ...shared.TestRun) ConcreteQuery {
 	queries := make([]ConcreteQuery, len(e.Args))
 	for i, arg := range e.Args {
 		var query ConcreteQuery
-		// For sequential + count, we pass all runs.
+		// For seq/count/lessThan/moreThan we pass all runs.
 		if _, isSeq := arg.(AbstractSequential); isSeq {
+			query = arg.BindToRuns(runs...)
+		} else if _, isMoreThan := arg.(AbstractMoreThan); isMoreThan {
+			query = arg.BindToRuns(runs...)
+		} else if _, isLessThan := arg.(AbstractLessThan); isLessThan {
 			query = arg.BindToRuns(runs...)
 		} else if _, isCount := arg.(AbstractCount); isCount {
 			query = arg.BindToRuns(runs...)

--- a/api/query/atoms.go
+++ b/api/query/atoms.go
@@ -202,7 +202,33 @@ func (c AbstractCount) BindToRuns(runs ...shared.TestRun) ConcreteQuery {
 	}
 }
 
-// AbstractLink is represents the root of a link query, whic matches Metadata URLs
+// AbstractMoreThan is the root of a moreThan query, where the number of runs
+// that satisfy the query must be more than the given count.
+type AbstractMoreThan struct {
+	AbstractCount
+}
+
+// BindToRuns binds each count query to all of the runs, so that it can count the
+// number of runs that match the criteria.
+func (m AbstractMoreThan) BindToRuns(runs ...shared.TestRun) ConcreteQuery {
+	c := m.AbstractCount.BindToRuns(runs...).(Count)
+	return MoreThan{c}
+}
+
+// AbstractLessThan is the root of a lessThan query, where the number of runs
+// that satisfy the query must be less than the given count.
+type AbstractLessThan struct {
+	AbstractCount
+}
+
+// BindToRuns binds each count query to all of the runs, so that it can count the
+// number of runs that match the criteria.
+func (l AbstractLessThan) BindToRuns(runs ...shared.TestRun) ConcreteQuery {
+	c := l.AbstractCount.BindToRuns(runs...).(Count)
+	return LessThan{c}
+}
+
+// AbstractLink is represents the root of a link query, which matches Metadata URLs
 // to a pattern string; it is independent of test runs.
 type AbstractLink struct {
 	Pattern string
@@ -747,6 +773,64 @@ func (c *AbstractCount) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// UnmarshalJSON for AbstractLessThan attempts to interpret a query atom as
+// {"count": int, "where": query}.
+func (l *AbstractLessThan) UnmarshalJSON(b []byte) error {
+	var data struct {
+		Count json.RawMessage `json:"lessThan"`
+		Where json.RawMessage `json:"where"`
+	}
+	err := json.Unmarshal(b, &data)
+	if err != nil {
+		return err
+	}
+	if len(data.Count) == 0 {
+		return errors.New(`Missing lessThan property: "lessThan"`)
+	}
+	if len(data.Where) == 0 {
+		return errors.New(`Missing count property: "where"`)
+	}
+
+	err = json.Unmarshal(data.Count, &l.Count)
+	if err != nil {
+		return err
+	}
+	l.Where, err = unmarshalQ(data.Where)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// UnmarshalJSON for AbstractMoreThan attempts to interpret a query atom as
+// {"count": int, "where": query}.
+func (m *AbstractMoreThan) UnmarshalJSON(b []byte) error {
+	var data struct {
+		Count json.RawMessage `json:"moreThan"`
+		Where json.RawMessage `json:"where"`
+	}
+	err := json.Unmarshal(b, &data)
+	if err != nil {
+		return err
+	}
+	if len(data.Count) == 0 {
+		return errors.New(`Missing moreThan property: "moreThan"`)
+	}
+	if len(data.Where) == 0 {
+		return errors.New(`Missing count property: "where"`)
+	}
+
+	err = json.Unmarshal(data.Count, &m.Count)
+	if err != nil {
+		return err
+	}
+	m.Where, err = unmarshalQ(data.Where)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // UnmarshalJSON for AbstractLink attempts to interpret a query atom as
 // {"link":<metadata url pattern string>}.
 func (l *AbstractLink) UnmarshalJSON(b []byte) error {
@@ -885,6 +969,20 @@ func unmarshalQ(b []byte) (AbstractQuery, error) {
 	}
 	{
 		var c AbstractCount
+		err := json.Unmarshal(b, &c)
+		if err == nil {
+			return c, nil
+		}
+	}
+	{
+		var c AbstractLessThan
+		err := json.Unmarshal(b, &c)
+		if err == nil {
+			return c, nil
+		}
+	}
+	{
+		var c AbstractMoreThan
 		err := json.Unmarshal(b, &c)
 		if err == nil {
 			return c, nil

--- a/api/query/atoms_test.go
+++ b/api/query/atoms_test.go
@@ -291,9 +291,9 @@ func TestStructuredQuery_all(t *testing.T) {
 	}`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(t, RunQuery{
-		RunIDs: []int64{0, 1, 2},
+		RunIDs:        []int64{0, 1, 2},
 		AbstractQuery: AbstractAll{[]AbstractQuery{TestNamePattern{"cssom"}}},
-		}, rq)
+	}, rq)
 }
 
 func TestStructuredQuery_none(t *testing.T) {
@@ -308,9 +308,9 @@ func TestStructuredQuery_none(t *testing.T) {
 	}`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(t, RunQuery{
-		RunIDs: []int64{0, 1, 2},
+		RunIDs:        []int64{0, 1, 2},
 		AbstractQuery: AbstractNone{[]AbstractQuery{TestNamePattern{"cssom"}}},
-		}, rq)
+	}, rq)
 }
 
 func TestStructuredQuery_sequential(t *testing.T) {
@@ -369,6 +369,56 @@ func TestStructuredQuery_count(t *testing.T) {
 						TestStatusEq{Status: shared.TestStatusValueFromString("PASS")},
 						TestStatusEq{Status: shared.TestStatusValueFromString("OK")},
 					}},
+				}},
+			}}, rq)
+}
+
+func TestStructuredQuery_moreThan(t *testing.T) {
+	var rq RunQuery
+	err := json.Unmarshal([]byte(`{
+		"run_ids": [0, 1, 2],
+		"query": {
+			"exists": [{
+				"moreThan": 3,
+				"where": {"status":"PASS"}
+			}]
+		}
+	}`), &rq)
+	assert.Nil(t, err)
+	assert.Equal(
+		t,
+		RunQuery{RunIDs: []int64{0, 1, 2},
+			AbstractQuery: AbstractExists{[]AbstractQuery{
+				AbstractMoreThan{
+					AbstractCount{
+						Count: 3,
+						Where: TestStatusEq{Status: shared.TestStatusValueFromString("PASS")},
+					},
+				}},
+			}}, rq)
+}
+
+func TestStructuredQuery_lessThan(t *testing.T) {
+	var rq RunQuery
+	err := json.Unmarshal([]byte(`{
+		"run_ids": [0, 1, 2],
+		"query": {
+			"exists": [{
+				"lessThan": 2,
+				"where": {"status":"PASS"}
+			}]
+		}
+	}`), &rq)
+	assert.Nil(t, err)
+	assert.Equal(
+		t,
+		RunQuery{RunIDs: []int64{0, 1, 2},
+			AbstractQuery: AbstractExists{[]AbstractQuery{
+				AbstractLessThan{
+					AbstractCount{
+						Count: 2,
+						Where: TestStatusEq{Status: shared.TestStatusValueFromString("PASS")},
+					},
 				}},
 			}}, rq)
 }

--- a/api/query/atoms_test.go
+++ b/api/query/atoms_test.go
@@ -291,7 +291,7 @@ func TestStructuredQuery_all(t *testing.T) {
 	}`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(t, RunQuery{
-		RunIDs:        []int64{0, 1, 2},
+		RunIDs: []int64{0, 1, 2},
 		AbstractQuery: AbstractAll{[]AbstractQuery{TestNamePattern{"cssom"}}},
 	}, rq)
 }

--- a/api/query/cache/index/index_filter_test.go
+++ b/api/query/cache/index/index_filter_test.go
@@ -464,7 +464,7 @@ func TestBindExecute_Link(t *testing.T) {
 	assert.Equal(t, expectedResult, srs[0])
 }
 
-func TestBindExecute_Is(t *testing.T) {
+func TestBindExecute_MoreThan(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	loader := NewMockReportLoader(ctrl)
@@ -504,8 +504,13 @@ func TestBindExecute_Is(t *testing.T) {
 		},
 	})
 
-	quality := query.MetadataQualityDifferent
-	plan, err := idx.Bind(runs, quality)
+	moreThan := query.AbstractMoreThan{
+		query.AbstractCount{
+			Count: 1,
+			Where: query.TestStatusEq{Status: shared.TestStatusPass},
+		},
+	}.BindToRuns(runs...)
+	plan, err := idx.Bind(runs, moreThan)
 	assert.Nil(t, err)
 
 	res := plan.Execute(runs, query.AggregationOpts{})
@@ -514,7 +519,72 @@ func TestBindExecute_Is(t *testing.T) {
 
 	assert.Equal(t, 1, len(srs))
 	expectedResult := shared.SearchResult{
-		Test: "/d/e/f", // /a/b/c was the same, /d/e/f differed.
+		Test: "/a/b/c", // /a/b/c has 2 passes.
+		LegacyStatus: []shared.LegacySearchRunResult{
+			shared.LegacySearchRunResult{Passes: 1, Total: 1},
+			shared.LegacySearchRunResult{Passes: 1, Total: 1},
+		},
+	}
+
+	assert.Equal(t, expectedResult, srs[0])
+}
+
+func TestBindExecute_LessThan(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	loader := NewMockReportLoader(ctrl)
+	idx, err := NewShardedWPTIndex(loader, testNumShards)
+	assert.Nil(t, err)
+
+	runs := mockTestRuns(loader, idx, []testRunData{
+		testRunData{
+			shared.TestRun{ID: 1},
+			&metrics.TestResultsReport{
+				Results: []*metrics.TestResults{
+					&metrics.TestResults{
+						Test:   "/a/b/c",
+						Status: "PASS",
+					},
+					&metrics.TestResults{
+						Test:   "/d/e/f",
+						Status: "FAIL",
+					},
+				},
+			},
+		},
+		testRunData{
+			shared.TestRun{ID: 2},
+			&metrics.TestResultsReport{
+				Results: []*metrics.TestResults{
+					&metrics.TestResults{
+						Test:   "/a/b/c",
+						Status: "PASS",
+					},
+					&metrics.TestResults{
+						Test:   "/d/e/f",
+						Status: "PASS",
+					},
+				},
+			},
+		},
+	})
+
+	moreThan := query.AbstractLessThan{
+		query.AbstractCount{
+			Count: 2,
+			Where: query.TestStatusEq{Status: shared.TestStatusPass},
+		},
+	}.BindToRuns(runs...)
+	plan, err := idx.Bind(runs, moreThan)
+	assert.Nil(t, err)
+
+	res := plan.Execute(runs, query.AggregationOpts{})
+	srs, ok := res.([]shared.SearchResult)
+	assert.True(t, ok)
+
+	assert.Equal(t, 1, len(srs))
+	expectedResult := shared.SearchResult{
+		Test: "/d/e/f", // /a/b/c has 1 passes.
 		LegacyStatus: []shared.LegacySearchRunResult{
 			shared.LegacySearchRunResult{Passes: 0, Total: 1},
 			shared.LegacySearchRunResult{Passes: 1, Total: 1},

--- a/api/query/concrete_query.go
+++ b/api/query/concrete_query.go
@@ -51,6 +51,18 @@ type Count struct {
 	Args  []ConcreteQuery
 }
 
+// MoreThan constrains search results to include only test results where the number
+// of runs that match the given criteria is more than the given count.
+type MoreThan struct {
+	Count
+}
+
+// LessThan constrains search results to include only test results where the number
+// of runs that match the given criteria is less than the given count.
+type LessThan struct {
+	Count
+}
+
 // Link is a ConcreteQuery of AbstractLink.
 type Link struct {
 	Pattern  string

--- a/webapp/components/test-search.js
+++ b/webapp/components/test-search.js
@@ -55,10 +55,12 @@ const QUERY_GRAMMAR = ohm.grammar(`
     Count = CountSpecifier "(" Exp ")"
 
     CountSpecifier
-      = "count:" number -- countN
-      | "three"         -- count3
-      | "two"           -- count2
-      | "one"           -- count1
+      = "count" inequality number -- countInequality
+      | "count:" number           -- countEq
+      | "count=" number           -- countN
+      | "three"                   -- count3
+      | "two"                     -- count2
+      | "one"                     -- count1
 
     Exists = ListOf<RootExp, space*>
 
@@ -85,6 +87,12 @@ const QUERY_GRAMMAR = ohm.grammar(`
     not
       = "!"
       | "not"
+
+    inequality
+      = ">="
+      | "<="
+      | ">"
+      | "<"
 
     Fragment
       = not Fragment -- not
@@ -192,15 +200,29 @@ const QUERY_SEMANTICS = QUERY_GRAMMAR.createSemantics().addOperation('eval', {
     return ps.length === 0 ? emptyQuery : {sequential: ps };
   },
   Count: (cs, _, exp, __) => {
-    return {
-      count: cs.eval(),
-      where: exp.eval(),
-    }
+    let count = cs.eval();
+    count.where = exp.eval();
+    return count;
   },
-  CountSpecifier_countN: (_, n) => n.eval(),
-  CountSpecifier_count3: (_) => 3,
-  CountSpecifier_count2: (_) => 2,
-  CountSpecifier_count1: (_) => 1,
+  CountSpecifier_countInequality: (_, c, n) => {
+    let inequality = c.eval();
+    switch (inequality) {
+      case ">=":
+        return { moreThan: parseInt(n.eval()) - 1 };
+      case ">":
+        return { moreThan: n.eval() };
+      case "<=":
+        return { lessThan: parseInt(n.eval()) + 1 };
+      case "<":
+        return { lessThan: n.eval() };
+    }
+    throw new Error('Unexpected inequality ' + inequality);
+  },
+  CountSpecifier_countEq: (_, n) => { return { count: n.eval() }; },
+  CountSpecifier_countN: (_, n) => { return { count: n.eval() }; },
+  CountSpecifier_count3: (_) => {return {count: 3}; },
+  CountSpecifier_count2: (_) => {return {count: 2}; },
+  CountSpecifier_count1: (_) => {return {count: 1}; },
   linkExp: (l, colon, r) => {
     const ps = r.eval();
     return ps.length === 0 ? emptyQuery : {link: ps };

--- a/webapp/components/test/test-search.html
+++ b/webapp/components/test/test-search.html
@@ -314,6 +314,21 @@ suite('<test-search>', () => {
           }]
         });
       }
+      assertQueryParse('count=5(status:PASS)', {
+        exists: [{ count: 5, where: {status: 'PASS'} }]
+      });
+      assertQueryParse('count>1(status:PASS)', {
+        exists: [{ moreThan: 1, where: {status: 'PASS'} }]
+      });
+      assertQueryParse('count>=2(status:PASS)', {
+        exists: [{ moreThan: 1, where: {status: 'PASS'} }]
+      });
+      assertQueryParse('count<3(status:PASS)', {
+        exists: [{ lessThan: 3, where: {status: 'PASS'} }]
+      });
+      assertQueryParse('count<=2(status:PASS)', {
+        exists: [{ lessThan: 3, where: {status: 'PASS'} }]
+      });
     });
 
     test('simple link search', () => {


### PR DESCRIPTION
Fixes #1496 

## Description
Adds `count<2([query])` style inequality count atoms to the structured search.