### PR TITLE
Update links to use wpt.live.

### DIFF
--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -427,7 +427,7 @@ class WPTResults extends WPTColors(WPTFlags(PathInfo(LoadingState(TestRunsUIBase
 
   computeLiveTestDomain() {
     if (this.webPlatformTestsLive) {
-      return 'web-platform-tests.live';
+      return 'wpt.live';
     }
     return 'w3c-test.org';
   }


### PR DESCRIPTION
web-platform-tests.live doesn't work at this point, and this will be the new domain per <https://github.com/web-platform-tests/rfcs/pull/36>.