### PR TITLE
Collect crashtest results from Taskcluster

### DIFF
--- a/api/taskcluster/webhook.go
+++ b/api/taskcluster/webhook.go
@@ -28,7 +28,7 @@ const flagPendingChecks = "pendingChecks"
 var (
 	// This should follow https://github.com/web-platform-tests/wpt/blob/master/.taskcluster.yml
 	// with a notable exception that "*-stability" runs are not included at the moment.
-	taskNameRegex = regexp.MustCompile(`^wpt-(\w+-\w+)-(testharness|reftest|wdspec|results|results-without-changes)(?:-\d+)?$`)
+	taskNameRegex = regexp.MustCompile(`^wpt-(\w+-\w+)-(testharness|reftest|wdspec|crashtest|results|results-without-changes)(?:-\d+)?$`)
 	// Taskcluster has used different forms of URLs in their Check & Status
 	// updates in history. We accept all of them.
 	// See TestExtractTaskGroupID for examples.

--- a/api/taskcluster/webhook.go
+++ b/api/taskcluster/webhook.go
@@ -26,7 +26,7 @@ const flagTaskclusterAllBranches = "taskclusterAllBranches"
 const flagPendingChecks = "pendingChecks"
 
 var (
-	// This should follow https://github.com/web-platform-tests/wpt/blob/master/.taskcluster.yml
+	// This should follow https://github.com/web-platform-tests/wpt/blob/master/tools/ci/tc/tasks/test.yml
 	// with a notable exception that "*-stability" runs are not included at the moment.
 	taskNameRegex = regexp.MustCompile(`^wpt-(\w+-\w+)-(testharness|reftest|wdspec|crashtest|results|results-without-changes)(?:-\d+)?$`)
 	// Taskcluster has used different forms of URLs in their Check & Status

--- a/api/taskcluster/webhook_test.go
+++ b/api/taskcluster/webhook_test.go
@@ -120,11 +120,12 @@ func TestParseTaskclusterURL(t *testing.T) {
 }
 
 func TestExtractArtifactURLs_all_success_master(t *testing.T) {
-	group := &taskGroupInfo{Tasks: make([]tcqueue.TaskDefinitionAndStatus, 4)}
+	group := &taskGroupInfo{Tasks: make([]tcqueue.TaskDefinitionAndStatus, 5)}
 	group.Tasks[0].Task.Metadata.Name = "wpt-firefox-nightly-testharness-1"
 	group.Tasks[1].Task.Metadata.Name = "wpt-firefox-nightly-testharness-2"
 	group.Tasks[2].Task.Metadata.Name = "wpt-chrome-dev-testharness-1"
 	group.Tasks[3].Task.Metadata.Name = "wpt-chrome-dev-reftest-1"
+	group.Tasks[4].Task.Metadata.Name = "wpt-chrome-dev-crashtest-1"
 	for i := 0; i < len(group.Tasks); i++ {
 		group.Tasks[i].Status.State = "completed"
 		group.Tasks[i].Status.TaskID = fmt.Sprint(i)
@@ -148,10 +149,12 @@ func TestExtractArtifactURLs_all_success_master(t *testing.T) {
 				Results: []string{
 					"https://tc.example.com/api/queue/v1/task/2/artifacts/public/results/wpt_report.json.gz",
 					"https://tc.example.com/api/queue/v1/task/3/artifacts/public/results/wpt_report.json.gz",
+					"https://tc.example.com/api/queue/v1/task/4/artifacts/public/results/wpt_report.json.gz",
 				},
 				Screenshots: []string{
 					"https://tc.example.com/api/queue/v1/task/2/artifacts/public/results/wpt_screenshot.txt.gz",
 					"https://tc.example.com/api/queue/v1/task/3/artifacts/public/results/wpt_screenshot.txt.gz",
+					"https://tc.example.com/api/queue/v1/task/4/artifacts/public/results/wpt_screenshot.txt.gz",
 				},
 			},
 		}, urls)
@@ -380,6 +383,7 @@ func TestTaskNameRegex(t *testing.T) {
 	assert.Equal(t, []string{"chrome-stable", "reftest"}, taskNameRegex.FindStringSubmatch("wpt-chrome-stable-reftest-1")[1:])
 	assert.Equal(t, []string{"firefox-nightly", "testharness"}, taskNameRegex.FindStringSubmatch("wpt-firefox-nightly-testharness-5")[1:])
 	assert.Equal(t, []string{"firefox-stable", "wdspec"}, taskNameRegex.FindStringSubmatch("wpt-firefox-stable-wdspec-1")[1:])
+	assert.Equal(t, []string{"firefox-beta", "crashtest"}, taskNameRegex.FindStringSubmatch("wpt-firefox-beta-crashtest-2")[1:])
 	assert.Equal(t, []string{"chrome-dev", "results-without-changes"}, taskNameRegex.FindStringSubmatch("wpt-chrome-dev-results-without-changes")[1:])
 	assert.Nil(t, taskNameRegex.FindStringSubmatch("wpt-chrome-dev-stability"))
 }


### PR DESCRIPTION
We forgot to add crashtest into the regex which is used to filter only
the recognized task names (and exclude e.g. Python unit tests).
