### PR TITLE
[Azure] Return error from azureAPI.GetBuild

### DIFF
--- a/api/azure/api_test.go
+++ b/api/azure/api_test.go
@@ -15,9 +15,9 @@ import (
 	"strings"
 	"testing"
 
-	logrustest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-github/v28/github"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/web-platform-tests/wpt.fyi/api/azure"
@@ -90,7 +90,7 @@ func TestHandleCheckRunEvent(t *testing.T) {
 	azureAPI := mock_azure.NewMockAPI(mockCtrl)
 	serverURL, _ := url.Parse(server.URL)
 	azureAPI.EXPECT().GetAzureArtifactsURL(repoOwner, repoName, int64(123)).Return(server.URL + "/123/artifacts")
-	azureAPI.EXPECT().GetBuild(repoOwner, repoName, int64(123)).Return(&build)
+	azureAPI.EXPECT().GetBuild(repoOwner, repoName, int64(123)).Return(&build, nil)
 
 	aeAPI := sharedtest.NewMockAppEngineAPI(mockCtrl)
 	aeAPI.EXPECT().GetVersionedHostname().AnyTimes().Return(serverURL.Host)

--- a/api/azure/mock_azure/api_mock.go
+++ b/api/azure/mock_azure/api_mock.go
@@ -49,11 +49,12 @@ func (mr *MockAPIMockRecorder) GetAzureArtifactsURL(arg0, arg1, arg2 interface{}
 }
 
 // GetBuild mocks base method
-func (m *MockAPI) GetBuild(arg0, arg1 string, arg2 int64) *azure.Build {
+func (m *MockAPI) GetBuild(arg0, arg1 string, arg2 int64) (*azure.Build, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBuild", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*azure.Build)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GetBuild indicates an expected call of GetBuild


### PR DESCRIPTION
And return early when err != nil or build == nil.

Drive-by: switch to the best practice of wrapping errors with more
information in Golang, instead of logging along the way.

Fixes #1406 .

(Note: tests will fail until we land #1752 .)