### PR TITLE
Implement Manifest.ContainsTest

### DIFF
--- a/shared/manifest.go
+++ b/shared/manifest.go
@@ -114,7 +114,6 @@ func (m *Manifest) ContainsTest(testURL string) (bool, error) {
 	testURL = strings.TrimLeft(testURL, "/")
 	path, query := ParseTestURL(testURL)
 	parts := strings.Split(path, "/")
-	// parts=["foo", "bar", "test.any.js"]
 	for _, trie := range m.imap {
 		leaf, ok := findNode(trie, parts).([]interface{})
 		if !ok {
@@ -128,7 +127,7 @@ func (m *Manifest) ContainsTest(testURL string) (bool, error) {
 			return false, ErrInvalidManifest
 		}
 		for _, v := range leaf[1:] {
-			// variant=[url, extra]
+			// variant=[url, extras...]
 			variant, ok := v.([]interface{})
 			if !ok || len(variant) < 2 {
 				return false, ErrInvalidManifest
@@ -234,7 +233,7 @@ func ExplodePossibleFilenames(filePath string) []string {
 // ParseTestURL parses a WPT test URL and returns its file path and query
 // components. If the test is a multi-global (auto-generated) test, the
 // function returns the underlying file name of the test.
-// e.g. testURL="foo/bar/test.any.worker.html?varaint"
+// e.g. testURL="foo/bar/test.any.worker.html?variant"
 //      filepath="foo/bar/test.any.js"
 //      query="?variant"
 func ParseTestURL(testURL string) (filePath, query string) {
@@ -244,10 +243,10 @@ func ParseTestURL(testURL string) (filePath, query string) {
 		query = testURL[qPos:]
 	}
 	for _, i := range implosions() {
-		tSuffix := i[0]
-		fSuffix := i[1]
-		if strings.HasSuffix(filePath, tSuffix) {
-			filePath = strings.TrimSuffix(filePath, tSuffix) + fSuffix
+		testSuffix := i[0]
+		fileSuffix := i[1]
+		if strings.HasSuffix(filePath, testSuffix) {
+			filePath = strings.TrimSuffix(filePath, testSuffix) + fileSuffix
 			break
 		}
 	}

--- a/shared/manifest_test.go
+++ b/shared/manifest_test.go
@@ -145,12 +145,30 @@ func TestExplodePossibleRenames_WorkerJS(t *testing.T) {
 	assert.Equal(t, ExplodePossibleRenames(before, after), renames)
 }
 
-func TestRecoverTestFilename(t *testing.T) {
-	assert.Equal(t, "/normal/file.html", RecoverTestFilename("/normal/file.html"))
-	assert.Equal(t, "file.html", RecoverTestFilename("file.html"))
-	assert.Equal(t, "/test/file.any.js", RecoverTestFilename("/test/file.any.html"))
-	assert.Equal(t, "file.any.js", RecoverTestFilename("file.any.worker.html"))
-	assert.Equal(t, "file.worker.js", RecoverTestFilename("file.worker.html"))
+func TestParseTestURL(t *testing.T) {
+	t.Run("normal/file.html", func(t *testing.T) {
+		p, q := ParseTestURL("normal/file.html")
+		assert.Equal(t, "normal/file.html", p)
+		assert.Equal(t, "", q)
+	})
+	t.Run("test/file.any.html", func(t *testing.T) {
+		p, q := ParseTestURL("test/file.any.html")
+		assert.Equal(t, "test/file.any.js", p)
+		assert.Equal(t, "", q)
+
+	})
+	t.Run("test/file.any.worker.html?variant", func(t *testing.T) {
+		p, q := ParseTestURL("test/file.any.worker.html?variant")
+		assert.Equal(t, "test/file.any.js", p)
+		assert.Equal(t, "?variant", q)
+
+	})
+	t.Run("file.worker.html?t=1/2", func(t *testing.T) {
+		p, q := ParseTestURL("file.worker.html?t=1/2")
+		assert.Equal(t, "file.worker.js", p)
+		assert.Equal(t, "?t=1/2", q)
+
+	})
 }
 
 func TestManifestContainsFile(t *testing.T) {


### PR DESCRIPTION
Rename `Contains` to `ContainsFile` to make it clear that it checks the
existence of a file path (or directory path), and implement a new
`ContainsTest` method to check the existence of a test URL.

`ContainsTest` supports both multi-global tests and test variants.

## Review Information

I'm not quite happy about some of the names (especially the exported one). Please feel free to give suggestions.