### PR TITLE
Support handling CheckSuite events for taskcluster

### DIFF
--- a/api/taskcluster/mock_taskcluster/webhook_mock.go
+++ b/api/taskcluster/mock_taskcluster/webhook_mock.go
@@ -6,6 +6,7 @@ package mock_taskcluster
 
 import (
 	gomock "github.com/golang/mock/gomock"
+	github "github.com/google/go-github/v31/github"
 	taskcluster "github.com/web-platform-tests/wpt.fyi/api/taskcluster"
 	reflect "reflect"
 )
@@ -46,4 +47,20 @@ func (m *MockAPI) GetTaskGroupInfo(arg0, arg1 string) (*taskcluster.TaskGroupInf
 func (mr *MockAPIMockRecorder) GetTaskGroupInfo(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTaskGroupInfo", reflect.TypeOf((*MockAPI)(nil).GetTaskGroupInfo), arg0, arg1)
+}
+
+// ListCheckRunsCheckSuite mocks base method
+func (m *MockAPI) ListCheckRunsCheckSuite(arg0, arg1 string, arg2 int64) (*github.ListCheckRunsResults, *github.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListCheckRunsCheckSuite", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*github.ListCheckRunsResults)
+	ret1, _ := ret[1].(*github.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// ListCheckRunsCheckSuite indicates an expected call of ListCheckRunsCheckSuite
+func (mr *MockAPIMockRecorder) ListCheckRunsCheckSuite(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCheckRunsCheckSuite", reflect.TypeOf((*MockAPI)(nil).ListCheckRunsCheckSuite), arg0, arg1, arg2)
 }

--- a/api/taskcluster/mock_taskcluster/webhook_mock.go
+++ b/api/taskcluster/mock_taskcluster/webhook_mock.go
@@ -49,18 +49,18 @@ func (mr *MockAPIMockRecorder) GetTaskGroupInfo(arg0, arg1 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTaskGroupInfo", reflect.TypeOf((*MockAPI)(nil).GetTaskGroupInfo), arg0, arg1)
 }
 
-// ListCheckRunsCheckSuite mocks base method
-func (m *MockAPI) ListCheckRunsCheckSuite(arg0, arg1 string, arg2 int64) (*github.ListCheckRunsResults, *github.Response, error) {
+// ListCheckRuns mocks base method
+func (m *MockAPI) ListCheckRuns(arg0, arg1 string, arg2 int64) (*github.ListCheckRunsResults, *github.Response, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListCheckRunsCheckSuite", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "ListCheckRuns", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*github.ListCheckRunsResults)
 	ret1, _ := ret[1].(*github.Response)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
 
-// ListCheckRunsCheckSuite indicates an expected call of ListCheckRunsCheckSuite
-func (mr *MockAPIMockRecorder) ListCheckRunsCheckSuite(arg0, arg1, arg2 interface{}) *gomock.Call {
+// ListCheckRuns indicates an expected call of ListCheckRuns
+func (mr *MockAPIMockRecorder) ListCheckRuns(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCheckRunsCheckSuite", reflect.TypeOf((*MockAPI)(nil).ListCheckRunsCheckSuite), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCheckRuns", reflect.TypeOf((*MockAPI)(nil).ListCheckRuns), arg0, arg1, arg2)
 }

--- a/api/taskcluster/webhook.go
+++ b/api/taskcluster/webhook.go
@@ -7,6 +7,7 @@
 package taskcluster
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -23,6 +24,9 @@ import (
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
+// AppID is the ID of the Community-TC GitHub app.
+const AppID = int64(40788)
+
 const uploaderName = "taskcluster"
 const flagPendingChecks = "pendingChecks"
 
@@ -32,8 +36,9 @@ var (
 	// Taskcluster has used different forms of URLs in their Check & Status
 	// updates in history. We accept all of them.
 	// See TestExtractTaskGroupID for examples.
-	inspectorURLRegex = regexp.MustCompile(`^(https://[^/]*)/task-group-inspector/#/([^/]*)`)
-	taskURLRegex      = regexp.MustCompile(`^(https://[^/]*)(?:/tasks)?/groups/([^/]*)(?:/tasks/([^/]*))?`)
+	inspectorURLRegex       = regexp.MustCompile(`^(https://[^/]*)/task-group-inspector/#/([^/]*)`)
+	taskURLRegex            = regexp.MustCompile(`^(https://[^/]*)(?:/tasks)?/groups/([^/]*)(?:/tasks/([^/]*))?`)
+	checkRunDetailsURLRegex = regexp.MustCompile(`^(https://[^/]*)/tasks/([^/]*)`)
 )
 
 // Non-fatal error when there is no result (e.g. nothing finishes yet).
@@ -65,15 +70,19 @@ type EventInfo struct {
 	Group   *TaskGroupInfo
 }
 
-// API is an interface for Taskcluster related methods.
+// API wraps externally provided methods so we can mock them for testing.
 type API interface {
 	GetTaskGroupInfo(string, string) (*TaskGroupInfo, error)
+	ListCheckRunsCheckSuite(owner string, repo string, checkSuiteID int64) (*github.ListCheckRunsResults, *github.Response, error)
 }
 
-type apiImpl struct{}
+type apiImpl struct {
+	ctx      context.Context
+	ghClient *github.Client
+}
 
-// GetEventInfo turns a StatusEventPayload into an EventInfo struct.
-func GetEventInfo(status StatusEventPayload, log shared.Logger, api API) (EventInfo, error) {
+// GetStatusEventInfo turns a StatusEventPayload into an EventInfo struct.
+func GetStatusEventInfo(status StatusEventPayload, log shared.Logger, api API) (EventInfo, error) {
 	if status.SHA == nil {
 		return EventInfo{}, errors.New("No sha on taskcluster status event")
 	}
@@ -106,10 +115,69 @@ func GetEventInfo(status StatusEventPayload, log shared.Logger, api API) (EventI
 	return event, nil
 }
 
+// GetCheckSuiteEventInfo turns a github.CheckSuiteEvent into an EventInfo struct.
+func GetCheckSuiteEventInfo(checkSuite github.CheckSuiteEvent, log shared.Logger, api API) (EventInfo, error) {
+	if checkSuite.GetCheckSuite().GetHeadSHA() == "" {
+		return EventInfo{}, errors.New("No sha on taskcluster check_suite event")
+	}
+
+	runs, _, err := api.ListCheckRunsCheckSuite(
+		shared.WPTRepoOwner, shared.WPTRepoName, checkSuite.GetCheckSuite().GetID())
+	if err != nil {
+		log.Errorf("Failed to fetch check runs for suite %v: %s", checkSuite.GetCheckSuite().GetID(), err.Error())
+		return EventInfo{}, err
+	}
+
+	if len(runs.CheckRuns) == 0 {
+		return EventInfo{}, errors.New("No check_runs for check_suite")
+	}
+
+	rootURL := ""
+	group := TaskGroupInfo{}
+	for _, run := range runs.CheckRuns {
+		matches := checkRunDetailsURLRegex.FindStringSubmatch(run.GetDetailsURL())
+		if matches == nil {
+			log.Errorf("Unable to parse details URL for suite %v, run %v: %s", checkSuite.GetCheckSuite().GetID(), run.GetID(), run.GetDetailsURL())
+			return EventInfo{}, errors.New("Unable to parse check_run details URL")
+		}
+		if rootURL != "" && rootURL != matches[1] {
+			log.Errorf("Conflicting root URLs for runs for suite %v (%s vs %s)", checkSuite.GetCheckSuite().GetID(), rootURL, matches[1])
+			return EventInfo{}, errors.New("Conflicting root URLs for runs in check_suite")
+		}
+		rootURL = matches[1]
+		taskID := matches[2]
+
+		// The task group's ID appear to be equivalent to the ID of the initial task
+		// that was created. For WPT, this is the decision task.
+		if run.GetName() == "wpt-decision-task" {
+			group.TaskGroupID = taskID
+		}
+
+		group.Tasks = append(group.Tasks, TaskInfo{
+			Name:   run.GetName(),
+			TaskID: taskID,
+			State:  run.GetStatus(),
+		})
+	}
+
+	event := EventInfo{
+		Sha:     checkSuite.GetCheckSuite().GetHeadSHA(),
+		RootURL: rootURL,
+		// The TaskID is a filter for a specific task. For check_suite events we
+		// only ever receieve events for an entire suite, so there is no TaskID.
+		TaskID: "",
+		Master: checkSuite.GetCheckSuite().GetHeadBranch() == "master",
+		Sender: checkSuite.GetSender().GetLogin(),
+		Group:  &group,
+	}
+
+	return event, nil
+}
+
 // tcStatusWebhookHandler reacts to GitHub status webhook events.
 func tcStatusWebhookHandler(w http.ResponseWriter, r *http.Request) {
-	if r.Header.Get("Content-Type") != "application/json" ||
-		r.Header.Get("X-GitHub-Event") != "status" {
+	eventName := r.Header.Get("X-GitHub-Event")
+	if r.Header.Get("Content-Type") != "application/json" || (eventName != "status" && eventName != "check_suite") {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
@@ -132,20 +200,59 @@ func tcStatusWebhookHandler(w http.ResponseWriter, r *http.Request) {
 	log.Debugf("GitHub Delivery: %s", r.Header.Get("X-GitHub-Delivery"))
 
 	aeAPI := shared.NewAppEngineAPI(ctx)
-	var status StatusEventPayload
-	if err := json.Unmarshal(payload, &status); err != nil {
-		log.Errorf("%v", err)
-		http.Error(w, err.Error(), http.StatusBadRequest)
+
+	ghClient, err := aeAPI.GetGitHubClient()
+	if err != nil {
+		log.Errorf("Failed to get GitHub client: %s", err.Error())
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	api := apiImpl{ctx: aeAPI.Context(), ghClient: ghClient}
 
-	if !ShouldProcessStatus(log, &status) {
-		w.WriteHeader(http.StatusNoContent)
-		fmt.Fprintln(w, "Status was ignored")
-		return
+	var event EventInfo
+	if eventName == "status" {
+		var status StatusEventPayload
+		if err := json.Unmarshal(payload, &status); err != nil {
+			log.Errorf("%v", err)
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		if !ShouldProcessStatus(log, &status) {
+			w.WriteHeader(http.StatusNoContent)
+			fmt.Fprintln(w, "Status was ignored")
+			return
+		}
+
+		event, err = GetStatusEventInfo(status, log, api)
+	} else {
+		var checkSuite github.CheckSuiteEvent
+		if err := json.Unmarshal(payload, &checkSuite); err != nil {
+			log.Errorf("%v", err)
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		if checkSuite.GetCheckSuite().GetApp().GetID() != AppID {
+			log.Debugf("Ignoring non-Taskcluster app: %s (%s)",
+				checkSuite.GetCheckSuite().GetApp().GetName(),
+				checkSuite.GetCheckSuite().GetApp().GetID())
+			w.WriteHeader(http.StatusNoContent)
+			fmt.Fprintln(w, "Status was ignored")
+			return
+		}
+
+		// As a webhook we should only receive completed check_suite events, as per
+		// https://developer.github.com/webhooks/event-payloads/#check_suite
+		if checkSuite.GetAction() != "completed" || checkSuite.GetCheckSuite().GetStatus() != "completed" {
+			log.Errorf("Received non-completed check_suite event (action: %s, status: %s)",
+				checkSuite.GetAction(), checkSuite.GetCheckSuite().GetStatus())
+			http.Error(w, "Non-completed check_suite event", http.StatusBadRequest)
+			return
+		}
+
+		event, err = GetCheckSuiteEventInfo(checkSuite, log, api)
 	}
-
-	event, err := GetEventInfo(status, log, &apiImpl{})
 	if err != nil {
 		log.Errorf("%v", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -304,6 +411,10 @@ func (api apiImpl) GetTaskGroupInfo(rootURL string, groupID string) (*TaskGroupI
 		}
 	}
 	return &group, nil
+}
+
+func (api apiImpl) ListCheckRunsCheckSuite(owner string, repo string, checkSuiteID int64) (*github.ListCheckRunsResults, *github.Response, error) {
+	return api.ghClient.Checks.ListCheckRunsCheckSuite(api.ctx, owner, repo, checkSuiteID, nil)
 }
 
 // ArtifactURLs holds the results and screenshot URLs for a Taskcluster run.

--- a/api/taskcluster/webhook.go
+++ b/api/taskcluster/webhook.go
@@ -73,7 +73,7 @@ type EventInfo struct {
 // API wraps externally provided methods so we can mock them for testing.
 type API interface {
 	GetTaskGroupInfo(string, string) (*TaskGroupInfo, error)
-	ListCheckRunsCheckSuite(owner string, repo string, checkSuiteID int64) (*github.ListCheckRunsResults, *github.Response, error)
+	ListCheckRuns(owner string, repo string, checkSuiteID int64) (*github.ListCheckRunsResults, *github.Response, error)
 }
 
 type apiImpl struct {
@@ -121,7 +121,7 @@ func GetCheckSuiteEventInfo(checkSuite github.CheckSuiteEvent, log shared.Logger
 		return EventInfo{}, errors.New("No sha on taskcluster check_suite event")
 	}
 
-	runs, _, err := api.ListCheckRunsCheckSuite(
+	runs, _, err := api.ListCheckRuns(
 		shared.WPTRepoOwner, shared.WPTRepoName, checkSuite.GetCheckSuite().GetID())
 	if err != nil {
 		log.Errorf("Failed to fetch check runs for suite %v: %s", checkSuite.GetCheckSuite().GetID(), err.Error())
@@ -413,7 +413,7 @@ func (api apiImpl) GetTaskGroupInfo(rootURL string, groupID string) (*TaskGroupI
 	return &group, nil
 }
 
-func (api apiImpl) ListCheckRunsCheckSuite(owner string, repo string, checkSuiteID int64) (*github.ListCheckRunsResults, *github.Response, error) {
+func (api apiImpl) ListCheckRuns(owner string, repo string, checkSuiteID int64) (*github.ListCheckRunsResults, *github.Response, error) {
 	return api.ghClient.Checks.ListCheckRunsCheckSuite(api.ctx, owner, repo, checkSuiteID, nil)
 }
 

--- a/api/taskcluster/webhook_test.go
+++ b/api/taskcluster/webhook_test.go
@@ -580,7 +580,7 @@ func TestGetCheckSuiteEventInfo_sha(t *testing.T) {
 		Status:     strPtr("completed"),
 		DetailsURL: strPtr("https://community-tc.services.mozilla.com/tasks/Jq4HzLz0R2eKkJFdmf47Bg"),
 	})
-	api.EXPECT().ListCheckRunsCheckSuite(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(&runs, nil, nil)
+	api.EXPECT().ListCheckRuns(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(&runs, nil, nil)
 
 	event := github.CheckSuiteEvent{
 		CheckSuite: &github.CheckSuite{
@@ -609,7 +609,7 @@ func TestGetCheckSuiteEventInfo_master(t *testing.T) {
 		Status:     strPtr("completed"),
 		DetailsURL: strPtr("https://community-tc.services.mozilla.com/tasks/Jq4HzLz0R2eKkJFdmf47Bg"),
 	})
-	api.EXPECT().ListCheckRunsCheckSuite(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(&runs, nil, nil)
+	api.EXPECT().ListCheckRuns(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(&runs, nil, nil)
 
 	event := github.CheckSuiteEvent{
 		CheckSuite: &github.CheckSuite{
@@ -639,7 +639,7 @@ func TestGetCheckSuiteEventInfo_sender(t *testing.T) {
 		Status:     strPtr("completed"),
 		DetailsURL: strPtr("https://community-tc.services.mozilla.com/tasks/Jq4HzLz0R2eKkJFdmf47Bg"),
 	})
-	api.EXPECT().ListCheckRunsCheckSuite(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(&runs, nil, nil)
+	api.EXPECT().ListCheckRuns(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(&runs, nil, nil)
 
 	event := github.CheckSuiteEvent{
 		Sender: &github.User{
@@ -666,7 +666,7 @@ func TestGetCheckSuiteEventInfo_checkRuns(t *testing.T) {
 	api := mock_tc.NewMockAPI(mockC)
 
 	runs := github.ListCheckRunsResults{}
-	api.EXPECT().ListCheckRunsCheckSuite(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(&runs, nil, nil)
+	api.EXPECT().ListCheckRuns(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(&runs, nil, nil)
 
 	// The list of check_run events give us two main pieces of information:
 	//
@@ -722,7 +722,7 @@ func TestGetCheckSuiteEventInfo_checkRunsEmpty(t *testing.T) {
 	mockC := gomock.NewController(t)
 	defer mockC.Finish()
 	api := mock_tc.NewMockAPI(mockC)
-	api.EXPECT().ListCheckRunsCheckSuite(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(&github.ListCheckRunsResults{}, nil, nil)
+	api.EXPECT().ListCheckRuns(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(&github.ListCheckRunsResults{}, nil, nil)
 
 	event := github.CheckSuiteEvent{
 		CheckSuite: &github.CheckSuite{
@@ -738,7 +738,7 @@ func TestGetCheckSuiteEventInfo_checkRunsFailed(t *testing.T) {
 	mockC := gomock.NewController(t)
 	defer mockC.Finish()
 	api := mock_tc.NewMockAPI(mockC)
-	api.EXPECT().ListCheckRunsCheckSuite(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil, nil, errors.New("failed"))
+	api.EXPECT().ListCheckRuns(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil, nil, errors.New("failed"))
 
 	event := github.CheckSuiteEvent{
 		CheckSuite: &github.CheckSuite{

--- a/api/taskcluster/webhook_test.go
+++ b/api/taskcluster/webhook_test.go
@@ -436,7 +436,7 @@ func TestTaskNameRegex(t *testing.T) {
 	assert.Nil(t, tc.TaskNameRegex.FindStringSubmatch("wpt-foo-bar-"))
 }
 
-func TestGetEventInfo_target_url(t *testing.T) {
+func TestGetStatusEventInfo_target_url(t *testing.T) {
 	mockC := gomock.NewController(t)
 	defer mockC.Finish()
 	api := mock_tc.NewMockAPI(mockC)
@@ -452,21 +452,21 @@ func TestGetEventInfo_target_url(t *testing.T) {
 	// The target URL must be present, and must at least be a recognized
 	// URL containing a taskGroupID. ParseTaskclusterURL is tested
 	// separately, so just do a basic check here.
-	event, err := tc.GetEventInfo(status, shared.NewNilLogger(), api)
+	event, err := tc.GetStatusEventInfo(status, shared.NewNilLogger(), api)
 	assert.Equal(t, event.RootURL, "https://tc.community.com")
 	assert.Equal(t, event.TaskID, "123")
 	assert.Nil(t, err)
 
 	status.TargetURL = strPtr("https://example.com/nope/not/right")
-	event, err = tc.GetEventInfo(status, shared.NewNilLogger(), api)
+	event, err = tc.GetStatusEventInfo(status, shared.NewNilLogger(), api)
 	assert.NotNil(t, err)
 
 	status.TargetURL = nil
-	event, err = tc.GetEventInfo(status, shared.NewNilLogger(), api)
+	event, err = tc.GetStatusEventInfo(status, shared.NewNilLogger(), api)
 	assert.NotNil(t, err)
 }
 
-func TestGetEventInfo_sha(t *testing.T) {
+func TestGetStatusEventInfo_sha(t *testing.T) {
 	mockC := gomock.NewController(t)
 	defer mockC.Finish()
 	api := mock_tc.NewMockAPI(mockC)
@@ -480,16 +480,16 @@ func TestGetEventInfo_sha(t *testing.T) {
 	status.SHA = strPtr("abcdef123")
 
 	// We don't place requirements on the SHA other than it exists.
-	event, err := tc.GetEventInfo(status, shared.NewNilLogger(), api)
+	event, err := tc.GetStatusEventInfo(status, shared.NewNilLogger(), api)
 	assert.Equal(t, event.Sha, "abcdef123")
 	assert.Nil(t, err)
 
 	status.SHA = nil
-	event, err = tc.GetEventInfo(status, shared.NewNilLogger(), api)
+	event, err = tc.GetStatusEventInfo(status, shared.NewNilLogger(), api)
 	assert.NotNil(t, err)
 }
 
-func TestGetEventInfo_master(t *testing.T) {
+func TestGetStatusEventInfo_master(t *testing.T) {
 	mockC := gomock.NewController(t)
 	defer mockC.Finish()
 	api := mock_tc.NewMockAPI(mockC)
@@ -504,24 +504,24 @@ func TestGetEventInfo_master(t *testing.T) {
 
 	// We check whether an event is for master by looking at the branches
 	// it is associated with.
-	event, err := tc.GetEventInfo(status, shared.NewNilLogger(), api)
+	event, err := tc.GetStatusEventInfo(status, shared.NewNilLogger(), api)
 	assert.Equal(t, event.Master, true)
 	assert.Nil(t, err)
 
 	status.Branches = branchInfos{&github.Branch{Name: strPtr("mybranch")}}
-	event, err = tc.GetEventInfo(status, shared.NewNilLogger(), api)
+	event, err = tc.GetStatusEventInfo(status, shared.NewNilLogger(), api)
 	assert.Equal(t, event.Master, false)
 	assert.Nil(t, err)
 
 	// Missing the 'branches' entry is not an error; the event just isn't
 	// for master.
 	status.Branches = nil
-	event, err = tc.GetEventInfo(status, shared.NewNilLogger(), api)
+	event, err = tc.GetStatusEventInfo(status, shared.NewNilLogger(), api)
 	assert.Equal(t, event.Master, false)
 	assert.Nil(t, err)
 }
 
-func TestGetEventInfo_sender(t *testing.T) {
+func TestGetStatusEventInfo_sender(t *testing.T) {
 	mockC := gomock.NewController(t)
 	defer mockC.Finish()
 	api := mock_tc.NewMockAPI(mockC)
@@ -536,17 +536,17 @@ func TestGetEventInfo_sender(t *testing.T) {
 
 	// The sender is entirely optional.
 	status.Commit = &github.RepositoryCommit{Author: &github.User{Login: strPtr("someuser")}}
-	event, err := tc.GetEventInfo(status, shared.NewNilLogger(), api)
+	event, err := tc.GetStatusEventInfo(status, shared.NewNilLogger(), api)
 	assert.Equal(t, event.Sender, "someuser")
 	assert.Nil(t, err)
 
 	status.Commit = nil
-	event, err = tc.GetEventInfo(status, shared.NewNilLogger(), api)
+	event, err = tc.GetStatusEventInfo(status, shared.NewNilLogger(), api)
 	assert.Equal(t, event.Sender, "")
 	assert.Nil(t, err)
 }
 
-func TestGetEventInfo_group(t *testing.T) {
+func TestGetStatusEventInfo_group(t *testing.T) {
 	mockC := gomock.NewController(t)
 	defer mockC.Finish()
 	api := mock_tc.NewMockAPI(mockC)
@@ -560,11 +560,192 @@ func TestGetEventInfo_group(t *testing.T) {
 	status.SHA = strPtr("abcdef123")
 
 	api.EXPECT().GetTaskGroupInfo(gomock.Any(), gomock.Any()).Return(group, nil).Times(1)
-	event, err := tc.GetEventInfo(status, shared.NewNilLogger(), api)
+	event, err := tc.GetStatusEventInfo(status, shared.NewNilLogger(), api)
 	assert.Equal(t, event.Group, group)
 	assert.Nil(t, err)
 
 	api.EXPECT().GetTaskGroupInfo(gomock.Any(), gomock.Any()).Return(nil, errors.New("failed")).Times(1)
-	event, err = tc.GetEventInfo(status, shared.NewNilLogger(), api)
+	event, err = tc.GetStatusEventInfo(status, shared.NewNilLogger(), api)
+	assert.NotNil(t, err)
+}
+
+func TestGetCheckSuiteEventInfo_sha(t *testing.T) {
+	mockC := gomock.NewController(t)
+	defer mockC.Finish()
+	api := mock_tc.NewMockAPI(mockC)
+
+	runs := github.ListCheckRunsResults{}
+	runs.CheckRuns = append(runs.CheckRuns, &github.CheckRun{
+		Name:       strPtr("wpt-decision-task"),
+		Status:     strPtr("completed"),
+		DetailsURL: strPtr("https://community-tc.services.mozilla.com/tasks/Jq4HzLz0R2eKkJFdmf47Bg"),
+	})
+	api.EXPECT().ListCheckRunsCheckSuite(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(&runs, nil, nil)
+
+	event := github.CheckSuiteEvent{
+		CheckSuite: &github.CheckSuite{
+			HeadSHA: strPtr("abcdef123"),
+		},
+	}
+
+	// We don't place requirements on the SHA other than it exists.
+	eventInfo, err := tc.GetCheckSuiteEventInfo(event, shared.NewNilLogger(), api)
+	assert.Equal(t, "abcdef123", eventInfo.Sha)
+	assert.Nil(t, err)
+
+	event.CheckSuite.HeadSHA = nil
+	eventInfo, err = tc.GetCheckSuiteEventInfo(event, shared.NewNilLogger(), api)
+	assert.NotNil(t, err)
+}
+
+func TestGetCheckSuiteEventInfo_master(t *testing.T) {
+	mockC := gomock.NewController(t)
+	defer mockC.Finish()
+	api := mock_tc.NewMockAPI(mockC)
+
+	runs := github.ListCheckRunsResults{}
+	runs.CheckRuns = append(runs.CheckRuns, &github.CheckRun{
+		Name:       strPtr("wpt-decision-task"),
+		Status:     strPtr("completed"),
+		DetailsURL: strPtr("https://community-tc.services.mozilla.com/tasks/Jq4HzLz0R2eKkJFdmf47Bg"),
+	})
+	api.EXPECT().ListCheckRunsCheckSuite(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(&runs, nil, nil)
+
+	event := github.CheckSuiteEvent{
+		CheckSuite: &github.CheckSuite{
+			HeadBranch: strPtr("master"),
+			HeadSHA:    strPtr("abcdef123"),
+		},
+	}
+
+	eventInfo, err := tc.GetCheckSuiteEventInfo(event, shared.NewNilLogger(), api)
+	assert.Equal(t, true, eventInfo.Master)
+	assert.Nil(t, err)
+
+	event.CheckSuite.HeadBranch = strPtr("my-branch")
+	eventInfo, err = tc.GetCheckSuiteEventInfo(event, shared.NewNilLogger(), api)
+	assert.Equal(t, false, eventInfo.Master)
+	assert.Nil(t, err)
+}
+
+func TestGetCheckSuiteEventInfo_sender(t *testing.T) {
+	mockC := gomock.NewController(t)
+	defer mockC.Finish()
+	api := mock_tc.NewMockAPI(mockC)
+
+	runs := github.ListCheckRunsResults{}
+	runs.CheckRuns = append(runs.CheckRuns, &github.CheckRun{
+		Name:       strPtr("wpt-decision-task"),
+		Status:     strPtr("completed"),
+		DetailsURL: strPtr("https://community-tc.services.mozilla.com/tasks/Jq4HzLz0R2eKkJFdmf47Bg"),
+	})
+	api.EXPECT().ListCheckRunsCheckSuite(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(&runs, nil, nil)
+
+	event := github.CheckSuiteEvent{
+		Sender: &github.User{
+			Login: strPtr("myuser"),
+		},
+		CheckSuite: &github.CheckSuite{
+			HeadSHA: strPtr("abcdef123"),
+		},
+	}
+
+	eventInfo, err := tc.GetCheckSuiteEventInfo(event, shared.NewNilLogger(), api)
+	assert.Equal(t, "myuser", eventInfo.Sender)
+	assert.Nil(t, err)
+
+	event.Sender.Login = nil
+	eventInfo, err = tc.GetCheckSuiteEventInfo(event, shared.NewNilLogger(), api)
+	assert.Equal(t, "", eventInfo.Sender)
+	assert.Nil(t, err)
+}
+
+func TestGetCheckSuiteEventInfo_checkRuns(t *testing.T) {
+	mockC := gomock.NewController(t)
+	defer mockC.Finish()
+	api := mock_tc.NewMockAPI(mockC)
+
+	runs := github.ListCheckRunsResults{}
+	api.EXPECT().ListCheckRunsCheckSuite(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(&runs, nil, nil)
+
+	// The list of check_run events give us two main pieces of information:
+	//
+	//	the RootURL, which must match across runs, and
+	//	the TaskGroupInfo:
+	//		TaskGroupID is the wpt-decision-tasks's taskID
+	//		Tasks is filled with each check_run's name, taskID, and status.
+	runs.CheckRuns = append(runs.CheckRuns, &github.CheckRun{
+		Name:       strPtr("wpt-decision-task"),
+		Status:     strPtr("completed"),
+		DetailsURL: strPtr("https://community-tc.services.mozilla.com/tasks/Jq4HzLz0R2eKkJFdmf47Bg"),
+	})
+	runs.CheckRuns = append(runs.CheckRuns, &github.CheckRun{
+		Name:       strPtr("wpt-chrome-dev-testharness-1"),
+		Status:     strPtr("completed"),
+		DetailsURL: strPtr("https://community-tc.services.mozilla.com/tasks/IWlO7NuxRnO0_8PKMuHFkw"),
+	})
+
+	event := github.CheckSuiteEvent{
+		CheckSuite: &github.CheckSuite{
+			HeadSHA: strPtr("abcdef123"),
+		},
+	}
+
+	eventInfo, err := tc.GetCheckSuiteEventInfo(event, shared.NewNilLogger(), api)
+	assert.Equal(t, "https://community-tc.services.mozilla.com", eventInfo.RootURL)
+	assert.Equal(t, "Jq4HzLz0R2eKkJFdmf47Bg", eventInfo.Group.TaskGroupID)
+	assert.Equal(t, "wpt-decision-task", eventInfo.Group.Tasks[0].Name)
+	assert.Equal(t, "Jq4HzLz0R2eKkJFdmf47Bg", eventInfo.Group.Tasks[0].TaskID)
+	assert.Equal(t, "completed", eventInfo.Group.Tasks[0].State)
+	assert.Equal(t, "wpt-chrome-dev-testharness-1", eventInfo.Group.Tasks[1].Name)
+	assert.Equal(t, "IWlO7NuxRnO0_8PKMuHFkw", eventInfo.Group.Tasks[1].TaskID)
+	assert.Equal(t, "completed", eventInfo.Group.Tasks[1].State)
+	assert.Nil(t, err)
+
+	// Check the case where a details URL will fail to parse.
+	runs.CheckRuns[0].DetailsURL = strPtr("https://example.com/nope/not/right")
+	eventInfo, err = tc.GetCheckSuiteEventInfo(event, shared.NewNilLogger(), api)
+	assert.NotNil(t, err)
+
+	// Check the case where a details URL is missing.
+	runs.CheckRuns[0].DetailsURL = nil
+	eventInfo, err = tc.GetCheckSuiteEventInfo(event, shared.NewNilLogger(), api)
+	assert.NotNil(t, err)
+
+	// Check the case where a details URL has a mismatching root URL.
+	runs.CheckRuns[0].DetailsURL = strPtr("https://tc.community.com/tasks/Jq4HzLz0R2eKkJFdmf47Bg")
+	eventInfo, err = tc.GetCheckSuiteEventInfo(event, shared.NewNilLogger(), api)
+	assert.NotNil(t, err)
+}
+
+func TestGetCheckSuiteEventInfo_checkRunsEmpty(t *testing.T) {
+	mockC := gomock.NewController(t)
+	defer mockC.Finish()
+	api := mock_tc.NewMockAPI(mockC)
+	api.EXPECT().ListCheckRunsCheckSuite(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(&github.ListCheckRunsResults{}, nil, nil)
+
+	event := github.CheckSuiteEvent{
+		CheckSuite: &github.CheckSuite{
+			HeadSHA: strPtr("abcdef123"),
+		},
+	}
+
+	_, err := tc.GetCheckSuiteEventInfo(event, shared.NewNilLogger(), api)
+	assert.NotNil(t, err)
+}
+
+func TestGetCheckSuiteEventInfo_checkRunsFailed(t *testing.T) {
+	mockC := gomock.NewController(t)
+	defer mockC.Finish()
+	api := mock_tc.NewMockAPI(mockC)
+	api.EXPECT().ListCheckRunsCheckSuite(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(nil, nil, errors.New("failed"))
+
+	event := github.CheckSuiteEvent{
+		CheckSuite: &github.CheckSuite{
+			HeadSHA: strPtr("abcdef123"),
+		},
+	}
+
+	_, err := tc.GetCheckSuiteEventInfo(event, shared.NewNilLogger(), api)
 	assert.NotNil(t, err)
 }


### PR DESCRIPTION
This PR adds the ability to handle GitHub `check_suite` events as part of the
Taskcluster webhook. Similarly to the existing flow for `status` events, we
extract the relevant event information and then post tasks to the receiver for
the found tasks.