### PR TITLE
Allow optional : in count inequalities

### DIFF
--- a/api/query/README.md
+++ b/api/query/README.md
@@ -77,10 +77,14 @@ Safari is the only one missing a result:
 Requires that the number of results matching the given query satisfies the given
 inequality comparator.
 
+    count=1(status:PASS)
     count>1(status:PASS)
     count<3(status:!FAIL)
     count<=1(status:FAIL)
     count>=1(status:MISSING)
+
+> NOTE: The colon after the `count` is optional for inequalities. Queries like
+> `count:>1(status:missing)`, with a syntax similar to GitHub's search, will work.
 
 ### Query atoms
 

--- a/webapp/components/test-search.js
+++ b/webapp/components/test-search.js
@@ -54,11 +54,11 @@ const QUERY_GRAMMAR = ohm.grammar(`
     Count = CountSpecifier "(" Exp ")"
 
     CountSpecifier
-      = "count" inequality number -- countInequality
-      | "count:" number           -- countN
-      | "three"                   -- count3
-      | "two"                     -- count2
-      | "one"                     -- count1
+      = "count" ":"? inequality number -- countInequality
+      | "count:" number                -- countN
+      | "three"                        -- count3
+      | "two"                          -- count2
+      | "one"                          -- count1
 
     Exists
       = "exists(" ListOf<Exp, space*> ")" -- explicit
@@ -213,7 +213,7 @@ const QUERY_SEMANTICS = QUERY_GRAMMAR.createSemantics().addOperation('eval', {
     count.where = exp.eval();
     return count;
   },
-  CountSpecifier_countInequality: (_, c, n) => {
+  CountSpecifier_countInequality: (_, __, c, n) => {
     let inequality = c.eval();
     switch (inequality) {
       case ">=":

--- a/webapp/components/test/test-search.html
+++ b/webapp/components/test/test-search.html
@@ -321,6 +321,12 @@ suite('<test-search>', () => {
       assertQueryParse('count>=2(status:PASS)', { moreThan: 1, where: {status: 'PASS' }});
       assertQueryParse('count<3(status:PASS)', { lessThan: 3, where: {status: 'PASS' }});
       assertQueryParse('count<=2(status:PASS)', { lessThan: 3, where: {status: 'PASS' }});
+
+      assertQueryParse('count:=5(status:PASS)', { count: 5, where: {status: 'PASS' }});
+      assertQueryParse('count:>1(status:PASS)', { moreThan: 1, where: {status: 'PASS' }});
+      assertQueryParse('count:>=2(status:PASS)', { moreThan: 1, where: {status: 'PASS' }});
+      assertQueryParse('count:<3(status:PASS)', { lessThan: 3, where: {status: 'PASS' }});
+      assertQueryParse('count:<=2(status:PASS)', { lessThan: 3, where: {status: 'PASS' }});
     });
 
     test('simple link search', () => {


### PR DESCRIPTION
## Description
Fixes #1510 
Allows an optional `:` after the `count` in the search syntax, which supports the same format as the GitHub inequality atoms.

## Review Information
- Visit deployed environment
- Search for `count:>3(status:pass)`
- See expected result.