### PR TITLE
Fix timestamps on /status page

### DIFF
--- a/webapp/components/wpt-processor.js
+++ b/webapp/components/wpt-processor.js
@@ -178,7 +178,7 @@ class WPTProcessor extends ProductInfo(LoadingState(PolymerElement)) {
       dateStyle: 'short',
       timeStyle: 'medium',
     };
-    return new Date(date).toLocaletring('en-US', opts);
+    return new Date(date).toLocaleString('en-US', opts);
   }
 
   refreshContextMenu(e) {

--- a/webapp/components/wpt-processor.js
+++ b/webapp/components/wpt-processor.js
@@ -178,7 +178,7 @@ class WPTProcessor extends ProductInfo(LoadingState(PolymerElement)) {
       dateStyle: 'short',
       timeStyle: 'medium',
     };
-    return new Date(date).toLocaleDateString('en-US', opts);
+    return new Date(date).toLocaletring('en-US', opts);
   }
 
   refreshContextMenu(e) {


### PR DESCRIPTION
Fixes #2106

## Review Information
Click the "processor" link on the staging deployment and switch to the "invalid" tab. You should see runs, and no errors in DevTools.