### PR TITLE
[Taskcluster] Reject tasks that have non-success state

### DIFF
--- a/api/taskcluster/webhook.go
+++ b/api/taskcluster/webhook.go
@@ -165,10 +165,11 @@ func GetCheckSuiteEventInfo(checkSuite github.CheckSuiteEvent, log shared.Logger
 
 		log.Debugf("Adding task: %s, id: %s, conclusion: %s", run.GetName(), taskID, run.GetConclusion())
 
-		// Match the GitHub Check Runs API to the old Taskcluster status API.
-		state := "completed"
-		if run.GetConclusion() != "success" {
-			state = run.GetConclusion()
+		// Reconstruct Taskcluster TaskInfo from the check run without calling Taskcluster API.
+		state := run.GetConclusion()
+		if state == "success" {
+			// Checked in ExtractArtifactURLs.
+			state = "completed"
 		}
 
 		group.Tasks = append(group.Tasks, TaskInfo{

--- a/api/taskcluster/webhook.go
+++ b/api/taskcluster/webhook.go
@@ -163,12 +163,18 @@ func GetCheckSuiteEventInfo(checkSuite github.CheckSuiteEvent, log shared.Logger
 			group.TaskGroupID = taskID
 		}
 
-		log.Debugf("Adding task: %s, id: %s, status: %s", run.GetName(), taskID, run.GetStatus())
+		log.Debugf("Adding task: %s, id: %s, conclusion: %s", run.GetName(), taskID, run.GetConclusion())
+
+		// Match the GitHub Check Runs API to the old Taskcluster status API.
+		state := "completed"
+		if run.GetConclusion() != "success" {
+			state = run.GetConclusion()
+		}
 
 		group.Tasks = append(group.Tasks, TaskInfo{
 			Name:   run.GetName(),
 			TaskID: taskID,
-			State:  run.GetStatus(),
+			State:  state,
 		})
 	}
 
@@ -501,7 +507,7 @@ func ExtractArtifactURLs(rootURL string, log shared.Logger, group *TaskGroupInfo
 		}
 
 		if task.State != "completed" {
-			log.Infof("Task group %s has an unfinished task: %s; %s will be ignored in this group.",
+			log.Infof("Task group %s has a non-successful task: %s; %s will be ignored in this group.",
 				group.TaskGroupID, id, product)
 			failures.Add(product)
 			continue

--- a/api/taskcluster/webhook_test.go
+++ b/api/taskcluster/webhook_test.go
@@ -738,11 +738,13 @@ func TestGetCheckSuiteEventInfo_checkRuns(t *testing.T) {
 		&github.CheckRun{
 			Name:       strPtr("wpt-decision-task"),
 			Status:     strPtr("completed"),
+			Conclusion: strPtr("success"),
 			DetailsURL: strPtr("https://community-tc.services.mozilla.com/tasks/Jq4HzLz0R2eKkJFdmf47Bg"),
 		},
 		&github.CheckRun{
 			Name:       strPtr("wpt-chrome-dev-testharness-1"),
 			Status:     strPtr("completed"),
+			Conclusion: strPtr("failed"),
 			DetailsURL: strPtr("https://community-tc.services.mozilla.com/tasks/IWlO7NuxRnO0_8PKMuHFkw"),
 		},
 	}
@@ -769,7 +771,7 @@ func TestGetCheckSuiteEventInfo_checkRuns(t *testing.T) {
 	assert.Equal(t, "completed", eventInfo.Group.Tasks[0].State)
 	assert.Equal(t, "wpt-chrome-dev-testharness-1", eventInfo.Group.Tasks[1].Name)
 	assert.Equal(t, "IWlO7NuxRnO0_8PKMuHFkw", eventInfo.Group.Tasks[1].TaskID)
-	assert.Equal(t, "completed", eventInfo.Group.Tasks[1].State)
+	assert.Equal(t, "failed", eventInfo.Group.Tasks[1].State)
 	assert.Nil(t, err)
 
 	// Check the case where a details URL will fail to parse.


### PR DESCRIPTION
During the migration to the GitHub Checks API for Taskcluster, we
mistakenly interpreted the 'status' field of a CheckRun as equivalent to
the 'status' field of a Taskcluster task. This is not the case; in the
Taskcluster case 'status' captures the success/failure state of a task,
but for CheckRuns it merely captures the finished/not-finished state.

Instead, CheckRuns should use the 'conclusion' field to get the result
of the task.

To keep things compatible with the existing logic that assumes
Taskcluster status results, we map 'success' --> 'completed'. In the
future we should remove the old status code and switch to just using the
conclusion.

Issue: https://github.com/web-platform-tests/wpt.fyi/issues/2091