### PR TITLE
Fix Docker autobuild

### DIFF
--- a/.github/actions/make-in-docker/action.yml
+++ b/.github/actions/make-in-docker/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: true
 runs:
   using: docker
-  image: docker://webplatformtests/wpt.fyi:docker-auto-build
+  image: docker://webplatformtests/wpt.fyi:latest
   args:
     - /usr/bin/make
     - ${{ inputs.target }}

--- a/.github/actions/make-in-docker/action.yml
+++ b/.github/actions/make-in-docker/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: true
 runs:
   using: docker
-  image: docker://hexcles/wpt.fyi-make-in-docker:latest
+  image: docker://webplatformtests/wpt.fyi:latest
   args:
     - /usr/bin/make
     - ${{ inputs.target }}

--- a/.github/actions/make-in-docker/action.yml
+++ b/.github/actions/make-in-docker/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: true
 runs:
   using: docker
-  image: docker://webplatformtests/wpt.fyi:latest
+  image: docker://webplatformtests/wpt.fyi:docker-auto-build
   args:
     - /usr/bin/make
     - ${{ inputs.target }}

--- a/.github/workflows/docker-update.yml
+++ b/.github/workflows/docker-update.yml
@@ -1,10 +1,12 @@
 name: Update Docker image
 on:
   push:
-    branches:
-      - master
+    # Rebuild the image when Dockerfile is changed. This is safe on a PR
+    # branch, too -- the automatically built Docker image will be tagged with
+    # the branch name instead of "latest".
     paths:
       - '.github/actions/make-in-docker/Dockerfile'
+      - '.github/workflows/docker-update.yml'
   schedule:
     # Rebuild the image weekly.
     - cron: '0 0 * * 0'
@@ -13,20 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/docker/login@master
-        # This action takes caution not to expose secrets in logs.
-        env:
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-      - uses: actions/docker/cli@master
-        name: docker build
+      - uses: elgohr/Publish-Docker-Github-Action@master
+        # https://github.com/elgohr/Publish-Docker-Github-Action
         with:
-          args: build -t hexcles/wpt.fyi-make-in-docker:latest -t hexcles/wpt.fyi-make-in-docker:${{ github.sha }} ./.github/actions/make-in-docker
-      - uses: actions/docker/cli@master
-        name: docker push SHA
-        with:
-          args: push hexcles/wpt.fyi-make-in-docker:${{ github.sha }}
-      - uses: actions/docker/cli@master
-        name: docker push latest
-        with:
-          args: push hexcles/wpt.fyi-make-in-docker:latest
+          name: webplatformtests/wpt.fyi
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+          dockerfile: .github/actions/make-in-docker/Dockerfile
+          snapshot: true


### PR DESCRIPTION
## Description
The official GitHub Action for interacting with Docker has been
deprecated and deleted (it used the alpha syntax), so we are switching
to a community-built action:
https://github.com/elgohr/Publish-Docker-Github-Action

Also switch from my personal account to a dedicated bot account with a
personal access token.

## Review Information

* Demo autobuild: https://github.com/web-platform-tests/wpt.fyi/pull/1561/checks?check_run_id=269028969
* Demo checks using the image built from this branch: https://github.com/web-platform-tests/wpt.fyi/pull/1561/checks?check_run_id=269028995

(The test commit will be reverted before merging.)