### PR TITLE
[web-components-test] Pin Chrome to 84 to workaround hang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,11 +114,10 @@ dev_appserver_deps: gcloud-app-engine-python gcloud-app-engine-go gcloud-cloud-d
 
 chrome: wget
 	if [[ -z "$$(which google-chrome)" ]]; then \
-		ARCHIVE=google-chrome-stable_current_amd64.deb; \
-		wget -q https://dl.google.com/linux/direct/$${ARCHIVE}; \
-		sudo dpkg --install $${ARCHIVE} 2>/dev/null || true; \
+		wget -q https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_84.0.4147.135-1_amd64.deb; \
+		sudo dpkg --install google-chrome-stable_84.0.4147.135-1_amd64.deb 2>/dev/null || true; \
 		sudo apt-get install --fix-broken -qqy; \
-		sudo dpkg --install $${ARCHIVE} 2>/dev/null; \
+		sudo dpkg --install google-chrome-stable_84.0.4147.135-1_amd64.deb 2>/dev/null; \
 	fi
 
 # https://sites.google.com/a/chromium.org/chromedriver/downloads/version-selection

--- a/Makefile
+++ b/Makefile
@@ -114,10 +114,11 @@ dev_appserver_deps: gcloud-app-engine-python gcloud-app-engine-go gcloud-cloud-d
 
 chrome: wget
 	if [[ -z "$$(which google-chrome)" ]]; then \
-		wget -q https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_84.0.4147.135-1_amd64.deb; \
-		sudo dpkg --install google-chrome-stable_84.0.4147.135-1_amd64.deb 2>/dev/null || true; \
+		ARCHIVE=google-chrome-stable_current_amd64.deb; \
+		wget -q https://dl.google.com/linux/direct/$${ARCHIVE}; \
+		sudo dpkg --install $${ARCHIVE} 2>/dev/null || true; \
 		sudo apt-get install --fix-broken -qqy; \
-		sudo dpkg --install google-chrome-stable_84.0.4147.135-1_amd64.deb 2>/dev/null; \
+		sudo dpkg --install $${ARCHIVE} 2>/dev/null; \
 	fi
 
 # https://sites.google.com/a/chromium.org/chromedriver/downloads/version-selection

--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,7 @@ lighthouse: chrome webapp_node_modules_all
 dev_appserver_deps: gcloud-app-engine-python gcloud-app-engine-go gcloud-cloud-datastore-emulator
 
 chrome: wget
+	# Pinned to Chrome 84 to workaround https://github.com/web-platform-tests/wpt.fyi/issues/2128
 	if [[ -z "$$(which google-chrome)" ]]; then \
 		wget -q https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_84.0.4147.135-1_amd64.deb; \
 		sudo dpkg --install google-chrome-stable_84.0.4147.135-1_amd64.deb 2>/dev/null || true; \


### PR DESCRIPTION
This is a hopefully temporary workaround for https://github.com/web-platform-tests/wpt.fyi/issues/2128,
to stop making unrelated PRs red and avoid missing real regressions.