### PR TITLE
[webhook] Make URL pattern matching more tolerant

### DIFF
--- a/api/taskcluster/webhook.go
+++ b/api/taskcluster/webhook.go
@@ -33,7 +33,7 @@ var (
 	// updates in history. We accept all of them.
 	// See TestExtractTaskGroupID for examples.
 	inspectorURLRegex = regexp.MustCompile(`^(https://[^/]*)/task-group-inspector/#/([^/]*)`)
-	taskURLRegex      = regexp.MustCompile(`^(https://[^/]*)/groups/([^/]*)(?:/tasks/([^/]*))?`)
+	taskURLRegex      = regexp.MustCompile(`^(https://[^/]*)(?:/tasks)?/groups/([^/]*)(?:/tasks/([^/]*))?`)
 )
 
 // Non-fatal error when there is no result (e.g. nothing finishes yet).

--- a/api/taskcluster/webhook_test.go
+++ b/api/taskcluster/webhook_test.go
@@ -111,6 +111,12 @@ func TestParseTaskclusterURL(t *testing.T) {
 		assert.Equal(t, "IWlO7NuxRnO0_8PKMuHFkw", group)
 		assert.Equal(t, "", task)
 	})
+	t.Run("CheckRun without task", func(t *testing.T) {
+		root, group, task := parseTaskclusterURL("https://tc.community.com/tasks/groups/IWlO7NuxRnO0_8PKMuHFkw")
+		assert.Equal(t, "https://tc.community.com", root)
+		assert.Equal(t, "IWlO7NuxRnO0_8PKMuHFkw", group)
+		assert.Equal(t, "", task)
+	})
 }
 
 func TestExtractArtifactURLs_all_success_master(t *testing.T) {


### PR DESCRIPTION
We are seeing target URLs from the new community Taskcluster instnace in
the form of:
https://community-tc.services.mozilla.com/tasks/groups/EhYVyJPYShqppX6EjsNWXQ

The /tasks/ part was unexpected by the previous pattern.

We should figure out a way to make this more robust, but let's take this quick fix for now for #1605 .