### PR TITLE
Support or-conjunction for root queries

### DIFF
--- a/api/query/README.md
+++ b/api/query/README.md
@@ -21,6 +21,10 @@ separately be true. e.g.
 
 Requires that more than one non-pass result is present, and none of the results are missing.
 
+Alternatively, root queries can be combined using `OR` by specifying it, e.g.
+
+    none(status:pass) or all(status:pass)
+
 #### Exists
 
 As stated above, exists is the implicit default.
@@ -216,7 +220,9 @@ a count of exactly the given number.
 
     {
         "count": 2,
-        "where": [query object]
+        "where": {
+            // query object
+        }
     }
 
 #### moreThan and lessThan
@@ -226,7 +232,9 @@ equality (exact count).
 
     {
         "moreThan": 2,
-        "where": [query object]
+        "where": {
+            // query object
+        }
     }
 
 #### and

--- a/api/query/README.md
+++ b/api/query/README.md
@@ -14,16 +14,21 @@ By default, a search query will be implicitly treated as an `exists` query (a di
 across each of the runs separately). However, there are several other root query types that
 can be invoked by wrapping the query(s), including explicitly wrapping with `exists`.
 
-If multiple root queries are used, they are combined with `AND`, i.e. each query must
-separately be true. e.g.
+If multiple root queries are used, they are implicitly combined with `AND`, i.e. each query
+must separately be true. e.g.
 
     count>1(status:!pass) none(status:missing)
 
 Requires that more than one non-pass result is present, and none of the results are missing.
+You can also explicitly combine the root queries with `and`, e.g.
 
-Alternatively, root queries can be combined using `OR` by specifying it, e.g.
+    count<3(status:pass) and none(status:missing)
+
+Alternatively, root queries can be combined using `or`, e.g.
 
     none(status:pass) or all(status:pass)
+
+Note that the `and` conjunction takes precedence over the `or` conjunction.
 
 #### Exists
 

--- a/webapp/components/test/test-search.html
+++ b/webapp/components/test/test-search.html
@@ -375,6 +375,18 @@ suite('<test-search>', () => {
           { none: [{ status: 'PASS' }] },
         ]
       });
+      assertQueryParse('idlharness all(status:fail)', {
+        and: [
+          { exists: [{ pattern: 'idlharness' }] },
+          { all: [{ status: 'FAIL' }] },
+        ]
+      });
+      assertQueryParse('2dcontext and all(status:fail)', {
+        and: [
+          { exists: [{ pattern: '2dcontext' }] },
+          { all: [{ status: 'FAIL' }] },
+        ]
+      });
     });
   });
 });

--- a/webapp/components/test/test-search.html
+++ b/webapp/components/test/test-search.html
@@ -361,6 +361,21 @@ suite('<test-search>', () => {
           }],
       });
     });
+
+    test('multi-root', () => {
+      assertQueryParse('none(status:missing) count>0(status:!pass)', {
+        and: [
+          { none: [{ status: 'UNKNOWN' }] },
+          { moreThan: 0, where: { status: { not: 'PASS' } } },
+        ]
+      });
+      assertQueryParse('all(status:pass) or none(status:pass)', {
+        or: [
+          { all: [{ status: 'PASS' }] },
+          { none: [{ status: 'PASS' }] },
+        ]
+      });
+    });
   });
 });
 </script>


### PR DESCRIPTION
## Description
Follow-up for https://github.com/web-platform-tests/wpt.fyi/pull/1500 to fix #1507 

## Review Information
- Visit the deployed environment
- Search for `all(status:pass) or none(status:pass)`
- See expected results