### PR TITLE
Tweak local testing setup in preparation for go1.12 switchover

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,6 @@ git: apt-get-git
 psmisc: apt-get-psmisc
 python3: apt-get-python3.7
 python: apt-get-python
-pip: apt-get-python-pip
 tox: apt-get-tox
 unzip: apt-get-unzip
 wget: apt-get-wget
@@ -206,6 +205,12 @@ gpg:
 	@ # gpg has a different apt-get package name.
 	if [[ "$$(which gpg)" == "" ]]; then \
 		sudo apt-get install -qqy --no-install-suggests gnupg; \
+	fi
+
+pip:
+	@ # pip has a different apt-get package name.
+	if [[ "$$(which pip2)" == "" ]]; then \
+		sudo apt-get install -qqy --no-install-suggests python-pip; \
 	fi
 
 node: curl gpg

--- a/Makefile
+++ b/Makefile
@@ -278,7 +278,7 @@ node-%: node
 
 pip-%: pip
 	@ echo "# installing $*..."
-	pip show $* >/dev/null || pip install --user $*
+	pip show $* >/dev/null || sudo pip install $*
 
 apt-get-%:
 	if [[ "$$(which $*)" == "" ]]; then sudo apt-get install -qqy --no-install-suggests $*; fi

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ web_components_test: xvfb firefox chrome webapp_node_modules_all psmisc
 lighthouse: chrome webapp_node_modules_all
 	cd webapp; npx lhci autorun --failOnUploadFailure
 
-dev_appserver_deps: gcloud-app-engine-python gcloud-app-engine-go gcloud-cloud-datastore-emulator
+dev_appserver_deps: gcloud-app-engine-python gcloud-app-engine-go gcloud-cloud-datastore-emulator pip-grpcio
 
 chrome: wget
 	# Pinned to Chrome 84 to workaround https://github.com/web-platform-tests/wpt.fyi/issues/2128
@@ -191,6 +191,7 @@ git: apt-get-git
 psmisc: apt-get-psmisc
 python3: apt-get-python3.7
 python: apt-get-python
+pip: apt-get-python-pip
 tox: apt-get-tox
 unzip: apt-get-unzip
 wget: apt-get-wget
@@ -274,6 +275,10 @@ node-%: node
 	@ echo "# Installing $*..."
 	# Hack to (more quickly) detect whether a package is already installed (available in node).
 	cd webapp; node -p "require('$*/package.json').version" 2>/dev/null || npm install --no-save $*
+
+pip-%: pip
+	@ echo "# installing $*..."
+	pip show $* >/dev/null || pip install --user $*
 
 apt-get-%:
 	if [[ "$$(which $*)" == "" ]]; then sudo apt-get install -qqy --no-install-suggests $*; fi

--- a/shared/sharedtest/util.go
+++ b/shared/sharedtest/util.go
@@ -8,20 +8,43 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
 
 	"github.com/golang/mock/gomock"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 	"google.golang.org/appengine/aetest"
 )
 
+// Instance represents a running instance of the development API Server.
+type Instance interface {
+	// Close kills the child api_server.py process, releasing its resources.
+	io.Closer
+	// NewRequest returns an *http.Request associated with this instance.
+	NewRequest(method, urlStr string, body io.Reader) (*http.Request, error)
+}
+
+type aeInstance struct {
+	Instance
+}
+
+func (i aeInstance) NewRequest(method, urlStr string, body io.Reader) (*http.Request, error) {
+	req, err := i.Instance.NewRequest(method, urlStr, body)
+	if err != nil {
+		return req, err
+	}
+	return req.WithContext(ctxWithNilLogger(req.Context())), err
+}
+
 // NewAEInstance creates a new aetest instance backed by dev_appserver whose
 // logs are suppressed. It takes a boolean argument for whether the Datastore
 // emulation should be strongly consistent.
