### PR TITLE
Fall back to the GitHub no-reply email

### DIFF
--- a/shared/triage_metadata.go
+++ b/shared/triage_metadata.go
@@ -286,6 +286,12 @@ func GetTriageMetadata(ctx context.Context, git MetadataGithub, logger Logger, f
 
 // GetMetadataGithub returns an instance of the MetadataGithub struct as a part of a triageMetadata struct.
 func GetMetadataGithub(githubClient *github.Client, authorName string, authorEmail string) MetadataGithub {
+	if authorEmail == "" {
+		// Email is required when pushing commits. Use the no-reply email provided
+		// by GitHub as the fallback if the user does not have a public email:
+		// https://help.github.com/en/github/setting-up-and-managing-your-github-user-account/setting-your-commit-email-address#about-commit-email-addresses
+		authorEmail = authorName + "@users.noreply.github.com"
+	}
 	return MetadataGithub{
 		githubClient: githubClient,
 		authorName:   authorName,

--- a/shared/triage_metadata_test.go
+++ b/shared/triage_metadata_test.go
@@ -303,3 +303,12 @@ links:
 	assert.Equal(t, "foo1", actual.Links[2].URL)
 	assert.Equal(t, "*", actual.Links[2].Results[0].TestPath)
 }
+
+func TestGetMetadataGithub(t *testing.T) {
+	m := GetMetadataGithub(nil, "testuser", "testemail@example.com")
+	assert.Equal(t, m.authorName, "testuser")
+	assert.Equal(t, m.authorEmail, "testemail@example.com")
+	m = GetMetadataGithub(nil, "testuser", "")
+	assert.Equal(t, m.authorName, "testuser")
+	assert.Equal(t, m.authorEmail, "testuser@users.noreply.github.com")
+}


### PR DESCRIPTION
if the user does not have a public email address on GitHub.

Fixes #1863.