### PR TITLE
Disable major upgrades for Golang

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,8 +2,8 @@
   "extends": ["config:base"],
   "enabledManagers": ["gomod", "npm"],
   "gomod": {
-    "minor": {
-      "automerge": true
+    "major": {
+      "enabled": false
     },
     "postUpdateOptions": ["gomodTidy"]
   }


### PR DESCRIPTION
Renovate does not support rewriting import paths yet. Simply changing
`go.mod` is pointless.

https://github.com/renovatebot/renovate/issues/3627

Also disable auto merge because Renovate can't auto merge when there is
branch protection (required review) in place.
