### PR TITLE
Remove remaining uses of urlfetch

### DIFF
--- a/api/query/cache/service/search.go
+++ b/api/query/cache/service/search.go
@@ -107,7 +107,7 @@ func searchHandlerImpl(w http.ResponseWriter, r *http.Request) *searchErr {
 			if err := store.Get(store.NewIDKey("TestRun", int64(id)), runPtr); err != nil {
 				return &searchErr{
 					Detail:  err,
-					Message: "Unknown test run ID " + string(id),
+					Message: fmt.Sprintf("Unknown test run ID %d", id),
 					Code:    http.StatusBadRequest,
 				}
 			}

--- a/shared/cache.go
+++ b/shared/cache.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"google.golang.org/appengine/memcache"
-	"google.golang.org/appengine/urlfetch"
 )
 
 var (
@@ -55,8 +54,8 @@ func (hr httpReadable) NewReadCloser(iURL interface{}) (io.ReadCloser, error) {
 		return nil, errNewReadCloserExpectedString
 	}
 
-	client := urlfetch.Client(hr.ctx)
-	r, err := client.Get(url)
+	aeAPI := NewAppEngineAPI(hr.ctx)
+	r, err := aeAPI.GetHTTPClient().Get(url)
 	if err != nil {
 		return nil, err
 	}

--- a/shared/run_diff.go
+++ b/shared/run_diff.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	mapset "github.com/deckarep/golang-set"
-	"google.golang.org/appengine/urlfetch"
 )
 
 // ErrRunNotInSearchCache is an error for 422 responses from the searchcache.
@@ -323,10 +322,10 @@ func FetchRunForSpec(ctx context.Context, spec ProductSpec) (*TestRun, error) {
 // FetchRunResultsJSON fetches the results JSON summary for the given test run, but does not include subtests (since
 // a full run can span 20k files).
 func FetchRunResultsJSON(ctx context.Context, run TestRun) (results ResultsSummary, err error) {
-	client := urlfetch.Client(ctx)
+	aeAPI := NewAppEngineAPI(ctx)
 	url := strings.TrimSpace(run.ResultsURL)
 	var resp *http.Response
-	if resp, err = client.Get(url); err != nil {
+	if resp, err = aeAPI.GetHTTPClient().Get(url); err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()


### PR DESCRIPTION
Part of #1747.

Drive-by: fix a warning discovered by the latest version of golang:
  api/query/cache/service/search.go:110:40: conversion from RunID (int64) to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
