### PR TITLE
Fix a crash when /api/manifest gets invalid SHAs

### DIFF
--- a/shared/params.go
+++ b/shared/params.go
@@ -34,8 +34,8 @@ const MaxCountMaxValue = 500
 // MaxCountMinValue is the minimum allowed value for the max-count param.
 const MaxCountMinValue = 1
 
-// SHARegex is a regex for 7 to 40 char prefix of a git hash.
-var SHARegex = regexp.MustCompile("[0-9a-fA-F]{7,40}")
+// SHARegex is the pattern for a valid SHA1 hash that's at least 7 characters long.
+var SHARegex = regexp.MustCompile(`^[0-9a-fA-F]{7,40}$`)
 
 // ParseSHAParam parses and validates any 'sha' param(s) for the request.
 func ParseSHAParam(v url.Values) (SHAs, error) {

--- a/shared/params_test.go
+++ b/shared/params_test.go
@@ -16,8 +16,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	mapset "github.com/deckarep/golang-set"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParseSHAParam(t *testing.T) {
@@ -50,15 +50,26 @@ func TestParseSHAParam_FullSHA(t *testing.T) {
 	assert.Equal(t, sha, runSHA.FirstOrLatest())
 }
 
-func TestParseSHAParam_NonSHA(t *testing.T) {
+func TestParseSHAParam_TooShortSHA(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/?sha=123", nil)
 	_, err := ParseSHAParam(r.URL.Query())
 	assert.NotNil(t, err)
 }
 
-func TestParseSHAParam_NonSHA_2(t *testing.T) {
-	r := httptest.NewRequest("GET", "http://wpt.fyi/?sha=zapper0123", nil)
+func TestParseSHAParam_TooLongSHA(t *testing.T) {
+	sha := "0123456789aaaaabbbbbcccccdddddeeeeefffff1"
+	r := httptest.NewRequest("GET", "http://wpt.fyi/?sha="+sha, nil)
 	_, err := ParseSHAParam(r.URL.Query())
+	assert.NotNil(t, err)
+}
+
+func TestParseSHAParam_NonSHAs(t *testing.T) {
+	r := httptest.NewRequest("GET", "http://wpt.fyi/?sha=xabcd0123", nil)
+	_, err := ParseSHAParam(r.URL.Query())
+	assert.NotNil(t, err)
+
+	r = httptest.NewRequest("GET", "http://wpt.fyi/?sha=abcd0123x", nil)
+	_, err = ParseSHAParam(r.URL.Query())
 	assert.NotNil(t, err)
 }
 


### PR DESCRIPTION
There are two fundamental problems:

1. The SHA param validation is not strict enough: regex matching is
   prefix matching by default unless the $ anchor is used, so there
   might be invalid characters at the end.
2. We construct regexes from untrusted user inputs, which is a big no
   and is also unnecessary in this use case.

Coincidentally, this PR also fixes the support for partial (short) SHA
in /api/manifest.

## Description

Example crash:
```
regexp: Compile(`MANIFEST-(fd56faf446\).json.gz`): error parsing regexp: missing closing ): `MANIFEST-(fd56faf446\).json.gz`
at google.golang.org/appengine/panic (panic.go:513)
at regexp.MustCompile (regexp.go:245)
at github.com/web-platform-tests/wpt.fyi/api/manifest.getGitHubReleaseAssetForSHA (api.go:88)
at github.com/web-platform-tests/wpt.fyi/api/manifest.apiImpl.GetManifestForSHA (api.go:40)
at github.com/web-platform-tests/wpt.fyi/api.getManifest (manifest.go:60)
at github.com/web-platform-tests/wpt.fyi/api.apiManifestHandler (manifest.go:33)
at net/http.HandlerFunc.ServeHTTP (server.go:1964)
at github.com/gorilla/handlers.(*cors).ServeHTTP (cors.go:54)
at net/http.Handler.ServeHTTP-fm (h2_bundle.go:5622)
at net/http.HandlerFunc.ServeHTTP (server.go:1964)
at github.com/web-platform-tests/wpt.fyi/shared.WrapApplicationJSON.func1 (routing.go:60)
at net/http.HandlerFunc.ServeHTTP (server.go:1964)
at github.com/web-platform-tests/wpt.fyi/shared.WrapHSTS.func1 (routing.go:38)
at net/http.HandlerFunc.ServeHTTP (server.go:1964)
at github.com/gorilla/mux.(*Router).ServeHTTP (mux.go:212)
at net/http.(*ServeMux).ServeHTTP (server.go:2361)
at google.golang.org/appengine/internal.executeRequestSafely (api.go:162)
at google.golang.org/appengine/internal.handleHTTP (api.go:121)
at net/http.HandlerFunc.ServeHTTP (server.go:1964)
at net/http.serverHandler.ServeHTTP (server.go:2741)
```

## Review Information

Unfortunately, `api.go` is difficult to test. I'll look to refactor it and/or find/generate a mock for go-github. I don't think this is a blocker, because we are essentially employing defense in depth here: fixing problem 1 is already enough to fix the crash on its own, and that fix is thoroughly tested.