### PR TITLE
Use GitHub to manage access to admin/* pages

### DIFF
--- a/api/diff.go
+++ b/api/diff.go
@@ -11,7 +11,6 @@ import (
 	"github.com/web-platform-tests/wpt.fyi/shared"
 
 	"google.golang.org/appengine"
-	"google.golang.org/appengine/datastore"
 )
 
 // apiDiffHandler takes 2 test-run results JSON blobs and produces JSON in the same format, with only the differences
@@ -40,7 +39,7 @@ func loadDiffRuns(store shared.Datastore, q url.Values) (shared.TestRuns, error)
 		if multiError, ok := err.(appengine.MultiError); ok {
 			all404s := true
 			for _, err := range multiError {
-				if err != datastore.ErrNoSuchEntity {
+				if err != shared.ErrNoSuchEntity {
 					all404s = false
 					break
 				}

--- a/api/test_run.go
+++ b/api/test_run.go
@@ -13,7 +13,6 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/web-platform-tests/wpt.fyi/shared"
-	"google.golang.org/appengine/datastore"
 )
 
 // apiTestRunHandler is responsible for emitting the test-run JSON for a specific run.
@@ -37,7 +36,7 @@ func apiTestRunHandler(w http.ResponseWriter, r *http.Request) {
 		run := new(shared.TestRun)
 		err = store.Get(store.NewIDKey("TestRun", id), run)
 		if err != nil {
-			if err == datastore.ErrNoSuchEntity {
+			if err == shared.ErrNoSuchEntity {
 				http.NotFound(w, r)
 				return
 			}

--- a/api/test_runs.go
+++ b/api/test_runs.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/web-platform-tests/wpt.fyi/shared"
-	"google.golang.org/appengine/datastore"
 )
 
 const nextPageTokenHeaderName = "wpt-next-page"
@@ -41,7 +40,7 @@ func apiTestRunsHandler(w http.ResponseWriter, r *http.Request) {
 	var nextPageToken string
 	if len(ids) > 0 {
 		testRuns, err = ids.LoadTestRuns(store)
-		if err == datastore.ErrNoSuchEntity {
+		if err == shared.ErrNoSuchEntity {
 			w.WriteHeader(http.StatusNotFound)
 			err = nil
 		}

--- a/shared/datastore.go
+++ b/shared/datastore.go
@@ -11,8 +11,12 @@ import (
 	"errors"
 )
 
-// ErrEntityAlreadyExists is returned by Datastore.Insert when the entity already exists.
-var ErrEntityAlreadyExists = errors.New("datastore: entity already exists")
+var (
+	// ErrEntityAlreadyExists is returned by Datastore.Insert when the entity already exists.
+	ErrEntityAlreadyExists = errors.New("datastore: entity already exists")
+	// ErrNoSuchEntity is returned by Datastore.Get when the key doesn't exist.
+	ErrNoSuchEntity = errors.New("datastore: entity not foun")
+)
 
 // MaxKeysPerLookup is the max number of keys allowed per lookup (e.g. GetMulti).
 // https://cloud.google.com/datastore/docs/concepts/limits

--- a/shared/datastore_ae.go
+++ b/shared/datastore_ae.go
@@ -73,7 +73,11 @@ func (d aeDatastore) GetAll(q Query, dst interface{}) ([]Key, error) {
 }
 
 func (d aeDatastore) Get(k Key, dst interface{}) error {
-	return datastore.Get(d.ctx, k.(*datastore.Key), dst)
+	err := datastore.Get(d.ctx, k.(*datastore.Key), dst)
+	if err == datastore.ErrNoSuchEntity {
+		return ErrNoSuchEntity
+	}
+	return err
 }
 
 func (d aeDatastore) GetMulti(keys []Key, dst interface{}) error {

--- a/shared/datastore_cloud.go
+++ b/shared/datastore_cloud.go
@@ -95,7 +95,11 @@ func (d cloudDatastore) GetAll(q Query, dst interface{}) ([]Key, error) {
 
 func (d cloudDatastore) Get(k Key, dst interface{}) error {
 	cast := k.(cloudKey).key
-	return d.client.Get(d.ctx, cast, dst)
+	err := d.client.Get(d.ctx, cast, dst)
+	if err == datastore.ErrNoSuchEntity {
+		return ErrNoSuchEntity
+	}
+	return err
 }
 
 func (d cloudDatastore) GetMulti(keys []Key, dst interface{}) error {

--- a/shared/sharedtest/github_oauth_mock.go
+++ b/shared/sharedtest/github_oauth_mock.go
@@ -162,6 +162,21 @@ func (m *MockGitHubAccessControl) EXPECT() *MockGitHubAccessControlMockRecorder 
 	return m.recorder
 }
 
+// IsValidAdmin mocks base method
+func (m *MockGitHubAccessControl) IsValidAdmin() (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsValidAdmin")
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsValidAdmin indicates an expected call of IsValidAdmin
+func (mr *MockGitHubAccessControlMockRecorder) IsValidAdmin() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsValidAdmin", reflect.TypeOf((*MockGitHubAccessControl)(nil).IsValidAdmin))
+}
+
 // IsValidWPTMember mocks base method
 func (m *MockGitHubAccessControl) IsValidWPTMember() (bool, error) {
 	m.ctrl.T.Helper()

--- a/webapp/login.go
+++ b/webapp/login.go
@@ -171,9 +171,9 @@ func setSession(ctx context.Context, ds shared.Datastore, user *shared.User, tok
 		"token": token,
 	}
 
-	sc, err := shared.GetSecureCookie(ctx, ds)
+	sc, err := shared.NewSecureCookie(ds)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create SecureCookie: %v", err)
 	}
 
 	if encoded, err := sc.Encode("session", value); err == nil {
@@ -201,9 +201,9 @@ func setSession(ctx context.Context, ds shared.Datastore, user *shared.User, tok
 
 func setState(ctx context.Context, ds shared.Datastore, state string, response http.ResponseWriter) error {
 	var err error
-	sc, err := shared.GetSecureCookie(ctx, ds)
+	sc, err := shared.NewSecureCookie(ds)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create SecureCookie: %v", err)
 	}
 
 	if encoded, err := sc.Encode("state", state); err == nil {
@@ -224,9 +224,9 @@ func setState(ctx context.Context, ds shared.Datastore, state string, response h
 
 func decodeState(ctx context.Context, ds shared.Datastore, encryptedState *http.Cookie) (string, error) {
 	cookieValue := ""
-	sc, err := shared.GetSecureCookie(ctx, ds)
+	sc, err := shared.NewSecureCookie(ds)
 	if err != nil {
-		return "", fmt.Errorf("failed to create securecookie decoder: %v", err)
+		return "", fmt.Errorf("failed to create SecureCookie: %v", err)
 	}
 
 	if err := sc.Decode("state", encryptedState.Value, &cookieValue); err != nil {

--- a/webapp/web/app.dev.yaml
+++ b/webapp/web/app.dev.yaml
@@ -48,12 +48,6 @@ handlers:
   expiration: 10m
   secure: always
 
-# Admin-only pages:
-- url: /admin/.*
-  script: auto
-  secure: always
-  login: admin
-
 # Remote API
 - url: /_ah/remote_api
   script: _go_app

--- a/webapp/web/app.yaml
+++ b/webapp/web/app.yaml
@@ -49,12 +49,6 @@ handlers:
   expiration: 10m
   secure: always
 
-# Admin-only pages:
-- url: /admin/.*
-  script: auto
-  secure: always
-  login: admin
-
 # Remote API
 - url: /_ah/remote_api
   script: auto

--- a/webapp/web/routes_test.go
+++ b/webapp/web/routes_test.go
@@ -118,7 +118,6 @@ func TestAdminResultsUploadBound(t *testing.T) {
 
 func TestAdminCacheFlushBound(t *testing.T) {
 	assertHandlerIs(t, "/admin/cache/flush", "admin-cache-flush")
-	assertHSTS(t, "/admin/cache/flush")
 }
 
 func TestApiMetadataCORS(t *testing.T) {


### PR DESCRIPTION
Extracted from #2173 (the first half)

#2173 will be rebased to contain only the api/* part after this lands. 

## Review Information

* Try https://admin-via-github-dot-wptdashboard-staging.uk.r.appspot.com/admin/flags ; You should see permission denied.
* Login on https://staging.wpt.fyi and copy the session cookies to https://admin-via-github-dot-wptdashboard-staging.uk.r.appspot.com . Then visit https://admin-via-github-dot-wptdashboard-staging.uk.r.appspot.com/admin/flags again ; you should see again permission denied.
* I'll add your GitHub handle to the admin table. Now you should see the admin page. Note that the actual upload function won't work until #2173 lands.

## Changes

It'd be easier to review by commits. Please skip all `*_mock.go` files.