### PR TITLE
Fix build: use Go modules properly in flex

### DIFF
--- a/api/query/cache/service/Dockerfile
+++ b/api/query/cache/service/Dockerfile
@@ -5,16 +5,14 @@ FROM gcr.io/gcp-runtimes/go1-builder:1.12 as builder
 
 RUN apt-get update
 RUN apt-get install -qy --no-install-suggests git
-WORKDIR /go/src/app
-COPY *.go .
+WORKDIR /go/src/wpt.fyi
 
-COPY wpt.fyi /root/go/src/github.com/web-platform-tests/wpt.fyi/
-RUN /usr/local/go/bin/go get -d .
-RUN /usr/local/go/bin/go build -o app .
+COPY wpt.fyi .
+RUN /usr/local/go/bin/go build -o ../../bin/app ./api/query/cache/service
 
 # Application image.
 FROM gcr.io/distroless/base:latest
 
-COPY --from=builder /go/src/app/app /usr/local/bin/app
+COPY --from=builder /go/bin/app /usr/local/bin/app
 
 CMD ["/usr/local/bin/app"]

--- a/revisions/service/Dockerfile
+++ b/revisions/service/Dockerfile
@@ -5,16 +5,14 @@ FROM gcr.io/gcp-runtimes/go1-builder:1.12 as builder
 
 RUN apt-get update
 RUN apt-get install -qy --no-install-suggests git
-WORKDIR /go/src/app
-COPY *.go .
+WORKDIR /go/src/wpt.fyi
 
-COPY wpt.fyi /root/go/src/github.com/web-platform-tests/wpt.fyi/
-RUN /usr/local/go/bin/go get -d .
-RUN /usr/local/go/bin/go build -o app .
+COPY wpt.fyi .
+RUN /usr/local/go/bin/go build -o ../../bin/app ./revisions/service
 
 # Application image.
 FROM gcr.io/distroless/base:latest
 
-COPY --from=builder /go/src/app/app /usr/local/bin/app
+COPY --from=builder /go/bin/app /usr/local/bin/app
 
 CMD ["/usr/local/bin/app"]


### PR DESCRIPTION
This fixes the build for Go App Engine Flex services (announcer &
searchcache) by building the services outside of GOPATH in the builder
container to make sure go.mod is in effect.

Background:

Previously, we did not use go.mod so we needed to copy source code into
GOPATH inside the builder container for Flex services. We did not change
that setup when created go.mod.

However, the Go toolchain does NOT enable the module mode when running
inside GOPATH. The setup happened to continue working because we had
been using the latest major versions (same as the master branches) of
all dependencies. This setup finally broke when go-github released v29
and we haven't upgraded.

This change fixes the root cause (bonus: now we are sure all deps are
also pinned properly in announcer & searchcach). We will upgrade
go-github later.
