### PR TITLE
Add href that searches test in Monorail

### DIFF
--- a/webapp/components/test/wpt-amend-metadata.html
+++ b/webapp/components/test/wpt-amend-metadata.html
@@ -52,6 +52,13 @@ suite('<wpt-amend-metadata>', () => {
     appFixture.populateDisplayData();
     assert.deepEqual(appFixture.displayedMetadata, expected);
   });
+  test('getSearchURLHref', () => {
+    expect(appFixture.getSearchURLHref('/a/b/*')).to.equal('https://bugs.chromium.org/p/chromium/issues/list?q=/a/b');
+    expect(appFixture.getSearchURLHref('/a/b.html')).to.equal('https://bugs.chromium.org/p/chromium/issues/list?q=/a/b');
+    expect(appFixture.getSearchURLHref('/a/b')).to.equal('https://bugs.chromium.org/p/chromium/issues/list?q=/a/b');
+    expect(appFixture.getSearchURLHref('/a/b.any.html')).to.equal('https://bugs.chromium.org/p/chromium/issues/list?q=/a/b');
+    expect(appFixture.getSearchURLHref('/a/b.worker.html')).to.equal('https://bugs.chromium.org/p/chromium/issues/list?q=/a/b');
+  });
 });
 </script>
 </body>

--- a/webapp/components/test/wpt-amend-metadata.html
+++ b/webapp/components/test/wpt-amend-metadata.html
@@ -53,11 +53,11 @@ suite('<wpt-amend-metadata>', () => {
     assert.deepEqual(appFixture.displayedMetadata, expected);
   });
   test('getSearchURLHref', () => {
-    expect(appFixture.getSearchURLHref('/a/b/*')).to.equal('https://bugs.chromium.org/p/chromium/issues/list?q=/a/b');
-    expect(appFixture.getSearchURLHref('/a/b.html')).to.equal('https://bugs.chromium.org/p/chromium/issues/list?q=/a/b');
-    expect(appFixture.getSearchURLHref('/a/b')).to.equal('https://bugs.chromium.org/p/chromium/issues/list?q=/a/b');
-    expect(appFixture.getSearchURLHref('/a/b.any.html')).to.equal('https://bugs.chromium.org/p/chromium/issues/list?q=/a/b');
-    expect(appFixture.getSearchURLHref('/a/b.worker.html')).to.equal('https://bugs.chromium.org/p/chromium/issues/list?q=/a/b');
+    expect(appFixture.getSearchURLHref('/a/b/*')).to.equal('https://bugs.chromium.org/p/chromium/issues/list?q="/a/b"');
+    expect(appFixture.getSearchURLHref('/a/b.html')).to.equal('https://bugs.chromium.org/p/chromium/issues/list?q="/a/b"');
+    expect(appFixture.getSearchURLHref('/a/b')).to.equal('https://bugs.chromium.org/p/chromium/issues/list?q="/a/b"');
+    expect(appFixture.getSearchURLHref('/a/b.any.html')).to.equal('https://bugs.chromium.org/p/chromium/issues/list?q="/a/b"');
+    expect(appFixture.getSearchURLHref('/a/b.worker.html')).to.equal('https://bugs.chromium.org/p/chromium/issues/list?q="/a/b"');
   });
 });
 </script>

--- a/webapp/components/wpt-amend-metadata.js
+++ b/webapp/components/wpt-amend-metadata.js
@@ -7,11 +7,13 @@
 import '../node_modules/@polymer/paper-dialog/paper-dialog.js';
 import '../node_modules/@polymer/paper-input/paper-input.js';
 import '../node_modules/@polymer/paper-toast/paper-toast.js';
+import '../node_modules/@polymer/paper-tooltip/paper-tooltip.js';
 import { html, PolymerElement } from '../node_modules/@polymer/polymer/polymer-element.js';
 import { LoadingState } from './loading-state.js';
 import { ProductInfo } from './product-info.js';
+import { PathInfo } from '../components/path.js';
 
