### PR TITLE
Use GitHub to authenticate admin access to api/*

### DIFF
--- a/api/checks/mock_checks/api_mock.go
+++ b/api/checks/mock_checks/api_mock.go
@@ -286,20 +286,6 @@ func (mr *MockAPIMockRecorder) IgnoreFailure(arg0, arg1, arg2, arg3, arg4 interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IgnoreFailure", reflect.TypeOf((*MockAPI)(nil).IgnoreFailure), arg0, arg1, arg2, arg3, arg4)
 }
 
-// IsAdmin mocks base method
-func (m *MockAPI) IsAdmin() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsAdmin")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsAdmin indicates an expected call of IsAdmin
-func (mr *MockAPIMockRecorder) IsAdmin() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsAdmin", reflect.TypeOf((*MockAPI)(nil).IsAdmin))
-}
-
 // IsFeatureEnabled mocks base method
 func (m *MockAPI) IsFeatureEnabled(arg0 string) bool {
 	m.ctrl.T.Helper()
@@ -312,35 +298,6 @@ func (m *MockAPI) IsFeatureEnabled(arg0 string) bool {
 func (mr *MockAPIMockRecorder) IsFeatureEnabled(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsFeatureEnabled", reflect.TypeOf((*MockAPI)(nil).IsFeatureEnabled), arg0)
-}
-
-// IsLoggedIn mocks base method
-func (m *MockAPI) IsLoggedIn() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsLoggedIn")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsLoggedIn indicates an expected call of IsLoggedIn
-func (mr *MockAPIMockRecorder) IsLoggedIn() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsLoggedIn", reflect.TypeOf((*MockAPI)(nil).IsLoggedIn))
-}
-
-// LoginURL mocks base method
-func (m *MockAPI) LoginURL(arg0 string) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LoginURL", arg0)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// LoginURL indicates an expected call of LoginURL
-func (mr *MockAPIMockRecorder) LoginURL(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoginURL", reflect.TypeOf((*MockAPI)(nil).LoginURL), arg0)
 }
 
 // ScheduleResultsProcessing mocks base method

--- a/api/receiver/mock_receiver/api_mock.go
+++ b/api/receiver/mock_receiver/api_mock.go
@@ -225,17 +225,17 @@ func (mr *MockAPIMockRecorder) GetVersionedHostname() *gomock.Call {
 }
 
 // IsAdmin mocks base method
-func (m *MockAPI) IsAdmin() bool {
+func (m *MockAPI) IsAdmin(arg0 *http.Request) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsAdmin")
+	ret := m.ctrl.Call(m, "IsAdmin", arg0)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
 // IsAdmin indicates an expected call of IsAdmin
-func (mr *MockAPIMockRecorder) IsAdmin() *gomock.Call {
+func (mr *MockAPIMockRecorder) IsAdmin(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsAdmin", reflect.TypeOf((*MockAPI)(nil).IsAdmin))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsAdmin", reflect.TypeOf((*MockAPI)(nil).IsAdmin), arg0)
 }
 
 // IsFeatureEnabled mocks base method
@@ -250,35 +250,6 @@ func (m *MockAPI) IsFeatureEnabled(arg0 string) bool {
 func (mr *MockAPIMockRecorder) IsFeatureEnabled(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsFeatureEnabled", reflect.TypeOf((*MockAPI)(nil).IsFeatureEnabled), arg0)
-}
-
-// IsLoggedIn mocks base method
-func (m *MockAPI) IsLoggedIn() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsLoggedIn")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsLoggedIn indicates an expected call of IsLoggedIn
-func (mr *MockAPIMockRecorder) IsLoggedIn() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsLoggedIn", reflect.TypeOf((*MockAPI)(nil).IsLoggedIn))
-}
-
-// LoginURL mocks base method
-func (m *MockAPI) LoginURL(arg0 string) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LoginURL", arg0)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// LoginURL indicates an expected call of LoginURL
-func (mr *MockAPIMockRecorder) LoginURL(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoginURL", reflect.TypeOf((*MockAPI)(nil).LoginURL), arg0)
 }
 
 // ScheduleResultsTask mocks base method

--- a/api/receiver/receive_results.go
+++ b/api/receiver/receive_results.go
@@ -33,7 +33,7 @@ func HandleResultsUpload(a API, w http.ResponseWriter, r *http.Request) {
 	// size on AppEngine.
 
 	var uploader string
-	if a.IsAdmin() {
+	if a.IsAdmin(r) {
 		uploader = r.FormValue("user")
 		if uploader == "" {
 			http.Error(w, "Please specify uploader", http.StatusBadRequest)

--- a/api/receiver/receive_results_test.go
+++ b/api/receiver/receive_results_test.go
@@ -67,7 +67,7 @@ func TestHandleResultsUpload_not_admin(t *testing.T) {
 	req := httptest.NewRequest("POST", "/api/results/upload", nil)
 	resp := httptest.NewRecorder()
 	mockAE := mock_receiver.NewMockAPI(mockCtrl)
-	mockAE.EXPECT().IsAdmin().Return(false)
+	mockAE.EXPECT().IsAdmin(req).Return(false)
 
 	HandleResultsUpload(mockAE, resp, req)
 	assert.Equal(t, resp.Code, http.StatusUnauthorized)
@@ -82,7 +82,7 @@ func TestHandleResultsUpload_http_basic_auth_invalid(t *testing.T) {
 	resp := httptest.NewRecorder()
 	mockAE := mock_receiver.NewMockAPI(mockCtrl)
 	gomock.InOrder(
-		mockAE.EXPECT().IsAdmin().Return(false),
+		mockAE.EXPECT().IsAdmin(req).Return(false),
 		mockAE.EXPECT().GetUploader("not_a_user").Return(shared.Uploader{}, fmt.Errorf("not found")),
 	)
 
@@ -119,7 +119,7 @@ func TestHandleResultsUpload_extra_params(t *testing.T) {
 	mockAE := mock_receiver.NewMockAPI(mockCtrl)
 	mockAE.EXPECT().Context().Return(sharedtest.NewTestContext()).AnyTimes()
 	gomock.InOrder(
-		mockAE.EXPECT().IsAdmin().Return(false),
+		mockAE.EXPECT().IsAdmin(req).Return(false),
 		mockAE.EXPECT().GetUploader("blade-runner").Return(shared.Uploader{"blade-runner", "123"}, nil),
 		mockAE.EXPECT().ScheduleResultsTask(
 			"blade-runner", []string{"http://wpt.fyi/test.json.gz"}, nil, extraParams).Return("task", nil),
@@ -153,7 +153,7 @@ func TestHandleResultsUpload_azure(t *testing.T) {
 	mockAE := mock_receiver.NewMockAPI(mockCtrl)
 	mockAE.EXPECT().Context().Return(sharedtest.NewTestContext()).AnyTimes()
 	gomock.InOrder(
-		mockAE.EXPECT().IsAdmin().Return(false),
+		mockAE.EXPECT().IsAdmin(req).Return(false),
 		mockAE.EXPECT().GetUploader("blade-runner").Return(shared.Uploader{"blade-runner", "123"}, nil),
 		mockAE.EXPECT().ScheduleResultsTask("blade-runner", nil, nil, extraParams).Return("task", nil),
 	)
@@ -183,7 +183,7 @@ func TestHandleResultsUpload_url(t *testing.T) {
 			mockAE := mock_receiver.NewMockAPI(mockCtrl)
 			mockAE.EXPECT().Context().Return(sharedtest.NewTestContext()).AnyTimes()
 			gomock.InOrder(
-				mockAE.EXPECT().IsAdmin().Return(false),
+				mockAE.EXPECT().IsAdmin(req).Return(false),
 				mockAE.EXPECT().GetUploader("blade-runner").Return(shared.Uploader{"blade-runner", "123"}, nil),
 				mockAE.EXPECT().ScheduleResultsTask("blade-runner", urls, screenshot, emptyParams).Return("task", nil),
 			)
@@ -216,7 +216,7 @@ func TestHandleResultsUpload_file(t *testing.T) {
 			mockAE := mock_receiver.NewMockAPI(mockCtrl)
 			mockAE.EXPECT().Context().Return(sharedtest.NewTestContext()).AnyTimes()
 			gomock.InOrder(
-				mockAE.EXPECT().IsAdmin().Return(false),
+				mockAE.EXPECT().IsAdmin(req).Return(false),
 				mockAE.EXPECT().GetUploader("blade-runner").Return(shared.Uploader{"blade-runner", "123"}, nil),
 				mockAE.EXPECT().ScheduleResultsTask("blade-runner", gomock.Any(), gomock.Any(), emptyParams).Return("task", nil),
 			)
@@ -247,7 +247,7 @@ func TestHandleResultsUpload_fail_uploading(t *testing.T) {
 	mockAE := mock_receiver.NewMockAPI(mockCtrl)
 	mockAE.EXPECT().Context().Return(sharedtest.NewTestContext()).AnyTimes()
 	gomock.InOrder(
-		mockAE.EXPECT().IsAdmin().Return(false),
+		mockAE.EXPECT().IsAdmin(req).Return(false),
 		mockAE.EXPECT().GetUploader("blade-runner").Return(shared.Uploader{"blade-runner", "123"}, nil),
 		mockAE.EXPECT().UploadToGCS(matchRegex(`^gs://wptd-results-buffer/blade-runner/.*\.json$`), gomock.Any(), true).Return(errGCS),
 	)
@@ -268,7 +268,7 @@ func TestHandleResultsUpload_empty_payload(t *testing.T) {
 	mockAE := mock_receiver.NewMockAPI(mockCtrl)
 	mockAE.EXPECT().Context().Return(sharedtest.NewTestContext()).AnyTimes()
 	gomock.InOrder(
-		mockAE.EXPECT().IsAdmin().Return(false),
+		mockAE.EXPECT().IsAdmin(req).Return(false),
 		mockAE.EXPECT().GetUploader("blade-runner").Return(shared.Uploader{"blade-runner", "123"}, nil),
 	)
 

--- a/shared/appengine.go
+++ b/shared/appengine.go
@@ -19,9 +19,6 @@ import (
 	"github.com/google/go-github/v31/github"
 	apps "google.golang.org/api/appengine/v1"
 	taskspb "google.golang.org/genproto/googleapis/cloud/tasks/v2"
-
-	// TODO(#1747): Deprecate this library.
-	"google.golang.org/appengine/user"
 )
 
 type clientsImpl struct {
@@ -64,11 +61,6 @@ type AppEngineAPI interface {
 	// http.Client
 	GetHTTPClient() *http.Client
 	GetHTTPClientWithTimeout(time.Duration) *http.Client
-
-	// AppEngine User API
-	IsAdmin() bool
-	IsLoggedIn() bool
-	LoginURL(redirect string) (string, error)
 
 	// GetVersion returns the version name for the current environment.
 	GetVersion() string
@@ -184,18 +176,6 @@ func (a *appEngineAPIImpl) GetGitHubClient() (*github.Client, error) {
 		a.githubClient = NewGitHubClientFromToken(a.ctx, secret)
 	}
 	return a.githubClient, nil
-}
-
-func (a appEngineAPIImpl) IsLoggedIn() bool {
-	return user.Current(a.ctx) != nil
-}
-
-func (a appEngineAPIImpl) LoginURL(redirect string) (string, error) {
-	return user.LoginURL(a.ctx, redirect)
-}
-
-func (a appEngineAPIImpl) IsAdmin() bool {
-	return user.IsAdmin(a.ctx)
 }
 
 func (a appEngineAPIImpl) IsFeatureEnabled(featureName string) bool {

--- a/shared/sharedtest/appengine_mock.go
+++ b/shared/sharedtest/appengine_mock.go
@@ -208,20 +208,6 @@ func (mr *MockAppEngineAPIMockRecorder) GetVersionedHostname() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVersionedHostname", reflect.TypeOf((*MockAppEngineAPI)(nil).GetVersionedHostname))
 }
 
-// IsAdmin mocks base method
-func (m *MockAppEngineAPI) IsAdmin() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsAdmin")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsAdmin indicates an expected call of IsAdmin
-func (mr *MockAppEngineAPIMockRecorder) IsAdmin() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsAdmin", reflect.TypeOf((*MockAppEngineAPI)(nil).IsAdmin))
-}
-
 // IsFeatureEnabled mocks base method
 func (m *MockAppEngineAPI) IsFeatureEnabled(arg0 string) bool {
 	m.ctrl.T.Helper()
@@ -234,35 +220,6 @@ func (m *MockAppEngineAPI) IsFeatureEnabled(arg0 string) bool {
 func (mr *MockAppEngineAPIMockRecorder) IsFeatureEnabled(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsFeatureEnabled", reflect.TypeOf((*MockAppEngineAPI)(nil).IsFeatureEnabled), arg0)
-}
-
-// IsLoggedIn mocks base method
-func (m *MockAppEngineAPI) IsLoggedIn() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsLoggedIn")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsLoggedIn indicates an expected call of IsLoggedIn
-func (mr *MockAppEngineAPIMockRecorder) IsLoggedIn() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsLoggedIn", reflect.TypeOf((*MockAppEngineAPI)(nil).IsLoggedIn))
-}
-
-// LoginURL mocks base method
-func (m *MockAppEngineAPI) LoginURL(arg0 string) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LoginURL", arg0)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// LoginURL indicates an expected call of LoginURL
-func (mr *MockAppEngineAPIMockRecorder) LoginURL(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoginURL", reflect.TypeOf((*MockAppEngineAPI)(nil).LoginURL), arg0)
 }
 
 // ScheduleTask mocks base method


### PR DESCRIPTION
## Description

This is a follow-up to #2175 (which is also a part of #1747 ), finishing up the remaining migration from appengine.user to GitHub OAuth in api/* (namely the results receiver and its admin upload page).

## Review Information

The tests should be fairly self-explanatory. For manual testing:

* Try https://admin-via-github-dot-wptdashboard-staging.uk.r.appspot.com/admin/results/upload ; You should see permission denied.
* Login on https://staging.wpt.fyi and copy the session cookies to https://admin-via-github-dot-wptdashboard-staging.uk.r.appspot.com . Then visit https://admin-via-github-dot-wptdashboard-staging.uk.r.appspot.com/admin/flags again ; you should see again permission denied.
* I'll add your GitHub handle to the admin table. Now you should see the admin upload page. Try uploading a random JSON (not necessarily a wptrunner output). You should see a task successfully scheduled (it won't create a run as the JSON is invalid).