### PR TITLE
Cleanup .gitignore and .gcloudignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-**/node_modules
+node_modules/
 debug.test
-**/packrd/
-**/*-packr.go
+packrd/
+*-packr.go

--- a/webapp/web/.gcloudignore
+++ b/webapp/web/.gcloudignore
@@ -1,3 +1,7 @@
+# Files matching the following rules won't be uploaded to AppEngine (webapp).
+# The syntax is the same as `.gitignore`; we do not use `.gitignore` directly
+# because we need to update some generated files.
+
 # Tests
 *_test.go
 test/

--- a/webapp/web/.gcloudignore
+++ b/webapp/web/.gcloudignore
@@ -4,10 +4,10 @@
 
 # Tests
 *_test.go
+/webapp/static/wptd-metrics/
+/webapp/static/24278ab617/
+/webdriver/
 test/
-webdriver/
-static/24278ab617/
-static/wptd-metrics/
 
 # Configurations
 .eslintrc.json
@@ -21,22 +21,22 @@ wct.conf.json
 .github/
 .lighthouseci/
 .vscode/
+/docs/
+/git/
 CODE_OF_CONDUCT.md
 CONTRIBUTING.md
 ISSUE_TEMPLATE.md
 ISSUE_TEMPLATE/
 PULL_REQUEST_TEMPLATE.md
 README.md
-docs/
-git/
 
 # Other services
-api/query/cache/service/
-results-processor/
-util/
+/api/query/cache/service/
+/results-processor/
+/util/
 
 # Ignore files bundled with packr
-api/checks/summaries/templates/
-webapp/dynamic-components/
-webapp/node_modules/
-webapp/templates/
+/api/checks/summaries/templates/
+/webapp/dynamic-components/
+/webapp/node_modules/
+/webapp/templates/

--- a/webapp/web/.gcloudignore
+++ b/webapp/web/.gcloudignore
@@ -1,28 +1,35 @@
-# Don't upload test data, package config, etc. to AppEngine.
-**/*_test.go
-.eslintrc.json
-.git/
-.github/
-.vscode/
-build/
-CODE_OF_CONDUCT.md
-components/test/
-docs/
-git/
-ISSUE_TEMPLATE/
-ISSUE_TEMPLATE.md
-LICENSE
-package-lock.json
-package.json
-PULL_REQUEST_TEMPLATE.md
-README.md
-results-processor/
-revisions/
+# Tests
+*_test.go
+test/
+webdriver/
 static/24278ab617/
 static/wptd-metrics/
-test/
+
+# Configurations
+.eslintrc.json
+package-lock.json
+package.json
+renovate.json
 wct.conf.json
-webdriver/
+
+# Misc
+.git/
+.github/
+.lighthouseci/
+.vscode/
+CODE_OF_CONDUCT.md
+CONTRIBUTING.md
+ISSUE_TEMPLATE.md
+ISSUE_TEMPLATE/
+PULL_REQUEST_TEMPLATE.md
+README.md
+docs/
+git/
+
+# Other services
+api/query/cache/service/
+results-processor/
+util/
 
 # Ignore files bundled with packr
 api/checks/summaries/templates/


### PR DESCRIPTION
* Some files no longer exist.
* Simplify rules (e.g. `**/foo` and `foo/*` are equivalent to `foo/`).
* Sort rules by categories.
