### PR TITLE
Hide the auto-complete drop-down arrow on Chrome/Safari

### DIFF
--- a/webapp/components/test-search.js
+++ b/webapp/components/test-search.js
@@ -342,6 +342,9 @@ class TestSearch extends WPTFlags(PolymerElement) {
         padding: 0.5em 0;
         width: 100%;
       }
+      input::-webkit-calendar-picker-indicator {
+        display: none;
+      }
       .help {
         font-size: x-small;
         float: right;


### PR DESCRIPTION
The arrow is visually unpleasant on Safari (always visible, strangely
vertical blue box). On Chrome it's not bad (only visible on mouseover,
just a grey arrow), but the webkit selector used to hide it hits both
browsers and I would rather not add UA sniffing.
