### PR TITLE
[Go 1.12] Set up Google Cloud Logging in standard AppEngine

### DIFF
--- a/api/azure/notify.go
+++ b/api/azure/notify.go
@@ -23,7 +23,7 @@ func notifyHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 	aeAPI := shared.NewAppEngineAPI(ctx)
 	azureAPI := NewAPI(ctx)
 	log := shared.GetLogger(ctx)

--- a/api/checks/update.go
+++ b/api/checks/update.go
@@ -28,7 +28,7 @@ const onlyChangesAsRegressionsFeature = "onlyChangesAsRegressions"
 
 // updateCheckHandler handles /api/checks/[commit] POST requests.
 func updateCheckHandler(w http.ResponseWriter, r *http.Request) {
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 	log := shared.GetLogger(ctx)
 
 	vars := mux.Vars(r)

--- a/api/checks/webhook.go
+++ b/api/checks/webhook.go
@@ -26,7 +26,7 @@ func isWPTFYIApp(appID int64) bool {
 //
 // [0]: https://github.com/apps/wpt-fyi and https://github.com/apps/staging-wpt-fyi
 func checkWebhookHandler(w http.ResponseWriter, r *http.Request) {
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 	log := shared.GetLogger(ctx)
 	ds := shared.NewAppEngineDatastore(ctx, false)
 

--- a/api/diff.go
+++ b/api/diff.go
@@ -73,7 +73,7 @@ func loadDiffRuns(store shared.Datastore, q url.Values) (shared.TestRuns, error)
 }
 
 func handleAPIDiffGet(w http.ResponseWriter, r *http.Request) {
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 	store := shared.NewAppEngineDatastore(ctx, true)
 	q := r.URL.Query()
 
@@ -116,7 +116,7 @@ func handleAPIDiffGet(w http.ResponseWriter, r *http.Request) {
 // handleAPIDiffPost handles POST requests to /api/diff, which allows the caller to produce the diff of an arbitrary
 // run result JSON blob against a historical production run.
 func handleAPIDiffPost(w http.ResponseWriter, r *http.Request) {
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 
 	params, err := url.ParseQuery(r.URL.RawQuery)
 	if err != nil {

--- a/api/interop.go
+++ b/api/interop.go
@@ -18,7 +18,7 @@ import (
 // interopHandler handles the view of test results broken down by the
 // number of browsers for which the test passes.
 func apiInteropHandler(w http.ResponseWriter, r *http.Request) {
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 
 	filters, err := shared.ParseTestRunFilterParams(r.URL.Query())
 	if err != nil {

--- a/api/labels.go
+++ b/api/labels.go
@@ -23,7 +23,7 @@ type LabelsHandler struct {
 // apiLabelsHandler is responsible for emitting just all labels used for test runs.
 func apiLabelsHandler(w http.ResponseWriter, r *http.Request) {
 	// Serve cached with 5 minute expiry. Delegate to LabelsHandler on cache miss.
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 	shared.NewCachingHandler(ctx, LabelsHandler{ctx}, shared.NewGZReadWritable(shared.NewMemcacheReadWritable(ctx, 5*time.Minute)), shared.AlwaysCachable, shared.URLAsCacheKey, shared.CacheStatusOK).ServeHTTP(w, r)
 }
 

--- a/api/labels_medium_test.go
+++ b/api/labels_medium_test.go
@@ -43,7 +43,7 @@ func TestLabelsHandler_Caches(t *testing.T) {
 	defer instance.Close()
 
 	r, _ := instance.NewRequest("GET", "/api/labels", nil)
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 
 	store := shared.NewAppEngineDatastore(ctx, false)
 	key := store.NewIncompleteKey("TestRun")

--- a/api/manifest.go
+++ b/api/manifest.go
@@ -26,7 +26,7 @@ func apiManifestHandler(w http.ResponseWriter, r *http.Request) {
 	paths := shared.ParsePathsParam(q)
 	sha := shas.FirstOrLatest()
 
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 	manifestAPI := manifest.NewAPI(ctx)
 	sha, manifest, err := getManifest(shared.GetLogger(ctx), manifestAPI, sha, paths)
 	if err != nil {

--- a/api/metadata_handler.go
+++ b/api/metadata_handler.go
@@ -29,7 +29,7 @@ func apiMetadataHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 	aeAPI := shared.NewAppEngineAPI(ctx)
 	logger := shared.GetLogger(ctx)
 	client := aeAPI.GetHTTPClient()
@@ -45,7 +45,7 @@ func apiMetadataHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func apiMetadataTriageHandler(w http.ResponseWriter, r *http.Request) {
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 	ds := shared.NewAppEngineDatastore(ctx, false)
 
 	user, token := shared.GetUserFromCookie(ctx, ds, r)

--- a/api/pending_test_runs.go
+++ b/api/pending_test_runs.go
@@ -17,7 +17,7 @@ import (
 // apiPendingTestRunsHandler is responsible for emitting JSON for
 // all the non-completed PendingTestRun entities.
 func apiPendingTestRunsHandler(w http.ResponseWriter, r *http.Request) {
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 	store := shared.NewAppEngineDatastore(ctx, false)
 
 	filter := strings.ToLower(mux.Vars(r)["filter"])

--- a/api/pending_test_runs_medium_test.go
+++ b/api/pending_test_runs_medium_test.go
@@ -33,7 +33,7 @@ func TestAPIPendingTestHandler(t *testing.T) {
 	r, err := i.NewRequest("GET", "/api/status", nil)
 	assert.Nil(t, err)
 
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 
 	now := time.Now().Truncate(time.Minute).In(time.UTC)
 	yesterday := now.Add(time.Hour * -24)

--- a/api/prs.go
+++ b/api/prs.go
@@ -24,7 +24,7 @@ type PRsHandler struct {
 // apiPRsHandler executes a search for PRs for a particular directory.
 func apiPRsHandler(w http.ResponseWriter, r *http.Request) {
 	// Serve cached with 5 minute expiry. Delegate to PRsHandler on cache miss.
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 	shared.NewCachingHandler(
 		ctx,
 		PRsHandler{ctx},

--- a/api/query/cache/service/main.go
+++ b/api/query/cache/service/main.go
@@ -175,7 +175,7 @@ func main() {
 
 	http.HandleFunc("/_ah/liveness_check", livenessCheckHandler)
 	http.HandleFunc("/_ah/readiness_check", readinessCheckHandler)
-	http.HandleFunc("/api/search/cache", shared.HandleWithGoogleCloudLogging(searchHandler, *projectID, childLogger, parentLogger))
+	http.HandleFunc("/api/search/cache", shared.HandleWithGCLFlex(searchHandler, *projectID, childLogger, parentLogger))
 	logrus.Infof("Listening on port %d", *port)
 	logrus.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", *port), nil))
 }

--- a/api/query/cache/service/main.go
+++ b/api/query/cache/service/main.go
@@ -22,12 +22,11 @@ import (
 	"github.com/web-platform-tests/wpt.fyi/api/query/cache/poll"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 	"google.golang.org/api/option"
-	mrpb "google.golang.org/genproto/googleapis/api/monitoredres"
 )
 
 var (
 	port                   = flag.Int("port", 8080, "Port to listen on")
-	projectID              = flag.String("project_id", "", "Google Cloud Platform project ID, if different from ID detected from environment")
+	projectID              = flag.String("project_id", "", "Google Cloud Platform project ID, used for connecting to Datastore")
 	gcpCredentialsFile     = flag.String("gcp_credentials_file", "", "Path to Google Cloud Platform credentials file, if necessary")
 	numShards              = flag.Int("num_shards", runtime.NumCPU(), "Number of shards for parallelizing query execution")
 	monitorInterval        = flag.Duration("monitor_interval", time.Second*5, "Polling interval for memory usage monitor")
@@ -45,8 +44,6 @@ var (
 	idx index.Index
 	mon monitor.Monitor
 )
-
-var monitoredResource mrpb.MonitoredResource
 
 func livenessCheckHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte("Alive"))
@@ -117,16 +114,6 @@ func init() {
 		} else {
 			logrus.Infof("Using project ID: %s", *projectID)
 		}
-	}
-
-	monitoredResource = mrpb.MonitoredResource{
-		Type: "gae_app",
-		Labels: map[string]string{
-			"project_id": *projectID,
-			// https://cloud.google.com/appengine/docs/flexible/go/migrating#modules
-			"module_id":  os.Getenv("GAE_SERVICE"),
-			"version_id": os.Getenv("GAE_VERSION"),
-		},
 	}
 }
 

--- a/api/query/search.go
+++ b/api/query/search.go
@@ -42,7 +42,7 @@ type structuredSearchHandler struct {
 }
 
 func apiSearchHandler(w http.ResponseWriter, r *http.Request) {
-	api := shared.NewAppEngineAPI(shared.NewAppEngineContext(r))
+	api := shared.NewAppEngineAPI(r.Context())
 	searchHandler{api}.ServeHTTP(w, r)
 }
 
@@ -224,7 +224,7 @@ var cacheKey = func(r *http.Request) interface{} {
 	data, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		msg := fmt.Sprintf("Failed to read non-GET request body for generating cache key: %v", err)
-		shared.GetLogger(shared.NewAppEngineContext(r)).Errorf(msg)
+		shared.GetLogger(r.Context()).Errorf(msg)
 		panic(msg)
 	}
 	defer body.Close()

--- a/api/query/search_medium_test.go
+++ b/api/query/search_medium_test.go
@@ -69,7 +69,7 @@ func TestUnstructuredSearchHandler(t *testing.T) {
 	{
 		req, err := i.NewRequest("GET", "/", nil)
 		assert.Nil(t, err)
-		ctx := shared.NewAppEngineContext(req)
+		ctx := req.Context()
 		store := shared.NewAppEngineDatastore(ctx, false)
 
 		for idx := range testRuns {
@@ -102,7 +102,7 @@ func TestUnstructuredSearchHandler(t *testing.T) {
 		url.QueryEscape(q))
 	r, err := i.NewRequest("GET", url, nil)
 	assert.Nil(t, err)
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 	w := httptest.NewRecorder()
 
 	// TODO: This is parroting apiSearchHandler details. Perhaps they should be
@@ -194,7 +194,7 @@ func TestStructuredSearchHandler_equivalentToUnstructured(t *testing.T) {
 	{
 		req, err := i.NewRequest("GET", "/", nil)
 		assert.Nil(t, err)
-		ctx := shared.NewAppEngineContext(req)
+		ctx := req.Context()
 		store := shared.NewAppEngineDatastore(ctx, false)
 
 		for idx, testRun := range testRuns {
@@ -230,7 +230,7 @@ func TestStructuredSearchHandler_equivalentToUnstructured(t *testing.T) {
 		"query": {"exists": [{"pattern": %s}] }
 	}`, testRuns[0].ID, testRuns[1].ID, string(q)))))
 	assert.Nil(t, err)
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 	w := httptest.NewRecorder()
 
 	// TODO: This is parroting apiSearchHandler details. Perhaps they should be
@@ -326,7 +326,7 @@ func TestUnstructuredSearchHandler_doNotCacheEmptyResult(t *testing.T) {
 	{
 		req, err := i.NewRequest("GET", "/", nil)
 		assert.Nil(t, err)
-		ctx := shared.NewAppEngineContext(req)
+		ctx := req.Context()
 		store := shared.NewAppEngineDatastore(ctx, false)
 
 		for idx, testRun := range testRuns {
@@ -361,7 +361,7 @@ func TestUnstructuredSearchHandler_doNotCacheEmptyResult(t *testing.T) {
 		url.QueryEscape(q))
 	r, err := i.NewRequest("GET", url, nil)
 	assert.Nil(t, err)
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 	w := httptest.NewRecorder()
 
 	// TODO: This is parroting apiSearchHandler details. Perhaps they should be
@@ -421,7 +421,7 @@ func TestStructuredSearchHandler_doNotCacheEmptyResult(t *testing.T) {
 	{
 		req, err := i.NewRequest("GET", "/", nil)
 		assert.Nil(t, err)
-		ctx := shared.NewAppEngineContext(req)
+		ctx := req.Context()
 		store := shared.NewAppEngineDatastore(ctx, false)
 
 		for idx, testRun := range testRuns {
@@ -457,7 +457,7 @@ func TestStructuredSearchHandler_doNotCacheEmptyResult(t *testing.T) {
 		"query": {"exists": [{"pattern": %s}] }
 	}`, testRuns[0].ID, testRuns[1].ID, string(q)))))
 	assert.Nil(t, err)
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 	w := httptest.NewRecorder()
 
 	// TODO: This is parroting apiSearchHandler details. Perhaps they should be

--- a/api/receiver/handlers.go
+++ b/api/receiver/handlers.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 
 	"github.com/web-platform-tests/wpt.fyi/api/checks"
-	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
 func apiResultsUploadHandler(w http.ResponseWriter, r *http.Request) {
@@ -17,7 +16,7 @@ func apiResultsUploadHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 	a := NewAPI(ctx)
 	HandleResultsUpload(a, w, r)
 }
@@ -28,7 +27,7 @@ func apiResultsCreateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 	a := NewAPI(ctx)
 	s := checks.NewAPI(ctx)
 	HandleResultsCreate(a, s, w, r)
@@ -40,7 +39,7 @@ func apiPendingTestRunUpdateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 	a := NewAPI(ctx)
 	HandleUpdatePendingTestRun(a, w, r)
 }

--- a/api/results_redirect_handler.go
+++ b/api/results_redirect_handler.go
@@ -28,7 +28,7 @@ func apiResultsRedirectHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 	store := shared.NewAppEngineDatastore(ctx, true)
 	one := 1
 	testRuns, err := store.TestRunQuery().LoadTestRuns(

--- a/api/screenshot/cache.go
+++ b/api/screenshot/cache.go
@@ -26,7 +26,7 @@ func parseParams(r *http.Request) (browser, browserVersion, os, osVersion string
 }
 
 func getHashesHandler(w http.ResponseWriter, r *http.Request) {
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 	ds := shared.NewAppEngineDatastore(ctx, false)
 
 	browser, browserVersion, os, osVersion := parseParams(r)
@@ -49,7 +49,7 @@ func uploadScreenshotHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 	aeAPI := shared.NewAppEngineAPI(ctx)
 	if receiver.AuthenticateUploader(aeAPI, r) != receiver.InternalUsername {
 		http.Error(w, "This is a private API.", http.StatusUnauthorized)

--- a/api/screenshot_redirect_handler.go
+++ b/api/screenshot_redirect_handler.go
@@ -23,7 +23,7 @@ func apiScreenshotRedirectHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Screenshot id missing", http.StatusBadRequest)
 	}
 
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 	aeAPI := shared.NewAppEngineAPI(ctx)
 	bucket := "wptd-screenshots-staging"
 	if aeAPI.GetHostname() == "wpt.fyi" {

--- a/api/shas.go
+++ b/api/shas.go
@@ -22,7 +22,7 @@ type SHAsHandler struct {
 // apiSHAsHandler is responsible for emitting just the revision SHAs for test runs.
 func apiSHAsHandler(w http.ResponseWriter, r *http.Request) {
 	// Serve cached with 5 minute expiry. Delegate to SHAsHandler on cache miss.
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 	shared.NewCachingHandler(ctx, SHAsHandler{ctx}, shared.NewGZReadWritable(shared.NewMemcacheReadWritable(ctx, 5*time.Minute)), shared.AlwaysCachable, shared.URLAsCacheKey, shared.CacheStatusOK).ServeHTTP(w, r)
 }
 

--- a/api/shas_medium_test.go
+++ b/api/shas_medium_test.go
@@ -21,7 +21,7 @@ func TestApiSHAsHandler(t *testing.T) {
 	defer i.Close()
 	r, err := i.NewRequest("GET", "/api/shas", nil)
 	assert.Nil(t, err)
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 
 	// No results - empty JSON array, 404
 	var shas []string

--- a/api/taskcluster/webhook.go
+++ b/api/taskcluster/webhook.go
@@ -201,7 +201,7 @@ func tcStatusWebhookHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 	ds := shared.NewAppEngineDatastore(ctx, false)
 	secret, err := shared.GetSecret(ds, "github-tc-webhook-secret")
 	if err != nil {

--- a/api/test_run.go
+++ b/api/test_run.go
@@ -24,7 +24,7 @@ func apiTestRunHandler(w http.ResponseWriter, r *http.Request) {
 
 	vars := mux.Vars(r)
 	idParam := vars["id"]
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 	store := shared.NewAppEngineDatastore(ctx, true)
 	var testRun shared.TestRun
 	if idParam != "" {

--- a/api/test_run_medium_test.go
+++ b/api/test_run_medium_test.go
@@ -23,7 +23,7 @@ func TestGetTestRunByID(t *testing.T) {
 	r = mux.SetURLVars(r, map[string]string{"id": "123"})
 	assert.Nil(t, err)
 
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 	resp := httptest.NewRecorder()
 	apiTestRunHandler(resp, r)
 	assert.Equal(t, http.StatusNotFound, resp.Code)

--- a/api/test_runs.go
+++ b/api/test_runs.go
@@ -20,7 +20,7 @@ const paginationTokenFeatureFlagName = "paginationTokens"
 // URL Params:
 //     sha: SHA[0:10] of the repo when the tests were executed (or 'latest')
 func apiTestRunsHandler(w http.ResponseWriter, r *http.Request) {
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 	log := shared.GetLogger(ctx)
 	store := shared.NewAppEngineDatastore(ctx, true)
 	aeAPI := shared.NewAppEngineAPI(ctx)

--- a/api/test_runs_medium_test.go
+++ b/api/test_runs_medium_test.go
@@ -26,7 +26,7 @@ func TestGetTestRuns_VersionPrefix(t *testing.T) {
 	assert.Nil(t, err)
 
 	// 'Yesterday', v66...139 earlier version.
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 	now := time.Now()
 	chrome := shared.TestRun{
 		ProductAtRevision: shared.ProductAtRevision{
@@ -98,7 +98,7 @@ func TestGetTestRuns_RunIDs(t *testing.T) {
 	r, err := i.NewRequest("GET", "/api/runs?run_id=123", nil)
 	assert.Nil(t, err)
 
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 	now := time.Now()
 	run := shared.TestRun{}
 	run.BrowserVersion = "66.0.3359.139"
@@ -147,7 +147,7 @@ func TestGetTestRuns_SHA(t *testing.T) {
 	r, err := i.NewRequest("GET", "/api/runs", nil)
 	assert.Nil(t, err)
 
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 	now := time.Now()
 	run := shared.TestRun{}
 	run.BrowserVersion = "66.0.3359.139"
@@ -221,7 +221,7 @@ func TestGetTestRuns_Pagination(t *testing.T) {
 	r, err := i.NewRequest("GET", "/api/runs", nil)
 	assert.Nil(t, err)
 
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 	store := shared.NewAppEngineDatastore(ctx, false)
 	now := time.Now()
 	run := shared.TestRun{}

--- a/api/user.go
+++ b/api/user.go
@@ -17,7 +17,7 @@ type loginResponse struct {
 }
 
 func apiUserHandler(w http.ResponseWriter, r *http.Request) {
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 	aeAPI := shared.NewAppEngineAPI(ctx)
 	if !aeAPI.IsFeatureEnabled("githubLogin") {
 		http.Error(w, "Feature not enabled", http.StatusNotImplemented)

--- a/api/versions.go
+++ b/api/versions.go
@@ -24,7 +24,7 @@ type VersionsHandler struct {
 func apiVersionsHandler(w http.ResponseWriter, r *http.Request) {
 	// Serve cached with 5 minute expiry. Delegate to VersionsHandler on cache
 	// miss.
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 	shared.NewCachingHandler(ctx, VersionsHandler{ctx}, shared.NewGZReadWritable(shared.NewMemcacheReadWritable(ctx, 5*time.Minute)), shared.AlwaysCachable, shared.URLAsCacheKey, shared.CacheStatusOK).ServeHTTP(w, r)
 }
 

--- a/api/versions_medium_test.go
+++ b/api/versions_medium_test.go
@@ -20,7 +20,7 @@ func TestApiVersionsHandler(t *testing.T) {
 	defer i.Close()
 	r, err := i.NewRequest("GET", "/api/versions", nil)
 	assert.Nil(t, err)
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 
 	// No results - empty JSON array, 404
 	var versions []string

--- a/shared/appengine.go
+++ b/shared/appengine.go
@@ -187,7 +187,6 @@ func isDevAppserver() bool {
 }
 
 // NewAppEngineAPI returns an AppEngineAPI for the given context.
-// Note that the context should be created using NewAppEngineContext.
 func NewAppEngineAPI(ctx context.Context) AppEngineAPI {
 	return &appEngineAPIImpl{
 		ctx: ctx,

--- a/shared/datastore_medium_test.go
+++ b/shared/datastore_medium_test.go
@@ -18,7 +18,7 @@ func TestIsFeatureEnabled(t *testing.T) {
 	assert.Nil(t, err)
 
 	flagName := "foo"
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 	ds := shared.NewAppEngineDatastore(ctx, false)
 	key := ds.NewNameKey("Flag", flagName)
 
@@ -40,7 +40,7 @@ func TestGetSecret(t *testing.T) {
 	assert.Nil(t, err)
 
 	tokenName := "foo"
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 	ds := shared.NewAppEngineDatastore(ctx, false)
 	key := ds.NewNameKey("Token", tokenName)
 

--- a/shared/logger.go
+++ b/shared/logger.go
@@ -92,12 +92,6 @@ func HandleWithStandardGCL(h http.HandlerFunc, project string, childLogger, pare
 	}
 }
 
-// NewAppEngineContext creates a new Google App Engine Standard-based
-// context bound to an http.Request.
-func NewAppEngineContext(r *http.Request) context.Context {
-	return r.Context()
-}
-
 type gcLogger struct {
 	logger      *gclog.Logger
 	traceID     string

--- a/shared/routing.go
+++ b/shared/routing.go
@@ -26,7 +26,7 @@ func Router() *mux.Router {
 // AddRoute is a helper for registering a handler for an http path (route).
 // Note that it adds an HSTS header to the response.
 func AddRoute(route, name string, h http.HandlerFunc) *mux.Route {
-	return Router().Handle(route, WrapHSTS(h)).Name(name)
+	return Router().Handle(route, HandleWithStandardGCL(WrapHSTS(h), runtimeIdentity.AppID, Clients.childLogger, Clients.parentLogger)).Name(name)
 }
 
 // WrapHSTS wraps the given handler func in one that sets the

--- a/shared/routing.go
+++ b/shared/routing.go
@@ -26,7 +26,7 @@ func Router() *mux.Router {
 // AddRoute is a helper for registering a handler for an http path (route).
 // Note that it adds an HSTS header to the response.
 func AddRoute(route, name string, h http.HandlerFunc) *mux.Route {
-	return Router().Handle(route, HandleWithStandardGCL(WrapHSTS(h), runtimeIdentity.AppID, Clients.childLogger, Clients.parentLogger)).Name(name)
+	return Router().Handle(route, HandleWithStandardGCL(WrapHSTS(h))).Name(name)
 }
 
 // WrapHSTS wraps the given handler func in one that sets the

--- a/shared/routing.go
+++ b/shared/routing.go
@@ -26,7 +26,7 @@ func Router() *mux.Router {
 // AddRoute is a helper for registering a handler for an http path (route).
 // Note that it adds an HSTS header to the response.
 func AddRoute(route, name string, h http.HandlerFunc) *mux.Route {
-	return Router().Handle(route, HandleWithStandardGCL(WrapHSTS(h))).Name(name)
+	return Router().Handle(route, HandleWithGCLStandard(WrapHSTS(h))).Name(name)
 }
 
 // WrapHSTS wraps the given handler func in one that sets the

--- a/shared/routing.go
+++ b/shared/routing.go
@@ -26,7 +26,7 @@ func Router() *mux.Router {
 // AddRoute is a helper for registering a handler for an http path (route).
 // Note that it adds an HSTS header to the response.
 func AddRoute(route, name string, h http.HandlerFunc) *mux.Route {
-	return Router().Handle(route, HandleWithGCLStandard(WrapHSTS(h))).Name(name)
+	return Router().Handle(route, HandleWithLogging(WrapHSTS(h))).Name(name)
 }
 
 // WrapHSTS wraps the given handler func in one that sets the

--- a/webapp/about_handler.go
+++ b/webapp/about_handler.go
@@ -11,7 +11,7 @@ import (
 )
 
 func aboutHandler(w http.ResponseWriter, r *http.Request) {
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 	aeAPI := shared.NewAppEngineAPI(ctx)
 	version := aeAPI.GetVersion()
 

--- a/webapp/admin_handler.go
+++ b/webapp/admin_handler.go
@@ -34,7 +34,7 @@ func checkAdmin(acl shared.GitHubAccessControl, log shared.Logger, w http.Respon
 }
 
 func adminUploadHandler(w http.ResponseWriter, r *http.Request) {
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 	a := shared.NewAppEngineAPI(ctx)
 	ds := shared.NewAppEngineDatastore(ctx, false)
 	log := shared.GetLogger(ctx)
@@ -63,7 +63,7 @@ func showAdminUploadForm(a shared.AppEngineAPI, acl shared.GitHubAccessControl, 
 }
 
 func adminFlagsHandler(w http.ResponseWriter, r *http.Request) {
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 	a := shared.NewAppEngineAPI(ctx)
 	ds := shared.NewAppEngineDatastore(ctx, false)
 	log := shared.GetLogger(ctx)
@@ -106,7 +106,7 @@ func handleAdminFlags(a shared.AppEngineAPI, ds shared.Datastore, acl shared.Git
 }
 
 func adminCacheFlushHandler(w http.ResponseWriter, r *http.Request) {
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 	a := shared.NewAppEngineAPI(ctx)
 	ds := shared.NewAppEngineDatastore(ctx, false)
 	log := shared.GetLogger(ctx)

--- a/webapp/analyzer_handler.go
+++ b/webapp/analyzer_handler.go
@@ -26,7 +26,7 @@ func analyzerHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 	aeAPI := shared.NewAppEngineAPI(ctx)
 	bucket := "wptd-screenshots-staging"
 	if aeAPI.GetHostname() == "wpt.fyi" {

--- a/webapp/dynamic_components_handler.go
+++ b/webapp/dynamic_components_handler.go
@@ -32,7 +32,7 @@ func init() {
 
 func flagsComponentHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Add("content-type", "text/javascript")
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 	ds := shared.NewAppEngineDatastore(ctx, false)
 	flags, err := shared.GetFeatureFlags(ds)
 	if err != nil {

--- a/webapp/login.go
+++ b/webapp/login.go
@@ -17,7 +17,7 @@ import (
 )
 
 func loginHandler(w http.ResponseWriter, r *http.Request) {
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 	aeAPI := shared.NewAppEngineAPI(ctx)
 	if !aeAPI.IsFeatureEnabled("githubLogin") {
 		http.Error(w, "Feature not enabled", http.StatusNotImplemented)
@@ -73,7 +73,7 @@ func handleLogin(g shared.GitHubOAuth, w http.ResponseWriter, r *http.Request) {
 }
 
 func oauthHandler(w http.ResponseWriter, r *http.Request) {
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 	githuboauthImp, err := shared.NewGitHubOAuth(ctx)
 	if err != nil {
 		http.Error(w, "Error creating githuboauthImp", http.StatusInternalServerError)
@@ -156,7 +156,7 @@ func handleOauth(g shared.GitHubOAuth, w http.ResponseWriter, r *http.Request) {
 }
 
 func logoutHandler(response http.ResponseWriter, r *http.Request) {
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 	log := shared.GetLogger(ctx)
 	clearSession(response)
 

--- a/webapp/service_worker_handler.go
+++ b/webapp/service_worker_handler.go
@@ -19,7 +19,7 @@ import (
 var sevenCharSHA, _ = regexp.Compile("^[0-9a-f]{7}$")
 
 func serviceWorkerHandler(w http.ResponseWriter, r *http.Request) {
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 	aeAPI := shared.NewAppEngineAPI(ctx)
 	if !aeAPI.IsFeatureEnabled("serviceWorker") {
 		http.NotFound(w, r)

--- a/webapp/template.go
+++ b/webapp/template.go
@@ -48,7 +48,7 @@ type templateData struct {
 func RenderTemplate(w http.ResponseWriter, r *http.Request, name string, data interface{}) {
 	tdata := templateData{Data: data}
 	if r != nil {
-		ctx := shared.NewAppEngineContext(r)
+		ctx := r.Context()
 		ds := shared.NewAppEngineDatastore(ctx, false)
 		tdata.User, _ = shared.GetUserFromCookie(ctx, ds, r)
 		tdata.EnableServiceWorker = shared.IsFeatureEnabled(ds, "serviceworker")

--- a/webapp/test_results_handler.go
+++ b/webapp/test_results_handler.go
@@ -82,7 +82,7 @@ func populateHomepageData(r *http.Request) (data homepageData, err error) {
 	if err != nil {
 		return data, err
 	}
-	ctx := shared.NewAppEngineContext(r)
+	ctx := r.Context()
 	aeAPI := shared.NewAppEngineAPI(ctx)
 
 	var pr *int

--- a/webapp/web/main.go
+++ b/webapp/web/main.go
@@ -29,6 +29,7 @@ func init() {
 
 func main() {
 	if err := shared.Clients.Init(context.Background()); err != nil {
+		shared.Clients.Close()
 		panic(err)
 	}
 	defer shared.Clients.Close()


### PR DESCRIPTION
A part of #1747, this PR migrates the appengine logging to Google Cloud Logging in standard AppEngine

With this change,  minor behavioral changes are introduced:

- In dev_appserver, logrus is attached to  HTTP incoming request contexts.

## Test
[See logs here](https://pantheon.corp.google.com/logs/query;query=resource.type%3D%22gae_app%22%20resource.labels.module_id%3D%22default%22%20resource.labels.version_id%3D%22gclog-standard%22%0AlogName%3D%22projects%2Fwptdashboard-staging%2Flogs%2Frequest_log%22;timeRange=PT1H?serviceId=default&project=wptdashboard-staging)
