### PR TITLE
Fix stale version cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,11 @@ env:
 # In jobs.include, each job will inherit the stage of the previous job and the
 # default stage is "test".
 stages:
-  - name: clean up versions
-    if: type = pull_request
   - name: deploy PR
-    if: (type = push) AND (branch = master)
+    if: type = pull_request
   - name: deploy master
+    if: (type = push) AND (branch = master)
+  - name: clean up versions
     if: (type = push) AND (branch = master)
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,11 @@ env:
 # In jobs.include, each job will inherit the stage of the previous job and the
 # default stage is "test".
 stages:
-  - name: deploy PR
-    if: type = pull_request
-  - name: deploy master
-    if: (type = push) AND (branch = master)
   - name: clean up versions
+    if: type = pull_request
+  - name: deploy PR
+    if: (type = push) AND (branch = master)
+  - name: deploy master
     if: (type = push) AND (branch = master)
 
 jobs:

--- a/util/cleanup-versions.sh
+++ b/util/cleanup-versions.sh
@@ -26,7 +26,7 @@ function cleanup() {
   gcloud app versions list $PROJECT_ARG $SERVICE_ARG --filter="$FILTER_ARG" --format="value(id)"
 
   for version in $( gcloud app versions list $PROJECT_ARG $SERVICE_ARG --filter="$FILTER_ARG" --format="value(id)" ); do
-    if ! git show-ref --quiet --verify refs/remotes/origin/$version; then
+    if ! git ls-remote --exit-code origin $version; then
       debug "'$version' is not a branch in upstream and will be deleted."
       versions_to_delete+=($version)
     fi
@@ -46,9 +46,6 @@ REMOTE_URL=$(git remote get-url origin)
 if [[ $REMOTE_URL != *web-platform-tests/wpt.fyi* ]]; then
   fatal "origin isn't web-platform-tests/wpt.fyi" 1
 fi
-
-# Ensure ALL remote branches are fetched.
-git fetch --unshallow origin
 
 git show-ref
 

--- a/util/cleanup-versions.sh
+++ b/util/cleanup-versions.sh
@@ -10,7 +10,7 @@ source "${UTIL_DIR}/logging.sh"
 
 # A safety cutoff. Only versions last deployed more than 1 day ago may be
 # deleted.
-CUTOFF="-P1H"
+CUTOFF="-P1D"
 
 # This is a constant instead of an argument because production versions should
 # be deleted carefully and manually.
@@ -22,8 +22,6 @@ function cleanup() {
   local SERVICE_ARG="-s $1"
   local FILTER_ARG="traffic_split=0.0 last_deployed_time.datetime<$CUTOFF"
   local versions_to_delete=()
-
-  gcloud app versions list $PROJECT_ARG $SERVICE_ARG --filter="$FILTER_ARG" --format="value(id)"
 
   for version in $( gcloud app versions list $PROJECT_ARG $SERVICE_ARG --filter="$FILTER_ARG" --format="value(id)" ); do
     if ! git ls-remote --exit-code origin $version; then
@@ -37,7 +35,7 @@ function cleanup() {
     return 0
   fi
 
-  #gcloud app versions delete --quiet $PROJECT_ARG $SERVICE_ARG ${versions_to_delete[*]}
+  gcloud app versions delete --quiet $PROJECT_ARG $SERVICE_ARG ${versions_to_delete[*]}
 }
 
 
@@ -46,8 +44,6 @@ REMOTE_URL=$(git remote get-url origin)
 if [[ $REMOTE_URL != *web-platform-tests/wpt.fyi* ]]; then
   fatal "origin isn't web-platform-tests/wpt.fyi" 1
 fi
-
-git show-ref
 
 cleanup "default"
 cleanup "processor"

--- a/util/cleanup-versions.sh
+++ b/util/cleanup-versions.sh
@@ -10,7 +10,7 @@ source "${UTIL_DIR}/logging.sh"
 
 # A safety cutoff. Only versions last deployed more than 1 day ago may be
 # deleted.
-CUTOFF="-P1D"
+CUTOFF="-P1H"
 
 # This is a constant instead of an argument because production versions should
 # be deleted carefully and manually.
@@ -22,6 +22,8 @@ function cleanup() {
   local SERVICE_ARG="-s $1"
   local FILTER_ARG="traffic_split=0.0 last_deployed_time.datetime<$CUTOFF"
   local versions_to_delete=()
+
+  gcloud app versions list $PROJECT_ARG $SERVICE_ARG --filter="$FILTER_ARG" --format="value(id)"
 
   for version in $( gcloud app versions list $PROJECT_ARG $SERVICE_ARG --filter="$FILTER_ARG" --format="value(id)" ); do
     if ! git show-ref --quiet --verify refs/remotes/origin/$version; then
@@ -35,7 +37,7 @@ function cleanup() {
     return 0
   fi
 
-  gcloud app versions delete --quiet $PROJECT_ARG $SERVICE_ARG ${versions_to_delete[*]}
+  #gcloud app versions delete --quiet $PROJECT_ARG $SERVICE_ARG ${versions_to_delete[*]}
 }
 
 
@@ -47,6 +49,8 @@ fi
 
 # Ensure ALL remote branches are fetched.
 git fetch --unshallow origin
+
+git show-ref
 
 cleanup "default"
 cleanup "processor"


### PR DESCRIPTION
##  Description

The version cleanup script deletes version older than 1 day without a corresponding branch in origin. Previously, this was done by checking the *local* refs fetched from the remote. There was a problem: Travis uses a shallow clone so we don't have all the refs, so I "worked around" it using `--unshallow`: #1290 . However, I didn't actually test it. Turns out the fix is not working. `git clone --depth=N` also implies `--single-branch`, so even with `--unshallow` we'd only only fetch the full history of the master branch, not the other branches.

This PR fixes the problem properly using `git ls-remote`, which directly queries the remote end without fetching. And this time, I tweaked the Travis setup to actually test it.

## Review Information

Example dry run (before reverting the debug commits): https://travis-ci.com/web-platform-tests/wpt.fyi/jobs/259816161