### PR TITLE
Include and display product info in pending runs

### DIFF
--- a/api/receiver/api.go
+++ b/api/receiver/api.go
@@ -97,11 +97,25 @@ func (a apiImpl) UpdatePendingTestRun(newRun shared.PendingTestRun) error {
 		if newRun.CheckRunID != 0 {
 			run.CheckRunID = newRun.CheckRunID
 		}
-		if newRun.FullRevisionHash != "" {
-			run.FullRevisionHash = newRun.FullRevisionHash
-		}
 		if newRun.Uploader != "" {
 			run.Uploader = newRun.Uploader
+		}
+		// ProductAtRevision
+		if newRun.BrowserName != "" {
+			run.BrowserName = newRun.BrowserName
+		}
+		if newRun.BrowserVersion != "" {
+			run.BrowserVersion = newRun.BrowserVersion
+		}
+		if newRun.OSName != "" {
+			run.OSName = newRun.OSName
+		}
+		if newRun.OSVersion != "" {
+			run.OSVersion = newRun.OSVersion
+		}
+		if newRun.FullRevisionHash != "" {
+			run.Revision = newRun.FullRevisionHash[:10]
+			run.FullRevisionHash = newRun.FullRevisionHash
 		}
 
 		if run.Created.IsZero() {
@@ -152,10 +166,12 @@ func (a apiImpl) ScheduleResultsTask(
 	}
 
 	pendingRun := shared.PendingTestRun{
-		ID:               key.IntID(),
-		Stage:            shared.StageWptFyiReceived,
-		Uploader:         uploader,
-		FullRevisionHash: extraParams["revision"],
+		ID:       key.IntID(),
+		Stage:    shared.StageWptFyiReceived,
+		Uploader: uploader,
+		ProductAtRevision: shared.ProductAtRevision{
+			FullRevisionHash: extraParams["revision"],
+		},
 	}
 	if err := a.UpdatePendingTestRun(pendingRun); err != nil {
 		return nil, err

--- a/api/receiver/create_run.go
+++ b/api/receiver/create_run.go
@@ -77,9 +77,9 @@ func HandleResultsCreate(a API, s checks.API, w http.ResponseWriter, r *http.Req
 
 	log := shared.GetLogger(a.Context())
 	pendingRun := shared.PendingTestRun{
-		ID:               testRun.ID,
-		Stage:            shared.StageValid,
-		FullRevisionHash: testRun.FullRevisionHash,
+		ID:                testRun.ID,
+		Stage:             shared.StageValid,
+		ProductAtRevision: testRun.ProductAtRevision,
 	}
 	if err := a.UpdatePendingTestRun(pendingRun); err != nil {
 		// This is a non-fatal error; don't return.

--- a/results-processor/processor.py
+++ b/results-processor/processor.py
@@ -257,9 +257,16 @@ class Processor(object):
         payload = {'id': int(run_id), 'stage': stage}
         if error:
             payload['error'] = error
-        revision = self.report.run_info.get('revision')
-        if revision:
-            payload['full_revision_hash'] = revision
+        if self.report.run_info.get('revision'):
+            payload['full_revision_hash'] = self.report.run_info['revision']
+        if self.report.run_info.get('product'):
+            payload['browser_name'] = self.report.run_info['product']
+        if self.report.run_info.get('browser_version'):
+            payload['browser_version'] = self.report.run_info['browser_version']
+        if self.report.run_info.get('os'):
+            payload['os_name'] = self.report.run_info['os']
+        if self.report.run_info.get('os_version'):
+            payload['os_version'] = self.report.run_info['os_version']
         try:
             response = requests.patch(api, auth=self.auth, json=payload)
             response.raise_for_status()

--- a/results-processor/processor_test.py
+++ b/results-processor/processor_test.py
@@ -2,6 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import json
 import unittest
 from unittest.mock import call, patch
 
@@ -255,16 +256,23 @@ class ProcessorAPIServerTest(unittest.TestCase):
         with Processor() as p:
             p._auth = AUTH_CREDENTIALS
             p.report.update_metadata(
+                browser_name='Chrome',
+                browser_version='70',
+                os_name='Linux',
+                os_version='5.0',
                 revision='21917b36553562d21c14fe086756a57cbe8a381b')
             p.update_status(
                 run_id='12345', stage='INVALID',
                 error='Sample error', callback_url=self.url)
         self.server.terminate()
         _, err = self.server.communicate()
-        self.assertEqual(
-            err,
-            b'{"id": 12345, "stage": "INVALID", "error": "Sample error", '
-            b'"full_revision_hash": "21917b36553562d21c14fe086756a57cbe8a381b"}\n')
+        response = json.loads(err)
+        self.assertDictEqual(response, {
+            'id': 12345, 'stage': 'INVALID', 'error': 'Sample error',
+            'browser_name': 'Chrome', 'browser_version': '70',
+            'os_name': 'Linux', 'os_version': '5.0',
+            'full_revision_hash': '21917b36553562d21c14fe086756a57cbe8a381b',
+        })
 
     def test_create_run(self):
         api = self.url + '/api/results/create'

--- a/shared/models.go
+++ b/shared/models.go
@@ -236,12 +236,12 @@ func (s *PendingTestRunStage) UnmarshalJSON(b []byte) error {
 // PendingTestRun represents a TestRun that has started, but is not yet
 // completed.
 type PendingTestRun struct {
-	ID               int64               `json:"id" datastore:"-"`
-	CheckRunID       int64               `json:"check_run_id" datastore:",omitempty"`
-	FullRevisionHash string              `json:"full_revision_hash"`
-	Uploader         string              `json:"uploader"`
-	Error            string              `json:"error" datastore:",omitempty"`
-	Stage            PendingTestRunStage `json:"stage"`
+	ID int64 `json:"id" datastore:"-"`
+	ProductAtRevision
+	CheckRunID int64               `json:"check_run_id" datastore:",omitempty"`
+	Uploader   string              `json:"uploader"`
+	Error      string              `json:"error" datastore:",omitempty"`
+	Stage      PendingTestRunStage `json:"stage"`
 
 	Created time.Time `json:"created"`
 	Updated time.Time `json:"updated"`

--- a/webapp/components/product-info.js
+++ b/webapp/components/product-info.js
@@ -168,7 +168,7 @@ const ProductInfo = (superClass) => class extends superClass {
     return parseProduct(name);
   }
 
-  getSpec(product) {
+  getSpec(product, withRevision=true) {
     let spec = product.browser_name;
     if (product.browser_version) {
       spec += `-${product.browser_version}`;
@@ -176,7 +176,7 @@ const ProductInfo = (superClass) => class extends superClass {
     if (product.labels && product.labels.length) {
       spec += `[${product.labels.join(',')}]`;
     }
-    if (product.revision && !this.computeIsLatest(product.revision)) {
+    if (withRevision && product.revision && !this.computeIsLatest(product.revision)) {
       spec += `@${product.revision}`;
     }
     return spec;

--- a/webapp/components/wpt-processor.js
+++ b/webapp/components/wpt-processor.js
@@ -13,8 +13,9 @@ import '../node_modules/@vaadin/vaadin-context-menu/vaadin-context-menu.js';
 import '../node_modules/@vaadin/vaadin-grid/vaadin-grid.js';
 import { html, PolymerElement } from '../node_modules/@polymer/polymer/polymer-element.js';
 import { LoadingState } from './loading-state.js';
+import { ProductInfo } from './product-info.js';
 
-class WPTProcessor extends LoadingState(PolymerElement) {
+class WPTProcessor extends ProductInfo(LoadingState(PolymerElement)) {
   static get template() {
     return html`
     <style>
@@ -73,23 +74,27 @@ class WPTProcessor extends LoadingState(PolymerElement) {
         <vaadin-grid-column auto-width header="GitHub Check Run" hidden>
           <template>[[item.check_run_id]]</template>
         </vaadin-grid-column>
-        <vaadin-grid-column auto-width header="SHA">
-          <template>[[item.full_revision_hash]]</template>
+        <vaadin-grid-column auto-width header="Product">
+          <template>[[_product(item)]]</template>
+        </vaadin-grid-column>
+        <!-- Set explicit width to only show the prefix of a SHA, but still allow find-in-page. -->
+        <vaadin-grid-column width="10em" header="SHA">
+          <template><code>[[item.full_revision_hash]]</code></template>
         </vaadin-grid-column>
         <vaadin-grid-column auto-width header="Uploader">
           <template>[[item.uploader]]</template>
         </vaadin-grid-column>
         <vaadin-grid-column auto-width header="Created">
-          <template>[[timestamp(item.created)]]</template>
+          <template>[[_timestamp(item.created)]]</template>
         </vaadin-grid-column>
         <vaadin-grid-column auto-width header="Uploaded">
-          <template>[[timestamp(item.updated)]]</template>
+          <template>[[_timestamp(item.updated)]]</template>
         </vaadin-grid-column>
         <vaadin-grid-column auto-width header="Stage">
           <template>[[item.stage]]</template>
         </vaadin-grid-column>
 
-        <vaadin-grid-column autowidth header="Show error">
+        <vaadin-grid-column auto-width header="Show error">
           <template class="header">
             Show error <vaadin-checkbox aria-label="Show all" on-checked-changed="toggleAllDetails" id="show-all"></vaadin-checkbox>
           </template>
@@ -162,7 +167,13 @@ class WPTProcessor extends LoadingState(PolymerElement) {
     }
   }
 
-  timestamp(date) {
+  _product(item) {
+    // Polymer data binding does not recognize boolean literals as arguments to
+    // computed bindings, so we wrap the function call here.
+    return this.getSpec(item, /* withRevision */ false);
+  }
+
+  _timestamp(date) {
     const opts = {
       dateStyle: 'short',
       timeStyle: 'medium',


### PR DESCRIPTION
Currently, a pending test run does not include product-related metadata, even though we sometimes do have the data in the JSON report. This change plugs said data into the `PendingTestRun` entity whenever it's available to make debugging much easier.

## Review

Again, the changes are split into multiple commits logically, so it'd be easier to review commit by commit.

Demo: https://pending-runs-dot-wptdashboard-staging.appspot.com/status
(Switch to "invalid runs" and you'll see an invalid run uploaded by me manually.)