### PR TITLE
Migrate from appengine/urlfetch to net/http

### DIFF
--- a/api/azure/api_test.go
+++ b/api/azure/api_test.go
@@ -98,7 +98,7 @@ func TestHandleCheckRunEvent(t *testing.T) {
 	aeAPI.EXPECT().GetResultsUploadURL().Return(uploadURL)
 	aeAPI.EXPECT().GetUploader("azure").Return(shared.Uploader{Username: "azure", Password: "123"}, nil)
 	aeAPI.EXPECT().GetHTTPClient().AnyTimes().Return(server.Client())
-	aeAPI.EXPECT().GetSlowHTTPClient(gomock.Any()).AnyTimes().Return(server.Client(), func() {})
+	aeAPI.EXPECT().GetHTTPClientWithTimeout(gomock.Any()).AnyTimes().Return(server.Client())
 
 	log, hook := logrustest.NewNullLogger()
 	ctx := context.WithValue(context.Background(), shared.DefaultLoggerCtxKey(), log)

--- a/api/query/search.go
+++ b/api/query/search.go
@@ -111,8 +111,7 @@ func (sh structuredSearchHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 		logger := shared.GetLogger(ctx)
 		logger.Infof("Forwarding structured search request to %s: %s", hostname, string(data))
 
-		client, cancel := sh.api.GetSlowHTTPClient(time.Second * 15)
-		defer cancel()
+		client := sh.api.GetHTTPClientWithTimeout(time.Second * 15)
 		req, err := http.NewRequest("POST", fwdURL.String(), bytes.NewBuffer(data))
 		if err != nil {
 			logger.Errorf("Failed to create request to POST %s: %v", fwdURL.String(), err)

--- a/api/query/search_test.go
+++ b/api/query/search_test.go
@@ -133,7 +133,7 @@ func TestStructuredSearchHandler_success(t *testing.T) {
 
 	api.EXPECT().Context().Return(sharedtest.NewTestContext())
 	api.EXPECT().GetServiceHostname("searchcache").Return(hostname)
-	api.EXPECT().GetSlowHTTPClient(gomock.Any()).Return(server.Client(), func() {})
+	api.EXPECT().GetHTTPClientWithTimeout(gomock.Any()).Return(server.Client())
 	w := httptest.NewRecorder()
 	structuredSearchHandler{queryHandler{}, api}.ServeHTTP(w, r)
 
@@ -163,7 +163,7 @@ func TestStructuredSearchHandler_failure(t *testing.T) {
 
 	api.EXPECT().Context().Return(sharedtest.NewTestContext())
 	api.EXPECT().GetServiceHostname("searchcache").Return(hostname)
-	api.EXPECT().GetSlowHTTPClient(gomock.Any()).Return(server.Client(), func() {})
+	api.EXPECT().GetHTTPClientWithTimeout(gomock.Any()).Return(server.Client())
 
 	w := httptest.NewRecorder()
 	structuredSearchHandler{queryHandler{}, api}.ServeHTTP(w, r)

--- a/api/receiver/client/client.go
+++ b/api/receiver/client/client.go
@@ -77,9 +77,8 @@ func (c client) CreateRun(
 	}
 	req.SetBasicAuth(username, password)
 
-	slowClient, cancel := c.aeAPI.GetSlowHTTPClient(UploadTimeout)
-	defer cancel()
-	resp, err := slowClient.Do(req)
+	hc := c.aeAPI.GetHTTPClientWithTimeout(UploadTimeout)
+	resp, err := hc.Do(req)
 	if err != nil {
 		return err
 	}

--- a/api/receiver/mock_receiver/api_mock.go
+++ b/api/receiver/mock_receiver/api_mock.go
@@ -98,6 +98,20 @@ func (mr *MockAPIMockRecorder) GetHTTPClient() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHTTPClient", reflect.TypeOf((*MockAPI)(nil).GetHTTPClient))
 }
 
+// GetHTTPClientWithTimeout mocks base method
+func (m *MockAPI) GetHTTPClientWithTimeout(arg0 time.Duration) *http.Client {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetHTTPClientWithTimeout", arg0)
+	ret0, _ := ret[0].(*http.Client)
+	return ret0
+}
+
+// GetHTTPClientWithTimeout indicates an expected call of GetHTTPClientWithTimeout
+func (mr *MockAPIMockRecorder) GetHTTPClientWithTimeout(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHTTPClientWithTimeout", reflect.TypeOf((*MockAPI)(nil).GetHTTPClientWithTimeout), arg0)
+}
+
 // GetHostname mocks base method
 func (m *MockAPI) GetHostname() string {
 	m.ctrl.T.Helper()
@@ -166,21 +180,6 @@ func (m *MockAPI) GetServiceHostname(arg0 string) string {
 func (mr *MockAPIMockRecorder) GetServiceHostname(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceHostname", reflect.TypeOf((*MockAPI)(nil).GetServiceHostname), arg0)
-}
-
-// GetSlowHTTPClient mocks base method
-func (m *MockAPI) GetSlowHTTPClient(arg0 time.Duration) (*http.Client, context.CancelFunc) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSlowHTTPClient", arg0)
-	ret0, _ := ret[0].(*http.Client)
-	ret1, _ := ret[1].(context.CancelFunc)
-	return ret0, ret1
-}
-
-// GetSlowHTTPClient indicates an expected call of GetSlowHTTPClient
-func (mr *MockAPIMockRecorder) GetSlowHTTPClient(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSlowHTTPClient", reflect.TypeOf((*MockAPI)(nil).GetSlowHTTPClient), arg0)
 }
 
 // GetUploader mocks base method

--- a/api/taskcluster/webhook_test.go
+++ b/api/taskcluster/webhook_test.go
@@ -256,7 +256,7 @@ func TestCreateAllRuns_success(t *testing.T) {
 	defer mockC.Finish()
 	aeAPI := sharedtest.NewMockAppEngineAPI(mockC)
 	aeAPI.EXPECT().GetVersionedHostname().AnyTimes().Return("localhost:8080")
-	aeAPI.EXPECT().GetSlowHTTPClient(uc.UploadTimeout).AnyTimes().Return(&http.Client{}, func() {})
+	aeAPI.EXPECT().GetHTTPClientWithTimeout(uc.UploadTimeout).AnyTimes().Return(server.Client())
 	aeAPI.EXPECT().GetResultsUploadURL().AnyTimes().Return(serverURL)
 
 	t.Run("master", func(t *testing.T) {
@@ -319,7 +319,7 @@ func TestCreateAllRuns_one_error(t *testing.T) {
 
 	aeAPI := sharedtest.NewMockAppEngineAPI(mockC)
 	aeAPI.EXPECT().GetVersionedHostname().MinTimes(1).Return("localhost:8080")
-	aeAPI.EXPECT().GetSlowHTTPClient(uc.UploadTimeout).Times(2).Return(&http.Client{}, func() {})
+	aeAPI.EXPECT().GetHTTPClientWithTimeout(uc.UploadTimeout).Times(2).Return(server.Client())
 	serverURL, _ := url.Parse(server.URL)
 	aeAPI.EXPECT().GetResultsUploadURL().AnyTimes().Return(serverURL)
 
@@ -355,7 +355,7 @@ func TestCreateAllRuns_all_errors(t *testing.T) {
 	aeAPI := sharedtest.NewMockAppEngineAPI(mockC)
 	aeAPI.EXPECT().GetVersionedHostname().MinTimes(1).Return("localhost:8080")
 	// Give a very short timeout (instead of the asked 1min) to make tests faster.
-	aeAPI.EXPECT().GetSlowHTTPClient(uc.UploadTimeout).MinTimes(1).Return(&http.Client{Timeout: time.Microsecond}, func() {})
+	aeAPI.EXPECT().GetHTTPClientWithTimeout(uc.UploadTimeout).MinTimes(1).Return(&http.Client{Timeout: time.Microsecond})
 	serverURL, _ := url.Parse(server.URL)
 	aeAPI.EXPECT().GetResultsUploadURL().AnyTimes().Return(serverURL)
 

--- a/shared/appengine.go
+++ b/shared/appengine.go
@@ -38,30 +38,32 @@ type AppEngineAPI interface {
 
 	// GetVersion returns the version name for the current environment.
 	GetVersion() string
-	// GetHostname returns the canonical hostname for the current AppEngine project,
-	// i.e. staging.wpt.fyi or wpt.fyi.
+	// GetHostname returns the canonical hostname for the current AppEngine
+	// project, i.e. staging.wpt.fyi or wpt.fyi.
 	GetHostname() string
-	// GetVersionedHostname returns the AppEngine hostname for the current version of the default service,
-	// i.e. version-dot-wptdashboard{,-staging}.appspot.com.
+	// GetVersionedHostname returns the AppEngine hostname for the current
+	// version of the default service, i.e.,
+	//   version-dot-wptdashboard{,-staging}.appspot.com.
 	// Note: if the default service does not have the current version,
 	// AppEngine routing will find a version according to traffic split.
 	// https://cloud.google.com/appengine/docs/standard/go/how-requests-are-routed#soft_routing
 	GetVersionedHostname() string
-	// GetServiceHostname returns the AppEngine hostname for the current version of the given service,
-	// i.e. version-dot-service-dot-wptdashboard{,-staging}.appspot.com.
+	// GetServiceHostname returns the AppEngine hostname for the current
+	// version of the given service, i.e.,
+	//   version-dot-service-dot-wptdashboard{,-staging}.appspot.com.
 	// Note: if the specified service does not have the current version,
 	// AppEngine routing will find a version according to traffic split;
 	// if the service does not exist at all, AppEngine will fall back to
 	// the default service.
 	GetServiceHostname(service string) string
 
-	// GetResultsURL returns a URL for the wpt.fyi results page for the test runs loaded for the
+	// GetResultsURL returns a URL to {staging.,}wpt.fyi/results with the
 	// given filter.
 	GetResultsURL(filter TestRunFilter) *url.URL
-	// GetRunsURL returns a URL for the wpt.fyi results page for the test runs loaded for the
-	// given filter.
+	// GetRunsURL returns a URL to {staging.,}wpt.fyi/runs with the given
+	// filter.
 	GetRunsURL(filter TestRunFilter) *url.URL
-	// GetResultsUploadURL returns a URL for uploading results (i.e. results receiver).
+	// GetResultsUploadURL returns a URL for uploading results.
 	GetResultsUploadURL() *url.URL
 
 	// Simple wrappers that delegate to Datastore

--- a/shared/run_diff.go
+++ b/shared/run_diff.go
@@ -390,7 +390,7 @@ func (d diffAPIImpl) getRunsDiffFromSearchCache(before, after TestRun, filter Di
 	}
 	body, _ := json.Marshal(diffBody{RunIDs: []int64{before.ID, after.ID}})
 
-	client, _ := d.aeAPI.GetSlowHTTPClient(time.Second * 10)
+	client := d.aeAPI.GetHTTPClientWithTimeout(time.Second * 10)
 	resp, err := client.Post(diffURL.String(), "application/json", bytes.NewBuffer(body))
 	if err != nil {
 		return diff, err

--- a/shared/sharedtest/appengine_mock.go
+++ b/shared/sharedtest/appengine_mock.go
@@ -81,6 +81,20 @@ func (mr *MockAppEngineAPIMockRecorder) GetHTTPClient() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHTTPClient", reflect.TypeOf((*MockAppEngineAPI)(nil).GetHTTPClient))
 }
 
+// GetHTTPClientWithTimeout mocks base method
+func (m *MockAppEngineAPI) GetHTTPClientWithTimeout(arg0 time.Duration) *http.Client {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetHTTPClientWithTimeout", arg0)
+	ret0, _ := ret[0].(*http.Client)
+	return ret0
+}
+
+// GetHTTPClientWithTimeout indicates an expected call of GetHTTPClientWithTimeout
+func (mr *MockAppEngineAPIMockRecorder) GetHTTPClientWithTimeout(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHTTPClientWithTimeout", reflect.TypeOf((*MockAppEngineAPI)(nil).GetHTTPClientWithTimeout), arg0)
+}
+
 // GetHostname mocks base method
 func (m *MockAppEngineAPI) GetHostname() string {
 	m.ctrl.T.Helper()
@@ -149,21 +163,6 @@ func (m *MockAppEngineAPI) GetServiceHostname(arg0 string) string {
 func (mr *MockAppEngineAPIMockRecorder) GetServiceHostname(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceHostname", reflect.TypeOf((*MockAppEngineAPI)(nil).GetServiceHostname), arg0)
-}
-
-// GetSlowHTTPClient mocks base method
-func (m *MockAppEngineAPI) GetSlowHTTPClient(arg0 time.Duration) (*http.Client, context.CancelFunc) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSlowHTTPClient", arg0)
-	ret0, _ := ret[0].(*http.Client)
-	ret1, _ := ret[1].(context.CancelFunc)
-	return ret0, ret1
-}
-
-// GetSlowHTTPClient indicates an expected call of GetSlowHTTPClient
-func (mr *MockAppEngineAPIMockRecorder) GetSlowHTTPClient(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSlowHTTPClient", reflect.TypeOf((*MockAppEngineAPI)(nil).GetSlowHTTPClient), arg0)
 }
 
 // GetUploader mocks base method

--- a/shared/sharedtest/run_diff_mock.go
+++ b/shared/sharedtest/run_diff_mock.go
@@ -5,7 +5,7 @@
 package sharedtest
 
 import (
-	golang_set "github.com/deckarep/golang-set"
+	mapset "github.com/deckarep/golang-set"
 	gomock "github.com/golang/mock/gomock"
 	shared "github.com/web-platform-tests/wpt.fyi/shared"
 	url "net/url"
@@ -64,7 +64,7 @@ func (mr *MockDiffAPIMockRecorder) GetMasterDiffURL(arg0, arg1 interface{}) *gom
 }
 
 // GetRunsDiff mocks base method
-func (m *MockDiffAPI) GetRunsDiff(arg0, arg1 shared.TestRun, arg2 shared.DiffFilterParam, arg3 golang_set.Set) (shared.RunDiff, error) {
+func (m *MockDiffAPI) GetRunsDiff(arg0, arg1 shared.TestRun, arg2 shared.DiffFilterParam, arg3 mapset.Set) (shared.RunDiff, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRunsDiff", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(shared.RunDiff)

--- a/shared/sharedtest/test_run_query_mock.go
+++ b/shared/sharedtest/test_run_query_mock.go
@@ -5,7 +5,7 @@
 package sharedtest
 
 import (
-	golang_set "github.com/deckarep/golang-set"
+	mapset "github.com/deckarep/golang-set"
 	gomock "github.com/golang/mock/gomock"
 	shared "github.com/web-platform-tests/wpt.fyi/shared"
 	reflect "reflect"
@@ -36,7 +36,7 @@ func (m *MockTestRunQuery) EXPECT() *MockTestRunQueryMockRecorder {
 }
 
 // GetAlignedRunSHAs mocks base method
-func (m *MockTestRunQuery) GetAlignedRunSHAs(arg0 shared.ProductSpecs, arg1 golang_set.Set, arg2, arg3 *time.Time, arg4, arg5 *int) ([]string, map[string]shared.KeysByProduct, error) {
+func (m *MockTestRunQuery) GetAlignedRunSHAs(arg0 shared.ProductSpecs, arg1 mapset.Set, arg2, arg3 *time.Time, arg4, arg5 *int) ([]string, map[string]shared.KeysByProduct, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAlignedRunSHAs", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].([]string)
@@ -52,7 +52,7 @@ func (mr *MockTestRunQueryMockRecorder) GetAlignedRunSHAs(arg0, arg1, arg2, arg3
 }
 
 // LoadTestRunKeys mocks base method
-func (m *MockTestRunQuery) LoadTestRunKeys(arg0 []shared.ProductSpec, arg1 golang_set.Set, arg2 []string, arg3, arg4 *time.Time, arg5, arg6 *int) (shared.KeysByProduct, error) {
+func (m *MockTestRunQuery) LoadTestRunKeys(arg0 []shared.ProductSpec, arg1 mapset.Set, arg2 []string, arg3, arg4 *time.Time, arg5, arg6 *int) (shared.KeysByProduct, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LoadTestRunKeys", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].(shared.KeysByProduct)
@@ -67,7 +67,7 @@ func (mr *MockTestRunQueryMockRecorder) LoadTestRunKeys(arg0, arg1, arg2, arg3, 
 }
 
 // LoadTestRuns mocks base method
-func (m *MockTestRunQuery) LoadTestRuns(arg0 []shared.ProductSpec, arg1 golang_set.Set, arg2 []string, arg3, arg4 *time.Time, arg5, arg6 *int) (shared.TestRunsByProduct, error) {
+func (m *MockTestRunQuery) LoadTestRuns(arg0 []shared.ProductSpec, arg1 mapset.Set, arg2 []string, arg3, arg4 *time.Time, arg5, arg6 *int) (shared.TestRunsByProduct, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LoadTestRuns", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].(shared.TestRunsByProduct)


### PR DESCRIPTION
We still don't know why #1808 is happening, but based on experiments
switching to net/http fixes #1808, and it is recommended anyway (also
part of #1747).

This unfortunately changes the signature of a widely used method.
