### PR TITLE
Let Renovate bump node dependencies as well

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": ["config:base"],
-  "enabledManagers": ["gomod"],
+  "enabledManagers": ["gomod", "npm"],
   "gomod": {
     "minor": {
       "automerge": true


### PR DESCRIPTION
The config added in https://github.com/web-platform-tests/wpt.fyi/pull/1548 leaves webdriver/package.json and webapp/package.json unmanaged. This *might* fix that.