### PR TITLE
Explode folder contents in UI and collapse folders in autocomplete suggestions

### DIFF
--- a/api/query/autocomplete.go
+++ b/api/query/autocomplete.go
@@ -7,6 +7,7 @@ package query
 import (
 	"encoding/json"
 	"net/http"
+	"path"
 	"sort"
 	"strings"
 	"time"
@@ -118,6 +119,14 @@ func prepareAutocompleteResponse(limit int, filters *shared.QueryFilter, testRun
 	for _, smry := range summaries {
 		for file := range smry {
 			fileSet.Add(file)
+			// Add all the dirs as options too.
+			prefix := "/"
+			dir, _ := path.Split(file)
+			bits := strings.Split(dir, "/")
+			for _, part := range bits {
+				prefix := prefix + part + "/"
+				fileSet.Add(prefix)
+			}
 		}
 	}
 

--- a/api/query/autocomplete_medium_test.go
+++ b/api/query/autocomplete_medium_test.go
@@ -37,8 +37,8 @@ func TestAutocompleteHandler(t *testing.T) {
 		},
 	}
 	summaryBytes := [][]byte{
-		[]byte(`{"/a/b/c":[1,2],"/b/c":[9,9]}`),
-		[]byte(`{"/z/b/c":[0,8],"/x/y/z":[3,4],"/b/c":[5,9]}`),
+		[]byte(`{"/a/b/c.html":[1,2],"/b/c.html":[9,9]}`),
+		[]byte(`{"/z/b/c.html":[0,8],"/x/y/z.html":[3,4],"/b/c.html":[5,9]}`),
 	}
 
 	i, err := sharedtest.NewAEInstance(true)
@@ -84,7 +84,7 @@ func TestAutocompleteHandler(t *testing.T) {
 		"/api/autocomplete?run_ids=%s&q=%s&limit=%s",
 		url.QueryEscape(fmt.Sprintf("%d,%d", testRuns[0].ID, testRuns[1].ID)),
 		url.QueryEscape(q),
-		url.QueryEscape("2"))
+		url.QueryEscape("3"))
 	r, err := i.NewRequest("GET", url, nil)
 	assert.Nil(t, err)
 	ctx := shared.NewAppEngineContext(r)
