### PR TITLE
Migrate from AppEngine memcache to Memorystore (Redis)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ jobs:
 
     - stage: deploy PR
       env:
-      - DEPLOY_PR_STAGING_TARGET=webapp/web
+      - DEPLOY_PR_STAGING_TARGET=webapp/web/app.staging.yaml
     - env:
       - DEPLOY_PR_STAGING_TARGET=results-processor
     - env:
@@ -64,7 +64,7 @@ jobs:
 
     - stage: deploy master
       env:
-      - DEPLOY_STAGING_TARGET=webapp/web
+      - DEPLOY_STAGING_TARGET=webapp/web/app.staging.yaml
       - MAKE_TEST_TARGET=go_large_test # Run integration tests after webapp deployment.
       - MAKE_TEST_FLAGS="STAGING=true"
     - env:

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/gobuffalo/packr/v2 v2.8.0
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/golang/mock v1.4.4
+	github.com/gomodule/redigo v1.8.2
 	github.com/google/go-github/v32 v32.1.0
 	github.com/google/uuid v1.1.2
 	github.com/gorilla/handlers v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -196,6 +196,9 @@ github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw
 github.com/golang/protobuf v1.4.3 h1:JjCZWpVbqXDqFVmTfYWEVTMIYrL/NPdPSCHPJ0T/raM=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/gomodule/redigo v1.8.2 h1:H5XSIre1MB5NbPYFp+i1NBbb5qN1W8Y8YAQoAYbkm8k=
+github.com/gomodule/redigo v1.8.2/go.mod h1:P9dn9mFrCBvWhGE1wpxx6fgq7BAeLBk+UUUzlpkBYO0=
+github.com/gomodule/redigo/redis v0.0.0-do-not-use h1:J7XIp6Kau0WoyT4JtXHT3Ei0gA1KkSc6bc87j9v9WIo=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=

--- a/shared/cache.go
+++ b/shared/cache.go
@@ -18,15 +18,17 @@ import (
 	"net/http"
 	"time"
 
-	"google.golang.org/appengine/memcache"
+	"github.com/gomodule/redigo/redis"
 )
 
 var (
 	errNewReadCloserExpectedString        = errors.New("NewReadCloser(arg) expected arg string")
 	errMemcacheWriteCloserWriteAfterClose = errors.New("memcacheWriteCloser: Write() after Close()")
+	errMemcacheInvalidResponseType        = errors.New("memcache: type received from GET is not []byte")
 	errByteCachedStoreExpectedByteSlice   = errors.New("contextualized byte CachedStore expected []byte output arg")
 	errDatastoreObjectStoreExpectedInt64  = errors.New("datastore ObjectStore expected int64 ID")
 	errCacheMiss                          = errors.New("cache miss")
+	errNoRedis                            = errors.New("not connected to redis")
 )
 
 // Readable is a provider interface for an io.ReadCloser.
