### PR TITLE
[checks] Fix logging

### DIFF
--- a/api/checks/update.go
+++ b/api/checks/update.go
@@ -61,10 +61,7 @@ func updateCheckHandler(w http.ResponseWriter, r *http.Request) {
 	filter.SHAs = shared.SHAs{sha}
 	headRun, baseRun, err := loadRunsToCompare(ctx, filter)
 	if err != nil {
-		msg := "Could not find runs to compare"
-		if err != nil {
-			msg = fmt.Sprintf("%s: %s", msg, err.Error())
-		}
+		msg := "Could not find runs to compare: " + err.Error()
 		log.Errorf(msg)
 		http.Error(w, msg, http.StatusNotFound)
 		return

--- a/api/checks/update.go
+++ b/api/checks/update.go
@@ -64,8 +64,8 @@ func updateCheckHandler(w http.ResponseWriter, r *http.Request) {
 		msg := "Could not find runs to compare"
 		if err != nil {
 			msg = fmt.Sprintf("%s: %s", msg, err.Error())
-			log.Errorf(msg)
 		}
+		log.Errorf(msg)
 		http.Error(w, msg, http.StatusNotFound)
 		return
 	}
@@ -77,6 +77,7 @@ func updateCheckHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Warningf("Failed to load CheckSuites for %s: %s", sha, err.Error())
 		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	} else if len(suites) < 1 {
 		log.Debugf("No CheckSuites found for %s", sha)
 	}

--- a/api/checks/webhook.go
+++ b/api/checks/webhook.go
@@ -48,6 +48,7 @@ func checkWebhookHandler(w http.ResponseWriter, r *http.Request) {
 
 	secret, err := shared.GetSecret(ds, "github-check-webhook-secret")
 	if err != nil {
+		log.Errorf("Missing secret: github-check-webhook-secret")
 		http.Error(w, "Unable to verify request: secret not found", http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
Make sure to log errors for 5xx responses and always return after
setting the error code.

This is a follow-up to the outage in #2158 .