### PR TITLE
Clean up logger.go for the migration

### DIFF
--- a/shared/logger.go
+++ b/shared/logger.go
@@ -21,56 +21,47 @@ type Logger interface {
 	Warningf(format string, args ...interface{})
 }
 
-// NewRequestContext creates a new  context bound to an *http.Request.
-func NewRequestContext(r *http.Request) context.Context {
-	ctx := r.Context()
-	return WithLogger(ctx, logrus.WithFields(logrus.Fields{
-		"request": r,
-	}))
+// LoggerCtxKey is a key for attaching a Logger to a context.Context.
+type LoggerCtxKey struct{}
+
+var lck = LoggerCtxKey{}
+
+// DefaultLoggerCtxKey returns the default key where a logger instance should be
+// stored in a context.Context object.
+func DefaultLoggerCtxKey() LoggerCtxKey {
+	return lck
 }
 
-// SplitLogger is a logger that sends logging operations to both A and B.
-type loggerMux struct {
-	delegates []Logger
+// withLogger is a strongly-typed setter for the logger value on the context.
+func withLogger(ctx context.Context, logger Logger) context.Context {
+	return context.WithValue(ctx, DefaultLoggerCtxKey(), logger)
 }
 
-// Debugf implements formatted debug logging to both A and B.
-func (lm loggerMux) Debugf(format string, args ...interface{}) {
-	for _, l := range lm.delegates {
-		l.Debugf(format, args...)
-	}
-}
+type nilLogger struct{}
 
-// Errorf implements formatted error logging to both A and B.
-func (lm loggerMux) Errorf(format string, args ...interface{}) {
-	for _, l := range lm.delegates {
-		l.Errorf(format, args...)
-	}
-}
+var nl = nilLogger{}
 
-// Infof implements formatted info logging to both A and B.
-func (lm loggerMux) Infof(format string, args ...interface{}) {
-	for _, l := range lm.delegates {
-		l.Infof(format, args...)
-	}
-}
+func (l nilLogger) Debugf(format string, args ...interface{}) {}
 
-// Warningf implements formatted warning logging to both A and B.
-func (lm loggerMux) Warningf(format string, args ...interface{}) {
-	for _, l := range lm.delegates {
-		l.Warningf(format, args...)
-	}
-}
+func (l nilLogger) Errorf(format string, args ...interface{}) {}
 
-// NewAppEngineContext creates a new Google App Engine Standard-based
-// context bound to an http.Request.
-func NewAppEngineContext(r *http.Request) context.Context {
-	ctx := r.Context()
-	return WithLogger(ctx, NewGAELogger(ctx))
+func (l nilLogger) Infof(format string, args ...interface{}) {}
+
+func (l nilLogger) Warningf(format string, args ...interface{}) {}
+
+// NewNilLogger returns a new logger that silently ignores all Logger calls.
+func NewNilLogger() Logger {
+	return nl
 }
 
 type gaeLogger struct {
 	ctx context.Context
+}
+
+// newGAELogger returns a Google App Engine Standard Environment logger bound to
+// the given context.
+func newGAELogger(ctx context.Context) Logger {
+	return gaeLogger{ctx}
 }
 
 func (l gaeLogger) Debugf(format string, args ...interface{}) {
@@ -89,104 +80,11 @@ func (l gaeLogger) Warningf(format string, args ...interface{}) {
 	gaelog.Warningf(l.ctx, format, args...)
 }
 
-type nilLogger struct{}
-
-func (l nilLogger) Debugf(format string, args ...interface{}) {}
-
-func (l nilLogger) Errorf(format string, args ...interface{}) {}
-
-func (l nilLogger) Infof(format string, args ...interface{}) {}
-
-func (l nilLogger) Warningf(format string, args ...interface{}) {}
-
-// LoggerCtxKey is a key for attaching a Logger to a context.Context.
-type LoggerCtxKey struct{}
-
-var (
-	gl  = gaeLogger{}
-	nl  = nilLogger{}
-	lck = LoggerCtxKey{}
-)
-
-// NewLoggerMux creates a multiplexing Logger that writes all log operations to
-// all delegates.
-func NewLoggerMux(delegates []Logger) Logger {
-	if len(delegates) == 0 {
-		return NewNilLogger()
-	}
-	return loggerMux{delegates}
-}
-
-// NewGAELogger returns a Google App Engine Standard Environment logger bound to
-// the given context.
-func NewGAELogger(ctx context.Context) Logger {
-	return gaeLogger{ctx}
-}
-
-// NewNilLogger returns a new logger that silently ignores all Logger calls.
-func NewNilLogger() Logger {
-	return nl
-}
-
-// DefaultLoggerCtxKey returns the default key where a logger instance should be
-// stored in a context.Context object.
-func DefaultLoggerCtxKey() LoggerCtxKey {
-	return lck
-}
-
-// WithLogger is a strongly-typed setter for the logger value on the context.
-func WithLogger(ctx context.Context, logger Logger) context.Context {
-	return context.WithValue(ctx, DefaultLoggerCtxKey(), logger)
-}
-
-// GetLogger retrieves a non-nil Logger that is appropriate for use in ctx. If
-// ctx does not provide a logger, then a nil-logger is returned.
-func GetLogger(ctx context.Context) Logger {
-	logger, ok := ctx.Value(DefaultLoggerCtxKey()).(Logger)
-	if !ok || logger == nil {
-		logrus.Warningf("Context without logger: %v; logs will be dropped", ctx)
-		return NewNilLogger()
-	}
-
-	return logger
-}
-
-// HandleWithGoogleCloudLogging handles the request with the given handler, setting the logger
-// on the request's context to be a Google Cloud logging client for the given project.
-//
-// commonResource is an optional override to the monitored resource details appended to each log.
-// e.g. in the Flex environment, it pays to override this value to type gae_app, to ensure finding
-// logs is consistent between services.
-func HandleWithGoogleCloudLogging(h http.HandlerFunc, project string, commonResource *mrpb.MonitoredResource) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		ctx, err := NewAppEngineFlexContext(r, project, commonResource)
-		if err != nil {
-			h(w, r)
-			return
-		}
-		h(w, r.WithContext(ctx))
-	}
-}
-
-// NewAppEngineFlexContext creates a new Google App Engine Flex-based
-// context, with a Google Cloud logger client bound to an http.Request.
-func NewAppEngineFlexContext(r *http.Request, project string, commonResource *mrpb.MonitoredResource) (ctx context.Context, err error) {
-	ctx = r.Context()
-	client, err := gclog.NewClient(ctx, project)
-	if err != nil {
-		return nil, err
-	}
-	// See https://cloud.google.com/appengine/docs/flexible/go/writing-application-logs
-	traceID := strings.Split(r.Header.Get("X-Cloud-Trace-Context"), "/")[0]
-	if traceID != "" {
-		traceID = fmt.Sprintf("projects/%s/traces/%s", project, traceID)
-	}
-	childLogger := client.Logger("request_log_entries", gclog.CommonResource(commonResource))
-	ctx = WithLogger(ctx, &gcLogger{
-		childLogger: childLogger,
-		traceID:     traceID,
-	})
-	return ctx, nil
+// NewAppEngineContext creates a new Google App Engine Standard-based
+// context bound to an http.Request.
+func NewAppEngineContext(r *http.Request) context.Context {
+	ctx := r.Context()
+	return withLogger(ctx, newGAELogger(ctx))
 }
 
 type gcLogger struct {
@@ -216,4 +114,54 @@ func (gcl *gcLogger) Warningf(format string, params ...interface{}) {
 
 func (gcl *gcLogger) Errorf(format string, params ...interface{}) {
 	gcl.log(gclog.Error, format, params...)
+}
+
+// newAppEngineFlexContext creates a new Google App Engine Flex-based
+// context, with a Google Cloud logger client bound to an http.Request.
+func newAppEngineFlexContext(r *http.Request, project string, commonResource *mrpb.MonitoredResource) (ctx context.Context, err error) {
+	ctx = r.Context()
+	client, err := gclog.NewClient(ctx, project)
+	if err != nil {
+		return nil, err
+	}
+	// See https://cloud.google.com/appengine/docs/flexible/go/writing-application-logs
+	traceID := strings.Split(r.Header.Get("X-Cloud-Trace-Context"), "/")[0]
+	if traceID != "" {
+		traceID = fmt.Sprintf("projects/%s/traces/%s", project, traceID)
+	}
+	childLogger := client.Logger("request_log_entries", gclog.CommonResource(commonResource))
+	ctx = withLogger(ctx, &gcLogger{
+		childLogger: childLogger,
+		traceID:     traceID,
+	})
+	return ctx, nil
+}
+
+// HandleWithGoogleCloudLogging handles the request with the given handler, setting the logger
+// on the request's context to be a Google Cloud logging client for the given project.
+//
+// commonResource is an optional override to the monitored resource details appended to each log.
+// e.g. in the Flex environment, it pays to override this value to type gae_app, to ensure finding
+// logs is consistent between services.
+func HandleWithGoogleCloudLogging(h http.HandlerFunc, project string, commonResource *mrpb.MonitoredResource) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx, err := newAppEngineFlexContext(r, project, commonResource)
+		if err != nil {
+			h(w, r)
+			return
+		}
+		h(w, r.WithContext(ctx))
+	}
+}
+
+// GetLogger retrieves a non-nil Logger that is appropriate for use in ctx. If
+// ctx does not provide a logger, then a nil-logger is returned.
+func GetLogger(ctx context.Context) Logger {
+	logger, ok := ctx.Value(DefaultLoggerCtxKey()).(Logger)
+	if !ok || logger == nil {
+		logrus.Warningf("Context without logger: %v; logs will be dropped", ctx)
+		return NewNilLogger()
+	}
+
+	return logger
 }

--- a/shared/logger.go
+++ b/shared/logger.go
@@ -58,12 +58,6 @@ type gaeLogger struct {
 	ctx context.Context
 }
 
-// newGAELogger returns a Google App Engine Standard Environment logger bound to
-// the given context.
-func newGAELogger(ctx context.Context) Logger {
-	return gaeLogger{ctx}
-}
-
 func (l gaeLogger) Debugf(format string, args ...interface{}) {
 	gaelog.Debugf(l.ctx, format, args...)
 }
@@ -78,6 +72,12 @@ func (l gaeLogger) Infof(format string, args ...interface{}) {
 
 func (l gaeLogger) Warningf(format string, args ...interface{}) {
 	gaelog.Warningf(l.ctx, format, args...)
+}
+
+// newGAELogger returns a Google App Engine Standard Environment logger bound to
+// the given context.
+func newGAELogger(ctx context.Context) Logger {
+	return gaeLogger{ctx}
 }
 
 // NewAppEngineContext creates a new Google App Engine Standard-based


### PR DESCRIPTION
A part of #1747, preparing for the logger migration. No behavioural changes.

- Removed unused `NewRequestContext`, `NewLoggerMux` functions and all `loggerMux` related methods
- Made `withLogger`, `newGAELogger`, `newAppEngineFlexContext` private
- Rearranged the order so it flows better

Verify [logs here](https://pantheon.corp.google.com/logs/viewer?project=wptdashboard-staging&resource=gae_app%2Fmodule_id%2Fdefault%2Fversion_id%2Fgo112-log&minLogLevel=0&expandAll=false&timestamp=2020-09-23T20:52:39.411000000Z&customFacets=&limitCustomFacetWidth=true&dateRangeStart=2020-09-23T19:52:39.662Z&dateRangeEnd=2020-09-23T20:52:39.662Z&interval=PT1H&logName=projects%2Fwptdashboard-staging%2Flogs%2Fappengine.googleapis.com%252Frequest_log&scrollTimestamp=2020-09-23T20:50:28.793821000Z)