### PR TITLE
Encapsulate MultiError from datastore SDKs

### DIFF
--- a/api/diff.go
+++ b/api/diff.go
@@ -9,8 +9,6 @@ import (
 
 	mapset "github.com/deckarep/golang-set"
 	"github.com/web-platform-tests/wpt.fyi/shared"
-
-	"google.golang.org/appengine"
 )
 
 // apiDiffHandler takes 2 test-run results JSON blobs and produces JSON in the same format, with only the differences
@@ -36,9 +34,9 @@ func loadDiffRuns(store shared.Datastore, q url.Values) (shared.TestRuns, error)
 		runs, err := runIDs.LoadTestRuns(store)
 		// If all errors are NoSuchEntity, we don't treat it as an error.
 		// If err is nil, the type conversion will fail.
-		if multiError, ok := err.(appengine.MultiError); ok {
+		if multiError, ok := err.(shared.MultiError); ok {
 			all404s := true
-			for _, err := range multiError {
+			for _, err := range multiError.Errors() {
 				if err != shared.ErrNoSuchEntity {
 					all404s = false
 					break

--- a/shared/errors_test.go
+++ b/shared/errors_test.go
@@ -19,9 +19,11 @@ func TestNewMultiErrorFromChan_non_empty(t *testing.T) {
 	errs <- errors.New("test2")
 	close(errs)
 	err := NewMultiErrorFromChan(errs, "testing")
-	assert.Equal(t, "2 error(s) occurred when testing:\ntest1\ntest2\n", err.Error())
-	_, ok := err.(*MultiError)
+	assert.Equal(t, "2 error(s) occurred when testing:\ntest1\ntest2", err.Error())
+	merr, ok := err.(MultiError)
 	assert.True(t, ok)
+	assert.Equal(t, 2, merr.Count())
+	assert.Equal(t, 2, len(merr.Errors()))
 }
 
 func TestNewMultiErrorFromChan_nil(t *testing.T) {
@@ -36,6 +38,22 @@ func TestNewMultiErrorFromChan_nil(t *testing.T) {
 	// NewMultiErrorFromChan incorrectly returns a concrete
 	// (*MultiError)(nil).
 	assert.Equal(t, nil, err)
-	_, ok := err.(*MultiError)
+	_, ok := err.(MultiError)
 	assert.False(t, ok)
+}
+
+func TestNewMultiError_non_empty(t *testing.T) {
+	errs := []error{errors.New("test1"), errors.New("test2")}
+	err := NewMultiError(errs, "testing")
+	assert.Equal(t, "2 error(s) occurred when testing:\ntest1\ntest2", err.Error())
+	merr, ok := err.(MultiError)
+	assert.True(t, ok)
+	assert.Equal(t, 2, merr.Count())
+	assert.Equal(t, 2, len(merr.Errors()))
+}
+
+func TestNewMultiError_nil(t *testing.T) {
+	var err error
+	err = NewMultiError(nil, "testing")
+	assert.Equal(t, nil, err)
 }


### PR DESCRIPTION
Return shared.MultiError from both AppEngine and Cloud
datastore.GetMulti, including unification of ErrNoSuchEntity.

Part of #1747 