### PR TITLE
Fix a panic in diff.go

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -211,6 +211,10 @@ in the format of an array of [improved, regressed, total-delta].
 
 __Parameters__
 
+__`run_ids`__ : Exactly two numerical IDs for the "before" and "after" runs (in
+that order), separted by a comma. IDs associated with runs can be obtained by
+querying the `/api/runs` API. This overrides the `before` and `after` params.
+
 __`before`__ : [product]@[sha] spec for the TestRun to use as the before state.
 
 __`after`__ : [product]@[sha] spec for the TestRun to use as the after state.

--- a/api/diff.go
+++ b/api/diff.go
@@ -30,77 +30,72 @@ func apiDiffHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-type diffResult struct {
-	Diff    shared.ResultsDiff `json:"diff"`
-	Renames map[string]string  `json:"renames,omitempty"`
+func loadDiffRuns(store shared.Datastore, q url.Values) (shared.TestRuns, error) {
+	if runIDs, err := shared.ParseRunIDsParam(q); err != nil {
+		return nil, err
+	} else if len(runIDs) > 0 {
+		runs, err := runIDs.LoadTestRuns(store)
+		// If all errors are NoSuchEntity, we don't treat it as an error.
+		// If err is nil, the type conversion will fail.
+		if multiError, ok := err.(appengine.MultiError); ok {
+			all404s := true
+			for _, err := range multiError {
+				if err != datastore.ErrNoSuchEntity {
+					all404s = false
+					break
+				}
+			}
+			if all404s {
+				return nil, nil
+			}
+		}
+		// err many be non nil here.
+		return runs, err
+	}
+
+	// NOTE: We use the same params as /results, but also support
+	// 'before' and 'after' and 'filter'.
+	runFilter, err := shared.ParseTestRunFilterParams(q)
+	if err != nil {
+		return nil, err
+	}
+	if beforeAndAfter, err := shared.ParseBeforeAndAfterParams(q); err != nil {
+		return nil, err
+	} else if len(beforeAndAfter) > 0 {
+		runFilter.Products = beforeAndAfter
+	}
+	runsByProduct, err := LoadTestRunsForFilters(store, runFilter)
+	if err != nil {
+		return nil, err
+	}
+	return runsByProduct.AllRuns(), nil
 }
 
 func handleAPIDiffGet(w http.ResponseWriter, r *http.Request) {
 	ctx := shared.NewAppEngineContext(r)
-
-	q := r.URL.Query()
-	runIDs, err := shared.ParseRunIDsParam(q)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-
-	var diffFilter shared.DiffFilterParam
-	var paths mapset.Set
-	if diffFilter, paths, err = shared.ParseDiffFilterParams(q); err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-
 	store := shared.NewAppEngineDatastore(ctx, true)
-	var runs shared.TestRuns
-	if len(runIDs) > 0 {
-		runs, err = runIDs.LoadTestRuns(store)
-		if err != nil {
-			if multiError, ok := err.(appengine.MultiError); ok {
-				all404s := true
-				for _, err := range multiError {
-					if err != datastore.ErrNoSuchEntity {
-						all404s = false
-					}
-				}
-				if all404s {
-					http.NotFound(w, r)
-					return
-				}
-			}
-		}
-	} else {
-		// NOTE: We use the same params as /results, but also support
-		// 'before' and 'after' and 'filter'.
-		runFilter, parseErr := shared.ParseTestRunFilterParams(q)
-		if parseErr != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-		beforeAndAfter, parseErr := shared.ParseBeforeAndAfterParams(q)
-		if parseErr != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-		if len(beforeAndAfter) > 0 {
-			runFilter.Products = beforeAndAfter
-		}
-		var runsByProduct shared.TestRunsByProduct
-		runsByProduct, err = LoadTestRunsForFilters(store, runFilter)
-		if err != nil {
-			runs = runsByProduct.AllRuns()
-		}
+	q := r.URL.Query()
+
+	runs, err := loadDiffRuns(store, q)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if runs == nil {
+		http.NotFound(w, r)
+		return
 	}
 
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	} else if len(runs) != 2 {
+	if len(runs) != 2 {
 		http.Error(w, fmt.Sprintf("Diffing requires exactly 2 runs, but found %v", len(runs)), http.StatusBadRequest)
 		return
 	}
 
+	diffFilter, paths, err := shared.ParseDiffFilterParams(q)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 	diffAPI := shared.NewDiffAPI(ctx)
 	diff, err := diffAPI.GetRunsDiff(runs[0], runs[1], diffFilter, paths)
 	if err != nil {
@@ -121,7 +116,6 @@ func handleAPIDiffGet(w http.ResponseWriter, r *http.Request) {
 func handleAPIDiffPost(w http.ResponseWriter, r *http.Request) {
 	ctx := shared.NewAppEngineContext(r)
 
-	var err error
 	params, err := url.ParseQuery(r.URL.RawQuery)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -149,7 +143,7 @@ func handleAPIDiffPost(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var afterJSON shared.ResultsSummary
-	if err = json.Unmarshal(body, &afterJSON); err != nil {
+	if err := json.Unmarshal(body, &afterJSON); err != nil {
 		http.Error(w, "Failed to parse JSON: "+err.Error(), http.StatusBadRequest)
 		return
 	}


### PR DESCRIPTION
panic: runtime error: invalid memory address or nil pointer dereference
goroutine 16 [running]:
google.golang.org/appengine/panic
	/usr/local/go/src/runtime/panic.go:513
github.com/web-platform-tests/wpt.fyi/api.handleAPIDiffGet
	/tmp/staging/srv/api/diff.go:83
github.com/web-platform-tests/wpt.fyi/api.apiDiffHandler
	/tmp/staging/srv/api/diff.go:25

The direct cause is trying to dereference an incorrect error (err
instead of parseErr). However, the whole function body was convoluted
and error-prone, so I've decided to refactor it (extract `loadDiffRuns`
out) to make error handling clearer.

Also remove an unused type definition.