### PR TITLE
User username instead of groupname in sudoers

### DIFF
--- a/util/commands.sh
+++ b/util/commands.sh
@@ -10,7 +10,7 @@ function wptd_useradd() {
   docker exec -u 0:0 "${DOCKER_INSTANCE}" groupadd -g $(id -g $USER) user || [ $? == 4 ]
   # Add user to audio & video groups to ensure Chrome can use sandbox.
   docker exec -u 0:0 "${DOCKER_INSTANCE}" useradd -u $(id -u $USER) -g $(id -g $USER) -G audio,video user
-  docker exec -u 0:0 "${DOCKER_INSTANCE}" sh -c 'echo "%user ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers'
+  docker exec -u 0:0 "${DOCKER_INSTANCE}" sh -c 'echo "user ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers'
 }
 function wptd_exec() {
   docker exec -u $(id -u $USER) "${DOCKER_INSTANCE}" sh -c "$*"


### PR DESCRIPTION
When the group already exists within Docker (e.g. on a macOS host where the
default user GID is 20), we won't create the "user" group in Docker, but we
always create a new user called "user", so using username ("user") instead
of groupname ("%user") in /etc/sudoers will work in both cases.

Fixes #1591 .

## Review Information

We don't have automated tests on macOS; I've tested locally.

Travis should still pass (which means this new setup would still work on Linux).