### PR TITLE
[TEST] Change the Trusted Origin

### DIFF
--- a/api/routes.go
+++ b/api/routes.go
@@ -74,5 +74,5 @@ func RegisterRoutes() {
 	shared.AddRoute("/api/metadata", "api-metadata", shared.WrapPermissiveCORS(apiMetadataHandler))
 
 	// API endpoint for modifying Metadata.
-	shared.AddRoute("/api/metadata/triage", "api-metadata-triage", shared.WrapTrustedCORS(apiMetadataTriageHandler, []string{"https://developer.mozilla.org"}, []string{"PATCH"}))
+	shared.AddRoute("/api/metadata/triage", "api-metadata-triage", shared.WrapTrustedCORS(apiMetadataTriageHandler, []string{"https://kyleju.github.io"}, []string{"PATCH"}))
 }


### PR DESCRIPTION
Test /api/metadata/triage from a trusted origin. See #1728 for more info.

Test it from https://kyleju.github.io/

e.g. input: {"/css/css-align/gaps/gap-animation-001.html":[{"url":"foo", "product":"chrome", "results": [{"status": 6 }]}]}
