### PR TITLE
Remove processTaskclusterCheckRunEvents flag from the admin UI

### DIFF
--- a/webapp/components/wpt-flags.js
+++ b/webapp/components/wpt-flags.js
@@ -56,7 +56,6 @@ Object.defineProperty(wpt, 'ServerSideFeatures', {
       'onlyChangesAsRegressions',
       'paginationTokens',
       'pendingChecks',
-      'processTaskclusterCheckRunEvents',
       'runsByPRNumber',
       'serviceWorker',
       'searchcacheDiffs',
@@ -338,11 +337,6 @@ class WPTEnvironmentFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ tr
     <paper-item>
       <paper-checkbox checked="{{pendingChecks}}">
         Create pending GitHub status check when results first arrive, and are being processed.
-      </paper-checkbox>
-    </paper-item>
-    <paper-item>
-      <paper-checkbox checked="{{processTaskclusterCheckRunEvents}}">
-        Process check run events from Taskcluster (needs to be enabled if Taskcluster is using Checks API).
       </paper-checkbox>
     </paper-item>
 `;


### PR DESCRIPTION
This flag is no longer in use after
https://github.com/web-platform-tests/wpt.fyi/pull/1956