### PR TITLE
Make lighthouse fail on upload failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ web_components_test: xvfb firefox chrome webapp_node_modules_all psmisc
 	util/wct.sh $(USE_FRAME_BUFFER)
 
 lighthouse: chrome webapp_node_modules_all
-	cd webapp; npx lhci autorun
+	cd webapp; npx lhci autorun --failOnUploadFailure
 
 dev_appserver_deps: gcloud-app-engine-python gcloud-app-engine-go gcloud-cloud-datastore-emulator
 


### PR DESCRIPTION
This new option was introduced to lhci in
https://github.com/GoogleChrome/lighthouse-ci/pull/329

It'd prevent regressions in upload from going unnoticed.
