### PR TITLE
Ask Renovate to ignore genproto

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,7 @@
     "major": {
       "enabled": false
     },
+    "ignoreDeps": ["google.golang.org/genproto"],
     "postUpdateOptions": ["gomodTidy"]
   },
   "npm": {


### PR DESCRIPTION
google.golang.org/genproto contains automatically and frequently updated code
generated from protobuf. Most of the time, there's no need to update it
explicitly.
