### PR TITLE
Manifest trie

### DIFF
--- a/api/manifest/util.go
+++ b/api/manifest/util.go
@@ -13,7 +13,7 @@ import (
 // Filter filters items in the the given manifest JSON, omitting anything that isn't an
 // item which has a URL beginning with one of the given paths.
 func Filter(body []byte, paths []string) (result []byte, err error) {
-	var parsed shared.Manifest
+	var parsed *shared.Manifest
 	if err = json.Unmarshal(body, &parsed); err != nil {
 		return nil, err
 	}

--- a/api/manifest/util_test.go
+++ b/api/manifest/util_test.go
@@ -7,55 +7,45 @@
 package manifest
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
-func TestFilter_Reftest(t *testing.T) {
+func TestFilter(t *testing.T) {
+	// This is a smoke test; see shared/manifest_test.go for more tests.
 	bytes := []byte(`{
-	"items": {
-		"reftest": {
-      "css/css-images/linear-gradient-2.html": [
-        [
-					"/css/css-images/linear-gradient-2.html",
-					[ ["/css/css-images/linear-gradient-ref.html","=="] ],
-          {}
-        ]
-      ],
-      "css/css-images/tiled-gradients.html": [
-        [
-					"/css/css-images/tiled-gradients.html",
-					[ ["/css/css-images/tiled-gradients-ref.html","=="] ],
-          {}
-        ]
+"items": {
+	"testharness": {
+		"foo": {
+			"bar": {
+				"test.html": [
+					"1d3166465cc6f2e8f9f18f53e499ca61e12d59bd",
+					[null, {}]
+				]
+
+			}
+		},
+		"foobar": {
+			"mytest.html": [
+				"2d3166465cc6f2e8f9f18f53e499ca61e12d59bd",
+				[null, {}]
+			]
+		}
+	},
+	"manual": {
+		"foobar": {
+			"test-manual.html": [
+				"3d3166465cc6f2e8f9f18f53e499ca61e12d59bd",
+				[null, {}]
 			]
 		}
 	}
+},
+"version": 8
 }`)
 
-	// Specific file
-	filtered, err := Filter(bytes, []string{"/css/css-images/tiled-gradients.html"})
+	filtered, err := Filter(bytes, []string{"/foo/bar"})
 	assert.Nil(t, err)
-	unmarshalled := shared.Manifest{}
-	json.Unmarshal(filtered, &unmarshalled)
-	assert.NotNil(t, unmarshalled.Items.Reftest)
-	assert.Equal(t, 1, len(unmarshalled.Items.Reftest))
-
-	// Prefix
-	filtered, err = Filter(bytes, []string{"/css/css-images/"})
-	assert.Nil(t, err)
-	unmarshalled = shared.Manifest{}
-	json.Unmarshal(filtered, &unmarshalled)
-	assert.NotNil(t, unmarshalled.Items.Reftest)
-	assert.Equal(t, 2, len(unmarshalled.Items.Reftest))
-
-	// No matches
-	filtered, err = Filter(bytes, []string{"/not-a-folder/test.html"})
-	assert.Nil(t, err)
-	unmarshalled = shared.Manifest{}
-	json.Unmarshal(filtered, &unmarshalled)
-	assert.Equal(t, 0, len(unmarshalled.Items.Reftest))
+	assert.Equal(t, `{"items":{"testharness":{"foo":{"bar":{"test.html":["1d3166465cc6f2e8f9f18f53e499ca61e12d59bd",[null,{}]]}}}},"version":8}`, string(filtered))
 }

--- a/shared/manifest.go
+++ b/shared/manifest.go
@@ -4,7 +4,73 @@
 
 package shared
 
-import "strings"
+import (
+	"encoding/json"
+	"strings"
+)
+
+// Manifest represents a JSON blob of all the WPT tests.
+type Manifest struct {
+	Items   map[string]rawManifestTrie `json:"items,omitempty"`
+	Version int                        `json:"version,omitempty"`
+	URLBase string                     `json:"url_base,omitempty"`
+}
+
+// We use a recursive map[string]json.RawMessage structure to parse one layer
+// at a time and only when needed (json.RawMessage stores the raw bytes). We
+// redefine json.RawMessage to add custom methods, but that means we have to
+// explicitly define and forward MarshalJSON/UnmarshalJSON to json.RawMessage.
+type rawManifestTrie json.RawMessage
+
+func (t rawManifestTrie) MarshalJSON() ([]byte, error) {
+	return json.RawMessage(t).MarshalJSON()
+}
+
+func (t *rawManifestTrie) UnmarshalJSON(b []byte) error {
+	return json.Unmarshal(b, (*json.RawMessage)(t))
+}
+
+// FilterByPath filters all the manifest items by path prefixes.
+func (m Manifest) FilterByPath(paths ...string) (*Manifest, error) {
+	result := &Manifest{Items: make(map[string]rawManifestTrie), Version: m.Version}
+	for _, p := range paths {
+		parts := strings.Split(p, "/")
+		// Split always returns at least one element.
+		// Remove the leading empty part.
+		if parts[0] == "" {
+			parts = parts[1:]
+		}
+		for testType, trie := range m.Items {
+			filtered, err := trie.FilterByPath(parts)
+			if err != nil {
+				return nil, err
+			}
+			if filtered != nil {
+				result.Items[testType] = filtered
+			}
+		}
+	}
+	return result, nil
+}
+
+func (t rawManifestTrie) FilterByPath(pathParts []string) (rawManifestTrie, error) {
+	if t == nil || len(pathParts) == 0 {
+		return t, nil
+	}
+
+	// Unmarshal one more layer.
+	var expanded map[string]rawManifestTrie
+	if err := json.Unmarshal(t, &expanded); err != nil {
+		return nil, err
+	}
+
+	subT, err := expanded[pathParts[0]].FilterByPath(pathParts[1:])
+	if subT == nil || err != nil {
+		return nil, err
+	}
+	filtered := map[string]rawManifestTrie{pathParts[0]: subT}
+	return json.Marshal(filtered)
+}
 
 // explosions returns a map of the exploded test by filename suffix.
 // https://web-platform-tests.org/writing-tests/testharness.html#multi-global-tests

--- a/shared/manifest_test.go
+++ b/shared/manifest_test.go
@@ -7,10 +7,93 @@
 package shared
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestManifestFilterByPath(t *testing.T) {
+	manifest := []byte(`{
+"items": {
+	"testharness": {
+		"foo": {
+			"bar": {
+				"test.html": [
+					"1d3166465cc6f2e8f9f18f53e499ca61e12d59bd",
+					[null, {}]
+				]
+
+			}
+		},
+		"foobar": {
+			"mytest.html": [
+				"2d3166465cc6f2e8f9f18f53e499ca61e12d59bd",
+				[null, {}]
+			]
+		}
+	},
+	"manual": {
+		"foobar": {
+			"test-manual.html": [
+				"3d3166465cc6f2e8f9f18f53e499ca61e12d59bd",
+				[null, {}]
+			]
+		}
+	}
+},
+"version": 8
+}`)
+
+	t.Run("empty match", func(t *testing.T) {
+		var m Manifest
+		err := json.Unmarshal(manifest, &m)
+		assert.Nil(t, err)
+
+		res, err := m.FilterByPath("/non-existent")
+		assert.Nil(t, err)
+		assert.Equal(t, 0, len(res.Items))
+		assert.Equal(t, 8, res.Version)
+	})
+
+	t.Run("match nested", func(t *testing.T) {
+		var m Manifest
+		err := json.Unmarshal(manifest, &m)
+		assert.Nil(t, err)
+
+		res, err := m.FilterByPath("/foo/bar")
+		assert.Nil(t, err)
+		assert.Equal(t, `{"foo":{"bar":{"test.html":["1d3166465cc6f2e8f9f18f53e499ca61e12d59bd",[null,{}]]}}}`, string(res.Items["testharness"]))
+		_, ok := res.Items["manual"]
+		assert.False(t, ok)
+		assert.Equal(t, 8, res.Version)
+	})
+
+	t.Run("match single", func(t *testing.T) {
+		var m Manifest
+		err := json.Unmarshal(manifest, &m)
+		assert.Nil(t, err)
+
+		res, err := m.FilterByPath("/foo")
+		assert.Nil(t, err)
+		assert.Equal(t, `{"foo":{"bar":{"test.html":["1d3166465cc6f2e8f9f18f53e499ca61e12d59bd",[null,{}]]}}}`, string(res.Items["testharness"]))
+		_, ok := res.Items["manual"]
+		assert.False(t, ok)
+		assert.Equal(t, 8, res.Version)
+	})
+
+	t.Run("match multiple", func(t *testing.T) {
+		var m Manifest
+		err := json.Unmarshal(manifest, &m)
+		assert.Nil(t, err)
+
+		res, err := m.FilterByPath("/foobar")
+		assert.Nil(t, err)
+		assert.Equal(t, `{"foobar":{"mytest.html":["2d3166465cc6f2e8f9f18f53e499ca61e12d59bd",[null,{}]]}}`, string(res.Items["testharness"]))
+		assert.Equal(t, `{"foobar":{"test-manual.html":["3d3166465cc6f2e8f9f18f53e499ca61e12d59bd",[null,{}]]}}`, string(res.Items["manual"]))
+		assert.Equal(t, 8, res.Version)
+	})
+}
 
 func TestExplodePossibleFilename_AnyJS(t *testing.T) {
 	filename := "/test/file.any.js"

--- a/shared/models.go
+++ b/shared/models.go
@@ -7,7 +7,6 @@ package shared
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
 	mapset "github.com/deckarep/golang-set"
@@ -421,70 +420,6 @@ type Browser struct {
 // Token is used for test result uploads.
 type Token struct {
 	Secret string `json:"secret"`
-}
-
-// Manifest represents a JSON blob of all the WPT tests.
-type Manifest struct {
-	Items   ManifestItems `json:"items,omitempty"`
-	Version *int          `json:"version,omitempty"`
-}
-
-// FilterByPath filters all the manifest items by path.
-func (m Manifest) FilterByPath(paths ...string) (result Manifest, err error) {
-	result = m
-	if result.Items.Manual, err = m.Items.Manual.FilterByPath(paths...); err != nil {
-		return result, err
-	}
-	if result.Items.Reftest, err = m.Items.Reftest.FilterByPath(paths...); err != nil {
-		return result, err
-	}
-	if result.Items.TestHarness, err = m.Items.TestHarness.FilterByPath(paths...); err != nil {
-		return result, err
-	}
-	if result.Items.WDSpec, err = m.Items.WDSpec.FilterByPath(paths...); err != nil {
-		return result, err
-	}
-	return result, nil
-}
-
-// ManifestItems groups the different manifest item types.
-type ManifestItems struct {
-	Manual      ManifestItem `json:"manual"`
-	Reftest     ManifestItem `json:"reftest"`
-	TestHarness ManifestItem `json:"testharness"`
-	WDSpec      ManifestItem `json:"wdspec"`
-}
-
-// ManifestItem represents a map of files to item details, for a specific test type.
-type ManifestItem map[string][][]*json.RawMessage
-
-// FilterByPath culls out entries in the ManifestItem that don't have any items with
-// a URL that starts with the given path.
-func (m ManifestItem) FilterByPath(paths ...string) (item ManifestItem, err error) {
-	if m == nil {
-		return nil, nil
-	}
-	filtered := make(ManifestItem)
-	for path, items := range m {
-		match := false
-		for _, item := range items {
-			var url string
-			if err = json.Unmarshal(*item[0], &url); err != nil {
-				return nil, err
-			}
-			for _, prefix := range paths {
-				if strings.Index(url, prefix) == 0 {
-					match = true
-					break
-				}
-			}
-		}
-		if !match {
-			continue
-		}
-		filtered[path] = items
-	}
-	return filtered, nil
 }
 
 // Uploader is a username/password combo accepted by


### PR DESCRIPTION
The first commit fixes #1777 , while the second commit implements a new API for `wpt-metadata` (cc @KyleJu : let me know if `Contains` isn't enough for wpt-metadata).