### PR TITLE
[webapp] Populate user header everywhere

### DIFF
--- a/webapp/about_handler.go
+++ b/webapp/about_handler.go
@@ -20,7 +20,5 @@ func aboutHandler(w http.ResponseWriter, r *http.Request) {
 	}{
 		Version: version,
 	}
-	if err := templates.ExecuteTemplate(w, "about.html", data); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-	}
+	RenderTemplate(w, r, "about.html", data)
 }

--- a/webapp/about_handler_medium_test.go
+++ b/webapp/about_handler_medium_test.go
@@ -1,4 +1,4 @@
-// +build small
+// +build medium
 
 package webapp
 
@@ -9,10 +9,16 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
 )
 
 func TestAboutHandler(t *testing.T) {
-	req := httptest.NewRequest("GET", "/about", nil)
+	i, err := sharedtest.NewAEInstance(true)
+	assert.Nil(t, err)
+	defer i.Close()
+	req, err := i.NewRequest("GET", "/about", nil)
+	assert.Nil(t, err)
 	resp := httptest.NewRecorder()
 	aboutHandler(resp, req)
 	assert.Equal(t, resp.Code, http.StatusOK)

--- a/webapp/admin_handler.go
+++ b/webapp/admin_handler.go
@@ -58,10 +58,8 @@ func showAdminUploadForm(a shared.AppEngineAPI, acl shared.GitHubAccessControl, 
 	}{
 		CallbackURL: fmt.Sprintf("https://%s/api/results/create", a.GetVersionedHostname()),
 	}
-	if err := templates.ExecuteTemplate(w, "admin_upload.html", data); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
+	// We don't need user info in this template.
+	RenderTemplate(w, nil, "admin_upload.html", data)
 }
 
 func adminFlagsHandler(w http.ResponseWriter, r *http.Request) {
@@ -90,10 +88,8 @@ func handleAdminFlags(a shared.AppEngineAPI, ds shared.Datastore, acl shared.Git
 		}{
 			Host: a.GetHostname(),
 		}
-		if err := templates.ExecuteTemplate(w, "admin_flags.html", data); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
+		// We don't need user info in this template.
+		RenderTemplate(w, nil, "admin_flags.html", data)
 	} else if r.Method == "POST" {
 		var flag shared.Flag
 		if bytes, err := ioutil.ReadAll(r.Body); err != nil {

--- a/webapp/analyzer_handler.go
+++ b/webapp/analyzer_handler.go
@@ -40,8 +40,5 @@ func analyzerHandler(w http.ResponseWriter, r *http.Request) {
 		fmt.Sprintf("https://storage.googleapis.com/%s/%s.png", bucket, screenshots[0]),
 		fmt.Sprintf("https://storage.googleapis.com/%s/%s.png", bucket, screenshots[1]),
 	}
-	if err := templates.ExecuteTemplate(w, "analyzer.html", data); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
+	RenderTemplate(w, r, "analyzer.html", data)
 }

--- a/webapp/components/github-login.js
+++ b/webapp/components/github-login.js
@@ -8,10 +8,11 @@ import '../node_modules/@polymer/paper-dialog/paper-dialog.js';
 import '../node_modules/@polymer/polymer/lib/elements/dom-if.js';
 import { html } from '../node_modules/@polymer/polymer/polymer-element.js';
 import { PolymerElement } from '../node_modules/@polymer/polymer/polymer-element.js';
-import '../node_modules/@polymer/paper-button/paper-button.js';
-import '../node_modules/@polymer/paper-menu-button/paper-menu-button.js';
 import '../node_modules/@polymer/iron-icon/iron-icon.js';
 import '../node_modules/@polymer/iron-icons/iron-icons.js';
+import '../node_modules/@polymer/paper-button/paper-button.js';
+import '../node_modules/@polymer/paper-icon-button/paper-icon-button.js';
+import '../node_modules/@polymer/paper-menu-button/paper-menu-button.js';
 import '../node_modules/@polymer/paper-styles/color.js';
 import '../node_modules/@polymer/paper-toggle-button/paper-toggle-button.js';
 

--- a/webapp/components/github-login.js
+++ b/webapp/components/github-login.js
@@ -11,7 +11,7 @@ import { PolymerElement } from '../node_modules/@polymer/polymer/polymer-element
 import '../node_modules/@polymer/paper-button/paper-button.js';
 import '../node_modules/@polymer/paper-menu-button/paper-menu-button.js';
 import '../node_modules/@polymer/iron-icon/iron-icon.js';
-import '../node_modules/@polymer/iron-icon/iron-icons.js';
+import '../node_modules/@polymer/iron-icons/iron-icons.js';
 import '../node_modules/@polymer/paper-styles/color.js';
 import '../node_modules/@polymer/paper-toggle-button/paper-toggle-button.js';
 

--- a/webapp/components/github-login.js
+++ b/webapp/components/github-login.js
@@ -11,6 +11,7 @@ import { PolymerElement } from '../node_modules/@polymer/polymer/polymer-element
 import '../node_modules/@polymer/paper-button/paper-button.js';
 import '../node_modules/@polymer/paper-menu-button/paper-menu-button.js';
 import '../node_modules/@polymer/iron-icon/iron-icon.js';
+import '../node_modules/@polymer/iron-icon/iron-icons.js';
 import '../node_modules/@polymer/paper-styles/color.js';
 import '../node_modules/@polymer/paper-toggle-button/paper-toggle-button.js';
 
@@ -35,7 +36,9 @@ class GitHubLogin extends PolymerElement {
       }
     </style>
     <template is="dom-if" if="[[!user]]">
-      <iron-icon class="help" icon="icons:help-outline" on-click="openHelpDialog"></iron-icon>
+      <template is="dom-if" if="[[showTriage]]">
+        <iron-icon class="help" icon="icons:help-outline" on-click="openHelpDialog"></iron-icon>
+      </template>
       <paper-button class="login-button" raised on-click="handleLogIn">
         <iron-icon class="github-icon" src="/static/github.svg"></iron-icon>
           Sign in with GitHub
@@ -43,8 +46,10 @@ class GitHubLogin extends PolymerElement {
     </template>
     <template is="dom-if" if="[[user]]">
       <div class="logged-in">
-        <paper-toggle-button checked="{{isTriageMode}}"></paper-toggle-button>
-        Triage Mode
+        <template is="dom-if" if="[[showTriage]]">
+          <paper-toggle-button checked="{{isTriageMode}}"></paper-toggle-button>
+          Triage Mode
+        </template>
         <iron-icon class="github-icon" src="/static/github.svg"></iron-icon>
         [[user]]
         <paper-icon-button title="Sign out" icon="exit-to-app" on-click="handleLogOut"></paper-icon-button>
@@ -75,6 +80,10 @@ class GitHubLogin extends PolymerElement {
       isTriageMode: {
         type: Boolean,
         notify: true,
+      },
+      showTriage: {
+        type: Boolean,
+        computed: 'computeShowTriage(isTriageMode)',
       }
     };
   }
@@ -95,5 +104,10 @@ class GitHubLogin extends PolymerElement {
     this.$.dialog.open();
   }
 
+  computeShowTriage(isTriageMode) {
+    // Hide triage button/help icon when isTriageMode is undefined, which only
+    // happens when the embedder does not pass the is-triage-mode property.
+    return isTriageMode !== undefined;
+  }
 }
 window.customElements.define(GitHubLogin.is, GitHubLogin);

