### PR TITLE
[API] Add `is:optional` command

### DIFF
--- a/api/query/README.md
+++ b/api/query/README.md
@@ -155,6 +155,11 @@ across the runs.
 Filters to tests that are marked as tentative (currently based on [file
 name](https://web-platform-tests.org/writing-tests/file-names.html)).
 
+##### `is:optional`
+
+Filters to tests that are marked as optional (currently based on [file
+name](https://web-platform-tests.org/writing-tests/file-names.html)).
+
 #### And-conjuction
 
     [query1] and [query2] [and ...]

--- a/api/query/README.md
+++ b/api/query/README.md
@@ -160,6 +160,10 @@ name](https://web-platform-tests.org/writing-tests/file-names.html)).
 Filters to tests that are marked as optional (currently based on [file
 name](https://web-platform-tests.org/writing-tests/file-names.html)).
 
+**Note**: At this time, the `may` and `should` [metadata
+flags](https://web-platform-tests.org/writing-tests/css-metadata.html#requirement-flags)
+are not supported.
+
 #### And-conjuction
 
     [query1] and [query2] [and ...]

--- a/api/query/atoms.go
+++ b/api/query/atoms.go
@@ -265,6 +265,9 @@ const (
 	// MetadataQualityTentative represents an is:tentative atom.
 	// "tentative" ensures that the results are from a tentative test.
 	MetadataQualityTentative
+	// MetadataQualityOptional represents an is:optional atom.
+	// "optional" ensures that the results are from an optional test.
+	MetadataQualityOptional
 )
 
 // BindToRuns for MetadataQuality is a no-op; it is independent of test runs.
@@ -907,6 +910,8 @@ func MetadataQualityFromString(quality string) (MetadataQuality, error) {
 		return MetadataQualityDifferent, nil
 	case "tentative":
 		return MetadataQualityTentative, nil
+	case "optional":
+		return MetadataQualityOptional, nil
 	}
 	return MetadataQualityUnknown, fmt.Errorf(`Unknown "is" quality "%s"`, quality)
 }

--- a/api/query/atoms_test.go
+++ b/api/query/atoms_test.go
@@ -492,6 +492,25 @@ func TestStructuredQuery_isTentative(t *testing.T) {
 	}, rq)
 }
 
+func TestStructuredQuery_isOptional(t *testing.T) {
+	var rq RunQuery
+	err := json.Unmarshal([]byte(`{
+		"run_ids": [0, 1, 2],
+		"query": {
+			"exists": [{
+				"is": "optional"
+			}]
+		}
+	}`), &rq)
+	assert.Nil(t, err)
+	assert.Equal(t, RunQuery{
+		RunIDs: []int64{0, 1, 2},
+		AbstractQuery: AbstractExists{[]AbstractQuery{
+			MetadataQualityOptional,
+		}},
+	}, rq)
+}
+
 func TestStructuredQuery_combinedlink(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{

--- a/api/query/cache/index/filter.go
+++ b/api/query/cache/index/filter.go
@@ -328,6 +328,8 @@ func (q MetadataQuality) Filter(t TestID) bool {
 		// is:optional only returns rows from tests with .optional.
 		// in their name. See
 		// https://web-platform-tests.org/writing-tests/file-names.html
+		// TODO(gh-1619): Handle the CSS meta flags; see
+		// https://web-platform-tests.org/writing-tests/css-metadata.html#requirement-flags
 		name, _, err := q.tests.GetName(t)
 		if (err != nil) {
 			return false

--- a/api/query/cache/index/filter.go
+++ b/api/query/cache/index/filter.go
@@ -324,6 +324,15 @@ func (q MetadataQuality) Filter(t TestID) bool {
 			return false
 		}
 		return strings.Contains(name, ".tentative.")
+	case query.MetadataQualityOptional:
+		// is:optional only returns rows from tests with .optional.
+		// in their name. See
+		// https://web-platform-tests.org/writing-tests/file-names.html
+		name, _, err := q.tests.GetName(t)
+		if (err != nil) {
+			return false
+		}
+		return strings.Contains(name, ".optional.")
 	default:
 		return false
 	}

--- a/api/query/cache/index/index_filter_test.go
+++ b/api/query/cache/index/index_filter_test.go
@@ -566,6 +566,49 @@ func TestBindExecute_IsTentative(t *testing.T) {
 	assert.Equal(t, expectedResult, srs[0])
 }
 
+func TestBindExecute_IsOptional(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	loader := NewMockReportLoader(ctrl)
+	idx, err := NewShardedWPTIndex(loader, testNumShards)
+	assert.Nil(t, err)
+	runs := mockTestRuns(loader, idx, []testRunData{
+		testRunData{
+			shared.TestRun{ID: 1},
+			&metrics.TestResultsReport{
+				Results: []*metrics.TestResults{
+					&metrics.TestResults{
+						Test:   "/a/b/c",
+						Status: "PASS",
+					},
+					&metrics.TestResults{
+						Test:   "/a/b/c.optional.html",
+						Status: "PASS",
+					},
+				},
+			},
+		},
+	})
+
+	quality := query.MetadataQualityOptional
+	plan, err := idx.Bind(runs, quality)
+	assert.Nil(t, err)
+
+	res := plan.Execute(runs, query.AggregationOpts{})
+	srs, ok := res.([]shared.SearchResult)
+	assert.True(t, ok)
+
+	assert.Equal(t, 1, len(srs))
+	expectedResult := shared.SearchResult{
+		Test: "/a/b/c.optional.html",
+		LegacyStatus: []shared.LegacySearchRunResult{
+			shared.LegacySearchRunResult{Passes: 1, Total: 1},
+		},
+	}
+
+	assert.Equal(t, expectedResult, srs[0])
+}
+
 func TestBindExecute_MoreThan(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/webapp/components/test-search.js
+++ b/webapp/components/test-search.js
@@ -146,6 +146,7 @@ const QUERY_GRAMMAR = ohm.grammar(`
     metadataQualityLiteral
       = caseInsensitive<"different">
       | caseInsensitive<"tentative">
+      | caseInsensitive<"optional">
 
     nameFragment
       = basicNameFragment                       -- basic

--- a/webapp/components/test/test-search.html
+++ b/webapp/components/test/test-search.html
@@ -308,6 +308,9 @@ suite('<test-search>', () => {
       assertQueryParse('is:tentative', {
         exists: [{ is: 'tentative' }]
       });
+      assertQueryParse('is:optional', {
+        exists: [{ is: 'optional' }]
+      });
     });
 
     test('count', () => {


### PR DESCRIPTION
Similar to `is:tentative`, this atom filters for tests marked as optional (currently based on file name).