### PR TITLE
Remove some unused code

### DIFF
--- a/api/taskcluster/webhook.go
+++ b/api/taskcluster/webhook.go
@@ -209,21 +209,6 @@ func (s StatusEventPayload) IsOnMaster() bool {
 	return false
 }
 
-// taskInfo is an abstraction of a Taskcluster task, containing the necessary
-// information for us to process the task in wpt.fyi.
-type taskInfo struct {
-	name   string
-	taskID string
-	state  string
-}
-
-// taskGroupInfo is an abstraction of a Taskcluster task group, containing the
-// necessary information for us to process the group in wpt.fyi.
-type taskGroupInfo struct {
-	taskGroupID string
-	tasks       []taskInfo
-}
-
 func processTaskclusterBuild(aeAPI shared.AppEngineAPI, event EventInfo, labels ...string) (bool, error) {
 	ctx := aeAPI.Context()
 	log := shared.GetLogger(ctx)


### PR DESCRIPTION
Due to a merge conflict, the original definitions of taskInfo and
taskGroupInfo were left behind when they were made into public
interfaces. (Their location in the file was moved at the same time).