### PR TITLE
Improve filters for PendingTestRuns

### DIFF
--- a/api/pending_test_runs.go
+++ b/api/pending_test_runs.go
@@ -26,14 +26,19 @@ func apiPendingTestRunsHandler(w http.ResponseWriter, r *http.Request) {
 	case "pending":
 		q = q.Order("-Stage").Filter("Stage < ", shared.StageValid)
 	case "invalid":
-		q = q.Order("-Stage").Filter("Stage > ", shared.StageValid)
+		q = q.Filter("Stage = ", shared.StageInvalid)
+	case "empty":
+		q = q.Filter("Stage = ", shared.StageEmpty)
+	case "duplicate":
+		q = q.Filter("Stage = ", shared.StageDuplicate)
 	case "":
 		// No-op
 	default:
 		http.Error(w, "Invalid filter: "+filter, http.StatusBadRequest)
 		return
 	}
-	q = q.Order("-Updated")
+	// TODO(Hexcles): Support pagination.
+	q = q.Order("-Updated").Limit(shared.MaxCountMaxValue)
 
 	var runs []shared.PendingTestRun
 	keys, err := store.GetAll(q, &runs)

--- a/api/routes.go
+++ b/api/routes.go
@@ -62,7 +62,7 @@ func RegisterRoutes() {
 	pendingTestRuns := shared.WrapApplicationJSON(
 		shared.WrapPermissiveCORS(apiPendingTestRunsHandler))
 	shared.AddRoute("/api/status", "api-pending-test-runs", pendingTestRuns)
-	shared.AddRoute("/api/status/{filter:pending|invalid}", "api-pending-test-runs", pendingTestRuns)
+	shared.AddRoute("/api/status/{filter:pending|invalid|empty|duplicate}", "api-pending-test-runs", pendingTestRuns)
 
 	// API endpoint for redirecting to a run's summary JSON blob.
 	shared.AddRoute("/api/results", "api-results", shared.WrapPermissiveCORS(apiResultsRedirectHandler))


### PR DESCRIPTION
1. Filter more precisely: /api/status/invalid now only returns invalid
   runs, but not empty or duplicate runs. /api/status/{empty,duplicate}
   would return those runs. The frontend isn't changed (i.e. we show
   only the invalid runs on /status now), because empty or duplicate
   runs aren't that interesting. We could tweak the UI later if needed.
2. Limit the max number of pending runs returned to 500 to fix #1642. We
   should add pagination support later.

## Review Information

Go to `/status` of the staging deployment. The page should now fast and the "invalid" tab should not include empty or duplicate runs.