### PR TITLE
Drop the /tasks/ part of the expected `target_url` for Taskcluster

### DIFF
--- a/api/taskcluster/webhook.go
+++ b/api/taskcluster/webhook.go
@@ -30,10 +30,11 @@ var (
 	// This should follow https://github.com/web-platform-tests/wpt/blob/master/.taskcluster.yml
 	// with a notable exception that "*-stability" runs are not included at the moment.
 	taskNameRegex = regexp.MustCompile(`^wpt-(\w+-\w+)-(testharness|reftest|wdspec|results|results-without-changes)(?:-\d+)?$`)
-	// This is the pattern for task detail URLs coming from Checks API.
+	// Taskcluster has used different forms of URLs in their Check & Status
+	// updates in history. We accept all of them.
+	// See TestExtractTaskGroupID for examples.
 	inspectorURLRegex = regexp.MustCompile("/task-group-inspector/#/([^/]*)")
-	// This is the pattern for task detail URLs coming from Status API.
-	taskURLRegex = regexp.MustCompile("/groups/([^/]*)")
+	taskURLRegex      = regexp.MustCompile("/groups/([^/]*)(?:/tasks/([^/]*))?")
 )
 
 // Non-fatal error when there is no result (e.g. nothing finishes yet).
@@ -226,6 +227,9 @@ func extractTaskGroupID(targetURL string) (string, string) {
 		return matches[1], ""
 	}
 	if matches := taskURLRegex.FindStringSubmatch(targetURL); len(matches) > 1 {
+		if len(matches) > 2 {
+			return matches[1], matches[2]
+		}
 		return matches[1], ""
 	}
 	return "", ""

--- a/api/taskcluster/webhook.go
+++ b/api/taskcluster/webhook.go
@@ -33,7 +33,7 @@ var (
 	// This is the pattern for task detail URLs coming from Checks API.
 	inspectorURLRegex = regexp.MustCompile("/task-group-inspector/#/([^/]*)")
 	// This is the pattern for task detail URLs coming from Status API.
-	taskURLRegex = regexp.MustCompile("/groups/([^/]*)/tasks/([^/]*)")
+	taskURLRegex = regexp.MustCompile("/groups/([^/]*)")
 )
 
 // Non-fatal error when there is no result (e.g. nothing finishes yet).
@@ -225,8 +225,8 @@ func extractTaskGroupID(targetURL string) (string, string) {
 	if matches := inspectorURLRegex.FindStringSubmatch(targetURL); len(matches) > 1 {
 		return matches[1], ""
 	}
-	if matches := taskURLRegex.FindStringSubmatch(targetURL); len(matches) > 2 {
-		return matches[1], matches[2]
+	if matches := taskURLRegex.FindStringSubmatch(targetURL); len(matches) > 1 {
+		return matches[1], ""
 	}
 	return "", ""
 }

--- a/api/taskcluster/webhook_test.go
+++ b/api/taskcluster/webhook_test.go
@@ -95,10 +95,15 @@ func TestExtractTaskGroupID(t *testing.T) {
 		assert.Equal(t, "Y4rnZeqDRXGiRNiqxT5Qeg", group)
 		assert.Equal(t, "", task)
 	})
-	t.Run("CheckRun", func(t *testing.T) {
+	t.Run("CheckRun with task", func(t *testing.T) {
 		group, task := extractTaskGroupID("https://tc.example.com/groups/IWlO7NuxRnO0_8PKMuHFkw/tasks/NOToWHr0T-u62B9yGQnD5w/details")
 		assert.Equal(t, "IWlO7NuxRnO0_8PKMuHFkw", group)
 		assert.Equal(t, "NOToWHr0T-u62B9yGQnD5w", task)
+	})
+	t.Run("CheckRun without task", func(t *testing.T) {
+		group, task := extractTaskGroupID("https://tc.example.com/groups/IWlO7NuxRnO0_8PKMuHFkw")
+		assert.Equal(t, "IWlO7NuxRnO0_8PKMuHFkw", group)
+		assert.Equal(t, "", task)
 	})
 }
 


### PR DESCRIPTION
Sample URL from a real webhook payload:
https://tools.taskcluster.net/groups/VFI9FCVDTLW5rkvwdyM_yQ

May fix https://github.com/web-platform-tests/wpt.fyi/issues/1598.