### PR TITLE
[processor] Add experimental label to canary channel

### DIFF
--- a/results-processor/wptreport.py
+++ b/results-processor/wptreport.py
@@ -38,6 +38,7 @@ CHANNEL_TO_LABEL = {
     'stable': 'stable',
     'beta': 'beta',
     'dev': 'experimental',
+    'canary': 'experimental',
     'experimental': 'experimental',
     'nightly': 'experimental',
     'preview': 'experimental',

--- a/results-processor/wptreport_test.py
+++ b/results-processor/wptreport_test.py
@@ -577,15 +577,24 @@ class HelpersTest(unittest.TestCase):
             prepare_labels(r, '', 'blade-runner'),
             {'blade-runner', 'dev', 'experimental', 'firefox'}
         )
+
         r._report['run_info']['browser_channel'] = 'nightly'
         self.assertSetEqual(
             prepare_labels(r, '', 'blade-runner'),
             {'blade-runner', 'experimental', 'firefox', 'nightly'}
         )
+
         r._report['run_info']['browser_channel'] = 'beta'
         self.assertSetEqual(
             prepare_labels(r, '', 'blade-runner'),
             {'beta', 'blade-runner', 'firefox'}
+        )
+
+        r._report['run_info']['product'] = 'chrome'
+        r._report['run_info']['browser_channel'] = 'canary'
+        self.assertSetEqual(
+            prepare_labels(r, '', 'blade-runner'),
+            {'blade-runner', 'canary', 'chrome', 'experimental'}
         )
 
     def test_normalize_product_edge_webdriver(self):


### PR DESCRIPTION
Fixes #1635 

This must land right after https://github.com/web-platform-tests/wpt/pull/20240 .