--- a/webapp/dynamic_components_handler.go
+++ b/webapp/dynamic_components_handler.go
@@ -41,5 +41,7 @@ func flagsComponentHandler(w http.ResponseWriter, r *http.Request) {
 		log.Errorf("Error loading flags: %s", err.Error())
 	}
 	data := struct{ Flags []shared.Flag }{flags}
-	componentTemplates.ExecuteTemplate(w, "wpt-env-flags.js", data)
+	if componentTemplates.ExecuteTemplate(w, "wpt-env-flags.js", data); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
 }

--- a/webapp/flags_handler.go
+++ b/webapp/flags_handler.go
@@ -9,7 +9,5 @@ import (
 )
 
 func flagsHandler(w http.ResponseWriter, r *http.Request) {
-	if err := templates.ExecuteTemplate(w, "flags.html", nil); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-	}
+	RenderTemplate(w, r, "flags.html", nil)
 }

--- a/webapp/insights_handler.go
+++ b/webapp/insights_handler.go
@@ -11,9 +11,5 @@ import (
 // insightsHandler handles the view listing a range of useful queries for the
 // wpt results.
 func insightsHandler(w http.ResponseWriter, r *http.Request) {
-	data := struct{}{}
-	if err := templates.ExecuteTemplate(w, "insights.html", data); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
+	RenderTemplate(w, r, "insights.html", nil)
 }

--- a/webapp/interop_handler.go
+++ b/webapp/interop_handler.go
@@ -11,13 +11,11 @@ import (
 // interopHandler handles the view of test results broken down by the
 // number of browsers for which the test passes.
 func interopHandler(w http.ResponseWriter, r *http.Request) {
-	data, err := populateTemplateData(r)
+	data, err := populateHomepageData(r)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	if err := templates.ExecuteTemplate(w, "index.html", data); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-	}
+	RenderTemplate(w, r, "index.html", data)
 }

--- a/webapp/processor.go
+++ b/webapp/processor.go
@@ -15,8 +15,5 @@ func processorStatusHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := templates.ExecuteTemplate(w, "processor.html", nil); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
+	RenderTemplate(w, r, "processor.html", nil)
 }

