### PR TITLE
Add the missing Content-Type header back

### DIFF
--- a/api/receiver/client/client.go
+++ b/api/receiver/client/client.go
@@ -76,6 +76,7 @@ func (c client) CreateRun(
 		return err
 	}
 	req.SetBasicAuth(username, password)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 	hc := c.aeAPI.GetHTTPClientWithTimeout(UploadTimeout)
 	resp, err := hc.Do(req)

--- a/api/receiver/client/client_test.go
+++ b/api/receiver/client/client_test.go
@@ -1,0 +1,59 @@
+// +build small
+
+// Copyright 2020 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package client
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
+)
+
+func TestCreateRun(t *testing.T) {
+	// To make sure we actually hit the assertion in the handler.
+	visited := false
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Header.Get("Content-Type"), "application/x-www-form-urlencoded")
+		user, pass, ok := r.BasicAuth()
+		assert.True(t, ok)
+		assert.Equal(t, "blade-runner", user)
+		assert.Equal(t, "password", pass)
+		assert.Nil(t, r.ParseForm())
+		assert.Equal(t, []string{"https://wpt.fyi/results.json.gz"}, r.PostForm["result_url"])
+		assert.Equal(t, []string{"https://wpt.fyi/screenshots.db.gz"}, r.PostForm["screenshot_url"])
+		assert.Equal(t, "foo,bar", r.PostForm.Get("labels"))
+		w.Write([]byte("OK"))
+		visited = true
+	}
+	server := httptest.NewServer(http.HandlerFunc(handler))
+	defer server.Close()
+	serverURL, _ := url.Parse(server.URL)
+
+	mockC := gomock.NewController(t)
+	defer mockC.Finish()
+	aeAPI := sharedtest.NewMockAppEngineAPI(mockC)
+	gomock.InOrder(
+		aeAPI.EXPECT().GetVersionedHostname().Return("localhost:8080"),
+		aeAPI.EXPECT().GetResultsUploadURL().Return(serverURL),
+		aeAPI.EXPECT().GetHTTPClientWithTimeout(UploadTimeout).Return(server.Client()),
+	)
+
+	uc := NewClient(aeAPI)
+	assert.Nil(t, uc.CreateRun(
+		"abcdef1234abcdef1234abcdef1234abcdef1234",
+		"blade-runner",
+		"password",
+		[]string{"https://wpt.fyi/results.json.gz"},
+		[]string{"https://wpt.fyi/screenshots.db.gz"},
+		[]string{"foo", "bar"},
+	))
+	assert.True(t, visited)
+}

--- a/api/receiver/receive_results_test.go
+++ b/api/receiver/receive_results_test.go
@@ -260,3 +260,23 @@ func TestHandleResultsUpload_fail_uploading(t *testing.T) {
 	HandleResultsUpload(mockAE, resp, req)
 	assert.Equal(t, resp.Code, http.StatusInternalServerError)
 }
+
+func TestHandleResultsUpload_empty_payload(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	req := httptest.NewRequest("POST", "/api/results/upload", nil)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth("blade-runner", "123")
+	resp := httptest.NewRecorder()
+
+	mockAE := mock_receiver.NewMockAPI(mockCtrl)
+	mockAE.EXPECT().Context().Return(sharedtest.NewTestContext()).AnyTimes()
+	gomock.InOrder(
+		mockAE.EXPECT().IsAdmin().Return(false),
+		mockAE.EXPECT().GetUploader("blade-runner").Return(shared.Uploader{"blade-runner", "123"}, nil),
+	)
+
+	HandleResultsUpload(mockAE, resp, req)
+	assert.Equal(t, resp.Code, http.StatusBadRequest)
+}


### PR DESCRIPTION
This attempts to fix #1830.

Missing Content-Type: application/x-url-form-encoded when posting an
HTTP form is clearly a bug, but it is unclear why it only started to
surface after #1811.

A preventative measure is also added to return an error when the upload
payload is empty, along with some minor improvements to logging.
