### PR TITLE
Move prod-deployment.md to correct template location

### DIFF
--- a/ISSUE_TEMPLATE/prod-deployment.md
+++ b/ISSUE_TEMPLATE/prod-deployment.md
@@ -1,12 +1,3 @@
----
-name: Prod Deployment
-about: Template for prod release tracking issues
-title: Deploy NEW_SHA to production
-labels: release, prod
-assignees: ''
-
----
-
 Previous deployment was #ISSUE_NUM (PREV_SHA)
 
 Changelist PREV_SHA...NEW_SHA


### PR DESCRIPTION
We are still using the legacy template style, which is just a markdown
file (with no metadata), because it allows you to specify a default
template that is automatically used for 'new issue' (without showing
a selection UI).