### PR TITLE
Migrate appengine.NewContext to request.Context()

### DIFF
--- a/api/interop_medium_test.go
+++ b/api/interop_medium_test.go
@@ -3,7 +3,6 @@
 package api
 
 import (
-	"context"
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
@@ -28,7 +27,7 @@ func TestApiInteropHandler_CompleteRunFallback(t *testing.T) {
 	defer i.Close()
 
 	r, _ := i.NewRequest("GET", "/api/interop?complete", nil)
-	ctx := context.Background()
+	ctx := r.Context()
 
 	firstRun := shared.TestRun{}
 	firstRun.Labels = []string{"stable"}

--- a/api/interop_medium_test.go
+++ b/api/interop_medium_test.go
@@ -3,6 +3,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
@@ -15,7 +16,6 @@ import (
 	"github.com/web-platform-tests/wpt.fyi/shared/metrics"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
-	"google.golang.org/appengine"
 	"google.golang.org/appengine/datastore"
 )
 
@@ -28,7 +28,7 @@ func TestApiInteropHandler_CompleteRunFallback(t *testing.T) {
 	defer i.Close()
 
 	r, _ := i.NewRequest("GET", "/api/interop?complete", nil)
-	ctx := appengine.NewContext(r)
+	ctx := context.Background()
 
 	firstRun := shared.TestRun{}
 	firstRun.Labels = []string{"stable"}

--- a/shared/logger.go
+++ b/shared/logger.go
@@ -8,7 +8,6 @@ import (
 
 	gclog "cloud.google.com/go/logging"
 	"github.com/sirupsen/logrus"
-	"google.golang.org/appengine"
 	gaelog "google.golang.org/appengine/log"
 	mrpb "google.golang.org/genproto/googleapis/api/monitoredres"
 )
@@ -24,7 +23,7 @@ type Logger interface {
 
 // NewRequestContext creates a new  context bound to an *http.Request.
 func NewRequestContext(r *http.Request) context.Context {
-	ctx := appengine.NewContext(r)
+	ctx := r.Context()
 	return WithLogger(ctx, logrus.WithFields(logrus.Fields{
 		"request": r,
 	}))
@@ -66,7 +65,7 @@ func (lm loggerMux) Warningf(format string, args ...interface{}) {
 // NewAppEngineContext creates a new Google App Engine Standard-based
 // context bound to an http.Request.
 func NewAppEngineContext(r *http.Request) context.Context {
-	ctx := appengine.NewContext(r)
+	ctx := r.Context()
 	return WithLogger(ctx, NewGAELogger(ctx))
 }
 

--- a/shared/sharedtest/util.go
+++ b/shared/sharedtest/util.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/web-platform-tests/wpt.fyi/shared"
-	"google.golang.org/appengine"
 	"google.golang.org/appengine/aetest"
 )
 
@@ -38,7 +37,7 @@ func NewAEContext(stronglyConsistentDatastore bool) (context.Context, func(), er
 		inst.Close()
 		return nil, nil, err
 	}
-	ctx := appengine.NewContext(req)
+	ctx := req.Context()
 	ctx = context.WithValue(ctx, shared.DefaultLoggerCtxKey(), shared.NewNilLogger())
 	return ctx, func() {
 		inst.Close()


### PR DESCRIPTION
A part of #1747,  AppEngine Context migration. 