### PR TITLE
[webapp] Implement metadata Cache for webapp

### DIFF
--- a/api/metadata_cache.go
+++ b/api/metadata_cache.go
@@ -24,7 +24,7 @@ func updateMetadataFromMemcache(ctx context.Context, log shared.Logger, client *
 		return
 	}
 
-	if err == nil {
+	if err == nil && cached != nil {
 		// Caches hit; update Metadata.
 		var metadataMap map[string][]byte
 		err = json.Unmarshal(cached.Value, &metadataMap)

--- a/api/metadata_cache.go
+++ b/api/metadata_cache.go
@@ -1,0 +1,59 @@
+// Copyright 2020 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/web-platform-tests/wpt.fyi/shared"
+	"google.golang.org/appengine/memcache"
+)
+
+const metadataCacheKey = "WPT-METADATA"
+
+func updateMetadataFromMemcache(ctx context.Context, log shared.Logger, client *http.Client) {
+	cached, err := memcache.Get(ctx, metadataCacheKey)
+
+	if err != nil && err != memcache.ErrCacheMiss {
+		log.Errorf("Error from getting Metadata in memcache: %s", err.Error())
+		return
+	}
+
+	if err == nil {
+		// Caches hit; update Metadata.
+		var metadataMap map[string][]byte
+		err = json.Unmarshal(cached.Value, &metadataMap)
+		if err != nil {
+			log.Errorf("Error from unmarshaling Metadata in memcache: %s", err.Error())
+			return
+		}
+
+		shared.UpdatedMetadataInWebapp(metadataMap)
+		return
+	}
+
+	// Caches missed.
+	metadataByteMap, err := shared.UpdatedMetadata(client, log)
+	if err != nil {
+		log.Errorf("Error from UpdatedMetadata in a cache miss: %s", err.Error())
+		return
+	}
+
+	body, err := json.Marshal(metadataByteMap)
+	if err != nil {
+		log.Errorf("Error from marshaling metadataByteMap in a cache miss: %s", err.Error())
+		return
+	}
+
+	item := &memcache.Item{
+		Key:        metadataCacheKey,
+		Value:      body,
+		Expiration: time.Minute * 10,
+	}
+	memcache.Set(ctx, item)
+}

--- a/shared/metadata_util.go
+++ b/shared/metadata_util.go
@@ -14,7 +14,27 @@ import (
 	"strings"
 )
 
+// metadataMapCached is the local cache of Metadata.
+var metadataMapCached map[string][]byte = nil
+
 const metadataArchiveURL = "https://api.github.com/repos/web-platform-tests/wpt-metadata/tarball"
+
+// UpdatedMetadataInWebapp updates metadataMapCached in webapp.
+func UpdatedMetadataInWebapp(metadataByteMap map[string][]byte) {
+	metadataMapCached = metadataByteMap
+}
+
+// UpdatedMetadata fetches Metadata from the wpt-metadata repo and updates metadataMapCached.
+func UpdatedMetadata(client *http.Client, log Logger) (res map[string][]byte, err error) {
+	metadataByteMap, err := CollectMetadataWithURL(client, MetadataArchiveURL)
+	if err != nil {
+		log.Errorf("Error from collectMetadataWithURL: %s", err.Error())
+		return nil, err
+	}
+
+	metadataMapCached = metadataByteMap
+	return metadataByteMap, nil
+}
 
 // CollectMetadata iterates through wpt-metadata repository and returns a
 // map that maps a test path to its META.yml file content.


### PR DESCRIPTION
Fix for #1776 in webapp. This change caches metadata on demand. Also see cache implementation in searchcache https://github.com/web-platform-tests/wpt.fyi/pull/1779