--- a/webapp/routes.go
+++ b/webapp/routes.go
@@ -2,33 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-//go:generate packr2
-
 package webapp
 
 import (
-	"html/template"
-
-	"github.com/gobuffalo/packr/v2"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 	_ "google.golang.org/appengine/remote_api" // Registers the remote API in init
 )
-
-var templates *template.Template
-
-func init() {
-	box := packr.New("html templates", "./templates/")
-	templates = template.New("all.html")
-	for _, t := range box.List() {
-		tmpl := templates.New(t)
-		body, err := box.FindString(t)
-		if err != nil {
-			panic(err)
-		} else if _, err = tmpl.Parse(body); err != nil {
-			panic(err)
-		}
-	}
-}
 
 // RegisterRoutes adds the route handlers for the webapp.
 func RegisterRoutes() {

--- a/webapp/service_worker_handler.go
+++ b/webapp/service_worker_handler.go
@@ -38,5 +38,6 @@ func serviceWorkerHandler(w http.ResponseWriter, r *http.Request) {
 	}{
 		Version: version,
 	}
-	templates.ExecuteTemplate(w, "service-worker.js", data)
+	// We don't need user info in this template.
+	RenderTemplate(w, nil, "service-worker.js", data)
 }

--- a/webapp/template.go
+++ b/webapp/template.go
@@ -1,0 +1,59 @@
+// Copyright 2020 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+//go:generate packr2
+
+package webapp
+
+import (
+	"html/template"
+	"net/http"
+
+	"github.com/gobuffalo/packr/v2"
+	"github.com/web-platform-tests/wpt.fyi/shared"
+)
+
+// templates contains all of the template objects parsed from templates/*,
+// created once at startup. Use RenderTemplate to render responses.
+var templates *template.Template
+
+func init() {
+	box := packr.New("html templates", "./templates/")
+	templates = template.New("all.html")
+	for _, t := range box.List() {
+		tmpl := templates.New(t)
+		body, err := box.FindString(t)
+		if err != nil {
+			panic(err)
+		} else if _, err = tmpl.Parse(body); err != nil {
+			panic(err)
+		}
+	}
+}
+
+type templateData struct {
+	Data                interface{}
+	EnableServiceWorker bool
+	User                *shared.User
+}
+
+// RenderTemplate renders an HTML template to a response. The provided data
+// will be available in the Data field in the template. There are some
+// additional fields extracted from the request (e.g. User) available in the
+// template if the request is not nil.
+// If an error is encountered, appropriate error codes and messages will be set
+// on the response; do not write additional data to the response after calling
+// this function.
+func RenderTemplate(w http.ResponseWriter, r *http.Request, name string, data interface{}) {
+	tdata := templateData{Data: data}
+	if r != nil {
+		ctx := shared.NewAppEngineContext(r)
+		ds := shared.NewAppEngineDatastore(ctx, false)
+		tdata.User, _ = shared.GetUserFromCookie(ctx, ds, r)
+		tdata.EnableServiceWorker = shared.IsFeatureEnabled(ds, "serviceworker")
+	}
+	if err := templates.ExecuteTemplate(w, name, tdata); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}

