### PR TITLE
Receive 100 check-runs per page

### DIFF
--- a/api/checks/runs.go
+++ b/api/checks/runs.go
@@ -86,7 +86,12 @@ func getExistingCheckRuns(ctx context.Context, suite shared.CheckSuite) ([]*gith
 		return nil, err
 	}
 
-	runs, _, err := client.Checks.ListCheckRunsForRef(ctx, suite.Owner, suite.Repo, suite.SHA, nil)
+	options := github.ListCheckRunsOptions {
+		ListOptions: github.ListOptions {
+			PerPage: 100,
+		},
+	}
+	runs, _, err := client.Checks.ListCheckRunsForRef(ctx, suite.Owner, suite.Repo, suite.SHA, &options)
 	if err != nil {
 		return nil, err
 	}

--- a/api/taskcluster/webhook.go
+++ b/api/taskcluster/webhook.go
@@ -432,7 +432,12 @@ func (api apiImpl) GetTaskGroupInfo(rootURL string, groupID string) (*TaskGroupI
 }
 
 func (api apiImpl) ListCheckRuns(owner string, repo string, checkSuiteID int64) (*github.ListCheckRunsResults, *github.Response, error) {
-	return api.ghClient.Checks.ListCheckRunsCheckSuite(api.ctx, owner, repo, checkSuiteID, nil)
+	options := github.ListCheckRunsOptions{
+		ListOptions: github.ListOptions {
+			PerPage: 100,
+		},
+	}
+	return api.ghClient.Checks.ListCheckRunsCheckSuite(api.ctx, owner, repo, checkSuiteID, &options)
 }
 
 // ArtifactURLs holds the results and screenshot URLs for a Taskcluster run.


### PR DESCRIPTION
This is a quick fix to workaround the missing shards from WPT results.
Longer term we should properly deal with pagination, but for now we use
the fact that we know there are less than 100 results.
