### PR TITLE
[Searchcache, webapp] Create Caching for WPT Metadata

### DIFF
--- a/api/metadata_cache.go
+++ b/api/metadata_cache.go
@@ -1,0 +1,75 @@
+// Copyright 2020 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/web-platform-tests/wpt.fyi/shared"
+	"google.golang.org/appengine/memcache"
+)
+
+const metadataCacheKey = "WPT-METADATA"
+
+type webappMetadataFetcher struct {
+	ctx    context.Context
+	client *http.Client
+	log    shared.Logger
+	url    string
+}
+
+func (f webappMetadataFetcher) Fetch() (res map[string][]byte, err error) {
+	metadataMap, err := getMetadataFromMemcache(f.ctx, f.log, f.client, f.url)
+	if err == nil && metadataMap != nil {
+		return metadataMap, nil
+	}
+
+	return shared.CollectMetadataWithURL(f.client, f.url)
+}
+
+func getMetadataFromMemcache(ctx context.Context, log shared.Logger, client *http.Client, url string) (res map[string][]byte, err error) {
+	cached, err := memcache.Get(ctx, metadataCacheKey)
+
+	if err != nil && err != memcache.ErrCacheMiss {
+		log.Errorf("Error from getting Metadata in memcache: %s", err.Error())
+		return nil, err
+	}
+
+	if err == nil && cached != nil {
+		// Caches hit; update Metadata.
+		var metadataMap map[string][]byte
+		err = json.Unmarshal(cached.Value, &metadataMap)
+		if err != nil {
+			log.Errorf("Error from unmarshaling Metadata in memcache: %s", err.Error())
+			return nil, err
+		}
+
+		return metadataMap, nil
+	}
+
+	// Caches missed.
+	metadataByteMap, err := shared.CollectMetadataWithURL(client, url)
+	if err != nil {
+		log.Errorf("Error from CollectMetadataWithURL in a cache miss: %s", err.Error())
+		return nil, err
+	}
+
+	body, err := json.Marshal(metadataByteMap)
+	if err != nil {
+		log.Errorf("Error from marshaling metadataByteMap in a cache miss: %s", err.Error())
+		return metadataByteMap, nil
+	}
+
+	item := &memcache.Item{
+		Key:        metadataCacheKey,
+		Value:      body,
+		Expiration: time.Minute * 10,
+	}
+	memcache.Set(ctx, item)
+	return metadataByteMap, nil
+}

