### PR TITLE
Revert "Add atom for filtering by test-file contents (#1216)"

### DIFF
--- a/api/query/README.md
+++ b/api/query/README.md
@@ -183,15 +183,6 @@ Combines filters, such that any must apply, e.g.
 > NOTE: Or-conjuction takes less precedence than `and`. Precedence can be modified
 > using parens, e.g. `chrome:pass and (firefox:!pass or safari:!pass)`
 
-#### File contents
-
-> BETA: This feature is under development and may change without warning.
-
-The `contains` atom filters result down to those where the test file's source
-contains the given query in its content.
-
-    `contains:shadowroot`
-
 ## /api/search
 
 The `/api/search` endpoint takes an HTTP `POST` method, where the body is of the format
@@ -342,12 +333,3 @@ Search triaged Chrome tests -
 
 See [#meta-qualities](Meta qualities) above for more information on other
 meta qualities than `"different"`.
-
-#### contains
-
-> BETA: This feature is under development and may change without warning.
-
-`contains` query atoms perform an appengine search for test files that contain
-the given string in their content.
-
-    {"contains": "shadowRoot"}

--- a/api/query/atoms.go
+++ b/api/query/atoms.go
@@ -56,16 +56,6 @@ func (tnp TestNamePattern) BindToRuns(runs ...shared.TestRun) ConcreteQuery {
 	return tnp
 }
 
-// FileContentsQuery is a query atom that matches test contents to a query string.
-type FileContentsQuery struct {
-	Query string
-}
-
-// BindToRuns for FileContentsQuery is a no-op; it is independent of test runs.
-func (fcq FileContentsQuery) BindToRuns(runs ...shared.TestRun) ConcreteQuery {
-	return fcq
-}
-
 // SubtestNamePattern is a query atom that matches subtest names to a pattern string.
 type SubtestNamePattern struct {
 	Subtest string
@@ -479,27 +469,6 @@ func (tnp *TestNamePattern) UnmarshalJSON(b []byte) error {
 	}
 
 	tnp.Pattern = pattern
-	return nil
-}
-
-// UnmarshalJSON for FileContentsQuery attempts to interpret a query atom as
-// {"contains":<test contents contains string>}.
-func (fcq *FileContentsQuery) UnmarshalJSON(b []byte) error {
-	var data map[string]*json.RawMessage
-	err := json.Unmarshal(b, &data)
-	if err != nil {
-		return err
-	}
-	containsData, ok := data["contains"]
-	if !ok {
-		return errors.New(`Missing test contents property: "contains"`)
-	}
-	var contains string
-	if err := json.Unmarshal(*containsData, &contains); err != nil {
-		return errors.New(`Test contents property "contains" is not a string`)
-	}
-
-	fcq.Query = contains
 	return nil
 }
 
@@ -979,109 +948,120 @@ func MetadataQualityFromString(quality string) (MetadataQuality, error) {
 func unmarshalQ(b []byte) (AbstractQuery, error) {
 	{
 		var tnp TestNamePattern
-		if err := json.Unmarshal(b, &tnp); err == nil {
+		err := json.Unmarshal(b, &tnp)
+		if err == nil {
 			return tnp, nil
 		}
 	}
 	{
-		var fcq FileContentsQuery
-		if err := json.Unmarshal(b, &fcq); err == nil {
-			return fcq, nil
-		}
-	}
-	{
 		var stnp SubtestNamePattern
-		if err := json.Unmarshal(b, &stnp); err == nil {
+		err := json.Unmarshal(b, &stnp)
+		if err == nil {
 			return stnp, nil
 		}
 	}
 	{
 		var tp TestPath
-		if err := json.Unmarshal(b, &tp); err == nil {
+		err := json.Unmarshal(b, &tp)
+		if err == nil {
 			return tp, nil
 		}
 	}
 	{
 		var tse TestStatusEq
-		if err := json.Unmarshal(b, &tse); err == nil {
+		err := json.Unmarshal(b, &tse)
+		if err == nil {
 			return tse, nil
 		}
 	}
 	{
 		var tsn TestStatusNeq
-		if err := json.Unmarshal(b, &tsn); err == nil {
+		err := json.Unmarshal(b, &tsn)
+		if err == nil {
 			return tsn, nil
 		}
 	}
 	{
 		var n AbstractNot
-		if err := json.Unmarshal(b, &n); err == nil {
+		err := json.Unmarshal(b, &n)
+		if err == nil {
 			return n, nil
 		}
 	}
 	{
 		var o AbstractOr
-		if err := json.Unmarshal(b, &o); err == nil {
+		err := json.Unmarshal(b, &o)
+		if err == nil {
 			return o, nil
 		}
 	}
 	{
 		var a AbstractAnd
-		if err := json.Unmarshal(b, &a); err == nil {
+		err := json.Unmarshal(b, &a)
+		if err == nil {
 			return a, nil
 		}
 	}
 	{
 		var e AbstractExists
-		if err := json.Unmarshal(b, &e); err == nil {
+		err := json.Unmarshal(b, &e)
+		if err == nil {
 			return e, nil
 		}
 	}
 	{
 		var a AbstractAll
-		if err := json.Unmarshal(b, &a); err == nil {
+		err := json.Unmarshal(b, &a)
+		if err == nil {
 			return a, nil
 		}
 	}
 	{
 		var n AbstractNone
-		if err := json.Unmarshal(b, &n); err == nil {
+		err := json.Unmarshal(b, &n)
+		if err == nil {
 			return n, nil
 		}
 	}
 	{
 		var s AbstractSequential
-		if err := json.Unmarshal(b, &s); err == nil {
+		err := json.Unmarshal(b, &s)
+		if err == nil {
 			return s, nil
 		}
 	}
 	{
 		var c AbstractCount
-		if err := json.Unmarshal(b, &c); err == nil {
+		err := json.Unmarshal(b, &c)
+		if err == nil {
 			return c, nil
 		}
 	}
 	{
 		var c AbstractLessThan
-		if err := json.Unmarshal(b, &c); err == nil {
+		err := json.Unmarshal(b, &c)
+		if err == nil {
 			return c, nil
 		}
 	}
 	{
 		var c AbstractMoreThan
-		if err := json.Unmarshal(b, &c); err == nil {
+		err := json.Unmarshal(b, &c)
+		if err == nil {
 			return c, nil
 		}
 	}
 	{
 		var l AbstractLink
-		if err := json.Unmarshal(b, &l); err == nil {
+		err := json.Unmarshal(b, &l)
+		if err == nil {
 			return l, nil
 		}
 	}
 	{
 		var i MetadataQuality
-		if err := json.Unmarshal(b, &i); err == nil {
+		err := json.Unmarshal(b, &i)
+		if err == nil {
 			return i, nil
 		}
 	}

--- a/api/query/atoms.go
+++ b/api/query/atoms.go
@@ -430,8 +430,7 @@ func (rq *RunQuery) UnmarshalJSON(b []byte) error {
 		RunIDs []int64         `json:"run_ids"`
 		Query  json.RawMessage `json:"query"`
 	}
-	err := json.Unmarshal(b, &data)
-	if err != nil {
+	if err := json.Unmarshal(b, &data); err != nil {
 		return err
 	}
 	if len(data.RunIDs) == 0 {
@@ -455,8 +454,7 @@ func (rq *RunQuery) UnmarshalJSON(b []byte) error {
 // {"pattern":<test name pattern string>}.
 func (tnp *TestNamePattern) UnmarshalJSON(b []byte) error {
 	var data map[string]*json.RawMessage
-	err := json.Unmarshal(b, &data)
-	if err != nil {
+	if err := json.Unmarshal(b, &data); err != nil {
 		return err
 	}
 	patternMsg, ok := data["pattern"]
@@ -476,8 +474,7 @@ func (tnp *TestNamePattern) UnmarshalJSON(b []byte) error {
 // {"subtest":<subtest name pattern string>}.
 func (tnp *SubtestNamePattern) UnmarshalJSON(b []byte) error {
 	var data map[string]*json.RawMessage
-	err := json.Unmarshal(b, &data)
-	if err != nil {
+	if err := json.Unmarshal(b, &data); err != nil {
 		return err
 	}
 	subtestMsg, ok := data["subtest"]
@@ -497,8 +494,7 @@ func (tnp *SubtestNamePattern) UnmarshalJSON(b []byte) error {
 // {"path":<test name pattern string>}.
 func (tp *TestPath) UnmarshalJSON(b []byte) error {
 	var data map[string]*json.RawMessage
-	err := json.Unmarshal(b, &data)
-	if err != nil {
+	if err := json.Unmarshal(b, &data); err != nil {
 		return err
 	}
 	pathMsg, ok := data["path"]
@@ -522,8 +518,7 @@ func (tse *TestStatusEq) UnmarshalJSON(b []byte) error {
 		Product     string `json:"product"`
 		Status      string `json:"status"`
 	}
-	err := json.Unmarshal(b, &data)
-	if err != nil {
+	if err := json.Unmarshal(b, &data); err != nil {
 		return err
 	}
 	if data.Product == "" && data.BrowserName != "" {
@@ -564,8 +559,7 @@ func (tsn *TestStatusNeq) UnmarshalJSON(b []byte) error {
 			Not string `json:"not"`
 		} `json:"status"`
 	}
-	err := json.Unmarshal(b, &data)
-	if err != nil {
+	if err := json.Unmarshal(b, &data); err != nil {
 		return err
 	}
 	if data.Product == "" && data.BrowserName != "" {
@@ -602,8 +596,7 @@ func (n *AbstractNot) UnmarshalJSON(b []byte) error {
 	var data struct {
 		Not json.RawMessage `json:"not"`
 	}
-	err := json.Unmarshal(b, &data)
-	if err != nil {
+	if err := json.Unmarshal(b, &data); err != nil {
 		return err
 	}
 	if len(data.Not) == 0 {
@@ -621,8 +614,7 @@ func (o *AbstractOr) UnmarshalJSON(b []byte) error {
 	var data struct {
 		Or []json.RawMessage `json:"or"`
 	}
-	err := json.Unmarshal(b, &data)
-	if err != nil {
+	if err := json.Unmarshal(b, &data); err != nil {
 		return err
 	}
 	if len(data.Or) == 0 {
@@ -647,8 +639,7 @@ func (a *AbstractAnd) UnmarshalJSON(b []byte) error {
 	var data struct {
 		And []json.RawMessage `json:"and"`
 	}
-	err := json.Unmarshal(b, &data)
-	if err != nil {
+	if err := json.Unmarshal(b, &data); err != nil {
 		return err
 	}
 	if len(data.And) == 0 {
@@ -673,8 +664,7 @@ func (e *AbstractExists) UnmarshalJSON(b []byte) error {
 	var data struct {
 		Exists []json.RawMessage `json:"exists"`
 	}
-	err := json.Unmarshal(b, &data)
-	if err != nil {
+	if err := json.Unmarshal(b, &data); err != nil {
 		return err
 	}
 	if len(data.Exists) == 0 {
@@ -699,8 +689,7 @@ func (e *AbstractAll) UnmarshalJSON(b []byte) error {
 	var data struct {
 		All []json.RawMessage `json:"all"`
 	}
-	err := json.Unmarshal(b, &data)
-	if err != nil {
+	if err := json.Unmarshal(b, &data); err != nil {
 		return err
 	}
 	if len(data.All) == 0 {
@@ -725,8 +714,7 @@ func (e *AbstractNone) UnmarshalJSON(b []byte) error {
 	var data struct {
 		None []json.RawMessage `json:"none"`
 	}
-	err := json.Unmarshal(b, &data)
-	if err != nil {
+	if err := json.Unmarshal(b, &data); err != nil {
 		return err
 	}
 	if len(data.None) == 0 {
@@ -751,8 +739,7 @@ func (e *AbstractSequential) UnmarshalJSON(b []byte) error {
 	var data struct {
 		Sequential []json.RawMessage `json:"sequential"`
 	}
-	err := json.Unmarshal(b, &data)
-	if err != nil {
+	if err := json.Unmarshal(b, &data); err != nil {
 		return err
 	}
 	if len(data.Sequential) == 0 {
@@ -773,13 +760,12 @@ func (e *AbstractSequential) UnmarshalJSON(b []byte) error {
 
 // UnmarshalJSON for AbstractCount attempts to interpret a query atom as
 // {"count": int, "where": query}.
-func (c *AbstractCount) UnmarshalJSON(b []byte) error {
+func (c *AbstractCount) UnmarshalJSON(b []byte) (err error) {
 	var data struct {
 		Count json.RawMessage `json:"count"`
 		Where json.RawMessage `json:"where"`
 	}
-	err := json.Unmarshal(b, &data)
-	if err != nil {
+	if err := json.Unmarshal(b, &data); err != nil {
 		return err
 	}
 	if len(data.Count) == 0 {
@@ -789,8 +775,7 @@ func (c *AbstractCount) UnmarshalJSON(b []byte) error {
 		return errors.New(`Missing count property: "where"`)
 	}
 
-	err = json.Unmarshal(data.Count, &c.Count)
-	if err != nil {
+	if err := json.Unmarshal(data.Count, &c.Count); err != nil {
 		return err
 	}
 	c.Where, err = unmarshalQ(data.Where)
@@ -807,8 +792,7 @@ func (l *AbstractLessThan) UnmarshalJSON(b []byte) error {
 		Count json.RawMessage `json:"lessThan"`
 		Where json.RawMessage `json:"where"`
 	}
-	err := json.Unmarshal(b, &data)
-	if err != nil {
+	if err := json.Unmarshal(b, &data); err != nil {
 		return err
 	}
 	if len(data.Count) == 0 {
@@ -818,7 +802,7 @@ func (l *AbstractLessThan) UnmarshalJSON(b []byte) error {
 		return errors.New(`Missing count property: "where"`)
 	}
 
-	err = json.Unmarshal(data.Count, &l.Count)
+	err := json.Unmarshal(data.Count, &l.Count)
 	if err != nil {
 		return err
 	}
@@ -831,13 +815,12 @@ func (l *AbstractLessThan) UnmarshalJSON(b []byte) error {
 
 // UnmarshalJSON for AbstractMoreThan attempts to interpret a query atom as
 // {"count": int, "where": query}.
-func (m *AbstractMoreThan) UnmarshalJSON(b []byte) error {
+func (m *AbstractMoreThan) UnmarshalJSON(b []byte) (err error) {
 	var data struct {
 		Count json.RawMessage `json:"moreThan"`
 		Where json.RawMessage `json:"where"`
 	}
-	err := json.Unmarshal(b, &data)
-	if err != nil {
+	if err := json.Unmarshal(b, &data); err != nil {
 		return err
 	}
 	if len(data.Count) == 0 {
@@ -847,8 +830,7 @@ func (m *AbstractMoreThan) UnmarshalJSON(b []byte) error {
 		return errors.New(`Missing count property: "where"`)
 	}
 
-	err = json.Unmarshal(data.Count, &m.Count)
-	if err != nil {
+	if err := json.Unmarshal(data.Count, &m.Count); err != nil {
 		return err
 	}
 	m.Where, err = unmarshalQ(data.Where)
@@ -862,8 +844,7 @@ func (m *AbstractMoreThan) UnmarshalJSON(b []byte) error {
 // {"link":<metadata url pattern string>}.
 func (l *AbstractLink) UnmarshalJSON(b []byte) error {
 	var data map[string]*json.RawMessage
-	err := json.Unmarshal(b, &data)
-	if err != nil {
+	if err := json.Unmarshal(b, &data); err != nil {
 		return err
 	}
 	patternMsg, ok := data["link"]
@@ -883,8 +864,7 @@ func (l *AbstractLink) UnmarshalJSON(b []byte) error {
 // {"triaged":<browser name>}.
 func (t *AbstractTriaged) UnmarshalJSON(b []byte) error {
 	var data map[string]*json.RawMessage
-	err := json.Unmarshal(b, &data)
-	if err != nil {
+	if err := json.Unmarshal(b, &data); err != nil {
 		return err
 	}
 
@@ -913,10 +893,9 @@ func (t *AbstractTriaged) UnmarshalJSON(b []byte) error {
 
 // UnmarshalJSON for MetadataQuality attempts to interpret a query atom as
 // {"is":<metadata quality>}.
-func (q *MetadataQuality) UnmarshalJSON(b []byte) error {
+func (q *MetadataQuality) UnmarshalJSON(b []byte) (err error) {
 	var data map[string]*json.RawMessage
-	err := json.Unmarshal(b, &data)
-	if err != nil {
+	if err := json.Unmarshal(b, &data); err != nil {
 		return err
 	}
 	is, ok := data["is"]
@@ -948,120 +927,103 @@ func MetadataQualityFromString(quality string) (MetadataQuality, error) {
 func unmarshalQ(b []byte) (AbstractQuery, error) {
 	{
 		var tnp TestNamePattern
-		err := json.Unmarshal(b, &tnp)
-		if err == nil {
+		if err := json.Unmarshal(b, &tnp); err == nil {
 			return tnp, nil
 		}
 	}
 	{
 		var stnp SubtestNamePattern
-		err := json.Unmarshal(b, &stnp)
-		if err == nil {
+		if err := json.Unmarshal(b, &stnp); err == nil {
 			return stnp, nil
 		}
 	}
 	{
 		var tp TestPath
-		err := json.Unmarshal(b, &tp)
-		if err == nil {
+		if err := json.Unmarshal(b, &tp); err == nil {
 			return tp, nil
 		}
 	}
 	{
 		var tse TestStatusEq
-		err := json.Unmarshal(b, &tse)
-		if err == nil {
+		if err := json.Unmarshal(b, &tse); err == nil {
 			return tse, nil
 		}
 	}
 	{
 		var tsn TestStatusNeq
-		err := json.Unmarshal(b, &tsn)
-		if err == nil {
+		if err := json.Unmarshal(b, &tsn); err == nil {
 			return tsn, nil
 		}
 	}
 	{
 		var n AbstractNot
-		err := json.Unmarshal(b, &n)
-		if err == nil {
+		if err := json.Unmarshal(b, &n); err == nil {
 			return n, nil
 		}
 	}
 	{
 		var o AbstractOr
-		err := json.Unmarshal(b, &o)
-		if err == nil {
+		if err := json.Unmarshal(b, &o); err == nil {
 			return o, nil
 		}
 	}
 	{
 		var a AbstractAnd
-		err := json.Unmarshal(b, &a)
-		if err == nil {
+		if err := json.Unmarshal(b, &a); err == nil {
 			return a, nil
 		}
 	}
 	{
 		var e AbstractExists
-		err := json.Unmarshal(b, &e)
-		if err == nil {
+		if err := json.Unmarshal(b, &e); err == nil {
 			return e, nil
 		}
 	}
 	{
 		var a AbstractAll
-		err := json.Unmarshal(b, &a)
-		if err == nil {
+		if err := json.Unmarshal(b, &a); err == nil {
 			return a, nil
 		}
 	}
 	{
 		var n AbstractNone
-		err := json.Unmarshal(b, &n)
-		if err == nil {
+		if err := json.Unmarshal(b, &n); err == nil {
 			return n, nil
 		}
 	}
 	{
 		var s AbstractSequential
-		err := json.Unmarshal(b, &s)
-		if err == nil {
+		if err := json.Unmarshal(b, &s); err == nil {
 			return s, nil
 		}
 	}
 	{
 		var c AbstractCount
-		err := json.Unmarshal(b, &c)
-		if err == nil {
+		if err := json.Unmarshal(b, &c); err == nil {
 			return c, nil
 		}
 	}
 	{
 		var c AbstractLessThan
-		err := json.Unmarshal(b, &c)
-		if err == nil {
+		if err := json.Unmarshal(b, &c); err == nil {
 			return c, nil
 		}
 	}
 	{
 		var c AbstractMoreThan
-		err := json.Unmarshal(b, &c)
-		if err == nil {
+		if err := json.Unmarshal(b, &c); err == nil {
 			return c, nil
 		}
 	}
 	{
 		var l AbstractLink
-		err := json.Unmarshal(b, &l)
-		if err == nil {
+		if err := json.Unmarshal(b, &l); err == nil {
 			return l, nil
 		}
 	}
 	{
 		var i MetadataQuality
-		err := json.Unmarshal(b, &i)
-		if err == nil {
+		if err := json.Unmarshal(b, &i); err == nil {
 			return i, nil
 		}
 	}

--- a/api/query/atoms_test.go
+++ b/api/query/atoms_test.go
@@ -136,18 +136,6 @@ func TestStructuredQuery_pattern(t *testing.T) {
 	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2}, AbstractQuery: TestNamePattern{"/2dcontext/"}}, rq)
 }
 
-func TestStructuredQuery_contains(t *testing.T) {
-	var rq RunQuery
-	err := json.Unmarshal([]byte(`{
-		"run_ids": [0, 1, 2],
-		"query": {
-			"contains": "shadowRoot"
-		}
-	}`), &rq)
-	assert.Nil(t, err)
-	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2}, AbstractQuery: FileContentsQuery{"shadowRoot"}}, rq)
-}
-
 func TestStructuredQuery_subtest(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{

--- a/api/query/cache/index/filter.go
+++ b/api/query/cache/index/filter.go
@@ -5,24 +5,17 @@
 package index
 
 import (
-	"context"
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
-	reflect "reflect"
+	"reflect"
 	"strings"
 	"sync"
 
-	"cloud.google.com/go/compute/metadata"
 	mapset "github.com/deckarep/golang-set"
 	"github.com/sirupsen/logrus"
-	log "github.com/sirupsen/logrus"
 	"github.com/web-platform-tests/wpt.fyi/api/query"
 	"github.com/web-platform-tests/wpt.fyi/shared"
-	"golang.org/x/oauth2/google"
-	"google.golang.org/appengine/remote_api"
-	"google.golang.org/appengine/search"
 )
 
 // True is a query.True equivalent, bound to an in-memory index.
@@ -39,64 +32,6 @@ type False struct {
 type TestNamePattern struct {
 	index
 	q query.TestNamePattern
-}
-
-// FileContentsQuery is a query.FileContentsQuery bound to an in-memory index.
-type FileContentsQuery struct {
-	index
-	q             query.FileContentsQuery
-	searchResults mapset.Set
-}
-
-func (fcq *FileContentsQuery) loadSearchResults() {
-	if fcq.searchResults != nil {
-		return
-	}
-	fcq.searchResults = mapset.NewSet()
-
-	ctx := context.Background()
-	hc, err := google.DefaultClient(ctx,
-		"https://www.googleapis.com/auth/appengine.apis",
-		"https://www.googleapis.com/auth/cloud-platform",
-		"https://www.googleapis.com/auth/cloud_search",
-		"https://www.googleapis.com/auth/userinfo.email",
-	)
-	if err != nil {
-		log.Errorf("Failed to create http client: %s", err.Error())
-		return
-	}
-
-	projectID, err := metadata.ProjectID()
-	if err != nil {
-		log.Errorf("Failed to get project id: %s", err.Error())
-	}
-	host := fmt.Sprintf("%s-dot-%s.appspot.com", os.Getenv("GAE_VERSION"), projectID)
-	remoteCtx, err := remote_api.NewRemoteContext(host, hc)
-	if err != nil {
-		log.Errorf("Failed to open remote context: %s", err.Error())
-		return
-	}
-	index, err := search.Open("test-content")
-	if err != nil {
-		log.Errorf("Failed to open search index: %s", err.Error())
-		return
-	}
-	iter := index.Search(remoteCtx, fcq.q.Query, &search.SearchOptions{
-		IDsOnly: true,
-	})
-	count := 0
-	for {
-		id, err := iter.Next(nil)
-		if err == search.Done {
-			break
-		} else if err != nil {
-			log.Errorf("Failed to fetch next result: %s", err.Error())
-			break
-		}
-		fcq.searchResults.Add(id)
-		count++
-	}
-	log.Debugf("Loaded %v results", count)
 }
 
 // SubtestNamePattern is a query.SubtestNamePattern bound to an in-memory index.
@@ -193,34 +128,22 @@ type index struct {
 func (i index) idx() index { return i }
 
 // Filter always returns true for true.
-func (*True) Filter(t TestID) bool {
+func (True) Filter(t TestID) bool {
 	return true
 }
 
 // Filter always returns false for false.
-func (*False) Filter(t TestID) bool {
+func (False) Filter(t TestID) bool {
 	return false
 }
 
 // Filter interprets a TestNamePattern as a filter function over TestIDs.
-func (tnp *TestNamePattern) Filter(t TestID) bool {
+func (tnp TestNamePattern) Filter(t TestID) bool {
 	name, _, err := tnp.tests.GetName(t)
 	if err != nil {
 		return false
 	}
 	return strings.Contains(name, tnp.q.Pattern)
-}
-
-// Filter interprets a FileContentsQuery as a filter function over TestIDs.
-func (fcq *FileContentsQuery) Filter(t TestID) bool {
-	if fcq.searchResults == nil {
-		fcq.loadSearchResults()
-	}
-	name, _, err := fcq.tests.GetName(t)
-	if err != nil {
-		return false
-	}
-	return fcq.searchResults.Contains(name)
 }
 
 // Filter interprets a SubtestNamePattern as a filter function over TestIDs.
@@ -236,7 +159,7 @@ func (tnp SubtestNamePattern) Filter(t TestID) bool {
 }
 
 // Filter interprets a TestPath as a filter function over TestIDs.
-func (tp *TestPath) Filter(t TestID) bool {
+func (tp TestPath) Filter(t TestID) bool {
 	name, _, err := tp.tests.GetName(t)
 	if err != nil {
 		return false
@@ -245,17 +168,17 @@ func (tp *TestPath) Filter(t TestID) bool {
 }
 
 // Filter interprets a runTestStatusEq as a filter function over TestIDs.
-func (rtse *runTestStatusEq) Filter(t TestID) bool {
+func (rtse runTestStatusEq) Filter(t TestID) bool {
 	return rtse.runResults[RunID(rtse.q.Run)].GetResult(t) == ResultID(rtse.q.Status)
 }
 
 // Filter interprets a runTestStatusNeq as a filter function over TestIDs.
-func (rtsn *runTestStatusNeq) Filter(t TestID) bool {
+func (rtsn runTestStatusNeq) Filter(t TestID) bool {
 	return rtsn.runResults[RunID(rtsn.q.Run)].GetResult(t) != ResultID(rtsn.q.Status)
 }
 
 // Filter interprets a Count as a filter function over TestIDs.
-func (c *Count) Filter(t TestID) bool {
+func (c Count) Filter(t TestID) bool {
 	args := c.args
 	matches := 0
 	for _, arg := range args {
@@ -307,7 +230,7 @@ func (l Link) Filter(t TestID) bool {
 	// Dir terminates with either '.' (when the top-level is a file) or '/'
 	// (when the top-level is a directory).
 	for !ok && len(dir) > 1 {
-		urls, ok = l.metadata[dir + "/*"]
+		urls, ok = l.metadata[dir+"/*"]
 		if ok {
 			break
 		}
@@ -406,7 +329,7 @@ func (q MetadataQuality) Filter(t TestID) bool {
 }
 
 // Filter interprets an And as a filter function over TestIDs.
-func (a *And) Filter(t TestID) bool {
+func (a And) Filter(t TestID) bool {
 	args := a.args
 	for _, arg := range args {
 		if !arg.Filter(t) {
@@ -417,7 +340,7 @@ func (a *And) Filter(t TestID) bool {
 }
 
 // Filter interprets an Or as a filter function over TestIDs.
-func (o *Or) Filter(t TestID) bool {
+func (o Or) Filter(t TestID) bool {
 	args := o.args
 	for _, arg := range args {
 		if arg.Filter(t) {
@@ -428,7 +351,7 @@ func (o *Or) Filter(t TestID) bool {
 }
 
 // Filter interprets a Not as a filter function over TestID.
-func (n *Not) Filter(t TestID) bool {
+func (n Not) Filter(t TestID) bool {
 	return !n.arg.Filter(t)
 }
 
@@ -438,66 +361,61 @@ func newFilter(idx index, q query.ConcreteQuery) (filter, error) {
 	}
 	switch v := q.(type) {
 	case query.True:
-		return &True{idx}, nil
+		return True{idx}, nil
 	case query.False:
-		return &False{idx}, nil
+		return False{idx}, nil
 	case query.TestNamePattern:
-		return &TestNamePattern{idx, v}, nil
-	case query.FileContentsQuery:
-		return &FileContentsQuery{
-			index: idx,
-			q:     v,
-		}, nil
+		return TestNamePattern{idx, v}, nil
 	case query.SubtestNamePattern:
-		return &SubtestNamePattern{idx, v}, nil
+		return SubtestNamePattern{idx, v}, nil
 	case query.TestPath:
-		return &TestPath{idx, v}, nil
+		return TestPath{idx, v}, nil
 	case query.RunTestStatusEq:
-		return &runTestStatusEq{idx, v}, nil
+		return runTestStatusEq{idx, v}, nil
 	case query.RunTestStatusNeq:
-		return &runTestStatusNeq{idx, v}, nil
+		return runTestStatusNeq{idx, v}, nil
 	case query.Count:
 		fs, err := filters(idx, v.Args)
 		if err != nil {
 			return nil, err
 		}
-		return &Count{idx, v.Count, fs}, nil
+		return Count{idx, v.Count, fs}, nil
 	case query.LessThan:
 		fs, err := filters(idx, v.Args)
 		if err != nil {
 			return nil, err
 		}
-		return &LessThan{idx, v.Count.Count, fs}, nil
+		return LessThan{idx, v.Count.Count, fs}, nil
 	case query.MoreThan:
 		fs, err := filters(idx, v.Args)
 		if err != nil {
 			return nil, err
 		}
-		return &MoreThan{idx, v.Count.Count, fs}, nil
+		return MoreThan{idx, v.Count.Count, fs}, nil
 	case query.Link:
-		return &Link{idx, v.Pattern, v.Metadata}, nil
+		return Link{idx, v.Pattern, v.Metadata}, nil
 	case query.Triaged:
-		return &Triaged{idx, v.Metadata}, nil
+		return Triaged{idx, v.Metadata}, nil
 	case query.MetadataQuality:
-		return &MetadataQuality{idx, v}, nil
+		return MetadataQuality{idx, v}, nil
 	case query.And:
 		fs, err := filters(idx, v.Args)
 		if err != nil {
 			return nil, err
 		}
-		return &And{idx, fs}, nil
+		return And{idx, fs}, nil
 	case query.Or:
 		fs, err := filters(idx, v.Args)
 		if err != nil {
 			return nil, err
 		}
-		return &Or{idx, fs}, nil
+		return Or{idx, fs}, nil
 	case query.Not:
 		f, err := newFilter(idx, v.Arg)
 		if err != nil {
 			return nil, err
 		}
-		return &Not{idx, f}, nil
+		return Not{idx, f}, nil
 	default:
 		return nil, fmt.Errorf("Unknown ConcreteQuery type %s", reflect.TypeOf(q))
 	}

--- a/api/query/cache/poll/poll.go
+++ b/api/query/cache/poll/poll.go
@@ -67,7 +67,7 @@ func KeepRunsUpdated(store shared.Datastore, logger shared.Logger, interval time
 			next := errs[1:]
 			for i := range next {
 				if errs[i] != nil && next[i] == nil {
-					logger.Errorf("Ingested run after skipping %d runs; ingest run attempt errors: %v", errs)
+					logger.Errorf("Ingested run after skipping %d runs; ingest run attempt errors: %v", i, errs)
 					break
 				}
 			}

--- a/api/query/cache/poll/poll.go
+++ b/api/query/cache/poll/poll.go
@@ -67,7 +67,7 @@ func KeepRunsUpdated(store shared.Datastore, logger shared.Logger, interval time
 			next := errs[1:]
 			for i := range next {
 				if errs[i] != nil && next[i] == nil {
-					logger.Errorf("Ingested run after skipping %d runs; ingest run attempt errors: %v", i, errs)
+					logger.Errorf("Ingested run after skipping %d runs; ingest run attempt errors: %v", errs)
 					break
 				}
 			}

--- a/api/query/concrete_query.go
+++ b/api/query/concrete_query.go
@@ -112,10 +112,6 @@ type Not struct {
 // substring match per test.
 func (TestNamePattern) Size() int { return 1 }
 
-// Size of FileContentsQuery has a size of 1: servicing such a query requires a
-// set lookup per test.
-func (FileContentsQuery) Size() int { return 1 }
-
 // Size of SubtestNamePattern has a size of 1: servicing such a query requires a
 // substring match per subtest.
 func (SubtestNamePattern) Size() int { return averageNumberOfSubtests }

--- a/webapp/components/test-search.js
+++ b/webapp/components/test-search.js
@@ -102,7 +102,6 @@ const QUERY_GRAMMAR = ohm.grammar(`
 
     Fragment
       = not Fragment -- not
-      | containsExp
       | linkExp
       | isExp
       | triagedExp
@@ -110,9 +109,6 @@ const QUERY_GRAMMAR = ohm.grammar(`
       | subtestExp
       | pathExp
       | patternExp
-
-    containsExp
-      = caseInsensitive<"contains"> ":" nameFragment
 
     statusExp
       = caseInsensitive<"status"> ":" statusLiteral  -- eq
@@ -308,9 +304,6 @@ const QUERY_SEMANTICS = QUERY_GRAMMAR.createSemantics().addOperation('eval', {
       product: l.sourceString.toLowerCase(),
       status: {not: r.eval()},
     };
-  },
-  containsExp: (l, colon, r) => {
-    return { contains: r.eval() };
   },
   isExp: (l, colon, r) => {
     return { is: r.eval() };

--- a/webapp/components/test/test-search.html
+++ b/webapp/components/test/test-search.html
@@ -311,12 +311,6 @@ suite('<test-search>', () => {
       });
     });
 
-    test('contains', () => {
-      assertQueryParse('contains:abc', {
-        exists: [{contains: 'abc'}],
-      });
-    });
-
     test('is', () => {
       assertQueryParse('is:different', {
         exists: [{ is: 'different' }]

--- a/webapp/routes.go
+++ b/webapp/routes.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/gobuffalo/packr/v2"
 	"github.com/web-platform-tests/wpt.fyi/shared"
-	_ "google.golang.org/appengine/remote_api" // Registers the remote API in init
 )
 
 var templates *template.Template

--- a/webapp/web/app.dev.yaml
+++ b/webapp/web/app.dev.yaml
@@ -48,10 +48,6 @@ handlers:
   expiration: 10m
   secure: always
 
-# Remote API
-- url: /_ah/remote_api
-  script: _go_app
-
 # Everything else (templates & APIs):
 - url: /.*
   script: auto

--- a/webapp/web/app.yaml
+++ b/webapp/web/app.yaml
@@ -49,9 +49,6 @@ handlers:
   expiration: 10m
   secure: always
 
-# Remote API
-- url: /_ah/remote_api
-  script: auto
 
 # Everything else (templates & APIs):
 - url: /.*


### PR DESCRIPTION
This reverts commit 14c45844f0ee96efb359a30b4361e584472b191c, removing
the search-by-content feature which never launched* and whose underlying
AppEngine API is being deprecated (#1747 ).

* It was a PoC. To launch it, we'd also need a cronjob to update the full-text search index.

Also remove the remote_api from the prod configuration; after this revert, we now only use remote_api locally for testing.

This is almost a pure revert (only one small merge conflict). To review, maybe try some structured queries in the staging instance to do some smoke tests.