### PR TITLE
Fix GitHub pagination handling

### DIFF
--- a/api/checks/runs.go
+++ b/api/checks/runs.go
@@ -106,7 +106,10 @@ func getExistingCheckRuns(ctx context.Context, suite shared.CheckSuite) ([]*gith
 
 		runs = append(runs, result.CheckRuns...)
 
-		if response.NextPage >= response.LastPage {
+		// GitHub APIs indicate being on the last page by not returning any
+		// value for NextPage, which go-github translates into zero.
+		// See https://gowalker.org/github.com/google/go-github/github#Response
+		if response.NextPage == 0 {
 			return runs, nil
 		}
 

--- a/api/taskcluster/webhook.go
+++ b/api/taskcluster/webhook.go
@@ -451,7 +451,10 @@ func (api apiImpl) ListCheckRuns(owner string, repo string, checkSuiteID int64) 
 
 		runs = append(runs, result.CheckRuns...)
 
-		if response.NextPage >= response.LastPage {
+		// GitHub APIs indicate being on the last page by not returning any
+		// value for NextPage, which go-github translates into zero.
+		// See https://gowalker.org/github.com/google/go-github/github#Response
+		if response.NextPage == 0 {
 			return runs, nil
 		}
 


### PR DESCRIPTION
The code as written was just pretty wrong for how GitHub APIs work. Firstly, it checked if `NextPage >= LastPage`, which is an off-by-one error. Secondly, go-github actually just returns 0 for **both** those fields once it reaches the last page... from a test file I wrote, querying check_suite 898247597:

```
$ go run main.go
request 0
NextPage: 2 PrevPage: 0 FirstPage: 0 LastPage: 2
request 1
NextPage: 0 PrevPage: 1 FirstPage: 1 LastPage: 0
done
```