### PR TITLE
Use a shorter version name

### DIFF
--- a/util/deploy.sh
+++ b/util/deploy.sh
@@ -54,7 +54,7 @@ if [[ "${APP_PATH}" == "webapp" ]]; then
 fi
 
 # Create a name for this version
-VERSION_BRANCH_NAME="$(echo -n ${BRANCH_NAME:-"$(git rev-parse --abbrev-ref HEAD)"} | tr [:upper:] [:lower:] | tr -c [:alnum:] - | cut -c 1-28)"
+VERSION_BRANCH_NAME="$(echo -n ${BRANCH_NAME:-"$(git rev-parse --abbrev-ref HEAD)"} | tr [:upper:] [:lower:] | tr -c [:alnum:] - | cut -c 1-22)"
 USER="$(git remote -v get-url origin | sed -E 's#(https?:\/\/|git@)github.com(\/|:)##' | sed 's#/.*$##')-"
 if [[ "${USER}" == "web-platform-tests-" ]]; then USER=""; fi
 


### PR DESCRIPTION
Set the length limit of version names to 22, to leave enough space for
the HTTPS domain name (which could have a very long suffix like
"-dot-searchcache-wptdashboard-staging"). Domain name parts can be no
longer than 63 characters.
