### PR TITLE
Fix "too many runs" in /api/runs

### DIFF
--- a/shared/datastore.go
+++ b/shared/datastore.go
@@ -14,6 +14,10 @@ import (
 // ErrEntityAlreadyExists is returned by Datastore.Insert when the entity already exists.
 var ErrEntityAlreadyExists = errors.New("datastore: entity already exists")
 
+// MaxKeysPerLookup is the max number of keys allowed per lookup (e.g. GetMulti).
+// https://cloud.google.com/datastore/docs/concepts/limits
+const MaxKeysPerLookup = 1000
+
 // Key abstracts an int64 based datastore.Key
 type Key interface {
 	IntID() int64

--- a/shared/params_test.go
+++ b/shared/params_test.go
@@ -404,7 +404,7 @@ func TestParseVersion(t *testing.T) {
 	assert.Nil(t, v.Revision)
 	assert.Empty(t, v.Channel)
 
-	// FF
+	// Firefox
 	v, err = ParseVersion("65.0a1")
 	assert.Nil(t, err)
 	assert.Equal(t, 65, v.Major)
@@ -421,6 +421,15 @@ func TestParseVersion(t *testing.T) {
 	assert.Equal(t, 3578, *v.Build)
 	assert.Equal(t, 20, *v.Revision)
 	assert.Equal(t, " dev", v.Channel)
+
+	// Safari Technology Preview
+	v, err = ParseVersion("100 preview")
+	assert.Nil(t, err)
+	assert.Equal(t, 100, v.Major)
+	assert.Nil(t, v.Minor)
+	assert.Nil(t, v.Build)
+	assert.Nil(t, v.Revision)
+	assert.Equal(t, " preview", v.Channel)
 }
 
 func TestParseProductSpec(t *testing.T) {
@@ -452,6 +461,11 @@ func TestParseProductSpec_BrowserVersion(t *testing.T) {
 	assert.Equal(t, "chrome", productSpec.BrowserName)
 	assert.Equal(t, "63.0", productSpec.BrowserVersion)
 	assert.Equal(t, "latest", productSpec.Revision)
+
+	productSpec, err = ParseProductSpec("safari-100 preview")
+	assert.Nil(t, err)
+	assert.Equal(t, "safari", productSpec.BrowserName)
+	assert.Equal(t, "100 preview", productSpec.BrowserVersion)
 }
 
 func TestParseProductSpec_OS(t *testing.T) {
@@ -659,7 +673,12 @@ func TestProductSpecMatches(t *testing.T) {
 
 	safariRun := TestRun{}
 	safariRun.BrowserName = "safari"
+	safariRun.BrowserVersion = "100 preview"
 	assert.False(t, chrome.Matches(safariRun))
+
+	safari100, err := ParseProductSpec("safari-100 preview")
+	assert.Nil(t, err)
+	assert.True(t, safari100.Matches(safariRun))
 }
 
 func TestProductSpecMatches_Labels(t *testing.T) {

--- a/shared/test_run_query.go
+++ b/shared/test_run_query.go
@@ -223,6 +223,8 @@ func clientSideFilter(
 	for key := range productIDFilter.Iter() {
 		keys = append(keys, store.NewIDKey("TestRun", key.(int64)))
 		if len(keys) == capacity {
+			// FIXME: This might produce incomplete results.
+			// https://github.com/web-platform-tests/wpt.fyi/pull/1914
 			break
 		}
 	}

--- a/shared/test_run_query.go
+++ b/shared/test_run_query.go
@@ -215,7 +215,7 @@ func clientSideFilter(
 	log := GetLogger(store.Context())
 	capacity := productIDFilter.Cardinality()
 	if productIDFilter.Cardinality() > MaxKeysPerLookup {
-		log.Warningf("Too many viable runs: %d>%d", productIDFilter.Cardinality(), MaxKeysPerLookup)
+		log.Warningf("%d viable runs exceed the lookup limit %d", productIDFilter.Cardinality(), MaxKeysPerLookup)
 		capacity = MaxKeysPerLookup
 	}
 	log.Debugf("Loading %d viable runs to filter.", capacity)


### PR DESCRIPTION
## Description

This fixes #1913 .

The root cause is that when the filter is too broad (e.g. without `label=master`), we will find thousands of candidates for further filtering in `clientSideFilter`, which exceeds the limit of `GetMulti` (up to 1000 entities per call). This PR sets a limit on the number of candidates, and adds a warning to logs.

Note that this is not a perfect fix. It is possible that we will miss runs. Due to Datastore limitations (inequality can only be used on one field), we cannot filter by timestamps here if we are already filtering by some other criterias, so we really need to get *all* runs matching all the other filters to make sure we don't miss any in the time range. However, this was already broken before and I don't see a good way to fix it properly without refactoring (once again) the query system.

## Review Information

The first commit is somewhat unrelated. I originally thought the bug was in parsing `safari-104 preview`, so I added a bunch of test cases which all passed, but they are still good to have anyway.

The root problem is somewhat difficult to test (it'd probably require adding thousands of runs to the test server). However, the bug would have been discovered easily through server errors (500) if we had checked the error returned by `clientSideFilter`. This error check is now added to prevent future regressions.

https://too-many-runs-dot-wptdashboard-staging.uk.r.appspot.com/api/runs?product=safari-100%20preview&max-count=10
https://wpt.fyi/api/runs?product=safari-100%20preview&max-count=10