@@ -105,8 +105,9 @@ func TestAutocompleteHandler(t *testing.T) {
 
 	assert.Equal(t, AutocompleteResponse{
 		Suggestions: []AutocompleteResult{
-			AutocompleteResult{"/b/c"},
-			AutocompleteResult{"/a/b/c"},
+			AutocompleteResult{"/b/"},
+			AutocompleteResult{"/b/c.html"},
+			AutocompleteResult{"/a/b/c.html"},
 		},
 	}, data)
 	assert.True(t, rs[0].IsClosed())

--- a/api/query/autocomplete_test.go
+++ b/api/query/autocomplete_test.go
@@ -163,6 +163,7 @@ func TestPrepareAutocompleteResponse_several(t *testing.T) {
 
 	resp := prepareAutocompleteResponse(50, &filters, testRuns, summaries)
 	assert.Equal(t, []AutocompleteResult{
+		AutocompleteResult{"/b/"},
 		AutocompleteResult{"/b/c"},
 		AutocompleteResult{"/a/b/c"},
 		AutocompleteResult{"/z/b/c"},
@@ -197,8 +198,9 @@ func TestPrepareAutocompleteResponse_limited(t *testing.T) {
 		},
 	}
 
-	resp := prepareAutocompleteResponse(2, &filters, testRuns, summaries)
+	resp := prepareAutocompleteResponse(3, &filters, testRuns, summaries)
 	assert.Equal(t, []AutocompleteResult{
+		AutocompleteResult{"/b/"},
 		AutocompleteResult{"/b/c"},
 		AutocompleteResult{"/a/b/c"},
 	}, resp.Suggestions)

--- a/webapp/components/path.js
+++ b/webapp/components/path.js
@@ -167,10 +167,6 @@ class PathPart extends PathInfo(PolymerElement) {
   }
 
   computeDisplayableRelativePath(path) {
-    if (!this.isDir) {
-      path = this.encodeTestPath(path || '');
-      return decodeURIComponent(path.substr(path.lastIndexOf('/') + 1));
-    }
     const windowPath = window.location.pathname.replace(`${this.prefix || ''}`, '');
     const pathPrefix = new RegExp(`^${windowPath}${windowPath.endsWith('/') ? '' : '/'}`);
     return `${path.replace(pathPrefix, '')}${this.isDir ? '/' : ''}`;

--- a/webapp/components/test-search.js
+++ b/webapp/components/test-search.js
@@ -428,7 +428,24 @@ class TestSearch extends WPTFlags(PolymerElement) {
       }
     }
     if (paths) {
-      let matches = Array.from(paths);
+      // Compute all the parent folders for the paths.
+      let folders = new Set();
+      for (const path of paths) {
+        const parts = path.split('/');
+        let c = '/';
+        for (let i = 1; i + 1 < parts.length; i++) {
+          c += parts[i] + '/';
+          folders.add(c);
+        }
+        if (query) {
+          if (!c.toLowerCase().includes(query)) {
+            continue;
+          }
+        } else if (folders.size >= 10) {
+          break;
+        }
+      }
+      let matches = Array.from(folders).sort().concat(Array.from(paths));
       if (query) {
         matches = matches
           .filter(p => p.toLowerCase())

--- a/webapp/views/wpt-app.js
+++ b/webapp/views/wpt-app.js
@@ -283,7 +283,11 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
 
   handleSearchAutocomplete(e) {
     this.shadowRoot.querySelector('test-search').clear();
-    this.set('subroute.path', e.detail.path);
+    let path = e.detail.path;
+    if (path.endsWith('/')) {
+      path = path.substring(0, path.length - 1);
+    }
+    this.set('subroute.path', path);
   }
 
   handleAddMasterLabel(e) {

--- a/webdriver/path_test.go
+++ b/webdriver/path_test.go
@@ -46,5 +46,22 @@ func testPath(t *testing.T, app AppServer, wd selenium.WebDriver, path, elementN
 	}
 	err := wd.WaitWithTimeout(resultsLoadedCondition, time.Second*10)
 	assert.Nil(t, err)
-	assertListIsFiltered(t, wd, elementName, paths...)
+
+	var pathParts []selenium.WebElement
+	filteredPathPartsCondition := func(wd selenium.WebDriver) (bool, error) {
+		pathParts, err = getPathPartElements(wd, elementName)
+		return err == nil, err
+	}
+	err = wd.WaitWithTimeout(filteredPathPartsCondition, time.Second*120)
+	if err != nil || len(pathParts) != 2 {
+		assert.Fail(t, "Expected 2 path-part elements")
+		return
+	}
+	for i := range pathParts {
+		text, err := FindShadowText(wd, pathParts[i], "a")
+		if err != nil {
+			assert.Fail(t, err.Error())
+		}
+		assert.Equal(t, paths[i], text)
+	}
 }

--- a/webdriver/search_test.go
+++ b/webdriver/search_test.go
@@ -5,6 +5,7 @@ package webdriver
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -69,27 +70,24 @@ func testSearch(t *testing.T, wd selenium.WebDriver, app AppServer, path, elemen
 	})
 }
 
-func assertListIsFiltered(t *testing.T, wd selenium.WebDriver, elementName string, paths ...string) {
+func assertListIsFiltered(t *testing.T, wd selenium.WebDriver, elementName string, path string) {
 	var pathParts []selenium.WebElement
 	var err error
 	filteredPathPartsCondition := func(wd selenium.WebDriver) (bool, error) {
 		pathParts, err = getPathPartElements(wd, elementName)
-		if err != nil {
-			return false, err
-		}
-		return len(pathParts) == len(paths), nil
+		return err == nil, err
 	}
 	err = wd.WaitWithTimeout(filteredPathPartsCondition, time.Second*120)
 	if err != nil {
-		assert.Fail(t, fmt.Sprintf("Expected exactly %v results", len(paths)))
+		assert.Fail(t, "Expected path-part elements")
 		return
 	}
-	for i := range paths {
+	for i := range pathParts {
 		text, err := FindShadowText(wd, pathParts[i], "a")
 		if err != nil {
 			assert.Fail(t, err.Error())
 		}
-		assert.Equal(t, paths[i], text)
+		assert.True(t, strings.HasPrefix(text, path), fmt.Sprintf("%s should start with %s", text, path))
 	}
 }
 


### PR DESCRIPTION
## Description
Changes the displayed row to explode out its contents when there's only one row, and it's a directory.

I did this to cover the behaviour of submitting a search which has results under some unique folder, because it also covers the general case of clicking/navigating down into a state with the same context (a single directory).

Additionally, contributes each separate folder of a test path as possible autocomplete suggestions, so that we can leverage the jump-on-autocomplete behaviour to achieve a different solution of the same issue.

## Review Information
- Head to the GitHub deployed environment
- Search for `web-animations/animation-model`
- See three rows, each of which is an exploded path nested under web-animations/animation-model