### PR TITLE
Fix version name errors when deploying master

### DIFF
--- a/util/deploy.sh
+++ b/util/deploy.sh
@@ -62,7 +62,8 @@ VERSION="${USER}${VERSION_BRANCH_NAME}"
 if [[ -n ${RELEASE} ]]
 then
   # Use SHA for releases.
-  VERSION="$(git rev-parse --short HEAD)"
+  # Add a prefix to prevent gcloud from interpreting the version name as a number.
+  VERSION="rev-$(git rev-parse --short HEAD)"
 fi
 
 PROMOTE_FLAG="--no-promote"


### PR DESCRIPTION
We used the short SHA of the version name when deploying master.
However, the short SHA might happen to take the form of scientific
notation, e.g. 1e12345, in which case it'd be interpreted as a floating
point number by gcloud command and the deployment would fail.

Add a prefix "rev-" to the version name to prevent this from happening.

Example: https://travis-ci.com/github/web-platform-tests/wpt.fyi/jobs/330780571#L1939