### PR TITLE
[results-processor] Fix experimental label for WebKitGTK

### DIFF
--- a/results-processor/wptreport.py
+++ b/results-processor/wptreport.py
@@ -515,13 +515,11 @@ def _channel_to_labels(browser: str, channel: str) -> Set[str]:
     if channel == 'dev' or channel == 'preview':
         # e.g. Chrome Dev and Safari Technology Preview
         labels.add('experimental')
-    if channel == 'nightly' and \
-            browser != 'chrome':
+    if channel == 'nightly' and browser != 'chrome':
         # Notably, we don't want to treat Chrome Nightly (Chromium trunk) as
         # experimental, as it would cause confusion with Chrome Dev.
         labels.add('experimental')
-    if channel == 'canary' and \
-            browser in ('chrome', 'edgechromium'):
+    if channel == 'canary' and browser in ('chrome', 'edgechromium'):
         # Chrome/Edge Canary is almost nightly.
         labels.add('nightly')
 

--- a/results-processor/wptreport.py
+++ b/results-processor/wptreport.py
@@ -516,7 +516,7 @@ def _channel_to_labels(browser: str, channel: str) -> Set[str]:
         # e.g. Chrome Dev and Safari Technology Preview
         labels.add('experimental')
     if channel == 'nightly' and \
-            browser in ('firefox', 'webkitgtk_minibrowser'):
+            browser != 'chrome':
         # Notably, we don't want to treat Chrome Nightly (Chromium trunk) as
         # experimental, as it would cause confusion with Chrome Dev.
         labels.add('experimental')

--- a/results-processor/wptreport_test.py
+++ b/results-processor/wptreport_test.py
@@ -613,7 +613,8 @@ class HelpersTest(unittest.TestCase):
         r._report['run_info']['product'] = 'webkitgtk_minibrowser'
         self.assertSetEqual(
             prepare_labels(r, '', 'blade-runner'),
-            {'blade-runner', 'nightly', 'experimental', 'webkitgtk_minibrowser'}
+            {'blade-runner', 'nightly', 'experimental',
+             'webkitgtk_minibrowser'}
         )
 
         # Firefox Nightly

--- a/results-processor/wptreport_test.py
+++ b/results-processor/wptreport_test.py
@@ -609,6 +609,13 @@ class HelpersTest(unittest.TestCase):
             {'blade-runner', 'nightly', 'chrome'}
         )
 
+        # WebKitGTK Nightly
+        r._report['run_info']['product'] = 'webkitgtk_minibrowser'
+        self.assertSetEqual(
+            prepare_labels(r, '', 'blade-runner'),
+            {'blade-runner', 'nightly', 'experimental', 'webkitgtk_minibrowser'}
+        )
+
         # Firefox Nightly
         r._report['run_info']['product'] = 'firefox'
         self.assertSetEqual(


### PR DESCRIPTION
Drive-by:
1. Use log.warning instead of deprecated log.warn
2. Use frozenset to prevent accidental modification

See https://github.com/web-platform-tests/wpt/issues/24752#issuecomment-672308403