### PR TITLE
TestPath is Missing When There is no Results Field in Metadata

### DIFF
--- a/shared/triage_metadata.go
+++ b/shared/triage_metadata.go
@@ -249,6 +249,12 @@ func appendTestName(test string, metadata MetadataResults) {
 	links := metadata[test]
 	_, testName := SplitWPTTestPath(test)
 	for linkIndex, link := range links {
+		if len(link.Results) == 0 {
+			links[linkIndex].Results = make([]MetadataTestResult, 0)
+			links[linkIndex].Results = append(link.Results, MetadataTestResult{TestPath: testName})
+			continue
+		}
+
 		for resultIndex := range link.Results {
 			metadata[test][linkIndex].Results[resultIndex].TestPath = testName
 		}

--- a/shared/triage_metadata_test.go
+++ b/shared/triage_metadata_test.go
@@ -64,16 +64,41 @@ func TestAppendTestName(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
+func TestAppendTestName_EmptyResults(t *testing.T) {
+	var actual, expected MetadataResults
+	json.Unmarshal([]byte(`{
+		"/foo1/bar1.html": [
+			{
+				"product": "chrome",
+				"url": "bugs.bar"
+			}
+		]
+	}`), &actual)
+
+	json.Unmarshal([]byte(`{
+		"/foo1/bar1.html": [
+			{
+				"product": "chrome",
+				"url": "bugs.bar",
+				"results": [
+					{"test": "bar1.html"}
+				]}
+		]
+	}`), &expected)
+	test := "/foo1/bar1.html"
+
+	appendTestName(test, actual)
+
+	assert.Equal(t, expected, actual)
+}
+
 func TestAddToFiles_AddNewFile(t *testing.T) {
 	var amendment MetadataResults
 	json.Unmarshal([]byte(`{
 		"/foo/foo1/bar.html": [
 			{
 				"url": "bugs.bar?id=456",
-				"product": "chrome",
-				"results": [
-					{"status": 6 }
-				]
+				"product": "chrome"
 			}
 		]
 	}`), &amendment)
@@ -111,7 +136,6 @@ links:
 	assert.Equal(t, "bugs.bar?id=456", actual.Links[0].URL)
 	assert.Equal(t, 1, len(actual.Links[0].Results))
 	assert.Equal(t, "bar.html", actual.Links[0].Results[0].TestPath)
-	assert.Equal(t, TestStatusFail, *actual.Links[0].Results[0].Status)
 }
 
 func TestAddToFiles_AddNewMetadataResult(t *testing.T) {


### PR DESCRIPTION
Fix the issue where `TestPath` is not being populated when the amendment has no `Results` field. e.g. https://github.com/web-platform-tests/wpt-metadata/pull/60