### PR TITLE
Improve error handling in results-processor and fix the missing SHAs in invalid runs

### DIFF
--- a/results-processor/processor.py
+++ b/results-processor/processor.py
@@ -257,7 +257,7 @@ class Processor(object):
         payload = {'id': int(run_id), 'stage': stage}
         if error:
             payload['error'] = error
-        revision = self.report.run_info.get('full_revision_hash')
+        revision = self.report.run_info.get('revision')
         if revision:
             payload['full_revision_hash'] = revision
         try:

--- a/results-processor/processor_test.py
+++ b/results-processor/processor_test.py
@@ -10,6 +10,7 @@ from werkzeug.datastructures import MultiDict
 import test_util
 import wptreport
 from processor import Processor, process_report
+from test_server import AUTH_CREDENTIALS
 
 
 class ProcessorTest(unittest.TestCase):
@@ -192,7 +193,11 @@ class MockProcessorTest(unittest.TestCase):
         mock.create_run.assert_not_called()
 
 
-class ProcessorServerTest(unittest.TestCase):
+class ProcessorDownloadServerTest(unittest.TestCase):
+    """This class tests behaviours of Processor related to downloading
+    artifacts (e.g. JSON reports) from an external server. test_server is used
+    to emulate the success and failure modes of an external server.
+    """
     def setUp(self):
         self.server, self.url = test_util.start_server(False)
 
@@ -232,3 +237,49 @@ class ProcessorServerTest(unittest.TestCase):
             # artifact_test.zip as the filename.
             path = p._download_single(self.url + '/download/attachment')
             self.assertTrue(path.endswith('.zip'))
+
+
+class ProcessorAPIServerTest(unittest.TestCase):
+    """This class tests API calls from Processor to webapp (e.g.
+    /api/results/create, /api/status). test_server is used to emulate webapp
+    and verify credentials and payloads.
+    """
+    def setUp(self):
+        self.server, self.url = test_util.start_server(True)
+
+    def tearDown(self):
+        if self.server.poll() is None:
+            self.server.kill()
+
+    def test_update_status(self):
+        with Processor() as p:
+            p._auth = AUTH_CREDENTIALS
+            p.report.update_metadata(
+                revision='21917b36553562d21c14fe086756a57cbe8a381b')
+            p.update_status(
+                run_id='12345', stage='INVALID',
+                error='Sample error', callback_url=self.url)
+        self.server.terminate()
+        _, err = self.server.communicate()
+        self.assertEqual(
+            err,
+            b'{"id": 12345, "stage": "INVALID", "error": "Sample error", '
+            b'"full_revision_hash": "21917b36553562d21c14fe086756a57cbe8a381b"}\n')
+
+    def test_create_run(self):
+        api = self.url + '/api/results/create'
+        with Processor() as p:
+            p._auth = AUTH_CREDENTIALS
+            p.report.update_metadata(
+                browser_name='chrome',
+                browser_version='70',
+                os_name='Linux',
+                revision='21917b36553562d21c14fe086756a57cbe8a381b')
+            p.create_run('12345', '', 'blade-runner', callback_url=api)
+            # p.test_run_id is set based on the response from the API, which in
+            # turn is set according to the request. Hence this verifies that we
+            # pass the run ID to the API correctly.
+            self.assertEqual(p.test_run_id, 12345)
+        self.server.terminate()
+        # This is needed to close the stdio pipes.
+        self.server.communicate()

--- a/results-processor/test_server.py
+++ b/results-processor/test_server.py
@@ -11,6 +11,9 @@ import time
 
 import flask
 
+# Exported credentials for authenticated APIs
+AUTH_CREDENTIALS = ('TEST_USERNAME', 'TEST_PASSWORD')
+
 logging.basicConfig(level=logging.ERROR, stream=sys.stdout)
 app = flask.Flask(__name__)
 
@@ -41,6 +44,26 @@ def download_attachment():
 @app.route('/download/test.txt', methods=['GET'])
 def download_json():
     return 'Hello, world!'
+
+
+@app.route('/api/status/<run_id>', methods=['PATCH'])
+def echo_status(run_id):
+    assert flask.request.authorization.username == AUTH_CREDENTIALS[0]
+    assert flask.request.authorization.password == AUTH_CREDENTIALS[1]
+    payload = flask.request.get_json()
+    assert str(payload.get('id')) == run_id
+    sys.stderr.write(flask.request.get_data(as_text=True))
+    sys.stderr.write('\n')
+    sys.stderr.flush()
+    return 'Success'
+
+
+@app.route('/api/results/create', methods=['POST'])
+def echo_create():
+    assert flask.request.authorization.username == AUTH_CREDENTIALS[0]
+    assert flask.request.authorization.password == AUTH_CREDENTIALS[1]
+    payload = flask.request.get_json()
+    return flask.jsonify(id=payload['id'])
 
 
 if __name__ == '__main__':

--- a/results-processor/wptreport_test.py
+++ b/results-processor/wptreport_test.py
@@ -651,6 +651,7 @@ class HelpersTest(unittest.TestCase):
             r.run_info['product'],
             'webkitgtk'
         )
+
     def test_normalize_product_noop(self):
         r = WPTReport()
         r._report = {


### PR DESCRIPTION
This PR contains two relatively independent commits, so it's best to review them separately:

1. Improvement: When there are conflicting fields in run_info, try to preserve as much information as possible by delaying raising exceptions.
2. Bug fix: The field name for the SHA in report.run_info should be `revision`; `full_revision_hash` is the field name used in Datastore on the server (due to historical reasons).

There's nothing to "preview". We rely on unit tests in results-processor, which are rather comprehensive.