### PR TITLE
Fixup: restore Content-Type in CloudTasks

### DIFF
--- a/shared/appengine.go
+++ b/shared/appengine.go
@@ -273,7 +273,11 @@ func (a appEngineAPIImpl) ScheduleTask(queueName, taskName, target string, param
 				AppEngineHttpRequest: &taskspb.AppEngineHttpRequest{
 					HttpMethod:  taskspb.HttpMethod_POST,
 					RelativeUri: target,
-					Body:        []byte(params.Encode()),
+					// In appengine.taskqueue, The default for POST task was
+					// application/x-www-form-urlencoded, but the new SDK
+					// defaults to application/octet-stream.
+					Headers: map[string]string{"Content-Tye": "application/x-www-form-urlencoded"},
+					Body:    []byte(params.Encode()),
 				},
 			},
 		},

--- a/shared/appengine.go
+++ b/shared/appengine.go
@@ -276,7 +276,7 @@ func (a appEngineAPIImpl) ScheduleTask(queueName, taskName, target string, param
 					// In appengine.taskqueue, The default for POST task was
 					// application/x-www-form-urlencoded, but the new SDK
 					// defaults to application/octet-stream.
-					Headers: map[string]string{"Content-Tye": "application/x-www-form-urlencoded"},
+					Headers: map[string]string{"Content-Type": "application/x-www-form-urlencoded"},
 					Body:    []byte(params.Encode()),
 				},
 			},


### PR DESCRIPTION
Follow up to #2153 and part of #1747 .

TODO (in a future PR): figure out a way to test this locally. The new SDK no longer provides a local emulator for TaskQueue.