### PR TITLE
Exclude wpt-env-flags in /components/ regex

### DIFF
--- a/webapp/web/app.dev.yaml
+++ b/webapp/web/app.dev.yaml
@@ -45,7 +45,7 @@ handlers:
   upload: static/favicon.ico
   secure: always
 # Static files that change often (i.e. our own code).
-- url: /components
+- url: /components/(?!wpt-env-flags.js)
   static_dir: ../components
   expiration: 10m
   secure: always

--- a/webapp/web/app.yaml
+++ b/webapp/web/app.yaml
@@ -42,7 +42,7 @@ handlers:
   upload: webapp/static/favicon.ico
   secure: always
 # Static files that change often (i.e. our own code).
-- url: /components
+- url: /components/(?!wpt-env-flags.js)
   static_dir: webapp/components
   expiration: 10m
   secure: always


### PR DESCRIPTION
## Review
- Visit the deployed environment's `/flags` endpoint
- See some client-side features are enabled (as per their environment defaults).