### PR TITLE
[Go 1.12] Refactor the direct use of /appengine/datastore library with datastore_ae

### DIFF
--- a/api/checks/api.go
+++ b/api/checks/api.go
@@ -15,7 +15,6 @@ import (
 	"github.com/google/go-github/v32/github"
 	"github.com/web-platform-tests/wpt.fyi/api/checks/summaries"
 	"github.com/web-platform-tests/wpt.fyi/shared"
-	"google.golang.org/appengine/datastore"
 )
 
 const (
@@ -74,7 +73,8 @@ func (s checksAPIImpl) ScheduleResultsProcessing(sha string, product shared.Prod
 // GetSuitesForSHA gets all existing check suites for the given Head SHA
 func (s checksAPIImpl) GetSuitesForSHA(sha string) ([]shared.CheckSuite, error) {
 	var suites []shared.CheckSuite
-	_, err := datastore.NewQuery("CheckSuite").Filter("SHA =", sha).GetAll(s.Context(), &suites)
+	store := shared.NewAppEngineDatastore(s.Context(), false)
+	_, err := store.GetAll(store.NewQuery("CheckSuite").Filter("SHA =", sha), &suites)
 	return suites, err
 }
 

--- a/api/checks/suites_medium_test.go
+++ b/api/checks/suites_medium_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
-	"google.golang.org/appengine/datastore"
 )
 
 func TestGetOrCreateCheckSuite(t *testing.T) {
@@ -30,6 +29,7 @@ func TestGetOrCreateCheckSuite(t *testing.T) {
 	assert.NotNil(t, suite2)
 	assert.Equal(t, *suite, *suite2)
 	suites := []shared.CheckSuite{}
-	datastore.NewQuery("CheckSuite").GetAll(ctx, &suites)
+	store := shared.NewAppEngineDatastore(ctx, false)
+	store.GetAll(store.NewQuery("CheckSuite"), &suites)
 	assert.Len(t, suites, 1)
 }

--- a/api/checks/update_medium_test.go
+++ b/api/checks/update_medium_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
-	"google.golang.org/appengine/datastore"
 )
 
 func TestLoadRunsToCompare_master(t *testing.T) {
@@ -31,12 +30,13 @@ func TestLoadRunsToCompare_master(t *testing.T) {
 		Labels: []string{"master"},
 	}
 	yesterday := time.Now().AddDate(0, 0, -1)
+	store := shared.NewAppEngineDatastore(ctx, false)
 	for i := 0; i < 2; i++ {
 		testRun.FullRevisionHash = strings.Repeat(strconv.Itoa(i), 40)
 		testRun.Revision = testRun.FullRevisionHash[:10]
 		testRun.TimeStart = yesterday.Add(time.Duration(i) * time.Hour)
-		key := datastore.NewIncompleteKey(ctx, "TestRun", nil)
-		key, _ = datastore.Put(ctx, key, &testRun)
+		key := store.NewIncompleteKey("TestRun")
+		key, _ = store.Put(key, &testRun)
 	}
 
 	chrome, _ := shared.ParseProductSpec("chrome")
@@ -60,6 +60,7 @@ func TestLoadRunsToCompare_pr_base_first(t *testing.T) {
 
 	labelsForRuns := [][]string{{"pr_base"}, {"pr_head"}}
 	yesterday := time.Now().AddDate(0, 0, -1)
+	store := shared.NewAppEngineDatastore(ctx, false)
 	for i := 0; i < 2; i++ {
 		testRun := shared.TestRun{
 			ProductAtRevision: shared.ProductAtRevision{
@@ -72,8 +73,8 @@ func TestLoadRunsToCompare_pr_base_first(t *testing.T) {
 			TimeStart: yesterday.Add(time.Duration(i) * time.Hour),
 			Labels:    labelsForRuns[i],
 		}
-		key := datastore.NewIncompleteKey(ctx, "TestRun", nil)
-		key, _ = datastore.Put(ctx, key, &testRun)
+		key := store.NewIncompleteKey("TestRun")
+		key, _ = store.Put(key, &testRun)
 	}
 
 	chrome, _ := shared.ParseProductSpec("chrome")
@@ -97,6 +98,7 @@ func TestLoadRunsToCompare_pr_head_first(t *testing.T) {
 
 	labelsForRuns := [][]string{{"pr_head"}, {"pr_base"}}
 	yesterday := time.Now().AddDate(0, 0, -1)
+	store := shared.NewAppEngineDatastore(ctx, false)
 	for i := 0; i < 2; i++ {
 		testRun := shared.TestRun{
 			ProductAtRevision: shared.ProductAtRevision{
@@ -109,8 +111,8 @@ func TestLoadRunsToCompare_pr_head_first(t *testing.T) {
 			TimeStart: yesterday.Add(time.Duration(i) * time.Hour),
 			Labels:    labelsForRuns[i],
 		}
-		key := datastore.NewIncompleteKey(ctx, "TestRun", nil)
-		key, _ = datastore.Put(ctx, key, &testRun)
+		key := store.NewIncompleteKey("TestRun")
+		key, _ = store.Put(key, &testRun)
 	}
 
 	chrome, _ := shared.ParseProductSpec("chrome")

--- a/api/interop.go
+++ b/api/interop.go
@@ -11,9 +11,8 @@ import (
 	"net/http"
 
 	mapset "github.com/deckarep/golang-set"
-	"github.com/web-platform-tests/wpt.fyi/shared/metrics"
 	"github.com/web-platform-tests/wpt.fyi/shared"
-	"google.golang.org/appengine/datastore"
+	"github.com/web-platform-tests/wpt.fyi/shared/metrics"
 )
 
 // interopHandler handles the view of test results broken down by the
@@ -69,12 +68,12 @@ func loadMostRecentInteropRun(ctx context.Context, filters shared.TestRunFilter)
 		return nil, nil
 	}
 	passRateType := metrics.GetDatastoreKindName(metrics.PassRateMetadata{})
-	query := datastore.NewQuery(passRateType).Order("-StartTime").Limit(1)
+	query := store.NewQuery(passRateType).Order("-StartTime").Limit(1)
 	for _, key := range keys.AllKeys() {
 		query = query.Filter("TestRunIDs =", key.IntID())
 	}
 	var results []metrics.PassRateMetadataLegacy
-	if _, err = query.GetAll(ctx, &results); err != nil {
+	if _, err = store.GetAll(query, &results); err != nil {
 		return nil, err
 	} else if len(results) < 1 {
 		return nil, nil
@@ -127,7 +126,7 @@ func loadFallbackInteropRun(ctx context.Context, filters shared.TestRunFilter) (
 	found := false
 	for {
 		_, err := it.Next(&interop)
-		if err == datastore.Done {
+		if err == store.Done().(error) {
 			return nil, nil
 		} else if err != nil {
 			return nil, err

--- a/api/interop.go
+++ b/api/interop.go
@@ -126,7 +126,7 @@ func loadFallbackInteropRun(ctx context.Context, filters shared.TestRunFilter) (
 	found := false
 	for {
 		_, err := it.Next(&interop)
-		if err == store.Done().(error) {
+		if err == store.Done() {
 			return nil, nil
 		} else if err != nil {
 			return nil, err

--- a/api/interop_medium_test.go
+++ b/api/interop_medium_test.go
@@ -80,7 +80,7 @@ func TestApiInteropHandler_CompleteRunFallback(t *testing.T) {
 	for i, key := range firstRunKeys {
 		interop.TestRunIDs[i] = key.IntID()
 	}
-	store.Put(store.NewIDKey(interopKindName, 0), &interop)
+	store.Put(store.NewIncompleteKey(interopKindName), &interop)
 
 	// Load the tests + clear the IDs, to match the output of apiInteropHandler below.
 	interop.LoadTestRuns(ctx)

--- a/api/interop_medium_test.go
+++ b/api/interop_medium_test.go
@@ -68,7 +68,7 @@ func TestApiInteropHandler_CompleteRunFallback(t *testing.T) {
 		interop.TestRunIDs[i] = key.IntID()
 	}
 	interopKindName := metrics.GetDatastoreKindName(metrics.PassRateMetadata{})
-	store.Put(store.NewIDKey(interopKindName, 0), &interop)
+	store.Put(store.NewIncompleteKey(interopKindName), &interop)
 
 	resp = httptest.NewRecorder()
 	apiInteropHandler(resp, r)

--- a/api/interop_medium_test.go
+++ b/api/interop_medium_test.go
@@ -46,7 +46,7 @@ func TestApiInteropHandler_CompleteRunFallback(t *testing.T) {
 	for i, product := range products {
 		run := firstRun
 		run.Product = product.Product
-		firstRunKeys[i], _ = store.Put(store.NewIDKey("TestRun", 0), &run)
+		firstRunKeys[i], _ = store.Put(store.NewIncompleteKey("TestRun"), &run)
 		run = secondRun
 		run.Product = product.Product
 		secondRunKeys[i], _ = store.Put(store.NewIDKey("TestRun", 0), &run)

--- a/api/interop_medium_test.go
+++ b/api/interop_medium_test.go
@@ -49,7 +49,7 @@ func TestApiInteropHandler_CompleteRunFallback(t *testing.T) {
 		firstRunKeys[i], _ = store.Put(store.NewIncompleteKey("TestRun"), &run)
 		run = secondRun
 		run.Product = product.Product
-		secondRunKeys[i], _ = store.Put(store.NewIDKey("TestRun", 0), &run)
+		secondRunKeys[i], _ = store.Put(store.NewIncompleteKey("TestRun"), &run)
 	}
 
 	// No interop data.

--- a/api/pending_test_runs_medium_test.go
+++ b/api/pending_test_runs_medium_test.go
@@ -16,12 +16,12 @@ import (
 	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
 
 	"github.com/stretchr/testify/assert"
-	"google.golang.org/appengine/datastore"
 )
 
 func createPendingRun(ctx context.Context, run *shared.PendingTestRun) error {
-	key := datastore.NewIncompleteKey(ctx, "PendingTestRun", nil)
-	key, err := datastore.Put(ctx, key, run)
+	store := shared.NewAppEngineDatastore(ctx, false)
+	key := store.NewIncompleteKey("PendingTestRun")
+	key, err := store.Put(key, run)
 	run.ID = key.IntID()
 	return err
 }

--- a/api/query/search_medium_test.go
+++ b/api/query/search_medium_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
-	"google.golang.org/appengine/datastore"
 )
 
 type shouldCache struct {
@@ -71,9 +70,10 @@ func TestUnstructuredSearchHandler(t *testing.T) {
 		req, err := i.NewRequest("GET", "/", nil)
 		assert.Nil(t, err)
 		ctx := shared.NewAppEngineContext(req)
+		store := shared.NewAppEngineDatastore(ctx, false)
 
 		for idx := range testRuns {
-			key, err := datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &testRuns[idx])
+			key, err := store.Put(store.NewIncompleteKey("TestRun"), &testRuns[idx])
 			assert.Nil(t, err)
 			id := key.IntID()
 			assert.NotEqual(t, 0, id)
@@ -195,9 +195,10 @@ func TestStructuredSearchHandler_equivalentToUnstructured(t *testing.T) {
 		req, err := i.NewRequest("GET", "/", nil)
 		assert.Nil(t, err)
 		ctx := shared.NewAppEngineContext(req)
+		store := shared.NewAppEngineDatastore(ctx, false)
 
 		for idx, testRun := range testRuns {
-			key, err := datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &testRun)
+			key, err := store.Put(store.NewIncompleteKey("TestRun"), &testRun)
 			assert.Nil(t, err)
 			id := key.IntID()
 			assert.NotEqual(t, 0, id)
@@ -326,9 +327,10 @@ func TestUnstructuredSearchHandler_doNotCacheEmptyResult(t *testing.T) {
 		req, err := i.NewRequest("GET", "/", nil)
 		assert.Nil(t, err)
 		ctx := shared.NewAppEngineContext(req)
+		store := shared.NewAppEngineDatastore(ctx, false)
 
 		for idx, testRun := range testRuns {
-			key, err := datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &testRun)
+			key, err := store.Put(store.NewIncompleteKey("TestRun"), &testRun)
 			assert.Nil(t, err)
 			id := key.IntID()
 			assert.NotEqual(t, 0, id)
@@ -420,9 +422,10 @@ func TestStructuredSearchHandler_doNotCacheEmptyResult(t *testing.T) {
 		req, err := i.NewRequest("GET", "/", nil)
 		assert.Nil(t, err)
 		ctx := shared.NewAppEngineContext(req)
+		store := shared.NewAppEngineDatastore(ctx, false)
 
 		for idx, testRun := range testRuns {
-			key, err := datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &testRun)
+			key, err := store.Put(store.NewIncompleteKey("TestRun"), &testRun)
 			assert.Nil(t, err)
 			id := key.IntID()
 			assert.NotEqual(t, 0, id)

--- a/api/receiver/api_medium_test.go
+++ b/api/receiver/api_medium_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/web-platform-tests/wpt.fyi/shared"
 	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
-	"google.golang.org/appengine/datastore"
 )
 
 type mockGcs struct {
@@ -170,7 +169,8 @@ func TestScheduleResultsTask(t *testing.T) {
 	assert.Nil(t, err)
 
 	var pendingRun shared.PendingTestRun
-	datastore.Get(ctx, datastore.NewKey(ctx, "PendingTestRun", "", 1, nil), &pendingRun)
+	store := shared.NewAppEngineDatastore(ctx, false)
+	store.Get(store.NewIDKey("PendingTestRun", 1), &pendingRun)
 	assert.Equal(t, "blade-runner", pendingRun.Uploader)
 	assert.Equal(t, shared.StageWptFyiReceived, pendingRun.Stage)
 }
@@ -194,7 +194,8 @@ func TestAddTestRun(t *testing.T) {
 	assert.Equal(t, int64(123456), key.IntID())
 
 	var testRun2 shared.TestRun
-	datastore.Get(ctx, datastore.NewKey(ctx, key.Kind(), "", key.IntID(), nil), &testRun2)
+	store := shared.NewAppEngineDatastore(ctx, false)
+	store.Get(store.NewIDKey(key.Kind(), key.IntID()), &testRun2)
 	testRun2.ID = key.IntID()
 	assert.Equal(t, testRun, testRun2)
 }
@@ -206,7 +207,8 @@ func TestUpdatePendingTestRun(t *testing.T) {
 	a := NewAPI(ctx)
 
 	sha := "0123456789012345678901234567890123456789"
-	key := datastore.NewKey(ctx, "PendingTestRun", "", 1, nil)
+	store := shared.NewAppEngineDatastore(ctx, false)
+	key := store.NewIDKey("PendingTestRun", 1)
 	run := shared.PendingTestRun{
 		ID:         1,
 		CheckRunID: 100,
@@ -217,7 +219,7 @@ func TestUpdatePendingTestRun(t *testing.T) {
 	}
 	assert.Nil(t, a.UpdatePendingTestRun(run))
 	var run2 shared.PendingTestRun
-	datastore.Get(ctx, key, &run2)
+	store.Get(key, &run2)
 	assert.Equal(t, shared.StageWptFyiReceived, run2.Stage)
 	assert.Equal(t, sha, run2.FullRevisionHash)
 	assert.Equal(t, sha[:10], run2.Revision)
@@ -227,7 +229,7 @@ func TestUpdatePendingTestRun(t *testing.T) {
 	run.Stage = shared.StageValid
 	assert.Nil(t, a.UpdatePendingTestRun(run))
 	var run3 shared.PendingTestRun
-	datastore.Get(ctx, key, &run3)
+	store.Get(key, &run3)
 	assert.Equal(t, int64(100), run3.CheckRunID)
 	assert.Equal(t, shared.StageValid, run3.Stage)
 	assert.Equal(t, run2.Created, run3.Created)
@@ -250,8 +252,9 @@ func TestAuthenticateUploader(t *testing.T) {
 	req.SetBasicAuth(InternalUsername, "123")
 	assert.Equal(t, "", AuthenticateUploader(a, req))
 
-	key := datastore.NewKey(ctx, "Uploader", InternalUsername, 0, nil)
-	datastore.Put(ctx, key, &shared.Uploader{Username: InternalUsername, Password: "123"})
+	store := shared.NewAppEngineDatastore(ctx, false)
+	key := store.NewNameKey("Uploader", InternalUsername)
+	store.Put(key, &shared.Uploader{Username: InternalUsername, Password: "123"})
 	assert.Equal(t, InternalUsername, AuthenticateUploader(a, req))
 
 	req.SetBasicAuth(InternalUsername, "456")

--- a/api/receiver/api_medium_test.go
+++ b/api/receiver/api_medium_test.go
@@ -195,7 +195,7 @@ func TestAddTestRun(t *testing.T) {
 
 	var testRun2 shared.TestRun
 	store := shared.NewAppEngineDatastore(ctx, false)
-	store.Get(store.NewIDKey(key.Kind(), key.IntID()), &testRun2)
+	store.Get(key, &testRun2)
 	testRun2.ID = key.IntID()
 	assert.Equal(t, testRun, testRun2)
 }

--- a/api/shas_medium_test.go
+++ b/api/shas_medium_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
-	"google.golang.org/appengine/datastore"
 )
 
 func TestApiSHAsHandler(t *testing.T) {
@@ -41,13 +40,14 @@ func TestApiSHAsHandler(t *testing.T) {
 			Revision: "abcdef0123",
 		},
 	}
+	store := shared.NewAppEngineDatastore(ctx, false)
 	for _, browser := range browserNames {
 		run.BrowserName = browser
-		datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
+		store.Put(store.NewIncompleteKey("TestRun"), &run)
 	}
 	run.FullRevisionHash = strings.Repeat("abcdef0000", 4)
 	run.Revision = run.FullRevisionHash[:10]
-	datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
+	store.Put(store.NewIncompleteKey("TestRun"), &run)
 
 	// Aligned
 	shas = nil

--- a/api/test_run_medium_test.go
+++ b/api/test_run_medium_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
-	"google.golang.org/appengine/datastore"
 )
 
 func TestGetTestRunByID(t *testing.T) {
@@ -38,7 +37,8 @@ func TestGetTestRunByID(t *testing.T) {
 		},
 	}
 
-	datastore.Put(ctx, datastore.NewKey(ctx, "TestRun", "", 123, nil), &chrome)
+	store := shared.NewAppEngineDatastore(ctx, false)
+	store.Put(store.NewIDKey("TestRun", 123), &chrome)
 	resp = httptest.NewRecorder()
 	apiTestRunHandler(resp, r)
 	assert.Equal(t, http.StatusOK, resp.Code)

--- a/api/versions_medium_test.go
+++ b/api/versions_medium_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
-	"google.golang.org/appengine/datastore"
 )
 
 func TestApiVersionsHandler(t *testing.T) {
@@ -37,11 +36,12 @@ func TestApiVersionsHandler(t *testing.T) {
 	someVersions := []string{"2", "1.1.1", "1.1", "1.1", "1.0", "1"}
 	run := shared.TestRun{}
 	browserNames := shared.GetDefaultBrowserNames()
+	store := shared.NewAppEngineDatastore(ctx, false)
 	for _, browser := range browserNames {
 		run.BrowserName = browser
 		for _, version := range someVersions {
 			run.BrowserVersion = version
-			datastore.Put(ctx, datastore.NewIncompleteKey(ctx, "TestRun", nil), &run)
+			store.Put(store.NewIncompleteKey("TestRun"), &run)
 		}
 	}
 

--- a/shared/datastore.go
+++ b/shared/datastore.go
@@ -53,12 +53,14 @@ type Datastore interface {
 	Done() interface{}
 	NewQuery(typeName string) Query
 	NewIDKey(typeName string, id int64) Key
+	NewIncompleteKey(typeName string) Key
 	NewNameKey(typeName string, name string) Key
 	ReserveID(typeName string) (Key, error)
 	Get(key Key, dst interface{}) error
 	GetAll(q Query, dst interface{}) ([]Key, error)
 	GetMulti(keys []Key, dst interface{}) error
 	Put(key Key, src interface{}) (Key, error)
+	PutMulti(keys []Key, src interface{}) ([]Key, error)
 
 	// Atomically insert a new entity.
 	Insert(key Key, src interface{}) error

--- a/shared/datastore_ae.go
+++ b/shared/datastore_ae.go
@@ -102,10 +102,10 @@ func (d aeDatastore) PutMulti(keys []Key, src interface{}) ([]Key, error) {
 		cast[i] = keys[i].(*datastore.Key)
 	}
 
-	cast, err := datastore.PutMulti(d.ctx, cast, src)
-	newKeys := make([]Key, len(cast))
-	for i := range cast {
-		newKeys[i] = cast[i]
+	srcKeys, err := datastore.PutMulti(d.ctx, cast, src)
+	newKeys := make([]Key, len(srcKeys))
+	for i := range srcKeys {
+		newKeys[i] = srcKeys[i]
 	}
 	return newKeys, err
 }

--- a/shared/datastore_ae.go
+++ b/shared/datastore_ae.go
@@ -51,6 +51,10 @@ func (d aeDatastore) NewIDKey(typeName string, id int64) Key {
 	return datastore.NewKey(d.ctx, typeName, "", id, nil)
 }
 
+func (d aeDatastore) NewIncompleteKey(typeName string) Key {
+	return datastore.NewIncompleteKey(d.ctx, typeName, nil)
+}
+
 func (d aeDatastore) ReserveID(typeName string) (Key, error) {
 	id, _, err := datastore.AllocateIDs(d.ctx, typeName, nil, 1)
 	if err != nil {
@@ -90,6 +94,20 @@ func (d aeDatastore) GetMulti(keys []Key, dst interface{}) error {
 
 func (d aeDatastore) Put(key Key, src interface{}) (Key, error) {
 	return datastore.Put(d.ctx, key.(*datastore.Key), src)
+}
+
+func (d aeDatastore) PutMulti(keys []Key, src interface{}) ([]Key, error) {
+	cast := make([]*datastore.Key, len(keys))
+	for i := range keys {
+		cast[i] = keys[i].(*datastore.Key)
+	}
+
+	cast, err := datastore.PutMulti(d.ctx, cast, src)
+	newKeys := make([]Key, len(cast))
+	for i := range cast {
+		newKeys[i] = cast[i]
+	}
+	return newKeys, err
 }
 
 func (d aeDatastore) Insert(key Key, src interface{}) error {

--- a/shared/models_test.go
+++ b/shared/models_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
-	"google.golang.org/appengine/datastore"
 )
 
 func TestTestRunIDs_LoadTestRuns(t *testing.T) {
@@ -29,17 +28,17 @@ func TestTestRunIDs_LoadTestRuns(t *testing.T) {
 	assert.Nil(t, err)
 	defer done()
 
-	keys := make([]*datastore.Key, 0, len(testRuns))
+	keys := make([]shared.Key, 0, len(testRuns))
+	store := shared.NewAppEngineDatastore(ctx, false)
 	for range testRuns {
-		keys = append(keys, datastore.NewIncompleteKey(ctx, "TestRun", nil))
+		keys = append(keys, store.NewIncompleteKey("TestRun"))
 	}
-	keys, err = datastore.PutMulti(ctx, keys, testRuns)
+	keys, err = store.PutMulti(keys, testRuns)
 	assert.Nil(t, err)
 	for i, key := range keys {
 		testRuns[i].ID = key.IntID()
 	}
 
-	store := shared.NewAppEngineDatastore(ctx, false)
 	trs, err := testRuns.GetTestRunIDs().LoadTestRuns(store)
 	assert.Nil(t, err)
 	assert.Equal(t, testRuns, trs)

--- a/shared/sharedtest/datastore_mock.go
+++ b/shared/sharedtest/datastore_mock.go
@@ -133,6 +133,20 @@ func (mr *MockDatastoreMockRecorder) NewIDKey(arg0, arg1 interface{}) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewIDKey", reflect.TypeOf((*MockDatastore)(nil).NewIDKey), arg0, arg1)
 }
 
+// NewIncompleteKey mocks base method
+func (m *MockDatastore) NewIncompleteKey(arg0 string) shared.Key {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewIncompleteKey", arg0)
+	ret0, _ := ret[0].(shared.Key)
+	return ret0
+}
+
+// NewIncompleteKey indicates an expected call of NewIncompleteKey
+func (mr *MockDatastoreMockRecorder) NewIncompleteKey(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewIncompleteKey", reflect.TypeOf((*MockDatastore)(nil).NewIncompleteKey), arg0)
+}
+
 // NewNameKey mocks base method
 func (m *MockDatastore) NewNameKey(arg0, arg1 string) shared.Key {
 	m.ctrl.T.Helper()
@@ -174,6 +188,21 @@ func (m *MockDatastore) Put(arg0 shared.Key, arg1 interface{}) (shared.Key, erro
 func (mr *MockDatastoreMockRecorder) Put(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockDatastore)(nil).Put), arg0, arg1)
+}
+
+// PutMulti mocks base method
+func (m *MockDatastore) PutMulti(arg0 []shared.Key, arg1 interface{}) ([]shared.Key, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PutMulti", arg0, arg1)
+	ret0, _ := ret[0].([]shared.Key)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PutMulti indicates an expected call of PutMulti
+func (mr *MockDatastoreMockRecorder) PutMulti(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutMulti", reflect.TypeOf((*MockDatastore)(nil).PutMulti), arg0, arg1)
 }
 
 // ReserveID mocks base method

--- a/util/populate_dev_data.go
+++ b/util/populate_dev_data.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	mapset "github.com/deckarep/golang-set"
-	"google.golang.org/appengine/datastore"
 	"google.golang.org/appengine/remote_api"
 
 	"github.com/web-platform-tests/wpt.fyi/shared"
@@ -315,28 +314,31 @@ func labelRuns(runs []shared.TestRun, labels ...string) {
 }
 
 func addSecretToken(ctx context.Context, id string, data interface{}) {
-	key := datastore.NewKey(ctx, "Token", id, 0, nil)
-	if _, err := datastore.Put(ctx, key, data); err != nil {
+	store := shared.NewAppEngineDatastore(ctx, false)
+	key := store.NewNameKey("Token", id)
+	if _, err := store.Put(key, data); err != nil {
 		log.Fatalf("Failed to add %s secret: %s", id, err.Error())
 	}
 	log.Printf("Added %s secret", id)
 }
 
 func addFlag(ctx context.Context, id string, data interface{}) {
-	key := datastore.NewKey(ctx, "Flag", id, 0, nil)
-	if _, err := datastore.Put(ctx, key, data); err != nil {
+	store := shared.NewAppEngineDatastore(ctx, false)
+	key := store.NewNameKey("Flag", id)
+	if _, err := store.Put(key, data); err != nil {
 		log.Fatalf("Failed to add %s flag: %s", id, err.Error())
 	}
 	log.Printf("Added %s flag", id)
 }
 
-func addData(ctx context.Context, kindName string, data []interface{}) (keys []*datastore.Key) {
-	keys = make([]*datastore.Key, len(data))
+func addData(ctx context.Context, kindName string, data []interface{}) (keys []shared.Key) {
+	store := shared.NewAppEngineDatastore(ctx, false)
+	keys = make([]shared.Key, len(data))
 	for i := range data {
-		keys[i] = datastore.NewIncompleteKey(ctx, kindName, nil)
+		keys[i] = store.NewIncompleteKey(kindName)
 	}
 	var err error
-	if keys, err = datastore.PutMulti(ctx, keys, data); err != nil {
+	if keys, err = store.PutMulti(keys, data); err != nil {
 		log.Fatalf("Failed to add %s entities: %s", kindName, err.Error())
 	}
 	log.Printf("Added %v %s entities", len(data), kindName)

--- a/util/populate_dev_data.go
+++ b/util/populate_dev_data.go
@@ -137,35 +137,36 @@ func main() {
 		metrics.PassRateMetadata{})
 
 	log.Print("Adding local (empty) secrets...")
-	addSecretToken(ctx, "upload-token", emptySecretToken)
-	addSecretToken(ctx, "github-wpt-fyi-bot-token", emptySecretToken)
-	addSecretToken(ctx, "github-oauth-client-id", emptySecretToken)
-	addSecretToken(ctx, "github-oauth-client-secret", emptySecretToken)
-	addSecretToken(ctx, "secure-cookie-hashkey", &shared.Token{
+	store := shared.NewAppEngineDatastore(ctx, false)
+	addSecretToken(store, "upload-token", emptySecretToken)
+	addSecretToken(store, "github-wpt-fyi-bot-token", emptySecretToken)
+	addSecretToken(store, "github-oauth-client-id", emptySecretToken)
+	addSecretToken(store, "github-oauth-client-secret", emptySecretToken)
+	addSecretToken(store, "secure-cookie-hashkey", &shared.Token{
 		Secret: "a-very-secret-sixty-four-bytes!!a-very-secret-sixty-four-bytes!!",
 	})
-	addSecretToken(ctx, "secure-cookie-blockkey", &shared.Token{
+	addSecretToken(store, "secure-cookie-blockkey", &shared.Token{
 		Secret: "a-very-secret-thirty-two-bytes!!",
 	})
 
 	log.Print("Adding flag defaults...")
-	addFlag(ctx, "queryBuilder", enabledFlag)
-	addFlag(ctx, "diffFilter", enabledFlag)
-	addFlag(ctx, "diffFromAPI", enabledFlag)
-	addFlag(ctx, "experimentalByDefault", enabledFlag)
-	addFlag(ctx, "experimentalAlignedExceptEdge", enabledFlag)
-	addFlag(ctx, "structuredQueries", enabledFlag)
-	addFlag(ctx, "diffRenames", enabledFlag)
-	addFlag(ctx, "paginationTokens", enabledFlag)
+	addFlag(store, "queryBuilder", enabledFlag)
+	addFlag(store, "diffFilter", enabledFlag)
+	addFlag(store, "diffFromAPI", enabledFlag)
+	addFlag(store, "experimentalByDefault", enabledFlag)
+	addFlag(store, "experimentalAlignedExceptEdge", enabledFlag)
+	addFlag(store, "structuredQueries", enabledFlag)
+	addFlag(store, "diffRenames", enabledFlag)
+	addFlag(store, "paginationTokens", enabledFlag)
 
 	log.Print("Adding uploader \"test\"...")
-	addData(ctx, "Uploader", []interface{}{
+	addData(store, "Uploader", []interface{}{
 		&shared.Uploader{Username: "test", Password: "123"},
 	})
 
 	if *staticRuns {
 		log.Print("Adding local mock data (static/)...")
-		for i, key := range addData(ctx, testRunKindName, staticTestRunMetadata) {
+		for i, key := range addData(store, testRunKindName, staticTestRunMetadata) {
 			staticTestRuns[i].ID = key.IntID()
 		}
 		stableRuns := shared.TestRuns{}
@@ -182,7 +183,7 @@ func main() {
 		stableInterop.TestRunIDs = stableRuns.GetTestRunIDs()
 		defaultInterop := passRateMetadata
 		defaultInterop.TestRunIDs = defaultRuns.GetTestRunIDs()
-		addData(ctx, passRateMetadataKindName, []interface{}{
+		addData(store, passRateMetadataKindName, []interface{}{
 			&stableInterop,
 			&defaultInterop,
 		})
@@ -202,34 +203,33 @@ func main() {
 			Labels:   extraLabels.Union(mapset.NewSetWith(shared.StableLabel)),
 			MaxCount: numRemoteRuns,
 		}
-		copyProdRuns(ctx, filters)
+		copyProdRuns(store, filters)
 
 		log.Print("Adding latest master TestRun data...")
 		filters.Labels = extraLabels.Union(mapset.NewSetWith(shared.MasterLabel))
-		copyProdRuns(ctx, filters)
+		copyProdRuns(store, filters)
 
 		log.Print("Adding latest experimental TestRun data...")
 		filters.Labels = extraLabels.Union(mapset.NewSetWith(shared.ExperimentalLabel))
-		copyProdRuns(ctx, filters)
+		copyProdRuns(store, filters)
 
 		log.Print("Adding latest beta TestRun data...")
 		filters.Labels = extraLabels.Union(mapset.NewSetWith(shared.BetaLabel))
-		copyProdRuns(ctx, filters)
+		copyProdRuns(store, filters)
 
 		log.Print("Adding latest aligned Edge stable and Chrome/Firefox/Safari experimental data...")
 		filters.Labels = extraLabels.Union(mapset.NewSet(shared.MasterLabel))
 		filters.Products, _ = shared.ParseProductSpecs("chrome[experimental]", "edge[stable]", "firefox[experimental]", "safari[experimental]")
-		copyProdRuns(ctx, filters)
+		copyProdRuns(store, filters)
 
 		log.Printf("Successfully copied a total of %v distinct TestRuns", seenTestRunIDs.Cardinality())
 
 		log.Print("Adding latest production PendingTestRun...")
-		copyProdPendingRuns(ctx, *numRemoteRuns)
+		copyProdPendingRuns(store, *numRemoteRuns)
 	}
 }
 
-func copyProdRuns(ctx context.Context, filters shared.TestRunFilter) {
-	store := shared.NewAppEngineDatastore(ctx, false)
+func copyProdRuns(store shared.Datastore, filters shared.TestRunFilter) {
 	q := store.TestRunQuery()
 	for _, aligned := range []bool{false, true} {
 		if aligned {
@@ -249,7 +249,7 @@ func copyProdRuns(ctx context.Context, filters shared.TestRunFilter) {
 				latestProductionTestRunMetadata = append(latestProductionTestRunMetadata, &prodTestRuns[i])
 			}
 		}
-		addData(ctx, "TestRun", latestProductionTestRunMetadata)
+		addData(store, "TestRun", latestProductionTestRunMetadata)
 
 		passRateMetadataKindName := metrics.GetDatastoreKindName(metrics.PassRateMetadata{})
 		filters.MaxCount = nil
@@ -289,11 +289,11 @@ func copyProdRuns(ctx context.Context, filters shared.TestRunFilter) {
 		for i := range prodPassRateMetadata.TestRunIDs {
 			prodPassRateMetadata.TestRunIDs[i] = localRunCopies[i].ID
 		}
-		addData(ctx, passRateMetadataKindName, []interface{}{&prodPassRateMetadata})
+		addData(store, passRateMetadataKindName, []interface{}{&prodPassRateMetadata})
 	}
 }
 
-func copyProdPendingRuns(ctx context.Context, numRuns int) {
+func copyProdPendingRuns(store shared.Datastore, numRuns int) {
 	pendingRuns, err := FetchPendingRuns(*remoteHost)
 	if err != nil {
 		log.Fatalf("Failed to fetch pending runs: %s", err.Error())
@@ -302,7 +302,7 @@ func copyProdPendingRuns(ctx context.Context, numRuns int) {
 	for i := range pendingRuns {
 		castRuns = append(castRuns, &pendingRuns[i])
 	}
-	addData(ctx, "PendingTestRun", castRuns)
+	addData(store, "PendingTestRun", castRuns)
 }
 
 func labelRuns(runs []shared.TestRun, labels ...string) {
@@ -313,8 +313,7 @@ func labelRuns(runs []shared.TestRun, labels ...string) {
 	}
 }
 
-func addSecretToken(ctx context.Context, id string, data interface{}) {
-	store := shared.NewAppEngineDatastore(ctx, false)
+func addSecretToken(store shared.Datastore, id string, data interface{}) {
 	key := store.NewNameKey("Token", id)
 	if _, err := store.Put(key, data); err != nil {
 		log.Fatalf("Failed to add %s secret: %s", id, err.Error())
@@ -322,8 +321,7 @@ func addSecretToken(ctx context.Context, id string, data interface{}) {
 	log.Printf("Added %s secret", id)
 }
 
-func addFlag(ctx context.Context, id string, data interface{}) {
-	store := shared.NewAppEngineDatastore(ctx, false)
+func addFlag(store shared.Datastore, id string, data interface{}) {
 	key := store.NewNameKey("Flag", id)
 	if _, err := store.Put(key, data); err != nil {
 		log.Fatalf("Failed to add %s flag: %s", id, err.Error())
@@ -331,8 +329,7 @@ func addFlag(ctx context.Context, id string, data interface{}) {
 	log.Printf("Added %s flag", id)
 }
 
-func addData(ctx context.Context, kindName string, data []interface{}) (keys []shared.Key) {
-	store := shared.NewAppEngineDatastore(ctx, false)
+func addData(store shared.Datastore, kindName string, data []interface{}) (keys []shared.Key) {
 	keys = make([]shared.Key, len(data))
 	for i := range data {
 		keys[i] = store.NewIncompleteKey(kindName)


### PR DESCRIPTION
This is part of #1747 and a pure refactor without any behaviour changes.

Refactor all direct use of .../appengine/datastore library with datastore_ae. Implement the missing `NewIncompleteKey` and `PutMulti` APIs.