--- a/webapp/templates/_ga.html
+++ b/webapp/templates/_ga.html
@@ -1,3 +1,4 @@
+{{- /* no data */ -}}
 <script>
 (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
 (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/webapp/templates/_head_common.html
+++ b/webapp/templates/_head_common.html
@@ -1,10 +1,11 @@
+{{- /* dot set to the root */ -}}
 <title>web-platform-tests dashboard</title>
 {{ template "_ga.html" }}
 <link rel="stylesheet" href="/static/common.css">
 <script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 <script type="module" src="/components/wpt-header.js"></script>
-{{if .EnableServiceWorker}}
+{{- if .EnableServiceWorker}}
 <script src="/service-worker-installer.js"></script>
-{{else}}
+{{- else}}
 <script src="/service-worker-uninstaller.js"></script>
-{{end}}
+{{- end}}

--- a/webapp/templates/_head_common.html
+++ b/webapp/templates/_head_common.html
@@ -2,10 +2,10 @@
 <title>web-platform-tests dashboard</title>
 {{ template "_ga.html" }}
 <link rel="stylesheet" href="/static/common.css">
-<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
-<script type="module" src="/components/wpt-header.js"></script>
 {{- if .EnableServiceWorker}}
 <script src="/service-worker-installer.js"></script>
 {{- else}}
 <script src="/service-worker-uninstaller.js"></script>
 {{- end}}
+<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+<script type="module" src="/components/wpt-header.js"></script>

--- a/webapp/templates/_test_run_query_params.html
+++ b/webapp/templates/_test_run_query_params.html
@@ -1,3 +1,4 @@
+{{- /* dot set to .Data */ -}}
           {{- if .Products}} product-specs="{{ .Products }}"{{end}}
           {{- if .SHAs}} shas="{{ .SHAs }}" {{end}}
           {{- if .Labels}} labels="{{ .Labels }}"{{end}}

--- a/webapp/templates/_test_run_ui_query_params.html
+++ b/webapp/templates/_test_run_ui_query_params.html
@@ -1,3 +1,4 @@
+{{- /* dot set to .Data */ -}}
           {{ template "_test_run_query_params.html" .}}
           {{- if .Diff}} diff{{end}}
           {{- if .DiffFilter}} diff-filter="{{.DiffFilter}}"{{end}}

--- a/webapp/templates/about.html
+++ b/webapp/templates/about.html
@@ -1,16 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  {{ template "_head_common.html" }}
-  <style>
-    .version {
-      color: #777;
-    }
-  </style>
+{{ template "_head_common.html" . }}
+<style>
+  .version {
+    color: #777;
+  }
+</style>
 </head>
 <body>
 <div id="content">
-  <wpt-header></wpt-header>
+  <wpt-header {{if .User}}user="{{.User.GitHubHandle}}"{{end}}></wpt-header>
   <article>
     <h1>About</h1>
     <p>The WPT Dashboard, <a href="http://wpt.fyi/">wpt.fyi</a>, displays results for the <a href="https://github.com/web-platform-tests/wpt">web-platform-tests</a>, or WPT, which are a group of test suites for many web platform specifications.</p>
@@ -38,8 +38,8 @@
     <p>Please file a <a href="https://github.com/web-platform-tests/wpt.fyi/issues/new">GitHub issue</a>. For other discussion, most people who contribute to the WPT Dashboard monitor the <a href="http://lists.w3.org/Archives/Public/public-test-infra/">public-test-infra@w3.org</a> mailing list.</p>
   </article>
   <article>
-    {{ if .Version }}
-    <i class="version">wpt.fyi version {{ .Version }}</i>
+    {{ if .Data.Version }}
+    <i class="version">wpt.fyi version {{ .Data.Version }}</i>
     {{ end }}
   </article>
 </div>

--- a/webapp/templates/admin_flags.html
+++ b/webapp/templates/admin_flags.html
@@ -1,14 +1,13 @@
 <!DOCTYPE html>
 <head>
-  <meta charset="utf-8">
-  <title>wpt.fyi - Feature flags</title>
+<meta charset="utf-8">
+<title>wpt.fyi - Feature flags</title>
 
-  <script type="module" src="/components/wpt-flags.js"></script>
+<script type="module" src="/components/wpt-flags.js"></script>
 </head>
 <body>
   <h3>
-    Environment-wide {{ .Host }} feature flags
+    Environment-wide {{ .Data.Host }} feature flags
   </h3>
   <wpt-environment-flags-editor />
 </body>
-

--- a/webapp/templates/admin_upload.html
+++ b/webapp/templates/admin_upload.html
@@ -42,7 +42,7 @@
 <div class="column">
   <h2>File payload</h2>
   <form method="POST" action="/api/results/upload" enctype="multipart/form-data">
-    {{if .CallbackURL}}<input type="hidden" name="callback_url" value="{{.CallbackURL}}">{{end}}
+    {{if .Data.CallbackURL}}<input type="hidden" name="callback_url" value="{{.Data.CallbackURL}}">{{end}}
     <paper-input-container auto-validate>
       <label slot="label">Uploader</label>
       <iron-input slot="input" required>
@@ -112,7 +112,7 @@
 <div class="column">
   <h2>URL payload</h2>
   <form method="POST" action="/api/results/upload">
-    {{if .CallbackURL}}<input type="hidden" name="callback_url" value="{{.CallbackURL}}">{{end}}
+    {{if .Data.CallbackURL}}<input type="hidden" name="callback_url" value="{{.Data.CallbackURL}}">{{end}}
     <paper-input-container auto-validate>
       <label slot="label">Uploader</label>
       <iron-input slot="input" required>

--- a/webapp/templates/analyzer.html
+++ b/webapp/templates/analyzer.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-{{ template "_head_common.html" }}
+{{ template "_head_common.html" . }}
 <script type="module">
 import '/components/reftest-analyzer.js';
 
@@ -16,8 +16,7 @@ document.body.addEventListener('keydown', e => {
 </head>
 <body>
 <div id="content">
-  <reftest-analyzer before="{{.Before}}"
-                    after="{{.After}}">
+  <reftest-analyzer before="{{.Data.Before}}" after="{{.Data.After}}">
   </reftest-analyzer>
 </div>
 </body>

--- a/webapp/templates/flags.html
+++ b/webapp/templates/flags.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  {{ template "_head_common.html" }}
+{{ template "_head_common.html" . }}
 </head>
 <body>
 <div id="content">
-  <wpt-header></wpt-header>
+  <wpt-header {{if .User}}user="{{.User.GitHubHandle}}"{{end}}></wpt-header>
   <article>
     <h1>Features</h1>
     <wpt-flags-editor></wpt-flags-editor>

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -8,7 +8,7 @@
 <body>
   <div id="content">
     <wpt-app {{if .User}}user="{{.User.GitHubHandle}}"{{end}}
-             {{- template "_test_run_ui_query_params.html" .Data }}></wpt-app>
+             {{- template "_test_run_ui_query_params.html" .Data -}}></wpt-app>
   </div>
 </body>
 </html>

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -1,14 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  {{ template "_head_common.html" }}
-  <script type="module" src="/views/wpt-app.js"></script>
-  <script type="module" src="/components/test-runs-query.js"></script>
+{{ template "_head_common.html" . }}
+<script type="module" src="/views/wpt-app.js"></script>
+<script type="module" src="/components/test-runs-query.js"></script>
 </head>
 <body>
   <div id="content">
-    <wpt-app {{if .User}}user="{{.User}}"{{end}}
-             {{- template "_test_run_ui_query_params.html" . }}></wpt-app>
+    <wpt-app {{if .User}}user="{{.User.GitHubHandle}}"{{end}}
+             {{- template "_test_run_ui_query_params.html" .Data }}></wpt-app>
   </div>
 </body>
 </html>

--- a/webapp/templates/insights.html
+++ b/webapp/templates/insights.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  {{ template "_head_common.html" }}
-  <script type="module" src="/components/wpt-insights.js"></script>
+{{ template "_head_common.html" . }}
+<script type="module" src="/components/wpt-insights.js"></script>
 </head>
 <body>
 <div id="content">
-  <wpt-header></wpt-header>
+  <wpt-header {{if .User}}user="{{.User.GitHubHandle}}"{{end}}></wpt-header>
   <wpt-insights></wpt-insights>
 </div>
 </body>

--- a/webapp/templates/processor.html
+++ b/webapp/templates/processor.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-{{ template "_head_common.html" }}
+{{ template "_head_common.html" . }}
 <script type="module" src="/components/wpt-processor.js"></script>
 <style>
   html, body { height: 100% }
@@ -19,7 +19,7 @@
 </head>
 <body>
 <div id="full-screen-content">
-  <wpt-header></wpt-header>
+  <wpt-header {{if .User}}user="{{.User.GitHubHandle}}"{{end}}></wpt-header>
   <wpt-processor></wpt-processor>
 </div>
 </body>

--- a/webapp/templates/test-runs.html
+++ b/webapp/templates/test-runs.html
@@ -1,15 +1,15 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-{{ template "_head_common.html" }}
+{{ template "_head_common.html" . }}
 <script type="module" src="/components/wpt-runs.js"></script>
 </head>
 <body>
 <div id="content">
-  <wpt-header></wpt-header>
+  <wpt-header {{if .User}}user="{{.User.GitHubHandle}}"{{end}}></wpt-header>
   <div>
-    <wpt-runs {{ template "_test_run_query_params.html" . }}
-              {{- if .PR }} pr="{{.PR}}"{{end}}></wpt-runs>
+    <wpt-runs {{ template "_test_run_query_params.html" .Data }}
+              {{- if .Data.PR }} pr="{{.Data.PR}}"{{end}}></wpt-runs>
   </div>
 </div>
 </body>

--- a/webapp/test_results_handler_medium_test.go
+++ b/webapp/test_results_handler_medium_test.go
@@ -14,43 +14,43 @@ import (
 	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
 )
 
-func TestPopulateTemplateData(t *testing.T) {
+func TestPopulateHomepageData(t *testing.T) {
 	i, err := sharedtest.NewAEInstance(true)
 	assert.Nil(t, err)
 	defer i.Close()
 	r, _ := i.NewRequest("GET", "/results/?max-count=3", nil)
 	assert.Nil(t, err)
 
-	f, err := populateTemplateData(r)
+	f, err := populateHomepageData(r)
 	assert.Nil(t, err)
 	assert.True(t, f.MaxCount != nil && *f.MaxCount == 3)
 
 	r, _ = i.NewRequest("GET", "/results/?products=chrome,safari&diff", nil)
-	f, err = populateTemplateData(r)
+	f, err = populateHomepageData(r)
 	assert.Nil(t, err)
 	assert.Equal(t, "[\"chrome\",\"safari\"]", f.Products)
 	assert.Equal(t, true, f.Diff)
 
 	r, _ = i.NewRequest("GET", "/results/?before=chrome&after=chrome[experimental]", nil)
-	f, err = populateTemplateData(r)
+	f, err = populateHomepageData(r)
 	assert.Nil(t, err)
 	assert.Equal(t, "[\"chrome\",\"chrome[experimental]\"]", f.Products)
 	assert.Equal(t, true, f.Diff)
 
 	r, _ = i.NewRequest("GET", "/results/?after=chrome&before=edge", nil)
-	f, err = populateTemplateData(r)
+	f, err = populateHomepageData(r)
 	assert.Nil(t, err)
 	assert.Equal(t, "[\"edge\",\"chrome\"]", f.Products)
 	assert.Equal(t, true, f.Diff)
 
 	// MasterOnly default query.
 	r, _ = i.NewRequest("GET", "/results/", nil)
-	f, err = populateTemplateData(r)
+	f, err = populateHomepageData(r)
 	assert.Nil(t, err)
 	assert.Contains(t, f.Labels, shared.MasterLabel)
 
 	r, _ = i.NewRequest("GET", "/results/?sha=0123456789", nil)
-	f, err = populateTemplateData(r)
+	f, err = populateHomepageData(r)
 	assert.Nil(t, err)
 	assert.NotContains(t, f.Labels, shared.MasterLabel)
 }

--- a/webapp/test_runs_handler.go
+++ b/webapp/test_runs_handler.go
@@ -23,10 +23,7 @@ func testRunsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := templates.ExecuteTemplate(w, "test-runs.html", filter); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
+	RenderTemplate(w, r, "test-runs.html", filter)
 }
 
 // parseTestRunsUIFilter parses the standard TestRunFilter, as well as the extra

--- a/webapp/views/wpt-app.js
+++ b/webapp/views/wpt-app.js
@@ -175,7 +175,10 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
         type: String,
         computed: 'computeResultsTotalsRangeMessage(page, path, searchResults, shas, productSpecs, to, from, maxCount, labels, master)',
       },
-      isTriageMode: Boolean,
+      isTriageMode: {
+        type: Boolean,
+        value: false,
+      }
     };
   }
 


### PR DESCRIPTION
## Description
This PR replaces #2166 and is a proper fix for https://github.com/web-platform-tests/wpt.fyi/pull/2166#issuecomment-696546751. With it, we now show the user header correctly and consistently across all of our public pages (in other words, except for admin/*), and only show triage-related help/toggle in the homepage.

## Review Information

Please review all changes at once (they'll be squash-merged).

### Not logged in
Homepage:
![image](https://user-images.githubusercontent.com/1436812/94502475-38a48c80-01d2-11eb-9bee-5ab292065b16.png)
Other pages:
![image](https://user-images.githubusercontent.com/1436812/94502500-4823d580-01d2-11eb-9805-4addeb452e37.png)

### Logged in
Homepage:
![image](https://user-images.githubusercontent.com/1436812/94502549-68ec2b00-01d2-11eb-8893-50d7f12b32fc.png)
Other pages:
![image](https://user-images.githubusercontent.com/1436812/94502571-799ca100-01d2-11eb-9995-2d0a34d49667.png)