-func NewAEInstance(stronglyConsistentDatastore bool) (aetest.Instance, error) {
-	return aetest.NewInstance(&aetest.Options{
+func NewAEInstance(stronglyConsistentDatastore bool) (Instance, error) {
+	instance, err := aetest.NewInstance(&aetest.Options{
 		StronglyConsistentDatastore: stronglyConsistentDatastore,
 		SuppressDevAppServerLog:     true,
 	})
+	return aeInstance{instance}, err
 }
 
 // NewAEContext creates a new aetest context backed by dev_appserver whose
@@ -37,8 +60,7 @@ func NewAEContext(stronglyConsistentDatastore bool) (context.Context, func(), er
 		inst.Close()
 		return nil, nil, err
 	}
-	ctx := req.Context()
-	ctx = context.WithValue(ctx, shared.DefaultLoggerCtxKey(), shared.NewNilLogger())
+	ctx := ctxWithNilLogger(req.Context())
 	return ctx, func() {
 		inst.Close()
 	}, nil
@@ -46,9 +68,11 @@ func NewAEContext(stronglyConsistentDatastore bool) (context.Context, func(), er
 
 // NewTestContext creates a new context.Context for small tests.
 func NewTestContext() context.Context {
-	ctx := context.Background()
-	ctx = context.WithValue(ctx, shared.DefaultLoggerCtxKey(), shared.NewNilLogger())
-	return ctx
+	return ctxWithNilLogger(context.Background())
+}
+
+func ctxWithNilLogger(ctx context.Context) context.Context {
+	return context.WithValue(ctx, shared.DefaultLoggerCtxKey(), shared.NewNilLogger())
 }
 
 type sameStringSpec struct {

--- a/shared/sharedtest/util.go
+++ b/shared/sharedtest/util.go
@@ -40,9 +40,11 @@ func (i aeInstance) NewRequest(method, urlStr string, body io.Reader) (*http.Req
 // logs are suppressed. It takes a boolean argument for whether the Datastore
 // emulation should be strongly consistent.
 func NewAEInstance(stronglyConsistentDatastore bool) (Instance, error) {
+	t := true
 	instance, err := aetest.NewInstance(&aetest.Options{
 		StronglyConsistentDatastore: stronglyConsistentDatastore,
 		SuppressDevAppServerLog:     true,
+		SupportDatastoreEmulator:    &t,
 	})
 	return aeInstance{instance}, err
 }

--- a/shared/sharedtest/util.go
+++ b/shared/sharedtest/util.go
@@ -43,8 +43,8 @@ func NewAEInstance(stronglyConsistentDatastore bool) (Instance, error) {
 	t := true
 	instance, err := aetest.NewInstance(&aetest.Options{
 		StronglyConsistentDatastore: stronglyConsistentDatastore,
-		SuppressDevAppServerLog:     true,
-		SupportDatastoreEmulator:    &t,
+		//SuppressDevAppServerLog:     true,
+		SupportDatastoreEmulator: &t,
 	})
 	return aeInstance{instance}, err
 }

--- a/shared/sharedtest/util.go
+++ b/shared/sharedtest/util.go
@@ -43,8 +43,8 @@ func NewAEInstance(stronglyConsistentDatastore bool) (Instance, error) {
 	t := true
 	instance, err := aetest.NewInstance(&aetest.Options{
 		StronglyConsistentDatastore: stronglyConsistentDatastore,
-		//SuppressDevAppServerLog:     true,
-		SupportDatastoreEmulator: &t,
+		SuppressDevAppServerLog:     true,
+		SupportDatastoreEmulator:    &t,
 	})
 	return aeInstance{instance}, err
 }

--- a/webdriver/webapp_server.go
+++ b/webdriver/webapp_server.go
@@ -153,10 +153,7 @@ func newDevAppServer() (s *devAppServerInstance, err error) {
 		// admin port directly so we don't need to use pickUnusedPort.
 		fmt.Sprintf("--admin_port=%d", 0),
 		"--automatic_restart=false",
-		// TODO(Hexcles): Force the legacy internal Datastore emulation
-		// in dev_appserver instead of the external one until
-		// https://issuetracker.google.com/issues/112817362 is solved.
-		"--support_datastore_emulator=false",
+		"--support_datastore_emulator=true",
 		"--skip_sdk_update_check=true",
 		"--clear_datastore=true",
 		"--datastore_consistency_policy=consistent",


### PR DESCRIPTION
Part of #1747 

1. Enable Cloud Datastore emulator when running tests (this will unblock us from switching to Cloud Datastore SDK)
2. Attach a nil logger to local dev_appserver (this suppresses a large number of "logs will be lost" warnings when running tests)