### PR TITLE
Try pinning wct-local instead

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,8 +143,7 @@ firefox_install: firefox_deps bzip2 wget java
 firefox_deps:
 	sudo apt-get install -qqy --no-install-suggests $$(apt-cache depends firefox | grep Depends | sed "s/.*ends:\ //" | tr '\n' ' ')
 
-geckodriver: node-selenium-standalone
-	cd webapp; npx selenium-standalone install --singleDriverInstall=firefox
+geckodriver: node-wct-local
 
 golint: git
 	if [ "$$(which golint)" == "" ]; then \

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -30,6 +30,7 @@
     "eslint": "7.5.0",
     "eslint-plugin-html": "6.0.2",
     "wct-browser-legacy": "1.0.2",
+    "wct-local": "2.1.5",
     "web-component-tester": "6.9.2"
   },
   "scripts": {
@@ -71,7 +72,6 @@
     "@vaadin/vaadin-date-picker": "4.2.0",
     "@vaadin/vaadin-grid": "5.6.6",
     "@webcomponents/webcomponentsjs": "2.4.3",
-    "pluralize": "8.0.0",
-    "selenium-standalone": "6.17.0"
+    "pluralize": "8.0.0"
   }
 }


### PR DESCRIPTION
Pinning selenium-standalone to the version wct-local wants at the top
level (#2099) caused Renovate to try to update it automatically (#2121).
Neither manully closing these PRs or ignoring selenium-standalone in
renovate.json is great, so try this instead.

Also move the dependency to dev.
