### PR TITLE
Refactor part of GitHub OAuth

### DIFF
--- a/api/metadata_handler.go
+++ b/api/metadata_handler.go
@@ -66,7 +66,11 @@ func apiMetadataTriageHandler(w http.ResponseWriter, r *http.Request) {
 		forceUpdate:  true}
 	tm := shared.NewTriageMetadata(ctx, botClient, user.GitHubHandle, user.GitHubEmail, fetcher)
 
-	gac := shared.NewGitAccessControl(ctx, ds, botClient, *token)
+	gac, err := shared.NewGitHubAccessControl(ctx, ds, botClient, user, *token)
+	if err != nil {
+		http.Error(w, "Unable to create GitHub OAuth client: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
 	handleMetadataTriage(ctx, gac, tm, w, r)
 }
 
@@ -101,25 +105,14 @@ func handleMetadataTriage(ctx context.Context, gac shared.GitHubAccessControl, t
 		return
 	}
 
-	code, err := gac.IsValidAccessToken()
-	if err != nil {
-		http.Error(w, "Failed to validate user token:"+err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	if code != http.StatusOK {
-		http.Error(w, "User token invalid; please log in again.", http.StatusUnauthorized)
-		return
-	}
-
-	code, err = gac.IsValidWPTMember()
+	valid, err := gac.IsValidWPTMember()
 	if err != nil {
 		http.Error(w, "Failed to validate web-platform-tests membership: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	if code != http.StatusOK {
-		http.Error(w, "Logged-in user must be a member of the web-platform-tests GitHub organization. To join, please contact wpt.fyi team members.", http.StatusBadRequest)
+	if !valid {
+		http.Error(w, "Logged-in user must be a member of the web-platform-tests GitHub organization. To join, please contact wpt.fyi team members.", http.StatusForbidden)
 		return
 	}
 

--- a/api/metadata_handler.go
+++ b/api/metadata_handler.go
@@ -51,21 +51,22 @@ func apiMetadataTriageHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	wptfyiBotClient, err := shared.NewGitHubClientFromToken(ctx, "github-wpt-fyi-bot-token")
+	botToken, err := shared.GetSecret(ds, "github-wpt-fyi-bot-token")
 	if err != nil {
 		http.Error(w, "Unable to get GitHub client for wpt-fyi-bot: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
+	botClient := shared.NewGitHubClientFromToken(ctx, botToken)
 
 	aeAPI := shared.NewAppEngineAPI(ctx)
 	fetcher := webappMetadataFetcher{
 		ctx:          ctx,
 		httpClient:   aeAPI.GetHTTPClient(),
-		gitHubClient: wptfyiBotClient,
+		gitHubClient: botClient,
 		forceUpdate:  true}
-	tm := shared.NewTriageMetadata(ctx, wptfyiBotClient, user.GitHubHandle, user.GitHubEmail, fetcher)
+	tm := shared.NewTriageMetadata(ctx, botClient, user.GitHubHandle, user.GitHubEmail, fetcher)
 
-	gac := shared.NewGitAccessControl(ctx, ds, wptfyiBotClient, *token)
+	gac := shared.NewGitAccessControl(ctx, ds, botClient, *token)
 	handleMetadataTriage(ctx, gac, tm, w, r)
 }
 

--- a/api/metadata_handler.go
+++ b/api/metadata_handler.go
@@ -46,7 +46,7 @@ func apiMetadataTriageHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := shared.NewAppEngineContext(r)
 	ds := shared.NewAppEngineDatastore(ctx, false)
 	user, token := shared.GetUserFromCookie(ctx, ds, r)
-	if user == nil || token == nil {
+	if user == nil {
 		http.Error(w, "User is not logged in", http.StatusUnauthorized)
 		return
 	}
@@ -66,7 +66,7 @@ func apiMetadataTriageHandler(w http.ResponseWriter, r *http.Request) {
 		forceUpdate:  true}
 	tm := shared.NewTriageMetadata(ctx, botClient, user.GitHubHandle, user.GitHubEmail, fetcher)
 
-	gac, err := shared.NewGitHubAccessControl(ctx, ds, botClient, user, *token)
+	gac, err := shared.NewGitHubAccessControl(ctx, ds, botClient, user, token)
 	if err != nil {
 		http.Error(w, "Unable to create GitHub OAuth client: "+err.Error(), http.StatusInternalServerError)
 		return

--- a/api/metadata_handler_test.go
+++ b/api/metadata_handler_test.go
@@ -40,8 +40,7 @@ func TestHandleMetadataTriage_Success(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 
 	mockgac := sharedtest.NewMockGitHubAccessControl(mockCtrl)
-	mockgac.EXPECT().IsValidAccessToken().Return(http.StatusOK, nil)
-	mockgac.EXPECT().IsValidWPTMember().Return(http.StatusOK, nil)
+	mockgac.EXPECT().IsValidWPTMember().Return(true, nil)
 
 	mocktm := sharedtest.NewMockTriageMetadata(mockCtrl)
 	mocktm.EXPECT().Triage(gomock.Any()).Return("", nil)

--- a/api/user.go
+++ b/api/user.go
@@ -25,8 +25,8 @@ func apiUserHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ds := shared.NewAppEngineDatastore(ctx, false)
-	user, token := shared.GetUserFromCookie(ctx, ds, r)
-	if user == nil || token == nil {
+	user, _ := shared.GetUserFromCookie(ctx, ds, r)
+	if user == nil {
 		response := loginResponse{Error: "Unable to retrieve login information, please log in again"}
 		marshalled, err := json.Marshal(response)
 		if err != nil {

--- a/shared/github_oauth.go
+++ b/shared/github_oauth.go
@@ -217,3 +217,11 @@ func GetUserFromCookie(ctx context.Context, ds Datastore, r *http.Request) (*Use
 	}
 	return nil, nil
 }
+
+// NewGitHubClientFromToken returns a new GitHub client from an access token.
+func NewGitHubClientFromToken(ctx context.Context, token string) *github.Client {
+	oauthClient := oauth2.NewClient(ctx, oauth2.StaticTokenSource(&oauth2.Token{
+		AccessToken: token,
+	}))
+	return github.NewClient(oauthClient)
+}

--- a/shared/github_oauth.go
+++ b/shared/github_oauth.go
@@ -56,7 +56,7 @@ type GitHubOAuth interface {
 	GetAccessToken() *string
 	SetRedirectURL(url string)
 	GetAuthCodeURL(state string, opts ...oauth2.AuthCodeOption) string
-	GetNewClient(oauthToken string) (*github.Client, error)
+	GetNewClient(oauthCode string) (*github.Client, error)
 	GetGitHubUser(client *github.Client) (*github.User, error)
 }
 
@@ -87,8 +87,8 @@ func (g *githubOAuthImpl) GetAuthCodeURL(state string, opts ...oauth2.AuthCodeOp
 	return g.conf.AuthCodeURL(state, opts...)
 }
 
-func (g *githubOAuthImpl) GetNewClient(oauthToken string) (*github.Client, error) {
-	token, err := g.conf.Exchange(g.ctx, oauthToken)
+func (g *githubOAuthImpl) GetNewClient(oauthCode string) (*github.Client, error) {
+	token, err := g.conf.Exchange(g.ctx, oauthCode)
 	if err != nil {
 		return nil, err
 	}

--- a/shared/github_oauth.go
+++ b/shared/github_oauth.go
@@ -15,7 +15,6 @@ import (
 	"github.com/gorilla/securecookie"
 	"golang.org/x/oauth2"
 	ghOAuth "golang.org/x/oauth2/github"
-	"google.golang.org/appengine"
 )
 
 func init() {
@@ -94,6 +93,7 @@ func (g *githubOAuthImpl) GetNewClient(oauthToken string) (*github.Client, error
 }
 
 func (g *githubOAuthImpl) GetGitHubUser(client *github.Client) (*github.User, error) {
+	// Passing the empty string will fetch the authenticated user.
 	ghUser, _, err := client.Users.Get(g.ctx, "")
 	if err != nil {
 		return nil, err
@@ -209,10 +209,9 @@ func GetUserFromCookie(ctx context.Context, ds Datastore, r *http.Request) (*Use
 			decodedToken, okToken := cookieValue["token"].(string)
 			if okUser && okToken {
 				return &decodedUser, &decodedToken
-			} else if appengine.IsDevAppServer() {
-				log.Errorf("Failed to cast user or token")
 			}
-		} else if appengine.IsDevAppServer() {
+			log.Errorf("Failed to cast user or token")
+		} else {
 			log.Errorf("Failed to Decode cookie: %s", err.Error())
 		}
 	}

--- a/shared/github_oauth.go
+++ b/shared/github_oauth.go
@@ -149,12 +149,8 @@ func (gaci githubAccessControlImpl) IsValidWPTMember() (bool, error) {
 	if !valid {
 		return false, errors.New("Invalid access token")
 	}
-	_, res, err := gaci.botClient.Organizations.GetOrgMembership(gaci.ctx, gaci.user.GitHubHandle, "web-platform-tests")
-	if err != nil {
-		return false, err
-	}
-
-	return res.StatusCode == http.StatusOK, nil
+	isMember, _, err := gaci.botClient.Organizations.IsMember(gaci.ctx, "web-platform-tests", gaci.user.GitHubHandle)
+	return isMember, err
 }
 
 // NewGitHubAccessControl returns a GitHubAccessControl for checking the permission of a logged-in GitHub user.

--- a/shared/github_oauth.go
+++ b/shared/github_oauth.go
@@ -117,7 +117,7 @@ func NewGitHubOAuth(ctx context.Context) (GitHubOAuth, error) {
 
 	clientID, secret, err := getOAuthClientIDSecret(store)
 	if err != nil {
-		log.Errorf("Failed to get github-oauth-client-{id,secret}: %e", err)
+		log.Errorf("Failed to get github-oauth-client-{id,secret}: %s", err.Error())
 		return nil, err
 	}
 

--- a/shared/sharedtest/github_oauth_mock.go
+++ b/shared/sharedtest/github_oauth_mock.go
@@ -162,26 +162,11 @@ func (m *MockGitHubAccessControl) EXPECT() *MockGitHubAccessControlMockRecorder 
 	return m.recorder
 }
 
-// IsValidAccessToken mocks base method
-func (m *MockGitHubAccessControl) IsValidAccessToken() (int, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsValidAccessToken")
-	ret0, _ := ret[0].(int)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// IsValidAccessToken indicates an expected call of IsValidAccessToken
-func (mr *MockGitHubAccessControlMockRecorder) IsValidAccessToken() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsValidAccessToken", reflect.TypeOf((*MockGitHubAccessControl)(nil).IsValidAccessToken))
-}
-
 // IsValidWPTMember mocks base method
-func (m *MockGitHubAccessControl) IsValidWPTMember() (int, error) {
+func (m *MockGitHubAccessControl) IsValidWPTMember() (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsValidWPTMember")
-	ret0, _ := ret[0].(int)
+	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/shared/sharedtest/github_oauth_mock.go
+++ b/shared/sharedtest/github_oauth_mock.go
@@ -65,10 +65,10 @@ func (mr *MockGitHubOAuthMockRecorder) Datastore() *gomock.Call {
 }
 
 // GetAccessToken mocks base method
-func (m *MockGitHubOAuth) GetAccessToken() *string {
+func (m *MockGitHubOAuth) GetAccessToken() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAccessToken")
-	ret0, _ := ret[0].(*string)
+	ret0, _ := ret[0].(string)
 	return ret0
 }
 
@@ -97,34 +97,34 @@ func (mr *MockGitHubOAuthMockRecorder) GetAuthCodeURL(arg0 interface{}, arg1 ...
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAuthCodeURL", reflect.TypeOf((*MockGitHubOAuth)(nil).GetAuthCodeURL), varargs...)
 }
 
-// GetGitHubUser mocks base method
-func (m *MockGitHubOAuth) GetGitHubUser(arg0 *github.Client) (*github.User, error) {
+// GetUser mocks base method
+func (m *MockGitHubOAuth) GetUser(arg0 *github.Client) (*github.User, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetGitHubUser", arg0)
+	ret := m.ctrl.Call(m, "GetUser", arg0)
 	ret0, _ := ret[0].(*github.User)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetGitHubUser indicates an expected call of GetGitHubUser
-func (mr *MockGitHubOAuthMockRecorder) GetGitHubUser(arg0 interface{}) *gomock.Call {
+// GetUser indicates an expected call of GetUser
+func (mr *MockGitHubOAuthMockRecorder) GetUser(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGitHubUser", reflect.TypeOf((*MockGitHubOAuth)(nil).GetGitHubUser), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUser", reflect.TypeOf((*MockGitHubOAuth)(nil).GetUser), arg0)
 }
 
-// GetNewClient mocks base method
-func (m *MockGitHubOAuth) GetNewClient(arg0 string) (*github.Client, error) {
+// NewClient mocks base method
+func (m *MockGitHubOAuth) NewClient(arg0 string) (*github.Client, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNewClient", arg0)
+	ret := m.ctrl.Call(m, "NewClient", arg0)
 	ret0, _ := ret[0].(*github.Client)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetNewClient indicates an expected call of GetNewClient
-func (mr *MockGitHubOAuthMockRecorder) GetNewClient(arg0 interface{}) *gomock.Call {
+// NewClient indicates an expected call of NewClient
+func (mr *MockGitHubOAuthMockRecorder) NewClient(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNewClient", reflect.TypeOf((*MockGitHubOAuth)(nil).GetNewClient), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewClient", reflect.TypeOf((*MockGitHubOAuth)(nil).NewClient), arg0)
 }
 
 // SetRedirectURL mocks base method

--- a/webapp/login.go
+++ b/webapp/login.go
@@ -115,13 +115,13 @@ func handleOauth(g shared.GitHubOAuth, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	oauthToken := r.FormValue("code")
-	if oauthToken == "" {
-		http.Error(w, "No token or username provided", http.StatusBadRequest)
+	oauthCode := r.FormValue("code")
+	if oauthCode == "" {
+		http.Error(w, "No OAuth code provided", http.StatusBadRequest)
 		return
 	}
 
-	client, err := g.GetNewClient(oauthToken)
+	client, err := g.GetNewClient(oauthCode)
 	if err != nil {
 		log.Errorf("Error creating GitHub client using OAuth2 token: %v", err)
 		http.Error(w, "Error creating GitHub client using OAuth2 token", http.StatusBadRequest)

--- a/webapp/login.go
+++ b/webapp/login.go
@@ -128,7 +128,6 @@ func handleOauth(g shared.GitHubOAuth, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Passing the empty string will fetch the authenticated user.
 	ghUser, err := g.GetGitHubUser(client)
 	if err != nil || ghUser == nil {
 		log.Errorf("Failed to get authenticated user: %v", err)

--- a/webapp/login.go
+++ b/webapp/login.go
@@ -35,7 +35,7 @@ func loginHandler(w http.ResponseWriter, r *http.Request) {
 func handleLogin(g shared.GitHubOAuth, w http.ResponseWriter, r *http.Request) {
 	ctx := g.Context()
 	ds := g.Datastore()
-	user, token := shared.GetUserFromCookie(ctx, ds, r)
+	user, _ := shared.GetUserFromCookie(ctx, ds, r)
 	returnURL := r.FormValue("return")
 	if returnURL == "" {
 		returnURL = "/"
@@ -43,7 +43,7 @@ func handleLogin(g shared.GitHubOAuth, w http.ResponseWriter, r *http.Request) {
 
 	redirect := ""
 	log := shared.GetLogger(ctx)
-	if user == nil || token == nil {
+	if user == nil {
 		log.Infof("Initiating a new user login.")
 		g.SetRedirectURL(getCallbackURI(returnURL, r))
 		state, err := generateRandomState(32)
@@ -121,14 +121,14 @@ func handleOauth(g shared.GitHubOAuth, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	client, err := g.GetNewClient(oauthCode)
+	client, err := g.NewClient(oauthCode)
 	if err != nil {
-		log.Errorf("Error creating GitHub client using OAuth2 token: %v", err)
-		http.Error(w, "Error creating GitHub client using OAuth2 token", http.StatusBadRequest)
+		log.Errorf("Error creating GitHub client using OAuth code: %v", err)
+		http.Error(w, "Error creating GitHub client using OAuth code", http.StatusBadRequest)
 		return
 	}
 
-	ghUser, err := g.GetGitHubUser(client)
+	ghUser, err := g.GetUser(client)
 	if err != nil || ghUser == nil {
 		log.Errorf("Failed to get authenticated user: %v", err)
 		http.Error(w, "Failed to get authenticated user", http.StatusBadRequest)
@@ -139,7 +139,12 @@ func handleOauth(g shared.GitHubOAuth, w http.ResponseWriter, r *http.Request) {
 		GitHubHandle: ghUser.GetLogin(),
 		GitHubEmail:  ghUser.GetEmail(),
 	}
-	setSession(ctx, ds, user, g.GetAccessToken(), w)
+	token := g.GetAccessToken()
+	if token == "" {
+		http.Error(w, "Got empty OAuth access token", http.StatusBadRequest)
+		return
+	}
+	setSession(ctx, ds, user, token, w)
 	if err != nil {
 		http.Error(w, "Failed to set credential cookie", http.StatusInternalServerError)
 		return
@@ -159,11 +164,11 @@ func logoutHandler(response http.ResponseWriter, r *http.Request) {
 	http.Redirect(response, r, "/", http.StatusFound)
 }
 
-func setSession(ctx context.Context, ds shared.Datastore, user *shared.User, token *string, response http.ResponseWriter) error {
+func setSession(ctx context.Context, ds shared.Datastore, user *shared.User, token string, response http.ResponseWriter) error {
 	var err error
 	value := map[string]interface{}{
 		"user":  *user,
-		"token": *token,
+		"token": token,
 	}
 
 	sc, err := shared.GetSecureCookie(ctx, ds)


### PR DESCRIPTION
This is in part a refactor to pave the way for migrating away from AppEngine User API to GitHub User API (part of #1747 ) and also a fix for #2157.

It'd be easier to review by commits.