### PR TITLE
Update references to "live" deployment

### DIFF
--- a/webapp/components/wpt-flags.js
+++ b/webapp/components/wpt-flags.js
@@ -46,7 +46,7 @@ Object.defineProperty(wpt, 'ClientSideFeatures', {
       'showTestRefURL',
       'structuredQueries',
       'searchPRsForDirectories',
-      'webPlatformTestsLive',
+      'wptLive',
     ];
   }
 });
@@ -239,8 +239,8 @@ class WPTFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ false) {
       </paper-checkbox>
     </paper-item>
     <paper-item>
-      <paper-checkbox checked="{{webPlatformTestsLive}}">
-        Use web-platform-tests.live.
+      <paper-checkbox checked="{{wptLive}}">
+        Use wpt.live.
       </paper-checkbox>
     </paper-item>
     <paper-item>

--- a/webapp/views/wpt-app.js
+++ b/webapp/views/wpt-app.js
@@ -94,14 +94,14 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
               <li>
                 <a href\$="https://github.com/web-platform-tests/wpt/blob/master[[path]]" target="_blank">View source on GitHub</a></li>
 
-                <template is="dom-if" if="[[ !webPlatformTestsLive ]]">
+                <template is="dom-if" if="[[ !wptLive ]]">
                   <li><a href\$="[[scheme]]://w3c-test.org[[path]]" target="_blank">Run in your
                   browser on w3c-test.org</a></li>
                 </template>
 
-                <template is="dom-if" if="[[ webPlatformTestsLive ]]">
-                  <li><a href\$="[[scheme]]://web-platform-tests.live[[path]]" target="_blank">Run in your
-                    browser on web-platform-tests.live</a></li>
+                <template is="dom-if" if="[[ wptLive ]]">
+                  <li><a href\$="[[scheme]]://wpt.live[[path]]" target="_blank">Run in your
+                    browser on wpt.live</a></li>
                 </template>
             </ul>
           </div>

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -424,8 +424,8 @@ class WPTResults extends WPTColors(WPTFlags(PathInfo(LoadingState(TestRunsUIBase
   }
 
   computeLiveTestDomain() {
-    if (this.webPlatformTestsLive) {
-      return 'web-platform-tests.live';
+    if (this.wptLive) {
+      return 'wpt.live';
     }
     return 'w3c-test.org';
   }


### PR DESCRIPTION
The deployment formally available at web-platform-tests.live is now
hosted at wpt.live. Update references accordingly.