### PR TITLE
[webhook] Support Taskcluster community deployment

### DIFF
--- a/api/taskcluster/api.go
+++ b/api/taskcluster/api.go
@@ -68,8 +68,10 @@ func (a apiImpl) HandleCheckSuiteEvent(event *github.CheckSuiteEvent) (bool, err
 		return false, err
 	}
 	byGroup := mapset.NewSet()
+	var rootURL string
 	for _, run := range runs.CheckRuns {
-		taskGroupID, _ := extractTaskGroupID(run.GetDetailsURL())
+		var taskGroupID string
+		rootURL, taskGroupID, _ = parseTaskclusterURL(run.GetDetailsURL())
 		if taskGroupID == "" {
 			return false, fmt.Errorf("unrecognized target_url: %s", run.GetDetailsURL())
 		}
@@ -82,7 +84,7 @@ func (a apiImpl) HandleCheckSuiteEvent(event *github.CheckSuiteEvent) (bool, err
 
 	processedSomething := false
 	for _, groupID := range shared.ToStringSlice(byGroup) {
-		processed, err := processTaskclusterBuild(a.aeAPI, groupID, "", sha, shared.ToStringSlice(labels)...)
+		processed, err := processTaskclusterBuild(a.aeAPI, rootURL, groupID, "", sha, shared.ToStringSlice(labels)...)
 		if err != nil {
 			log.Errorf("Failed to process %s: %s", groupID, err.Error())
 			continue

--- a/api/taskcluster/webhook.go
+++ b/api/taskcluster/webhook.go
@@ -16,7 +16,7 @@ import (
 	mapset "github.com/deckarep/golang-set"
 	"github.com/google/go-github/v28/github"
 	tcurls "github.com/taskcluster/taskcluster-lib-urls"
-	"github.com/taskcluster/taskcluster/clients/client-go/v20/tcqueue"
+	"github.com/taskcluster/taskcluster/clients/client-go/v22/tcqueue"
 	uc "github.com/web-platform-tests/wpt.fyi/api/receiver/client"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )

--- a/api/taskcluster/webhook.go
+++ b/api/taskcluster/webhook.go
@@ -134,7 +134,8 @@ func (s statusEventPayload) IsCompleted() bool {
 }
 
 func (s statusEventPayload) IsTaskcluster() bool {
-	return s.Context != nil && strings.HasPrefix(*s.Context, "Taskcluster")
+	return s.Context != nil && (strings.HasPrefix(*s.Context, "Taskcluster") ||
+		strings.HasPrefix(*s.Context, "Community-TC"))
 }
 
 func (s statusEventPayload) IsOnMaster() bool {

--- a/api/taskcluster/webhook_test.go
+++ b/api/taskcluster/webhook_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-github/v28/github"
 	"github.com/stretchr/testify/assert"
-	"github.com/taskcluster/taskcluster/clients/client-go/v20/tcqueue"
+	"github.com/taskcluster/taskcluster/clients/client-go/v22/tcqueue"
 	uc "github.com/web-platform-tests/wpt.fyi/api/receiver/client"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"

--- a/api/taskcluster/webhook_test.go
+++ b/api/taskcluster/webhook_test.go
@@ -89,19 +89,22 @@ func TestIsOnMaster(t *testing.T) {
 	assert.False(t, status.IsOnMaster())
 }
 
-func TestExtractTaskGroupID(t *testing.T) {
+func TestParseTaskclusterURL(t *testing.T) {
 	t.Run("Status", func(t *testing.T) {
-		group, task := extractTaskGroupID("https://tc.example.com/task-group-inspector/#/Y4rnZeqDRXGiRNiqxT5Qeg")
+		root, group, task := parseTaskclusterURL("https://tc.example.com/task-group-inspector/#/Y4rnZeqDRXGiRNiqxT5Qeg")
+		assert.Equal(t, "https://tc.example.com", root)
 		assert.Equal(t, "Y4rnZeqDRXGiRNiqxT5Qeg", group)
 		assert.Equal(t, "", task)
 	})
 	t.Run("CheckRun with task", func(t *testing.T) {
-		group, task := extractTaskGroupID("https://tc.example.com/groups/IWlO7NuxRnO0_8PKMuHFkw/tasks/NOToWHr0T-u62B9yGQnD5w/details")
+		root, group, task := parseTaskclusterURL("https://tc.example.com/groups/IWlO7NuxRnO0_8PKMuHFkw/tasks/NOToWHr0T-u62B9yGQnD5w/details")
+		assert.Equal(t, "https://tc.example.com", root)
 		assert.Equal(t, "IWlO7NuxRnO0_8PKMuHFkw", group)
 		assert.Equal(t, "NOToWHr0T-u62B9yGQnD5w", task)
 	})
 	t.Run("CheckRun without task", func(t *testing.T) {
-		group, task := extractTaskGroupID("https://tc.example.com/groups/IWlO7NuxRnO0_8PKMuHFkw")
+		root, group, task := parseTaskclusterURL("https://tc.other-example.com/groups/IWlO7NuxRnO0_8PKMuHFkw")
+		assert.Equal(t, "https://tc.other-example.com", root)
 		assert.Equal(t, "IWlO7NuxRnO0_8PKMuHFkw", group)
 		assert.Equal(t, "", task)
 	})

--- a/api/taskcluster/webhook_test.go
+++ b/api/taskcluster/webhook_test.go
@@ -36,6 +36,9 @@ func TestShouldProcessStatus_states(t *testing.T) {
 	status.Branches = branchInfos{&github.Branch{Name: strPtr(shared.MasterLabel)}}
 	assert.True(t, shouldProcessStatus(shared.NewNilLogger(), false, &status))
 
+	status.Context = strPtr("Community-TC")
+	assert.True(t, shouldProcessStatus(shared.NewNilLogger(), false, &status))
+
 	status.State = strPtr("failure")
 	assert.True(t, shouldProcessStatus(shared.NewNilLogger(), false, &status))
 

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/stoewer/go-strcase v1.0.2
 	github.com/stretchr/testify v1.4.0
 	github.com/taskcluster/taskcluster-lib-urls v12.0.0+incompatible
-	github.com/taskcluster/taskcluster/clients/client-go/v20 v20.0.0
+	github.com/taskcluster/taskcluster/clients/client-go/v22 v22.0.0
 	github.com/tebeka/selenium v0.9.9
 	github.com/web-platform-tests/wpt-metadata v0.0.0-20190925201856-2889886bed8f
 	go.opencensus.io v0.22.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -203,8 +203,8 @@ github.com/taskcluster/taskcluster-base-go v1.0.0 h1:Jh2R/J7+a23LjtYEHQtkFV04QBx
 github.com/taskcluster/taskcluster-base-go v1.0.0/go.mod h1:ByyzyqqufsfZTrAHUw+0Grp8FwZAizZOKzVE1IpDXxQ=
 github.com/taskcluster/taskcluster-lib-urls v12.0.0+incompatible h1:57WLzh7B04y6ahTOJ8wjvdkbwYqnyJkwLXQ1Tu4E/DU=
 github.com/taskcluster/taskcluster-lib-urls v12.0.0+incompatible/go.mod h1:ALqTgi15AmJGEGubRKM0ydlLAFatlQPrQrmal9YZpQs=
-github.com/taskcluster/taskcluster/clients/client-go/v20 v20.0.0 h1:AjD0jOYZ1IFWGRkEau44OvvZDAj6L7ve8ZkiYVn19WA=
-github.com/taskcluster/taskcluster/clients/client-go/v20 v20.0.0/go.mod h1:RZ6Hw2naatnAS1uqimkNZAJsurWOSozFNZY91TyfiGA=
+github.com/taskcluster/taskcluster/clients/client-go/v22 v22.0.0 h1:xL0R35SgFECKq0IgxwzQ06QKKK1O/1XSgfth/uwHqRY=
+github.com/taskcluster/taskcluster/clients/client-go/v22 v22.0.0/go.mod h1:hUL+oOiiJHvt5/ftjYtOS4ElmUeL8WM2SrdaJShkydI=
 github.com/tebeka/selenium v0.9.9 h1:cNziB+etNgyH/7KlNI7RMC1ua5aH1+5wUlFQyzeMh+w=
 github.com/tebeka/selenium v0.9.9/go.mod h1:5Fr8+pUvU6B1OiPfkdCKdXZyr5znvVkxuPd0NOdZCQc=
 github.com/tent/hawk-go v0.0.0-20161026210932-d341ea318957 h1:6Fre/uvwovW5YY4nfHZk66cAg9HjT9YdFSAJHUUgOyQ=

--- a/webapp/web/app.dev.yaml
+++ b/webapp/web/app.dev.yaml
@@ -13,9 +13,6 @@ inbound_services:
 
 default_expiration: "1d"
 
-env_variables:
-  TASKCLUSTER_ROOT_URL: https://taskcluster.net
-
 # Also refer to dispatch.yaml for higher-priority routing rules.
 handlers:
 # Special dynamic components:

--- a/webapp/web/app.yaml
+++ b/webapp/web/app.yaml
@@ -10,9 +10,6 @@ inbound_services:
 
 default_expiration: "1d"
 
-env_variables:
-  TASKCLUSTER_ROOT_URL: https://taskcluster.net
-
 # Also refer to dispatch.yaml for higher-priority routing rules.
 handlers:
 # Special dynamic components:


### PR DESCRIPTION
This change allows us to accept GitHub events from both `taskcluster.net` and `community-tc.services.mozilla.com` (the new community deployment) by:
1. Extracting base URL from the target URL of the event
2. Accepting both `Taskcluster` and `Community-TC` context strings.

Fixes #1605 .

## Review Information

Tests should pass. And we can merge it to staging monitor that runs keep coming in correctly.