### PR TITLE
[taskcluster] Allow underscore (_) for the browser name identifier.

### DIFF
--- a/api/taskcluster/webhook.go
+++ b/api/taskcluster/webhook.go
@@ -27,7 +27,7 @@ const flagPendingChecks = "pendingChecks"
 
 var (
 	// The pattern is based on task names in https://github.com/web-platform-tests/wpt/blob/master/tools/ci/tc/tasks/test.yml
-	taskNameRegex = regexp.MustCompile(`^wpt-([a-z]+-[a-z]+)-([a-z]+(?:-[a-z]+)*)(?:-\d+)?$`)
+	taskNameRegex = regexp.MustCompile(`^wpt-([a-z_]+-[a-z]+)-([a-z]+(?:-[a-z]+)*)(?:-\d+)?$`)
 	// Taskcluster has used different forms of URLs in their Check & Status
 	// updates in history. We accept all of them.
 	// See TestExtractTaskGroupID for examples.

--- a/api/taskcluster/webhook_test.go
+++ b/api/taskcluster/webhook_test.go
@@ -386,6 +386,7 @@ func TestTaskNameRegex(t *testing.T) {
 	assert.Equal(t, []string{"firefox-beta", "crashtest"}, taskNameRegex.FindStringSubmatch("wpt-firefox-beta-crashtest-2")[1:])
 	assert.Equal(t, []string{"firefox-nightly", "testharness"}, taskNameRegex.FindStringSubmatch("wpt-firefox-nightly-testharness-5")[1:])
 	assert.Equal(t, []string{"firefox-stable", "wdspec"}, taskNameRegex.FindStringSubmatch("wpt-firefox-stable-wdspec-1")[1:])
+	assert.Equal(t, []string{"webkitgtk_minibrowser-nightly", "testharness"}, taskNameRegex.FindStringSubmatch("wpt-webkitgtk_minibrowser-nightly-testharness-2")[1:])
 	assert.Nil(t, taskNameRegex.FindStringSubmatch("wpt-foo-bar--1"))
 	assert.Nil(t, taskNameRegex.FindStringSubmatch("wpt-foo-bar-"))
 }


### PR DESCRIPTION
## Description
Since commit b8fac0b the webkitgtk runs from taskcluster are not longer updated to wpt.fyi
This is caused because the browser identifier on TC has an underscore.
This fixes: https://github.com/web-platform-tests/wpt/issues/23313

## Review Information
Tested by:
```
go test -tags=small -v  ./... -run TestTaskNameRegex
```