-class AmendMetadata extends LoadingState(ProductInfo(PolymerElement)) {
+class AmendMetadata extends LoadingState(PathInfo(ProductInfo(PolymerElement))) {
   static get is() {
     return 'wpt-amend-metadata';
   }
@@ -59,7 +61,16 @@ class AmendMetadata extends LoadingState(ProductInfo(PolymerElement)) {
             <paper-input label="Bug URL" value="{{node.url}}" autofocus></paper-input>
           </div>
           <template is="dom-repeat" items="[[node.tests]]" as="test">
-            <li>[[test]]</li>
+            <template is="dom-if" if="[[hasHref(node.product)]]">
+              <li>
+                <a href="[[getSearchURLHref(test)]]" target="_blank">[[test]]</a>
+                <paper-tooltip offset="0" animation-delay="0">Search this test in Monorail</paper-tooltip>
+              </li>
+            </template>
+
+            <template is="dom-if" if="[[!hasHref(node.product)]]">
+              <li>[[test]]</li>
+            </template>
           </template>
         </template>
         <div class="buttons">
@@ -133,6 +144,21 @@ class AmendMetadata extends LoadingState(ProductInfo(PolymerElement)) {
       }
     }
     return link;
+  }
+
+  hasHref(product) {
+    return product === 'chrome';
+  }
+
+  getSearchURLHref(testName) {
+    if (this.computePathIsATestFile(testName)) {
+      // Remove name flags and extensions: https://web-platform-tests.org/writing-tests/file-names.html
+      testName = testName.split('.')[0];
+    } else {
+      testName = testName.replace(/((\/\*)?$)/, '');
+    }
+
+    return 'https://bugs.chromium.org/p/chromium/issues/list?q=' + testName;
   }
 
   populateDisplayData() {

--- a/webapp/components/wpt-amend-metadata.js
+++ b/webapp/components/wpt-amend-metadata.js
@@ -7,7 +7,6 @@
 import '../node_modules/@polymer/paper-dialog/paper-dialog.js';
 import '../node_modules/@polymer/paper-input/paper-input.js';
 import '../node_modules/@polymer/paper-toast/paper-toast.js';
-import '../node_modules/@polymer/paper-tooltip/paper-tooltip.js';
 import { html, PolymerElement } from '../node_modules/@polymer/polymer/polymer-element.js';
 import { LoadingState } from './loading-state.js';
 import { ProductInfo } from './product-info.js';

--- a/webapp/components/wpt-amend-metadata.js
+++ b/webapp/components/wpt-amend-metadata.js
@@ -51,6 +51,14 @@ class AmendMetadata extends LoadingState(PathInfo(ProductInfo(PolymerElement))) 
           margin-top: 5px;
           margin-left: 30px;
         }
+        .testname {
+          text-overflow: ellipsis;
+          overflow: hidden;
+          white-space: nowrap;
+          max-width: 100ch;
+          display: inline-block;
+          vertical-align: bottom;
+        }
       </style>
       <paper-dialog id="dialog">
         <h3>Triage Failing Tests</h3>
@@ -61,16 +69,12 @@ class AmendMetadata extends LoadingState(PathInfo(ProductInfo(PolymerElement))) 
             <paper-input label="Bug URL" value="{{node.url}}" autofocus></paper-input>
           </div>
           <template is="dom-repeat" items="[[node.tests]]" as="test">
-            <template is="dom-if" if="[[hasHref(node.product)]]">
-              <li>
-                <a href="[[getSearchURLHref(test)]]" target="_blank">[[test]]</a>
-                <paper-tooltip offset="0" animation-delay="0">Search this test in Monorail</paper-tooltip>
-              </li>
-            </template>
-
-            <template is="dom-if" if="[[!hasHref(node.product)]]">
-              <li>[[test]]</li>
-            </template>
+            <li>
+              <div class="testname"> [[test]] </div>
+              <template is="dom-if" if="[[hasHref(node.product)]]">
+                <a href="[[getSearchURLHref(test)]]" target="_blank"> [Search in Monorail] </a>
+              </template>
+            </li>
           </template>
         </template>
         <div class="buttons">

--- a/webapp/components/wpt-amend-metadata.js
+++ b/webapp/components/wpt-amend-metadata.js
@@ -71,7 +71,7 @@ class AmendMetadata extends LoadingState(PathInfo(ProductInfo(PolymerElement))) 
             <li>
               <div class="list"> [[test]] </div>
               <template is="dom-if" if="[[hasHref(node.product)]]">
-                <a href="[[getSearchURLHref(test)]]" target="_blank"> [Search in Monorail] </a>
+                <a href="[[getSearchURLHref(test)]]" target="_blank"> [Search on crbug] </a>
               </template>
             </li>
           </template>

--- a/webapp/components/wpt-amend-metadata.js
+++ b/webapp/components/wpt-amend-metadata.js
@@ -36,7 +36,7 @@ class AmendMetadata extends LoadingState(PathInfo(ProductInfo(PolymerElement))) 
           margin-bottom: 20px;
           margin-left: 10px;
         }
-        .metadataEntry {
+        .metadata-entry {
           display: flex;
           align-items: center;
           margin-top: 20px;
@@ -50,7 +50,7 @@ class AmendMetadata extends LoadingState(PathInfo(ProductInfo(PolymerElement))) 
           margin-top: 5px;
           margin-left: 30px;
         }
-        .testname {
+        .list {
           text-overflow: ellipsis;
           overflow: hidden;
           white-space: nowrap;
@@ -62,14 +62,14 @@ class AmendMetadata extends LoadingState(PathInfo(ProductInfo(PolymerElement))) 
       <paper-dialog id="dialog">
         <h3>Triage Failing Tests</h3>
         <template is="dom-repeat" items="[[displayedMetadata]]" as="node">
-          <div class="metadataEntry">
+          <div class="metadata-entry">
             <img class="browser" src="[[displayLogo(node.product)]]">
             : 
             <paper-input label="Bug URL" value="{{node.url}}" autofocus></paper-input>
           </div>
           <template is="dom-repeat" items="[[node.tests]]" as="test">
             <li>
-              <div class="testname"> [[test]] </div>
+              <div class="list"> [[test]] </div>
               <template is="dom-if" if="[[hasHref(node.product)]]">
                 <a href="[[getSearchURLHref(test)]]" target="_blank"> [Search in Monorail] </a>
               </template>


### PR DESCRIPTION
Add a href that links to a test search in Monorail.


### Test
Enable the Triage Metadata toggle, click on failing chrome tests and click on Triage. The tests on the triage view are hyperlinks to Monorail