### PR TITLE
[webapp] Fix lhci upload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,7 +105,7 @@ script:
   - |
     # Run tests
     if [[ "${MAKE_TEST_TARGET}" == "lighthouse" ]]; then
-      docker exec -e LHCI_GITHUB_APP_TOKEN -t "${DOCKER_INSTANCE}" make lighthouse;
+      docker exec -e LHCI_GITHUB_APP_TOKEN -e TRAVIS_BRANCH -e TRAVIS_PULL_REQUEST_BRANCH -t "${DOCKER_INSTANCE}" make lighthouse;
     elif [[ -n "${MAKE_TEST_TARGET}" ]]; then
       docker exec -t "${DOCKER_INSTANCE}" make "${MAKE_TEST_TARGET}" ${MAKE_TEST_FLAGS};
     fi


### PR DESCRIPTION
This is a regression caused by lhci 0.3.9 (#1805 ). First failure:
https://travis-ci.com/github/web-platform-tests/wpt.fyi/jobs/289437504#L2179

The root cause is that lhci-cli started to require branch names when uploading results:
https://github.com/GoogleChrome/lighthouse-ci/commit/8691dcb75b40a302d6db84fc3f963ff2f7040fb9#diff-cc0cba378c8a7fa9b550e5c205605ccfR80

However, the upload failure is only a warning so we didn't notice. I've filed https://github.com/GoogleChrome/lighthouse-ci/issues/325 for that.

The fix is to pass `TRAVIS_BRANCH` and `TRAVIS_PULL_REQUEST_BRANCH` into Docker, which will be used by
https://github.com/GoogleChrome/lighthouse-ci/blob/master/packages/utils/src/build-context.js#L104