### PR TITLE
More a11y improvements

### DIFF
--- a/webapp/.lighthouserc.yml
+++ b/webapp/.lighthouserc.yml
@@ -8,11 +8,13 @@ ci:
     assertions:
       categories:accessibility:
         - error
-        - minScore: 0.75
+        - minScore: 0.9
       color-contrast: error
       document-title: error
       html-has-lang: error
       html-lang-valid: error
+      label: error
+      link-name: error
 
   upload:
     target: temporary-public-storage

--- a/webapp/components/path.js
+++ b/webapp/components/path.js
@@ -79,8 +79,13 @@ const PathInfo = (superClass) => class extends superClass {
   }
 
   splitPathIntoLinkedParts(inputPath) {
-    const encoded = this.encodeTestPath(inputPath);
-    const parts = encoded.split('/').slice(1);
+    // Remove the leading slash.
+    const encoded = this.encodeTestPath(inputPath).slice(1);
+    if (encoded === '') {
+      // Return an empty array instead of an array with an empty string.
+      return [];
+    }
+    const parts = encoded.split('/');
     let path = '';
     const linkedParts = parts.map(part => {
       path += `/${part}`;

--- a/webapp/components/test-file-results.js
+++ b/webapp/components/test-file-results.js
@@ -44,7 +44,7 @@ class TestFileResults extends WPTFlags(LoadingState(PathInfo(
 
     <div class="right">
       <paper-toggle-button checked="{{isVerbose}}">
-        Expand
+        Show Details
       </paper-toggle-button>
     </div>
 
@@ -304,4 +304,3 @@ class TestFileResults extends WPTFlags(LoadingState(PathInfo(
 window.customElements.define(TestFileResults.is, TestFileResults);
 
 export { TestFileResults };
-

--- a/webapp/components/test-file-results.js
+++ b/webapp/components/test-file-results.js
@@ -32,7 +32,7 @@ class TestFileResults extends WPTFlags(LoadingState(PathInfo(
         display: flex;
         justify-content: flex-end;
       }
-      .right .pad {
+      .right paper-toggle-button {
         padding: 8px;
       }
       paper-toggle-button {
@@ -43,8 +43,8 @@ class TestFileResults extends WPTFlags(LoadingState(PathInfo(
     </style>
 
     <div class="right">
-      <label class="pad">Expand</label>
-      <paper-toggle-button class="pad" checked="{{isVerbose}}">
+      <paper-toggle-button checked="{{isVerbose}}">
+        Expand
       </paper-toggle-button>
     </div>
 

--- a/webapp/components/test-search.js
+++ b/webapp/components/test-search.js
@@ -345,13 +345,14 @@ class TestSearch extends WPTFlags(PolymerElement) {
         width: 100%;
       }
       .help {
-        font-size: x-small;
         float: right;
       }
     </style>
 
     <div>
-      <input value="{{ queryInput::input }}" class="query" list="query-list" placeholder="[[placeholder]]" onchange="[[onChange]]" onkeyup="[[onKeyUp]]" onkeydown="[[onKeyDown]]" onfocus="[[onFocus]]" onblur="[[onBlur]]">
+      <input class="query" list="query-list" aria-label="Search test files"
+             value="{{ queryInput::input }}" placeholder="[[placeholder]]"
+             onchange="[[onChange]]" onkeyup="[[onKeyUp]]" onkeydown="[[onKeyDown]]" onfocus="[[onFocus]]" onblur="[[onBlur]]">
       <span class="help">
         For information on the search syntax, <a href="https://github.com/web-platform-tests/wpt.fyi/blob/master/api/query/README.md">view the search documentation</a>
       </span>

--- a/webapp/components/test/path.html
+++ b/webapp/components/test/path.html
@@ -85,6 +85,8 @@ suite('PathInfo', () => {
   });
 
   test('splitPathIntoLinkedParts', () => {
+    expect(pathInfo.splitPathIntoLinkedParts('/')).to.deep.equal([]);
+
     expect(pathInfo.splitPathIntoLinkedParts('/a/b.html')).to.deep.equal([
       {name: 'a', path: '/a'},
       {name: 'b.html', path: '/a/b.html'},


### PR DESCRIPTION
1. Add labels to the expand toggle button and the search box.
2. Get rid of tiny fonts.
3. Remove empty `<a>` elements.

This brings the Lighthouse a11y scores over 90.