### PR TITLE
Add Triage Metadata Tests for Asterisks and Subtests

### DIFF
--- a/shared/triage_metadata_test.go
+++ b/shared/triage_metadata_test.go
@@ -301,5 +301,5 @@ links:
 	assert.Equal(t, "https://bug.com/item", actual.Links[1].URL)
 	assert.Equal(t, "chrome", actual.Links[2].Product.BrowserName)
 	assert.Equal(t, "foo1", actual.Links[2].URL)
-	assert.Equal(t, "0", actual.Links[2].Results[0].TestPath)
+	assert.Equal(t, "*", actual.Links[2].Results[0].TestPath)
 }


### PR DESCRIPTION
Add Triage Metadata Tests for Asterisks and Subtests. In preparation for landing #1866