### PR TITLE
Retrieve wpt.fyi Github Bot Client Instance

### DIFF
--- a/shared/appengine.go
+++ b/shared/appengine.go
@@ -201,9 +201,9 @@ func getURL(host, path string, filter TestRunFilter) *url.URL {
 	return detailsURL
 }
 
-func (a appEngineAPIImpl) getGithubClientFromKey(key string) (*github.Client, error) {
+func (a appEngineAPIImpl) getGithubClientFromKey(token string) (*github.Client, error) {
 	ds := NewAppEngineDatastore(a.ctx, false)
-	secret, err := GetSecret(ds, key)
+	secret, err := GetSecret(ds, token)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Create a method to retrieve an instance of wpt.fyi Github Bot client, for the implementation of /api/metadata PATCH endpoint. See [design](https://docs.google.com/document/d/1iRkaK6cGgXp3DKbNbPMVsYGMaOHO-5CfqEuLPUR_2HM/edit#heading=h.tx8rv4daaxk9)
