### PR TITLE
[webapp] Increase the contrast of "show history"

### DIFF
--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -115,7 +115,7 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
         color: var(--paper-red-500);
       }
       #show-history {
-        background: var(--paper-blue-500);
+        background: var(--paper-blue-700);
         color: white;
       }
       .test-type {


### PR DESCRIPTION
See https://storage.googleapis.com/lighthouse-infrastructure.appspot.com/reports/1590518415027-18038.report.html#accessibility

This button was somehow missed by older versions of lhci (including the one built into Chrome 83) but picked up by the new version.