### PR TITLE
Create a valid robots.txt

### DIFF
--- a/webapp/static/robots.txt
+++ b/webapp/static/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /api/

--- a/webapp/web/app.yaml
+++ b/webapp/web/app.yaml
@@ -35,6 +35,10 @@ handlers:
   static_files: webapp/static/favicon.ico
   upload: webapp/static/favicon.ico
   secure: always
+- url: /robots.txt
+  static_files: webapp/static/robots.txt
+  upload: webapp/static/robots.txt
+  secure: always
 # Static files that change often (i.e. our own code).
 - url: /components
   static_dir: webapp/components


### PR DESCRIPTION
Otherwise based on our routing rules, the request will be redirected to
/results/robots.txt.

This stops Lighthouse from showing a big warning.