### PR TITLE
Add webkitgtk as a known browser:

### DIFF
--- a/results-processor/wptreport.py
+++ b/results-processor/wptreport.py
@@ -555,6 +555,9 @@ def normalize_product(report: WPTReport) -> Set[str]:
     elif product == 'edgechromium':
         report.run_info['product'] = 'edge'
         return {'edge', 'edgechromium'}
+    elif product == 'webkitgtk_minibrowser':
+        report.run_info['product'] = 'webkitgtk'
+        return {'webkitgtk', 'minibrowser'}
     else:
         return set()
 

--- a/results-processor/wptreport_test.py
+++ b/results-processor/wptreport_test.py
@@ -620,6 +620,21 @@ class HelpersTest(unittest.TestCase):
             'edge'
         )
 
+    def test_normalize_product_webkitgtk_minibrowser(self):
+        r = WPTReport()
+        r._report = {
+            'run_info': {
+                'product': 'webkitgtk_minibrowser',
+            }
+        }
+        self.assertSetEqual(
+            normalize_product(r),
+            {'webkitgtk', 'minibrowser'}
+        )
+        self.assertEqual(
+            r.run_info['product'],
+            'webkitgtk'
+        )
     def test_normalize_product_noop(self):
         r = WPTReport()
         r._report = {

--- a/shared/browsers.go
+++ b/shared/browsers.go
@@ -14,7 +14,7 @@ var defaultBrowsers = []string{
 
 // An extra list of known browsers.
 var extraBrowsers = []string{
-	"android_webview", "epiphany", "uc",
+	"android_webview", "epiphany", "webkitgtk", "uc",
 }
 
 var allBrowsers mapset.Set

--- a/shared/browsers_test.go
+++ b/shared/browsers_test.go
@@ -20,6 +20,7 @@ func TestGetDefaultBrowserNames(t *testing.T) {
 	for _, n := range names {
 		assert.NotEqual(t, "android_webview", n)
 		assert.NotEqual(t, "epiphany", n)
+		assert.NotEqual(t, "webkitgtk", n)
 		assert.NotEqual(t, "uc", n)
 	}
 }
@@ -31,6 +32,7 @@ func TestIsBrowserName(t *testing.T) {
 	assert.True(t, IsBrowserName("safari"))
 	assert.True(t, IsBrowserName("android_webview"))
 	assert.True(t, IsBrowserName("epiphany"))
+	assert.True(t, IsBrowserName("webkitgtk"))
 	assert.True(t, IsBrowserName("uc"))
 	assert.False(t, IsBrowserName("not-a-browser"))
 }


### PR DESCRIPTION
## Description
This adds `webkitgtk` as a known browser. We want to start sending reports with runs of this browser to staging.wpt.fyi
The product from the wptreport is `webkitgtk_minibrowser`, which is normalized to `webkitgtk`

For related pull-request adding this browser to wpt see https://github.com/web-platform-tests/wpt/pull/19227

// cc @foolip 