### PR TITLE
[taskcluster] Relax regex and add tests

### DIFF
--- a/api/taskcluster/webhook.go
+++ b/api/taskcluster/webhook.go
@@ -26,9 +26,8 @@ const flagTaskclusterAllBranches = "taskclusterAllBranches"
 const flagPendingChecks = "pendingChecks"
 
 var (
-	// This should follow https://github.com/web-platform-tests/wpt/blob/master/tools/ci/tc/tasks/test.yml
-	// with a notable exception that "*-stability" runs are not included at the moment.
-	taskNameRegex = regexp.MustCompile(`^wpt-(\w+-\w+)-(testharness|reftest|wdspec|crashtest|results|results-without-changes)(?:-\d+)?$`)
+	// The pattern is based on task names in https://github.com/web-platform-tests/wpt/blob/master/tools/ci/tc/tasks/test.yml
+	taskNameRegex = regexp.MustCompile(`^wpt-([a-z]+-[a-z]+)-([a-z]+(?:-[a-z]+)*)(?:-\d+)?$`)
 	// Taskcluster has used different forms of URLs in their Check & Status
 	// updates in history. We accept all of them.
 	// See TestExtractTaskGroupID for examples.
@@ -288,11 +287,14 @@ func extractArtifactURLs(rootURL string, log shared.Logger, group *taskGroupInfo
 
 		matches := taskNameRegex.FindStringSubmatch(task.Task.Metadata.Name)
 		if len(matches) != 3 { // full match, browser-channel, test type
-			log.Debugf("Ignoring unrecognized task: %s", task.Task.Metadata.Name)
+			log.Infof("Ignoring unrecognized task: %s", task.Task.Metadata.Name)
 			continue
 		}
 		product := matches[1]
 		switch matches[2] {
+		case "stability":
+			// Skip stability checks.
+			continue
 		case "results":
 			product += "-" + shared.PRHeadLabel
 		case "results-without-changes":

--- a/api/taskcluster/webhook_test.go
+++ b/api/taskcluster/webhook_test.go
@@ -179,7 +179,7 @@ func TestExtractArtifactURLs_all_success_master(t *testing.T) {
 func TestExtractArtifactURLs_all_success_pr(t *testing.T) {
 	group := &taskGroupInfo{Tasks: make([]tcqueue.TaskDefinitionAndStatus, 3)}
 	group.Tasks[0].Task.Metadata.Name = "wpt-chrome-dev-results"
-	group.Tasks[1].Task.Metadata.Name = "wpt-chrome-dev-stability"
+	group.Tasks[1].Task.Metadata.Name = "wpt-chrome-dev-stability" // must be skipped
 	group.Tasks[2].Task.Metadata.Name = "wpt-chrome-dev-results-without-changes"
 	for i := 0; i < len(group.Tasks); i++ {
 		group.Tasks[i].Status.State = "completed"
@@ -380,10 +380,12 @@ func TestCreateAllRuns_all_errors(t *testing.T) {
 
 func TestTaskNameRegex(t *testing.T) {
 	assert.Equal(t, []string{"chrome-dev", "results"}, taskNameRegex.FindStringSubmatch("wpt-chrome-dev-results")[1:])
+	assert.Equal(t, []string{"chrome-dev", "results-without-changes"}, taskNameRegex.FindStringSubmatch("wpt-chrome-dev-results-without-changes")[1:])
+	assert.Equal(t, []string{"chrome-dev", "stability"}, taskNameRegex.FindStringSubmatch("wpt-chrome-dev-stability")[1:])
 	assert.Equal(t, []string{"chrome-stable", "reftest"}, taskNameRegex.FindStringSubmatch("wpt-chrome-stable-reftest-1")[1:])
+	assert.Equal(t, []string{"firefox-beta", "crashtest"}, taskNameRegex.FindStringSubmatch("wpt-firefox-beta-crashtest-2")[1:])
 	assert.Equal(t, []string{"firefox-nightly", "testharness"}, taskNameRegex.FindStringSubmatch("wpt-firefox-nightly-testharness-5")[1:])
 	assert.Equal(t, []string{"firefox-stable", "wdspec"}, taskNameRegex.FindStringSubmatch("wpt-firefox-stable-wdspec-1")[1:])
-	assert.Equal(t, []string{"firefox-beta", "crashtest"}, taskNameRegex.FindStringSubmatch("wpt-firefox-beta-crashtest-2")[1:])
-	assert.Equal(t, []string{"chrome-dev", "results-without-changes"}, taskNameRegex.FindStringSubmatch("wpt-chrome-dev-results-without-changes")[1:])
-	assert.Nil(t, taskNameRegex.FindStringSubmatch("wpt-chrome-dev-stability"))
+	assert.Nil(t, taskNameRegex.FindStringSubmatch("wpt-foo-bar--1"))
+	assert.Nil(t, taskNameRegex.FindStringSubmatch("wpt-foo-bar-"))
 }


### PR DESCRIPTION
Follow up to #1883

Stupid me... I clicked the button right after entering `git push` and ended up merging the #1883 without including this change.