### PR TITLE
[UI] Clarify github repos on the about page

### DIFF
--- a/webapp/components/wpt-header.js
+++ b/webapp/components/wpt-header.js
@@ -59,7 +59,6 @@ class WPTHeader extends WPTFlags(PolymerElement) {
           <a href="/status">Processor</a>
         </template>
         <a href="/about">About</a>
-        <a href="https://github.com/web-platform-tests/wpt.fyi">GitHub Source</a>
       </nav>
       <info-banner id="caveat" type="error">
         wpt.fyi is a work in progress. The reported results do not necessarily reflect the true capabilities of each web browser, so they should not be used evaluate or compare feature support.

--- a/webapp/templates/about.html
+++ b/webapp/templates/about.html
@@ -25,7 +25,15 @@
       </li>
     </ul>
     <h2>Source and Documentation</h2>
-    <p>The source code for both running and serving test results is on <a href="https://github.com/web-platform-tests/wpt.fyi">GitHub</a>.</p>
+    <p>The source code for both running and serving test results is on GitHub:</p>
+    <ul>
+      <li>
+        <b>Running:</b> <a href="https://github.com/web-platform-tests/wpt">web-platform-tests/wpt</a>
+      </li>
+      <li>
+        <b>Serving:</b> <a href="https://github.com/web-platform-tests/wpt.fyi">web-platform-tests/wpt.fyi</a>
+      </li>
+    </ul>
     <h2>Contact</h2>
     <p>Please file a <a href="https://github.com/web-platform-tests/wpt.fyi/issues/new">GitHub issue</a>. For other discussion, most people who contribute to the WPT Dashboard monitor the <a href="http://lists.w3.org/Archives/Public/public-test-infra/">public-test-infra@w3.org</a> mailing list.</p>
   </article>


### PR DESCRIPTION
Previously it seemed like wpt.fyi was the one repo for both running and
serving the tests. Split that section into two.
