### PR TITLE
[UI] Unable to deselect test directories

### DIFF
--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -1045,8 +1045,10 @@ class WPTResults extends Pluralizer(WPTColors(WPTFlags(PathInfo(LoadingState(Tes
     }
   }
 
-  handleSelectMetadata(index, test) {
+  handleSelectMetadata() {
     return (e) => {
+      // Prevent accidentally modifying these captured parameters in the closure.
+      const [index, test] = arguments;
       const td = e.target.closest('td');
       const browser = this.products[index].browser_name;
 

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -1046,9 +1046,9 @@ class WPTResults extends Pluralizer(WPTColors(WPTFlags(PathInfo(LoadingState(Tes
   }
 
   handleSelectMetadata() {
+    // Prevent accidentally modifying these captured parameters in the closure.
+    const [index, test] = arguments;
     return (e) => {
-      // Prevent accidentally modifying these captured parameters in the closure.
-      const [index, test] = arguments;
       const td = e.target.closest('td');
       const browser = this.products[index].browser_name;
 

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -1049,16 +1049,18 @@ class WPTResults extends Pluralizer(WPTColors(WPTFlags(PathInfo(LoadingState(Tes
     return (e) => {
       const td = e.target.closest('td');
       const browser = this.products[index].browser_name;
+
+      let selectedTest = test;
       if (this.computePathIsASubfolder(test)) {
-        test = test + '/*';
+        selectedTest = test + '/*';
       }
 
-      if (this.selectedMetadata.find(s => s.test === test && s.product === browser)) {
-        this.selectedMetadata = this.selectedMetadata.filter(s => !(s.test === test && s.product === browser));
+      if (this.selectedMetadata.find(s => s.test === selectedTest && s.product === browser)) {
+        this.selectedMetadata = this.selectedMetadata.filter(s => !(s.test === selectedTest && s.product === browser));
         this.selectedCells = this.selectedCells.filter(c => c !== td);
         td.removeAttribute('selected');
       } else {
-        const selected = { test: test, product: browser };
+        const selected = { test: selectedTest, product: browser };
         this.selectedMetadata = [...this.selectedMetadata, selected];
         td.setAttribute('selected', 'selected');
         this.selectedCells.push(td);


### PR DESCRIPTION
Fix for #1951. Users are unable to deselect test directories in the Triage Metadata UI.

The issue is caused by the fact that the `test` is being overwritten with extra `/*` inside of `handleSelectMetadata`