### PR TITLE
Update counts on path change

### DIFF
--- a/webapp/components/test/wpt-app.html
+++ b/webapp/components/test/wpt-app.html
@@ -38,7 +38,15 @@ suite('<wpt-app>', () => {
         appFixture.searchResults = [];
         expect(appFixture.resultsTotalsRangeMessage).to.not.contain('0 tests');
         appFixture.page = 'results';
-        expect(appFixture.resultsTotalsRangeMessage).to.contain('0 tests');
+        expect(appFixture.resultsTotalsRangeMessage).to.not.contain('0 tests');
+      });
+
+      test('single', () => {
+        appFixture.searchResults = [
+          {test: '/abc.html', legacy_status: [{total: 1}, {total: 1}]},
+        ];
+        expect(appFixture.resultsTotalsRangeMessage).to.not.contain('1 tests');
+        expect(appFixture.resultsTotalsRangeMessage).to.not.contain('1 subtests');
       });
 
       test('some sum', () => {

--- a/webapp/views/wpt-app.js
+++ b/webapp/views/wpt-app.js
@@ -178,7 +178,7 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
       searchResults: Array,
       resultsTotalsRangeMessage: {
         type: String,
-        computed: 'computeResultsTotalsRangeMessage(page, searchResults, shas, productSpecs, to, from, maxCount, labels, master)',
+        computed: 'computeResultsTotalsRangeMessage(page, path, searchResults, shas, productSpecs, to, from, maxCount, labels, master)',
       },
     };
   }
@@ -297,7 +297,7 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
     this.dismissToast(e);
   }
 
-  computeResultsTotalsRangeMessage(page, searchResults, shas, productSpecs, from, to, maxCount, labels, master) {
+  computeResultsTotalsRangeMessage(page, path, searchResults, shas, productSpecs, from, to, maxCount, labels, master) {
     const msg = super.computeResultsRangeMessage(shas, productSpecs, from, to, maxCount, labels, master);
     if (page === 'results' && searchResults) {
       let subtests = 0, tests = 0;
@@ -307,9 +307,27 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
           subtests += Math.max(...r.legacy_status.map(s => s.total));
         }
       }
+      if (this.computePathIsATestFile(path)) {
+        if (subtests <= 1) {
+          return msg;
+        }
+        return msg.replace('Showing ', `Showing ${subtests} subtests from `);
+      }
+      let folder = '';
+      if (path && path.length > 1) {
+        folder = ` in ${path.substring(1)}`;
+      }
+      let testsAndSubtests = '';
+      if (tests > 1) {
+        testsAndSubtests += `${tests} tests`;
+        if (subtests > 1) {
+          testsAndSubtests += ` (${subtests} subtests)`;
+        }
+        testsAndSubtests += folder;
+      }
       return msg.replace(
         'Showing ',
-        `Showing ${tests} tests (${subtests} subtests) from `);
+        `Showing ${testsAndSubtests} from `);
     }
     return msg;
   }


### PR DESCRIPTION
## Description
Fixes https://github.com/web-platform-tests/wpt.fyi/issues/1455

Factor in the current path when computing the summary message. Also omits the test count when looking at a folder with just one test, or a single file (always 1 test), and the subtest count when there's exactly one subtest.

## Review Information
- Visit the deployed environment
- Navigate around, verify that the message is sensible.