### PR TITLE
Remove broken code to handle '-experimental' in product

### DIFF
--- a/webapp/components/display-logo.js
+++ b/webapp/components/display-logo.js
@@ -119,8 +119,6 @@ class DisplayLogo extends ProductInfo(PolymerElement) {
     if (labels) {
       labels = new Set(labels);
       if (labels.has('experimental') || labels.has('dev')) {
-        // Legacy run distinction had name suffix -experimental
-        name.replace(/-experimental$/, '');
         name += '-dev';
       } else if (labels.has('beta')) {
         name += '-beta';


### PR DESCRIPTION
`replace` return a new string, so this didn't do anything.