### PR TITLE
Remove references to wpt-tc-checks repository

### DIFF
--- a/api/taskcluster/webhook.go
+++ b/api/taskcluster/webhook.go
@@ -123,11 +123,9 @@ func GetCheckSuiteEventInfo(checkSuite github.CheckSuiteEvent, log shared.Logger
 
 	log.Debugf("Parsing check_suite event for commit %s", checkSuite.GetCheckSuite().GetHeadSHA())
 
-	// TODO(smcgruer): Remove 'wpt-tc-checks' case once migration to
-	// Taskcluster Checks is complete.
 	owner := checkSuite.GetRepo().GetOwner().GetLogin()
 	repo := checkSuite.GetRepo().GetName()
-	if owner != shared.WPTRepoOwner || (repo != shared.WPTRepoName && repo != "wpt-tc-checks") {
+	if owner != shared.WPTRepoOwner || repo != shared.WPTRepoName {
 		log.Errorf("Received check_suite event from invalid repo %s/%s", owner, repo)
 		return EventInfo{}, errors.New("Invalid source repository")
 	}


### PR DESCRIPTION
This repo was a temporary testing ground for moving WPT to the
Taskcluster Checks api. That migration has now taken place, so the
repository is no longer needed.