### PR TITLE
Avoid dereferencing null in webdriver tests

### DIFF
--- a/webdriver/webdriver.go
+++ b/webdriver/webdriver.go
@@ -126,7 +126,7 @@ func FindShadowElements(
 		result, err := d.ExecuteScriptRaw(
 			fmt.Sprintf(`return Array.from(arguments)
 				.reduce((s, e) => {
-					return s.concat(Array.from(e.shadowRoot.querySelectorAll('%s')))
+					return e.shadowRoot ? s.concat(Array.from(e.shadowRoot.querySelectorAll('%s'))) : s
 				}, [])`,
 				selector),
 			interfaces)


### PR DESCRIPTION
`e.shadowRoot` might be null if the custom element hasn't been defined, in which case we should not try to query elements in the shadow DOM (and retry instead).

Example panic:
```
panic: javascript error: javascript error: Cannot read property 'querySelectorAll' of null
  (Session info: chrome=80.0.3987.132)
  (Driver info: chromedriver=80.0.3987.106 (f68069574609230cf9b635cd784cfb1bf81bb53a-refs/branch-heads/3987@{#882}),platform=Linux 5.0.0-1032-azure x86_64) [recovered]
	panic: javascript error: javascript error: Cannot read property 'querySelectorAll' of null
  (Session info: chrome=80.0.3987.132)
  (Driver info: chromedriver=80.0.3987.106 (f68069574609230cf9b635cd784cfb1bf81bb53a-refs/branch-heads/3987@{#882}),platform=Linux 5.0.0-1032-azure x86_64)
```