### PR TITLE
[results-processor] Handle Chrome Nightly

### DIFF
--- a/results-processor/wptreport.py
+++ b/results-processor/wptreport.py
@@ -559,6 +559,8 @@ def prepare_labels(report: WPTReport,
     elif not (labels & RELEASE_CHANNEL_LABELS):
         # Default to "stable" if no channel label or browser_channel is present
         # TODO(Hexcles): remove this fallback default eventually.
+        _log.warn('Test run does not have browser_channel or any channel label,'
+                  ' assumed stable.')
         labels.add('stable')
 
     # Remove any empty labels.
@@ -615,6 +617,8 @@ def create_test_run(report, run_id, labels_str, uploader, auth,
     """
     if callback_url is None:
         callback_url = config.project_baseurl() + '/api/results/create'
+    _log.info('Creating run %s from %s using %s',
+              run_id, uploader, callback_url)
 
     labels = prepare_labels(report, labels_str, uploader)
     assert len(labels) > 0

--- a/results-processor/wptreport.py
+++ b/results-processor/wptreport.py
@@ -499,7 +499,10 @@ class WPTReport(object):
 
 
 def _channel_to_labels(browser: str, channel: str) -> Set[str]:
-    """Maps browser-specific channels to well-known labels.
+    """Maps a browser-specific channel to labels.
+
+    The original channel is always preserved as a label. In addition,
+    well-known aliases of browser-specific channels are added.
 
     This aligns channels to RELEASE_CHANNEL_LABELS so that different browsers
     can be compared meaningfully on wpt.fyi. A few other aliases are added for

--- a/results-processor/wptreport.py
+++ b/results-processor/wptreport.py
@@ -562,8 +562,8 @@ def prepare_labels(report: WPTReport,
     elif not (labels & RELEASE_CHANNEL_LABELS):
         # Default to "stable" if no channel label or browser_channel is present
         # TODO(Hexcles): remove this fallback default eventually.
-        _log.warn('Test run does not have browser_channel or any channel label,'
-                  ' assumed stable.')
+        _log.warn('Test run does not have browser_channel or any channel label'
+                  ', assumed stable.')
         labels.add('stable')
 
     # Remove any empty labels.

--- a/results-processor/wptreport.py
+++ b/results-processor/wptreport.py
@@ -33,15 +33,8 @@ from mypy_extensions import TypedDict
 import config
 
 DEFAULT_PROJECT = 'wptdashboard'
-CHANNEL_TO_LABEL = {
-    'release': 'stable',
-    'stable': 'stable',
-    'beta': 'beta',
-    'dev': 'experimental',
-    'experimental': 'experimental',
-    'nightly': 'experimental',
-    'preview': 'experimental',
-}
+# These are the release channels understood by wpt.fyi.
+RELEASE_CHANNEL_LABELS = {'stable', 'beta', 'experimental'}
 # Ignore inconsistent browser minor versions for now.
 # TODO(Hexcles): Remove this when the TC decision task is implemented.
 IGNORED_CONFLICTS = {'browser_build_id', 'browser_changeset'}
@@ -505,6 +498,33 @@ class WPTReport(object):
         self.write_gzip_json(filepath, self._report)
 
 
+def _channel_to_labels(browser: str, channel: str) -> Set[str]:
+    """Maps browser-specific channels to well-known labels.
+
+    This aligns channels to RELEASE_CHANNEL_LABELS so that different browsers
+    can be compared meaningfully on wpt.fyi. A few other aliases are added for
+    convenience.
+    """
+    labels = {channel}
+    if channel == 'release':
+        # e.g. Edge release
+        labels.add('stable')
+    if channel == 'dev' or channel == 'preview':
+        # e.g. Chrome Dev and Safari Technology Preview
+        labels.add('experimental')
+    if channel == 'nightly' and browser == 'firefox':
+        # Only treat Firefox Nightly, but not Chrome Nightly, as experimental.
+        labels.add('experimental')
+    if channel == 'canary' and (
+            browser == 'chrome' or browser == 'edgechromium'):
+        # Chrome/Edge Canary is almost nightly.
+        labels.add('nightly')
+
+    # TODO(Hexcles): Figure out how we'd like to handle Chrome/Edge Canary.
+    # https://github.com/web-platform-tests/wpt.fyi/issues/1635
+    return labels
+
+
 def prepare_labels(report: WPTReport,
                    labels_str: str,
                    uploader: str) -> Set[str]:
@@ -523,20 +543,22 @@ def prepare_labels(report: WPTReport,
     Returns:
         A set of strings.
     """
+    browser = report.run_info['product']
+    # browser_channel is an optional field.
+    channel = report.run_info.get('browser_channel')
     labels = set()
-    labels.add(report.run_info['product'])
+    labels.add(browser)
     labels.add(uploader)
     # Empty labels may be generated here, but they will be removed later.
     for label in labels_str.split(','):
         labels.add(label.strip())
 
     # Add the release channel label.
-    if report.run_info.get('browser_channel'):
-        labels.add(report.run_info['browser_channel'])
-        if report.run_info['browser_channel'] in CHANNEL_TO_LABEL:
-            labels.add(CHANNEL_TO_LABEL[report.run_info['browser_channel']])
-    elif not any([i in labels for i in set(CHANNEL_TO_LABEL.values())]):
-        # Default to "stable".
+    if channel:
+        labels |= _channel_to_labels(browser, channel)
+    elif not (labels & RELEASE_CHANNEL_LABELS):
+        # Default to "stable" if no channel label or browser_channel is present
+        # TODO(Hexcles): remove this fallback default eventually.
         labels.add('stable')
 
     # Remove any empty labels.

--- a/results-processor/wptreport_test.py
+++ b/results-processor/wptreport_test.py
@@ -582,26 +582,45 @@ class HelpersTest(unittest.TestCase):
         )
 
     def test_prepare_labels_from_browser_channel(self):
+        # Chrome Dev
         r = WPTReport()
         r._report = {
             'run_info': {
-                'product': 'firefox',
+                'product': 'chrome',
                 'browser_channel': 'dev',
             }
         }
         self.assertSetEqual(
             prepare_labels(r, '', 'blade-runner'),
-            {'blade-runner', 'dev', 'experimental', 'firefox'}
+            {'blade-runner', 'dev', 'experimental', 'chrome'}
         )
+
+        # Chrome Canary
+        r._report['run_info']['browser_channel'] = 'canary'
+        self.assertSetEqual(
+            prepare_labels(r, '', 'blade-runner'),
+            {'blade-runner', 'canary', 'nightly', 'chrome'}
+        )
+
+        # Chrome Nightly
         r._report['run_info']['browser_channel'] = 'nightly'
         self.assertSetEqual(
             prepare_labels(r, '', 'blade-runner'),
-            {'blade-runner', 'experimental', 'firefox', 'nightly'}
+            {'blade-runner', 'nightly', 'chrome'}
         )
+
+        # Firefox Nightly
+        r._report['run_info']['product'] = 'firefox'
+        self.assertSetEqual(
+            prepare_labels(r, '', 'blade-runner'),
+            {'blade-runner', 'nightly', 'experimental', 'firefox'}
+        )
+
+        # Firefox Beta
         r._report['run_info']['browser_channel'] = 'beta'
         self.assertSetEqual(
             prepare_labels(r, '', 'blade-runner'),
-            {'beta', 'blade-runner', 'firefox'}
+            {'blade-runner', 'beta', 'firefox'}
         )
 
     def test_normalize_product_edge_webdriver(self):


### PR DESCRIPTION
This change refactors the logic for adding release channel labels based
on browser_channel so that the mapping is browser-dependent, with two
changes in behaviours:

1. Treat Chrome Nightly differently from Firefox Nightly. Chrome Nightly
   is in fact Chromium ToT (recently added in
   https://github.com/web-platform-tests/wpt/pull/24702), and we don't
   want to add the experimental label to it which would mix it with the
   official Chrome Dev.
2. Add a "nightly" label to Chrome/Edge Canary (we only have Edge Canary
   runs as of now) to allow easy comparison between e.g. Chrome Nightly
   (Chromium ToT) and Edge Canary.
