### PR TITLE
[Go 1.12] Correct the Google Cloud logging setup for searchcache

### DIFF
--- a/api/query/cache/service/main.go
+++ b/api/query/cache/service/main.go
@@ -167,6 +167,7 @@ func main() {
 	}
 	defer gclogClient.Close()
 
+	// Reuse loggers to prevent leaking goroutines: https://github.com/googleapis/google-cloud-go/issues/720#issuecomment-346199870
 	childLogger := gclogClient.Logger("request_log_entries", gclog.CommonResource(&monitoredResource))
 	parentLogger := gclogClient.Logger("request_log", gclog.CommonResource(&monitoredResource))
 

--- a/api/query/cache/service/main.go
+++ b/api/query/cache/service/main.go
@@ -160,17 +160,17 @@ func main() {
 		Timeout: time.Second * 5,
 	}
 
-	// Initializes Logger
-	var gcClient *gclog.Client
+	// Initializes Logger.
+	var gclogClient *gclog.Client
 
-	gcClient, err = gclog.NewClient(context.Background(), *projectID)
+	gclogClient, err = gclog.NewClient(context.Background(), *projectID)
 	if err != nil {
-		logrus.Fatalf("Failed to initiate gclog: %v", err)
+		logrus.Fatalf("Failed to initiate gclog Client: %v", err)
 	}
-	defer gcClient.Close()
+	defer gclogClient.Close()
 
-	childLogger := gcClient.Logger("request_log_entries", gclog.CommonResource(&monitoredResource))
-	parentLogger := gcClient.Logger("request_log", gclog.CommonResource(&monitoredResource))
+	childLogger := gclogClient.Logger("request_log_entries", gclog.CommonResource(&monitoredResource))
+	parentLogger := gclogClient.Logger("request_log", gclog.CommonResource(&monitoredResource))
 
 	// Polls Metadata update every 10 minutes.
 	go poll.KeepMetadataUpdated(netClient, logger, time.Minute*10)

--- a/api/query/cache/service/main.go
+++ b/api/query/cache/service/main.go
@@ -169,15 +169,15 @@ func main() {
 	}
 	defer gcClient.Close()
 
-	childrenLogger := gcClient.Logger("request_logs", gclog.CommonResource(&monitoredResource))
-	parentLogger := gcClient.Logger("request", gclog.CommonResource(&monitoredResource))
+	childLogger := gcClient.Logger("request_log_entries", gclog.CommonResource(&monitoredResource))
+	parentLogger := gcClient.Logger("request_log", gclog.CommonResource(&monitoredResource))
 
 	// Polls Metadata update every 10 minutes.
 	go poll.KeepMetadataUpdated(netClient, logger, time.Minute*10)
 
 	http.HandleFunc("/_ah/liveness_check", livenessCheckHandler)
 	http.HandleFunc("/_ah/readiness_check", readinessCheckHandler)
-	http.HandleFunc("/api/search/cache", shared.HandleWithGoogleCloudLogging(searchHandler, gcClient, *projectID, childrenLogger, parentLogger))
+	http.HandleFunc("/api/search/cache", shared.HandleWithGoogleCloudLogging(searchHandler, *projectID, childLogger, parentLogger))
 	logrus.Infof("Listening on port %d", *port)
 	logrus.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", *port), nil))
 }

--- a/api/query/cache/service/main.go
+++ b/api/query/cache/service/main.go
@@ -161,9 +161,7 @@ func main() {
 	}
 
 	// Initializes Logger.
-	var gclogClient *gclog.Client
-
-	gclogClient, err = gclog.NewClient(context.Background(), *projectID)
+	gclogClient, err := gclog.NewClient(context.Background(), *projectID)
 	if err != nil {
 		logrus.Fatalf("Failed to initiate gclog Client: %v", err)
 	}

--- a/shared/logger.go
+++ b/shared/logger.go
@@ -138,7 +138,7 @@ func (gw gcResponseWriter) Write(b []byte) (int, error) {
 	// Otherwise, w.Write would call its own w.WriteHeader instead of our
 	// own WriteHeader due to the lack of true polymorphism.
 	if gw.gcLogger.statusCode == 0 {
-		gw.w.WriteHeader(http.StatusOK)
+		gw.WriteHeader(http.StatusOK)
 	}
 	return gw.w.Write(b)
 }

--- a/shared/logger.go
+++ b/shared/logger.go
@@ -148,7 +148,7 @@ func HandleWithGoogleCloudLogging(h http.HandlerFunc, gcClient *gclog.Client, pr
 			return
 		}
 		h(w, r.WithContext(ctx))
-		parentLogger := gcClient.Logger("request")
+		parentLogger := gcClient.Logger("request", gclog.CommonResource(commonResource))
 		e := gclog.Entry{
 			Trace:    traceID,
 			Severity: gclog.Info,

--- a/shared/logger.go
+++ b/shared/logger.go
@@ -94,7 +94,8 @@ type gcLogger struct {
 }
 
 func (gcl *gcLogger) log(severity gclog.Severity, format string, params ...interface{}) {
-	// The underlying type of gclog.Severity is int, https://pkg.go.dev/cloud.google.com/go/logging#Severity.
+	// "Severity levels are ordered, with numerically smaller levels treated as less severe than numerically larger levels".
+	// https://pkg.go.dev/cloud.google.com/go/logging#Severity.
 	if int(severity) > int(gcl.maxSeverity) {
 		gcl.maxSeverity = severity
 	}


### PR DESCRIPTION
A part of https://github.com/web-platform-tests/wpt.fyi/issues/1747, this PR modifies searchcache logging to the correct google cloud logging setup.

With this change, searcache logging will show structured logging and severity in the appengine. A few behavioral changes are introduced:

- When fail to initiate gclog, the program is [terminated](https://github.com/web-platform-tests/wpt.fyi/pull/2190/files#diff-29135f505c736f13d37da653c9755a6a17118cd4363bee5998e54d5a04cb615cR168), rather than [continue without a logger](https://github.com/web-platform-tests/wpt.fyi/pull/2190/files#diff-63407b1c55c2275cab0b2de74003827d3e5a4fdaa4c3208dcce9e5fb91b580bcL150)
- HTTP response status codes are not set for gclog, and it might also affect Stackdriver alerting; see the [discussions](https://github.com/web-platform-tests/wpt.fyi/pull/2190#discussion_r502648715). This issue can be sort of bypassed by filtering the severity level of parent logs in appengine.
- In process of testing, the staging instance occasionally returns 502 errors; see the [comment here](https://github.com/web-platform-tests/wpt.fyi/pull/2190#pullrequestreview-505048774).


## Test
 To view this log, go to [appengine](https://pantheon.corp.google.com/logs/query;query=resource.type%3D%22gae_app%22%20resource.labels.module_id%3D%22searchcache%22%20resource.labels.version_id%3D%22go112-log-draft%22%0AlogName%3D%22projects%2Fwptdashboard-staging%2Flogs%2Frequest_log%22;timeRange=PT1H?serviceId=searchcache&project=wptdashboard-staging) and search log_name `request_log`.
