### PR TITLE
Fix an uncaught exception when keydown on Firefox

### DIFF
--- a/webapp/views/wpt-app.js
+++ b/webapp/views/wpt-app.js
@@ -261,7 +261,7 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
 
   handleKeyDown(e) {
     // Ignore when something other than body has focus.
-    if (!e.path.length || e.path[0] !== document.body) {
+    if (e.target !== document.body) {
       return;
     }
     if (e.key === 'n') {


### PR DESCRIPTION
keydown events do not have the `path` property on Firefox.

## Review Information

Open the staging deployment on Firefox and press some random keys. No exceptions should be raised.