### PR TITLE
Products and TestRuns mismatch

### DIFF
--- a/webapp/components/product-info.js
+++ b/webapp/components/product-info.js
@@ -106,6 +106,16 @@ function parseProduct(name) {
   };
 }
 
+function createProduct(browserName, browserVersion, labels, revision) {
+  const product = {
+    browser_name: browserName,
+    browser_version: browserVersion,
+    labels: labels,
+    revision: revision,
+  };
+  return product;
+}
+
 // eslint-disable-next-line no-unused-vars
 const ProductInfo = (superClass) => class extends superClass {
   static get properties() {
@@ -232,4 +242,5 @@ export {
   ProductInfo,
   parseProductSpec,
   parseProduct,
+  createProduct,
 };

--- a/webapp/components/product-info.js
+++ b/webapp/components/product-info.js
@@ -106,12 +106,12 @@ function parseProduct(name) {
   };
 }
 
-function createProduct(browserName, browserVersion, labels, revision) {
+function productFromRun(run) {
   const product = {
-    browser_name: browserName,
-    browser_version: browserVersion,
-    labels: labels,
-    revision: revision,
+    browser_name: run.browser_name,
+    browser_version: run.browser_version,
+    labels: run.labels,
+    revision: run.revision,
   };
   return product;
 }
@@ -242,5 +242,5 @@ export {
   ProductInfo,
   parseProductSpec,
   parseProduct,
-  createProduct,
+  productFromRun,
 };

--- a/webapp/components/test-file-results-table.js
+++ b/webapp/components/test-file-results-table.js
@@ -17,6 +17,7 @@ import { PathInfo } from './path.js';
 import { Pluralizer } from './pluralize.js';
 import { WPTFlags } from './wpt-flags.js';
 import { AmendMetadataMixin } from './wpt-amend-metadata.js';
+import { createProduct } from './product-info.js';
 
 class TestFileResultsTable extends WPTFlags(Pluralizer(AmendMetadataMixin(WPTColors(PathInfo(TestRunsBase))))) {
   static get is() {
@@ -208,6 +209,10 @@ class TestFileResultsTable extends WPTFlags(Pluralizer(AmendMetadataMixin(WPTCol
         type: Boolean,
         value: false,
       },
+      displayedProducts: {
+        type: Array,
+        computed: 'computeDisplayedProducts(testRuns)',
+      },
       matchers: {
         type: Array,
         value: [
@@ -267,6 +272,10 @@ class TestFileResultsTable extends WPTFlags(Pluralizer(AmendMetadataMixin(WPTCol
     this.toggleDiffFilter = () => {
       this.onlyShowDifferences = !this.onlyShowDifferences;
     };
+  }
+
+  computeDisplayedProducts(testRuns) {
+    return testRuns.map(r => createProduct(r.browser_name, r.browser_version, r.labels, r.revision));
   }
 
   subtestMessage(result, verbose) {
@@ -396,7 +405,7 @@ class TestFileResultsTable extends WPTFlags(Pluralizer(AmendMetadataMixin(WPTCol
         return;
       }
 
-      this.handleSelect(e.target.closest('td'), this.products[index].browser_name, test, this.$['selected-toast']);
+      this.handleSelect(e.target.closest('td'), this.displayedProducts[index].browser_name, test, this.$['selected-toast']);
     };
   }
 

--- a/webapp/components/test-file-results-table.js
+++ b/webapp/components/test-file-results-table.js
@@ -17,7 +17,7 @@ import { PathInfo } from './path.js';
 import { Pluralizer } from './pluralize.js';
 import { WPTFlags } from './wpt-flags.js';
 import { AmendMetadataMixin } from './wpt-amend-metadata.js';
-import { createProduct } from './product-info.js';
+import { productFromRun } from './product-info.js';
 
 class TestFileResultsTable extends WPTFlags(Pluralizer(AmendMetadataMixin(WPTColors(PathInfo(TestRunsBase))))) {
   static get is() {
@@ -275,7 +275,7 @@ class TestFileResultsTable extends WPTFlags(Pluralizer(AmendMetadataMixin(WPTCol
   }
 
   computeDisplayedProducts(testRuns) {
-    return testRuns.map(r => createProduct(r.browser_name, r.browser_version, r.labels, r.revision));
+    return testRuns.map(productFromRun);
   }
 
   subtestMessage(result, verbose) {

--- a/webapp/components/test-runs.js
+++ b/webapp/components/test-runs.js
@@ -22,6 +22,7 @@ const TestRunsQueryLoader = (superClass) =>
           notify: true,
         },
         nextPageToken: String,
+        displayedProducts: Array,
       };
     }
 
@@ -50,7 +51,7 @@ const TestRunsQueryLoader = (superClass) =>
         return sum.concat(Array.isArray(item) ? item : [item]);
       }, []);
       this.testRuns = flattened;
-      this.products = this.testRuns.map(r => createProduct(r.browser_name, r.browser_version, r.labels, r.revision));
+      this.displayedProducts = this.testRuns.map(r => createProduct(r.browser_name, r.browser_version, r.labels, r.revision));
       return flattened;
     }
 

--- a/webapp/components/test-runs.js
+++ b/webapp/components/test-runs.js
@@ -6,6 +6,7 @@
 
 import { PolymerElement } from '../node_modules/@polymer/polymer/polymer-element.js';
 import { TestRunsQuery, TestRunsUIQuery } from './test-runs-query.js';
+import { createProduct } from './product-info.js';
 
 /**
  * Base class for re-use of results-fetching behaviour, between
@@ -49,6 +50,7 @@ const TestRunsQueryLoader = (superClass) =>
         return sum.concat(Array.isArray(item) ? item : [item]);
       }, []);
       this.testRuns = flattened;
+      this.products = this.testRuns.map(r => createProduct(r.browser_name, r.browser_version, r.labels, r.revision));
       return flattened;
     }
 

--- a/webapp/components/test-runs.js
+++ b/webapp/components/test-runs.js
@@ -6,7 +6,7 @@
 
 import { PolymerElement } from '../node_modules/@polymer/polymer/polymer-element.js';
 import { TestRunsQuery, TestRunsUIQuery } from './test-runs-query.js';
-import { createProduct } from './product-info.js';
+import { productFromRun } from './product-info.js';
 
 /**
  * Base class for re-use of results-fetching behaviour, between
@@ -51,7 +51,7 @@ const TestRunsQueryLoader = (superClass) =>
         return sum.concat(Array.isArray(item) ? item : [item]);
       }, []);
       this.testRuns = flattened;
-      this.displayedProducts = this.testRuns.map(r => createProduct(r.browser_name, r.browser_version, r.labels, r.revision));
+      this.displayedProducts = this.testRuns.map(productFromRun);
       return flattened;
     }
 

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -326,7 +326,7 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
     </template>
 
     <template is="dom-if" if="[[displayMetadata]]">
-      <wpt-metadata products="[[products]]"
+      <wpt-metadata products="[[displayedProducts]]"
                     path="[[path]]"
                     search-results="[[searchResults]]"
                     metadata-map="{{metadataMap}}"></wpt-metadata>
@@ -1035,7 +1035,7 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
         return;
       }
 
-      this.handleSelect(e.target.closest('td'), this.products[index].browser_name, node.path, this.$['selected-toast']);
+      this.handleSelect(e.target.closest('td'), this.displayedProducts[index].browser_name, node.path, this.$['selected-toast']);
     };
   }
 
@@ -1048,7 +1048,7 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
   }
 
   getMetadataUrl(index, testname, metadataMap) {
-    const key = testname + this.products[index].browser_name;
+    const key = testname + this.displayedProducts[index].browser_name;
     if (key in metadataMap) {
       return metadataMap[key];
     }


### PR DESCRIPTION
Fix for https://github.com/web-platform-tests/wpt.fyi/issues/2006, https://github.com/web-platform-tests/wpt.fyi/issues/1896

The mismatch between `products` and `testRuns` lies at the use of `/api/run` and `api/search`. When `run_ids` and `q` are used directly in `api/search`, `products` becomes outdated. However, updating `products` immediately after `testRuns` is fetched will trigger another cycle of `testRuns` update.

IMO, `products` should be named something like `queryProducts` because it's exclusively used for the query parameters of `/api/runs`. For https://github.com/web-platform-tests/wpt.fyi/issues/1896, the question is when a user deletes/adds a product, are they deleting a `queryProducts` or a `displayedProduct`?