### PR TITLE
[webhook] Fix URL handling for old Taskcluster

### DIFF
--- a/api/taskcluster/webhook.go
+++ b/api/taskcluster/webhook.go
@@ -226,7 +226,7 @@ func parseTaskclusterURL(targetURL string) (rootURL, taskGroupID, taskID string)
 		rootURL = matches[1]
 		taskGroupID = matches[2]
 	} else if matches := taskURLRegex.FindStringSubmatch(targetURL); len(matches) > 2 {
-		if len(matches) > 2 {
+		if len(matches) > 3 {
 			rootURL = matches[1]
 			taskGroupID = matches[2]
 			taskID = matches[3]

--- a/api/taskcluster/webhook.go
+++ b/api/taskcluster/webhook.go
@@ -222,15 +222,14 @@ func shouldProcessStatus(log shared.Logger, processAllBranches bool, status *sta
 }
 
 func parseTaskclusterURL(targetURL string) (rootURL, taskGroupID, taskID string) {
-	if matches := inspectorURLRegex.FindStringSubmatch(targetURL); len(matches) > 2 {
+	if matches := inspectorURLRegex.FindStringSubmatch(targetURL); matches != nil {
 		rootURL = matches[1]
 		taskGroupID = matches[2]
-	} else if matches := taskURLRegex.FindStringSubmatch(targetURL); len(matches) > 2 {
+	} else if matches := taskURLRegex.FindStringSubmatch(targetURL); matches != nil {
 		rootURL = matches[1]
 		taskGroupID = matches[2]
-		if len(matches) > 3 {
-			taskID = matches[3]
-		}
+		// matches[3] may be an empty string -- the capturing group is optional.
+		taskID = matches[3]
 	}
 	// Special case for old Taskcluster instance, which uses subdomains for
 	// different services and we need to strip the subdomain away.

--- a/api/taskcluster/webhook.go
+++ b/api/taskcluster/webhook.go
@@ -226,13 +226,10 @@ func parseTaskclusterURL(targetURL string) (rootURL, taskGroupID, taskID string)
 		rootURL = matches[1]
 		taskGroupID = matches[2]
 	} else if matches := taskURLRegex.FindStringSubmatch(targetURL); len(matches) > 2 {
+		rootURL = matches[1]
+		taskGroupID = matches[2]
 		if len(matches) > 3 {
-			rootURL = matches[1]
-			taskGroupID = matches[2]
 			taskID = matches[3]
-		} else {
-			rootURL = matches[1]
-			taskGroupID = matches[2]
 		}
 	}
 	// Special case for old Taskcluster instance, which uses subdomains for

--- a/api/taskcluster/webhook.go
+++ b/api/taskcluster/webhook.go
@@ -223,15 +223,24 @@ func shouldProcessStatus(log shared.Logger, processAllBranches bool, status *sta
 
 func parseTaskclusterURL(targetURL string) (rootURL, taskGroupID, taskID string) {
 	if matches := inspectorURLRegex.FindStringSubmatch(targetURL); len(matches) > 2 {
-		return matches[1], matches[2], ""
-	}
-	if matches := taskURLRegex.FindStringSubmatch(targetURL); len(matches) > 2 {
+		rootURL = matches[1]
+		taskGroupID = matches[2]
+	} else if matches := taskURLRegex.FindStringSubmatch(targetURL); len(matches) > 2 {
 		if len(matches) > 2 {
-			return matches[1], matches[2], matches[3]
+			rootURL = matches[1]
+			taskGroupID = matches[2]
+			taskID = matches[3]
+		} else {
+			rootURL = matches[1]
+			taskGroupID = matches[2]
 		}
-		return matches[1], matches[2], ""
 	}
-	return "", "", ""
+	// Special case for old Taskcluster instance, which uses subdomains for
+	// different services and we need to strip the subdomain away.
+	if strings.HasSuffix(rootURL, "taskcluster.net") {
+		rootURL = "https://taskcluster.net"
+	}
+	return rootURL, taskGroupID, taskID
 }
 
 type taskGroupInfo struct {

--- a/api/taskcluster/webhook_test.go
+++ b/api/taskcluster/webhook_test.go
@@ -94,8 +94,8 @@ func TestIsOnMaster(t *testing.T) {
 
 func TestParseTaskclusterURL(t *testing.T) {
 	t.Run("Status", func(t *testing.T) {
-		root, group, task := parseTaskclusterURL("https://tc.example.com/task-group-inspector/#/Y4rnZeqDRXGiRNiqxT5Qeg")
-		assert.Equal(t, "https://tc.example.com", root)
+		root, group, task := parseTaskclusterURL("https://tools.taskcluster.net/task-group-inspector/#/Y4rnZeqDRXGiRNiqxT5Qeg")
+		assert.Equal(t, "https://taskcluster.net", root)
 		assert.Equal(t, "Y4rnZeqDRXGiRNiqxT5Qeg", group)
 		assert.Equal(t, "", task)
 	})


### PR DESCRIPTION
Old Taskcluster instance, which uses subdomains for different services
and we need to strip the subdomain away. For example, GitHub events from
the old Taskcluster instance have "tools.taskcluster.net" in their
target URLs, but the root URL should be "taskcluster.net".

#1605