### PR TITLE
Remove always-on 'taskclusterAllBranches' flag

### DIFF
--- a/api/taskcluster/webhook.go
+++ b/api/taskcluster/webhook.go
@@ -22,7 +22,6 @@ import (
 )
 
 const uploaderName = "taskcluster"
-const flagTaskclusterAllBranches = "taskclusterAllBranches"
 const flagPendingChecks = "pendingChecks"
 
 var (
@@ -72,9 +71,8 @@ func tcStatusWebhookHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	processAllBranches := aeAPI.IsFeatureEnabled(flagTaskclusterAllBranches)
 	var processed bool
-	if !shouldProcessStatus(log, processAllBranches, &status) {
+	if !shouldProcessStatus(log, &status) {
 		processed = false
 	} else {
 		processed, err = func() (bool, error) {
@@ -206,15 +204,12 @@ func processTaskclusterBuild(aeAPI shared.AppEngineAPI, rootURL, taskGroupID, ta
 	return true, nil
 }
 
-func shouldProcessStatus(log shared.Logger, processAllBranches bool, status *statusEventPayload) bool {
+func shouldProcessStatus(log shared.Logger, status *statusEventPayload) bool {
 	if !status.IsCompleted() {
 		log.Debugf("Ignoring status: %s", status.GetState())
 		return false
 	} else if !status.IsTaskcluster() {
 		log.Debugf("Ignoring non-Taskcluster context: %s", status.GetContext())
-		return false
-	} else if !processAllBranches && !status.IsOnMaster() {
-		log.Debugf("Ignoring non-master status event")
 		return false
 	}
 	return true

--- a/api/taskcluster/webhook_test.go
+++ b/api/taskcluster/webhook_test.go
@@ -34,19 +34,19 @@ func TestShouldProcessStatus_states(t *testing.T) {
 	status.State = strPtr("success")
 	status.Context = strPtr("Taskcluster")
 	status.Branches = branchInfos{&github.Branch{Name: strPtr(shared.MasterLabel)}}
-	assert.True(t, shouldProcessStatus(shared.NewNilLogger(), false, &status))
+	assert.True(t, shouldProcessStatus(shared.NewNilLogger(), &status))
 
 	status.Context = strPtr("Community-TC")
-	assert.True(t, shouldProcessStatus(shared.NewNilLogger(), false, &status))
+	assert.True(t, shouldProcessStatus(shared.NewNilLogger(), &status))
 
 	status.State = strPtr("failure")
-	assert.True(t, shouldProcessStatus(shared.NewNilLogger(), false, &status))
+	assert.True(t, shouldProcessStatus(shared.NewNilLogger(), &status))
 
 	status.State = strPtr("error")
-	assert.False(t, shouldProcessStatus(shared.NewNilLogger(), false, &status))
+	assert.False(t, shouldProcessStatus(shared.NewNilLogger(), &status))
 
 	status.State = strPtr("pending")
-	assert.False(t, shouldProcessStatus(shared.NewNilLogger(), false, &status))
+	assert.False(t, shouldProcessStatus(shared.NewNilLogger(), &status))
 }
 
 func TestShouldProcessStatus_notTaskcluster(t *testing.T) {
@@ -54,7 +54,7 @@ func TestShouldProcessStatus_notTaskcluster(t *testing.T) {
 	status.State = strPtr("success")
 	status.Context = strPtr("Travis")
 	status.Branches = branchInfos{&github.Branch{Name: strPtr(shared.MasterLabel)}}
-	assert.False(t, shouldProcessStatus(shared.NewNilLogger(), false, &status))
+	assert.False(t, shouldProcessStatus(shared.NewNilLogger(), &status))
 }
 
 func TestShouldProcessStatus_notOnMaster(t *testing.T) {
@@ -62,8 +62,7 @@ func TestShouldProcessStatus_notOnMaster(t *testing.T) {
 	status.State = strPtr("success")
 	status.Context = strPtr("Taskcluster")
 	status.Branches = branchInfos{&github.Branch{Name: strPtr("gh-pages")}}
-	assert.False(t, shouldProcessStatus(shared.NewNilLogger(), false, &status))
-	assert.True(t, shouldProcessStatus(shared.NewNilLogger(), true, &status))
+	assert.True(t, shouldProcessStatus(shared.NewNilLogger(), &status))
 }
 
 func TestIsOnMaster(t *testing.T) {

--- a/webapp/components/wpt-flags.js
+++ b/webapp/components/wpt-flags.js
@@ -59,7 +59,6 @@ Object.defineProperty(wpt, 'ServerSideFeatures', {
       'processTaskclusterCheckRunEvents',
       'runsByPRNumber',
       'serviceWorker',
-      'taskclusterAllBranches',
       'searchcacheDiffs',
     ];
   }
@@ -292,11 +291,6 @@ class WPTEnvironmentFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ tr
     <paper-item sub-item>
       <paper-checkbox checked="{{experimentalAlignedExceptEdge}}">
         All experimental, except edge[stable], and aligned
-      </paper-checkbox>
-    </paper-item>
-    <paper-item>
-      <paper-checkbox checked="{{taskclusterAllBranches}}">
-        Process all taskcluster results (not just master)
       </paper-checkbox>
     </paper-item>
     <paper-item>


### PR DESCRIPTION
This flag decides whether or not taskcluster runs on all branches or
just master. Turning the flag off today would break pull request checks
and epoch runs, so it seems like a candidate for flag clean-up.