@@ -152,9 +154,9 @@ type memcacheReadWritable struct {
 }
 
 type memcacheWriteCloser struct {
-	memcacheReadWritable
+	rw         memcacheReadWritable
+	conn       redis.Conn
 	key        string
-	expiry     time.Duration
 	b          bytes.Buffer
 	hasWritten bool
 	isClosed   bool
@@ -165,14 +167,24 @@ func (mc memcacheReadWritable) NewReadCloser(iKey interface{}) (io.ReadCloser, e
 	if !ok {
 		return nil, errNewReadCloserExpectedString
 	}
-
-	item, err := memcache.Get(mc.ctx, key)
-	if err == memcache.ErrCacheMiss {
-		return nil, errCacheMiss
-	} else if err != nil {
-		return nil, err
+	if Clients.redisPool == nil {
+		return nil, errNoRedis
 	}
-	return ioutil.NopCloser(bytes.NewReader(item.Value)), nil
+	conn := Clients.redisPool.Get()
+	defer conn.Close()
+
+	// https://redis.io/commands/get
+	result, err := conn.Do("GET", key)
+	if err != nil {
+		return nil, err
+	} else if result == nil {
+		return nil, errCacheMiss
+	}
+	b, ok := result.([]byte)
+	if !ok {
+		return nil, errMemcacheInvalidResponseType
+	}
+	return ioutil.NopCloser(bytes.NewReader(b)), nil
 }
 
 func (mc memcacheReadWritable) NewWriteCloser(iKey interface{}) (io.WriteCloser, error) {
@@ -180,8 +192,11 @@ func (mc memcacheReadWritable) NewWriteCloser(iKey interface{}) (io.WriteCloser,
 	if !ok {
 		return nil, errNewReadCloserExpectedString
 	}
-
-	return &memcacheWriteCloser{mc, key, mc.expiry, bytes.Buffer{}, false, false}, nil
+	var conn redis.Conn
+	if Clients.redisPool != nil {
+		conn = Clients.redisPool.Get()
+	}
+	return &memcacheWriteCloser{mc, conn, key, bytes.Buffer{}, false, false}, nil
 }
 
 func (mw *memcacheWriteCloser) Write(p []byte) (n int, err error) {
@@ -194,15 +209,17 @@ func (mw *memcacheWriteCloser) Write(p []byte) (n int, err error) {
 
 func (mw *memcacheWriteCloser) Close() error {
 	mw.isClosed = true
+	if mw.conn == nil {
+		return nil
+	}
+	defer mw.conn.Close()
 	if !mw.hasWritten {
 		return nil
 	}
 
-	return memcache.Set(mw.ctx, &memcache.Item{
-		Key:        mw.key,
-		Value:      mw.b.Bytes(),
-		Expiration: mw.expiry,
-	})
+	// https://redis.io/commands/set
+	_, err := mw.conn.Do("SET", mw.key, mw.b.Bytes(), "EX", int(mw.rw.expiry.Seconds()))
+	return err
 }
 
 // NewMemcacheReadWritable produces a ReadWritable that performs read/write
@@ -246,7 +263,7 @@ func (cs byteCachedStore) Get(cacheID, storeID, iValue interface{}) error {
 		}
 	}
 
-	if err != errCacheMiss {
+	if err != errCacheMiss && err != errNoRedis {
 		logger.Warningf("Error fetching cache key %v: %v", cacheID, err)
 	}
 	err = nil
@@ -410,4 +427,16 @@ func (cs objectCachedStore) Get(cacheID, storeID, value interface{}) error {
 // and ObjectStore.
 func NewObjectCachedStore(ctx context.Context, cache ObjectCache, store ObjectStore) CachedStore {
 	return objectCachedStore{ctx, cache, store}
+}
+
+// FlushCache purges everything from Memorystore.
+func FlushCache() error {
+	if Clients.redisPool == nil {
+		return errNoRedis
+	}
+	conn := Clients.redisPool.Get()
+	defer conn.Close()
+	// https://redis.io/commands/flushall
+	_, err := conn.Do("FLUSHALL")
+	return err
 }

--- a/shared/cache_test.go
+++ b/shared/cache_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
-	"google.golang.org/appengine/memcache"
 )
 
 func TestGet_cacheHit(t *testing.T) {
@@ -48,9 +47,10 @@ func TestGet_cacheMiss(t *testing.T) {
 	cs := shared.NewByteCachedStore(sharedtest.NewTestContext(), cache, store)
 
 	data := []byte("{}")
+	errMissing := errors.New("Failed to fetch from store")
 	cw := sharedtest.NewMockWriteCloser(t)
 	sr := sharedtest.NewMockReadCloser(t, data)
-	cache.EXPECT().NewReadCloser(&cacheID).Return(nil, memcache.ErrCacheMiss)
+	cache.EXPECT().NewReadCloser(&cacheID).Return(nil, errMissing)
 	store.EXPECT().NewReadCloser(&storeID).Return(sr, nil)
 	cache.EXPECT().NewWriteCloser(&cacheID).Return(cw, nil)
 
@@ -72,7 +72,7 @@ func TestGet_missing(t *testing.T) {
 	cs := shared.NewByteCachedStore(sharedtest.NewTestContext(), cache, store)
 
 	errMissing := errors.New("Failed to fetch from store")
-	cache.EXPECT().NewReadCloser(&cacheID).Return(nil, memcache.ErrCacheMiss)
+	cache.EXPECT().NewReadCloser(&cacheID).Return(nil, errMissing)
 	store.EXPECT().NewReadCloser(&storeID).Return(nil, errMissing)
 
 	var v []byte

--- a/util/deploy.sh
+++ b/util/deploy.sh
@@ -37,6 +37,7 @@ done
 if [[ "${APP_PATH}" == ""  ]]; then fatal "app path not specified."; fi
 case "${APP_PATH}" in
   "webapp/web" | \
+  "webapp/web/app.staging.yaml" | \
   "results-processor" | \
   "api/query/cache/service" | \
   "api/query/cache/service/app.staging.yaml")

--- a/util/travis-deploy-staging.sh
+++ b/util/travis-deploy-staging.sh
@@ -21,10 +21,9 @@ done
 if [[ "${APP_PATH}" == ""  ]]; then fatal "app path not specified."; fi
 
 APP_DEPS="${APP_PATH}"
-if [[ "${APP_PATH}" == "webapp/web" ]]; then APP_DEPS="webapp|api|shared"; fi
+if [[ "${APP_PATH}" == webapp/web* ]]; then APP_DEPS="webapp|api|shared"; fi
 # Be more conservative: only deploy searchcache when it's directly modified.
-# if [[ "${APP_PATH}" == "api/query/cache/service" ]]; then APP_DEPS="shared|api/query"; fi
-if [[ "${APP_PATH}" == "api/query/cache/service/app.staging.yaml" ]]; then APP_DEPS="api/query"; fi
+if [[ "${APP_PATH}" == api/query/cache/service* ]]; then APP_DEPS="api/query"; fi
 APP_DEPS_REGEX="^(${APP_DEPS})/"
 
 EXCLUSIONS="_test.go$|webapp/components/test/"

--- a/webapp/admin_handler.go
+++ b/webapp/admin_handler.go
@@ -10,8 +10,6 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"google.golang.org/appengine/memcache"
-
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
@@ -120,7 +118,7 @@ func adminCacheFlushHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := memcache.Flush(ctx); err != nil {
+	if err := shared.FlushCache(); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	} else {
 		w.Write([]byte("Successfully flushed cache"))

--- a/webapp/web/app.dev.yaml
+++ b/webapp/web/app.dev.yaml
@@ -12,6 +12,7 @@ inbound_services:
 - warmup
 
 default_expiration: "1d"
+
 # Also refer to dispatch.yaml for higher-priority routing rules.
 handlers:
 # Special dynamic components:

--- a/webapp/web/app.dev.yaml
+++ b/webapp/web/app.dev.yaml
@@ -12,7 +12,6 @@ inbound_services:
 - warmup
 
 default_expiration: "1d"
-
 # Also refer to dispatch.yaml for higher-priority routing rules.
 handlers:
 # Special dynamic components:

--- a/webapp/web/app.staging.yaml
+++ b/webapp/web/app.staging.yaml
@@ -11,7 +11,7 @@ inbound_services:
 default_expiration: "1d"
 
 vpc_access_connector:
-  name: projects/wptdashboard/locations/us-central1/connectors/appengine-connector
+  name: projects/wptdashboard-staging/locations/us-east4/connectors/appengine-connector
 
 env_variables:
   REDISHOST: "10.171.142.203"

--- a/webapp/web/app.yaml
+++ b/webapp/web/app.yaml
@@ -10,6 +10,14 @@ inbound_services:
 
 default_expiration: "1d"
 
+vpc_access_connector:
+  name: projects/wptdashboard-staging/locations/us-east4/connectors/appengine-connector
+
+env_variables:
+  REDISHOST: '10.171.142.203'
+  REDISPORT: '6379'
+
+
 # Also refer to dispatch.yaml for higher-priority routing rules.
 handlers:
 # Special dynamic components:

--- a/webapp/web/app.yaml
+++ b/webapp/web/app.yaml
@@ -14,9 +14,8 @@ vpc_access_connector:
   name: projects/wptdashboard-staging/locations/us-east4/connectors/appengine-connector
 
 env_variables:
-  REDISHOST: '10.171.142.203'
-  REDISPORT: '6379'
-
+  REDISHOST: "10.171.142.203"
+  REDISPORT: "6379"
 
 # Also refer to dispatch.yaml for higher-priority routing rules.
 handlers:


### PR DESCRIPTION
Part of #1747 . I followed https://cloud.google.com/appengine/docs/standard/go/using-memorystore#setup_redis_db for the setup (note that this needs to be repeated on prod before the next prod release; **update**: I've completed this).

This completely migrates us off of the legacy memcache in AppEngine to Cloud Memorystore (Redis). With this change, each instance of webapp creates a pool of Redis connections on startup for API handlers to use if it is running in the cloud; when running locally, it'd skip memcache altogether.

Tested manually (by verifying the logs and inspecting the Redis instance). Unfortunately we have to drop a test for now as it requires a local Redis, which we don't have.