--- a/api/metadata_cache.go
+++ b/api/metadata_cache.go
@@ -19,12 +19,11 @@ const metadataCacheKey = "WPT-METADATA"
 type webappMetadataFetcher struct {
 	ctx    context.Context
 	client *http.Client
-	log    shared.Logger
 	url    string
 }
 
 func (f webappMetadataFetcher) Fetch() (res map[string][]byte, err error) {
-	metadataMap, err := getMetadataFromMemcache(f.ctx, f.log, f.client, f.url)
+	metadataMap, err := getMetadataFromMemcache(f.ctx, f.client, f.url)
 	if err == nil && metadataMap != nil {
 		return metadataMap, nil
 	}
@@ -32,7 +31,8 @@ func (f webappMetadataFetcher) Fetch() (res map[string][]byte, err error) {
 	return shared.CollectMetadataWithURL(f.client, f.url)
 }
 
-func getMetadataFromMemcache(ctx context.Context, log shared.Logger, client *http.Client, url string) (res map[string][]byte, err error) {
+func getMetadataFromMemcache(ctx context.Context, client *http.Client, url string) (res map[string][]byte, err error) {
+	log := shared.GetLogger(ctx)
 	cached, err := memcache.Get(ctx, metadataCacheKey)
 
 	if err != nil && err != memcache.ErrCacheMiss {

--- a/api/metadata_handler.go
+++ b/api/metadata_handler.go
@@ -5,7 +5,6 @@
 package api
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -202,25 +201,4 @@ func filterMetadata(linkQuery query.AbstractLink, metadata shared.MetadataResult
 		}
 	}
 	return res
-}
-
-// TODO(kyleju): Refactor this part to shared package.
-var cacheKey = func(r *http.Request) interface{} {
-	if r.Method == "GET" {
-		return shared.URLAsCacheKey(r)
-	}
-
-	body := r.Body
-	data, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		msg := fmt.Sprintf("Failed to read non-GET request body for generating cache key: %v", err)
-		shared.GetLogger(shared.NewAppEngineContext(r)).Errorf(msg)
-		panic(msg)
-	}
-	defer body.Close()
-
-	// Ensure that r.Body can be read again by other request handling routines.
-	r.Body = ioutil.NopCloser(bytes.NewBuffer(data))
-
-	return fmt.Sprintf("%s#%s", r.URL.String(), string(data))
 }

--- a/api/metadata_handler_test.go
+++ b/api/metadata_handler_test.go
@@ -120,7 +120,9 @@ func TestFilterMetadataHanlder_Success(t *testing.T) {
 	w := httptest.NewRecorder()
 	client := server.Client()
 
-	metadataHandler := MetadataHandler{shared.NewNilLogger(), client, server.URL}
+	ctx := sharedtest.NewTestContext()
+	fetcher := webappMetadataFetcher{ctx, client, shared.NewNilLogger(), server.URL}
+	metadataHandler := MetadataHandler{shared.NewNilLogger(), fetcher}
 	metadataHandler.ServeHTTP(w, r)
 
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -159,7 +161,7 @@ func TestFilterMetadataHanlder_MissingProducts(t *testing.T) {
 	r := httptest.NewRequest("GET", "/abd/api/metadata?", nil)
 	w := httptest.NewRecorder()
 
-	metadataHandler := MetadataHandler{shared.NewNilLogger(), nil, ""}
+	metadataHandler := MetadataHandler{shared.NewNilLogger(), nil}
 	metadataHandler.ServeHTTP(w, r)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
@@ -183,7 +185,9 @@ func TestFilterMetadataHandlerPost_Success(t *testing.T) {
 	w := httptest.NewRecorder()
 	client := server.Client()
 
-	metadataHandler := MetadataHandler{shared.NewNilLogger(), client, server.URL}
+	ctx := sharedtest.NewTestContext()
+	fetcher := webappMetadataFetcher{ctx, client, shared.NewNilLogger(), server.URL}
+	metadataHandler := MetadataHandler{shared.NewNilLogger(), fetcher}
 	metadataHandler.ServeHTTP(w, r)
 
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -224,7 +228,7 @@ func TestFilterMetadataHandlerPost_MissingProducts(t *testing.T) {
 	r := httptest.NewRequest("GET", "/abd/api/metadata?", bodyReader)
 	w := httptest.NewRecorder()
 
-	metadataHandler := MetadataHandler{shared.NewNilLogger(), nil, ""}
+	metadataHandler := MetadataHandler{shared.NewNilLogger(), nil}
 	metadataHandler.ServeHTTP(w, r)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
@@ -241,7 +245,7 @@ func TestFilterMetadataHandlerPost_NotLink(t *testing.T) {
 	r := httptest.NewRequest("POST", "/abd/api/metadata?product=chrome&product=safari", bodyReader)
 	w := httptest.NewRecorder()
 
-	metadataHandler := MetadataHandler{shared.NewNilLogger(), nil, ""}
+	metadataHandler := MetadataHandler{shared.NewNilLogger(), nil}
 	metadataHandler.ServeHTTP(w, r)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
@@ -261,7 +265,7 @@ func TestFilterMetadataHandlerPost_NotJustLink(t *testing.T) {
 	r := httptest.NewRequest("POST", "/abd/api/metadata?product=chrome&product=safari", bodyReader)
 	w := httptest.NewRecorder()
 
-	metadataHandler := MetadataHandler{shared.NewNilLogger(), nil, ""}
+	metadataHandler := MetadataHandler{shared.NewNilLogger(), nil}
 	metadataHandler.ServeHTTP(w, r)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)

--- a/api/metadata_handler_test.go
+++ b/api/metadata_handler_test.go
@@ -121,7 +121,7 @@ func TestFilterMetadataHanlder_Success(t *testing.T) {
 	client := server.Client()
 
 	ctx := sharedtest.NewTestContext()
-	fetcher := webappMetadataFetcher{ctx, client, shared.NewNilLogger(), server.URL}
+	fetcher := webappMetadataFetcher{ctx, client, server.URL}
 	metadataHandler := MetadataHandler{shared.NewNilLogger(), fetcher}
 	metadataHandler.ServeHTTP(w, r)
 
@@ -186,7 +186,7 @@ func TestFilterMetadataHandlerPost_Success(t *testing.T) {
 	client := server.Client()
 
 	ctx := sharedtest.NewTestContext()
-	fetcher := webappMetadataFetcher{ctx, client, shared.NewNilLogger(), server.URL}
+	fetcher := webappMetadataFetcher{ctx, client, server.URL}
 	metadataHandler := MetadataHandler{shared.NewNilLogger(), fetcher}
 	metadataHandler.ServeHTTP(w, r)
 

--- a/api/query/atoms.go
+++ b/api/query/atoms.go
@@ -8,9 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 	"strings"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/web-platform-tests/wpt.fyi/shared"
@@ -239,11 +237,7 @@ type AbstractLink struct {
 
 // BindToRuns for AbstractLink is a no-op; it is independent of test runs
 func (l AbstractLink) BindToRuns(runs ...shared.TestRun) ConcreteQuery {
-	var netClient = &http.Client{
-		Timeout: time.Second * 5,
-	}
-
-	fetcher := searchcacheMetadataFetcher{client: netClient, url: shared.MetadataArchiveURL}
+	fetcher := searchcacheMetadataFetcher{url: shared.MetadataArchiveURL}
 	metadata, _ := shared.GetMetadataResponse(runs, logrus.StandardLogger(), fetcher)
 	metadataMap := shared.PrepareLinkFilter(metadata)
 

--- a/api/query/atoms.go
+++ b/api/query/atoms.go
@@ -243,7 +243,8 @@ func (l AbstractLink) BindToRuns(runs ...shared.TestRun) ConcreteQuery {
 		Timeout: time.Second * 5,
 	}
 
-	metadata, _ := shared.GetMetadataResponse(runs, netClient, logrus.StandardLogger(), shared.MetadataArchiveURL)
+	fetcher := searchcacheMetadataFetcher{client: netClient, url: shared.MetadataArchiveURL}
+	metadata, _ := shared.GetMetadataResponse(runs, logrus.StandardLogger(), fetcher)
 	metadataMap := shared.PrepareLinkFilter(metadata)
 
 	return Link{

--- a/api/query/cache/service/main.go
+++ b/api/query/cache/service/main.go
@@ -313,6 +313,12 @@ func main() {
 	// after backfilling was started.
 	go poll.KeepRunsUpdated(store, logger, *updateInterval, *updateMaxRuns, idx)
 
+	var netClient = &http.Client{
+		Timeout: time.Second * 5,
+	}
+	// Polls Metadata update every 10 minutes.
+	go poll.KeepMetadataUpdated(netClient, logger, time.Minute*10)
+
 	http.HandleFunc("/_ah/liveness_check", livenessCheckHandler)
 	http.HandleFunc("/_ah/readiness_check", readinessCheckHandler)
 	http.HandleFunc("/api/search/cache", shared.HandleWithGoogleCloudLogging(searchHandler, *projectID, &monitoredResource))

--- a/api/query/metadata_cache.go
+++ b/api/query/metadata_cache.go
@@ -1,0 +1,27 @@
+// Copyright 2020 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package query
+
+import (
+	"net/http"
+
+	"github.com/web-platform-tests/wpt.fyi/shared"
+)
+
+// MetadataMapCached is the local cache of Metadata in searchcache.
+var MetadataMapCached map[string][]byte = nil
+
+type searchcacheMetadataFetcher struct {
+	client *http.Client
+	url    string
+}
+
+func (f searchcacheMetadataFetcher) Fetch() (res map[string][]byte, err error) {
+	if MetadataMapCached != nil {
+		return MetadataMapCached, nil
+	}
+
+	return shared.CollectMetadataWithURL(f.client, f.url)
+}

--- a/api/query/metadata_cache.go
+++ b/api/query/metadata_cache.go
@@ -6,6 +6,7 @@ package query
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
@@ -14,8 +15,7 @@ import (
 var MetadataMapCached map[string][]byte = nil
 
 type searchcacheMetadataFetcher struct {
-	client *http.Client
-	url    string
+	url string
 }
 
 func (f searchcacheMetadataFetcher) Fetch() (res map[string][]byte, err error) {
@@ -23,5 +23,8 @@ func (f searchcacheMetadataFetcher) Fetch() (res map[string][]byte, err error) {
 		return MetadataMapCached, nil
 	}
 
-	return shared.CollectMetadataWithURL(f.client, f.url)
+	var netClient = &http.Client{
+		Timeout: time.Second * 5,
+	}
+	return shared.CollectMetadataWithURL(netClient, f.url)
 }

--- a/shared/metadata.go
+++ b/shared/metadata.go
@@ -5,7 +5,6 @@
 package shared
 
 import (
-	"net/http"
 	"strings"
 
 	"gopkg.in/yaml.v2"
@@ -52,13 +51,13 @@ type MetadataTestResult struct {
 }
 
 // GetMetadataResponse retrieves the response to a WPT Metadata query.
-func GetMetadataResponse(testRuns []TestRun, client *http.Client, log Logger, url string) (MetadataResults, error) {
+func GetMetadataResponse(testRuns []TestRun, log Logger, fetcher MetadataFetcher) (MetadataResults, error) {
 	var productSpecs = make([]ProductSpec, len(testRuns))
 	for i, run := range testRuns {
 		productSpecs[i] = ProductSpec{ProductAtRevision: run.ProductAtRevision, Labels: run.LabelsSet()}
 	}
 
-	metadata, err := GetMetadataByteMap(client, log, url)
+	metadata, err := GetMetadataByteMap(log, fetcher)
 	if err != nil {
 		return nil, err
 	}
@@ -67,8 +66,8 @@ func GetMetadataResponse(testRuns []TestRun, client *http.Client, log Logger, ur
 }
 
 // GetMetadataResponseOnProducts constructs the response to a WPT Metadata query, given ProductSpecs.
-func GetMetadataResponseOnProducts(productSpecs ProductSpecs, client *http.Client, log Logger, url string) (MetadataResults, error) {
-	metadata, err := GetMetadataByteMap(client, log, url)
+func GetMetadataResponseOnProducts(productSpecs ProductSpecs, log Logger, fetcher MetadataFetcher) (MetadataResults, error) {
+	metadata, err := GetMetadataByteMap(log, fetcher)
 	if err != nil {
 		return nil, err
 	}
@@ -78,10 +77,10 @@ func GetMetadataResponseOnProducts(productSpecs ProductSpecs, client *http.Clien
 
 // GetMetadataByteMap collects and parses all META.yml files from
 // the wpt-metadata repository.
-func GetMetadataByteMap(client *http.Client, log Logger, url string) (map[string]Metadata, error) {
-	metadataByteMap, err := CollectMetadataWithURL(client, url)
+func GetMetadataByteMap(log Logger, fetcher MetadataFetcher) (map[string]Metadata, error) {
+	metadataByteMap, err := fetcher.Fetch()
 	if err != nil {
-		log.Errorf("Error from CollectMetadataWithURL: %s", err.Error())
+		log.Errorf("Error from FetchMetadata: %s", err.Error())
 		return nil, err
 	}
 

--- a/shared/metadata_util.go
+++ b/shared/metadata_util.go
@@ -14,12 +14,10 @@ import (
 	"strings"
 )
 
-const metadataArchiveURL = "https://api.github.com/repos/web-platform-tests/wpt-metadata/tarball"
-
-// CollectMetadata iterates through wpt-metadata repository and returns a
-// map that maps a test path to its META.yml file content.
-func CollectMetadata(client *http.Client) (res map[string][]byte, err error) {
-	return CollectMetadataWithURL(client, metadataArchiveURL)
+// MetadataFetcher is an abstract interface that encapsulates the Fetch() method. Fetch() fetches metadata
+// for webapp and searchcache.
+type MetadataFetcher interface {
+	Fetch() (res map[string][]byte, err error)
 }
 
 // CollectMetadataWithURL iterates through wpt-metadata repository and returns a

--- a/shared/triage_metadata.go
+++ b/shared/triage_metadata.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"errors"
 	"math/rand"
-	"net/http"
 	"strconv"
 	"time"
 
@@ -27,8 +26,8 @@ type TriageMetadataInterface interface {
 type triageMetadata struct {
 	ctx context.Context
 	MetadataGithub
-	logger     Logger
-	httpClient *http.Client
+	fetcher MetadataFetcher
+	logger  Logger
 }
 
 // MetadataGithub encapsulates all Github Information for the createWPTMetadataPR() method.
@@ -266,7 +265,7 @@ func generateRandomInt() string {
 }
 
 func (tm triageMetadata) Triage(metadata MetadataResults) (string, error) {
-	filesMap, err := GetMetadataByteMap(tm.httpClient, tm.logger, MetadataArchiveURL)
+	filesMap, err := GetMetadataByteMap(tm.logger, tm.fetcher)
 	if err != nil {
 		return "", err
 	}
@@ -277,12 +276,12 @@ func (tm triageMetadata) Triage(metadata MetadataResults) (string, error) {
 }
 
 // GetTriageMetadata returns an instance of the triageMetadata struct to run Triage() method.
-func GetTriageMetadata(ctx context.Context, git MetadataGithub, logger Logger, httpClient *http.Client) TriageMetadataInterface {
+func GetTriageMetadata(ctx context.Context, git MetadataGithub, logger Logger, fetcher MetadataFetcher) TriageMetadataInterface {
 	return triageMetadata{
 		ctx:            ctx,
 		MetadataGithub: git,
 		logger:         logger,
-		httpClient:     httpClient}
+		fetcher:        fetcher}
 }
 
 // GetMetadataGithub returns an instance of the MetadataGithub struct as a part of a triageMetadata struct.


### PR DESCRIPTION
Fix for #1776 in searchcache and webapp. This change polls Metadata update in the background in searchcache and update Metadata through memcache in webapp on a 10-minute interval.