### PR TITLE
webkitgtk: capitalize the name and show minor version as significant.

### DIFF
--- a/shared/product_spec.go
+++ b/shared/product_spec.go
@@ -78,6 +78,8 @@ func (p ProductSpec) DisplayName() string {
 		return "Firefox"
 	case "safari":
 		return "Safari"
+	case "webkitgtk":
+		return "WebKitGTK"
 	default:
 		return p.BrowserName
 	}

--- a/webapp/components/product-info.js
+++ b/webapp/components/product-info.js
@@ -10,6 +10,7 @@ const DisplayNames = (() => {
   ['firefox', 'firefox-experimental'].forEach(n => m.set(n, 'Firefox'));
   ['safari', 'safari-experimental'].forEach(n => m.set(n, 'Safari'));
   m.set('uc', 'UC Browser');
+  m.set('webkitgtk', 'WebKitGTK');
   // Platforms
   m.set('android', 'Android');
   m.set('linux', 'Linux');
@@ -118,7 +119,7 @@ const ProductInfo = (superClass) => class extends superClass {
   }
 
   minorIsSignificant(browserName) {
-    return browserName === 'safari';
+    return browserName === 'safari' || browserName === 'webkitgtk';
   }
 
   /**

--- a/webapp/components/test/test-run.html
+++ b/webapp/components/test/test-run.html
@@ -112,11 +112,23 @@ suite('<test-run>', () => {
         assert.equal(trf.shortVersion('safari', '56.0a'), '56.0');
       });
 
+      test('valid, major and minor', () => {
+        assert.equal(trf.shortVersion('webkitgtk', '1'), '1');
+        assert.equal(trf.shortVersion('webkitgtk', '2.3'), '2.3');
+        assert.equal(trf.shortVersion('webkitgtk', '3.4.5'), '3.4');
+        assert.equal(trf.shortVersion('webkitgtk', '4.5.6.7'), '4.5');
+        assert.equal(trf.shortVersion('webkitgtk', '765.687'), '765.687');
+        assert.equal(trf.shortVersion('webkitgtk', '   11.0 '), '11.0');
+        assert.equal(trf.shortVersion('webkitgtk', '56.0a'), '56.0');
+      });
+
       test('invalid', () => {
         assert.equal(trf.shortVersion('chrome', 'five'), 'five');
         assert.equal(trf.shortVersion('chrome', ''), '');
         assert.equal(trf.shortVersion('safari', 'five'), 'five');
         assert.equal(trf.shortVersion('safari', ''), '');
+        assert.equal(trf.shortVersion('webkitgtk', 'five'), 'five');
+        assert.equal(trf.shortVersion('webkitgtk', ''), '');
       });
     });
 


### PR DESCRIPTION
## Description


* The minor version of WebKitGTK is significant: wpt.fyi should display `2.26` instead of `2`.

* Also the product name should be capitalized as WebKitGTK.


/cc @foolip 