### PR TITLE
Prevent a potential race condition when closing clients

### DIFF
--- a/shared/appengine.go
+++ b/shared/appengine.go
@@ -86,7 +86,11 @@ func (c *clientsImpl) Init(ctx context.Context) (err error) {
 // Close closes all clients in Clients. It must be called once and only once
 // before the server exits. Do not use AppEngineAPI afterwards.
 func (c *clientsImpl) Close() {
-	log.Printf("Closing clients")
+	log.Println("Closing clients")
+	// In the code below, we set clients to nil before closing them. This would
+	// cause a panic if we use a client that's being closed, which should never
+	// happen but we are not sure how exactly App Engine manages instances.
+
 	if c.cloudtasks != nil {
 		client := c.cloudtasks
 		c.cloudtasks = nil

--- a/shared/appengine.go
+++ b/shared/appengine.go
@@ -86,27 +86,31 @@ func (c *clientsImpl) Init(ctx context.Context) (err error) {
 // Close closes all clients in Clients. It must be called once and only once
 // before the server exits. Do not use AppEngineAPI afterwards.
 func (c *clientsImpl) Close() {
+	log.Printf("Closing clients")
 	if c.cloudtasks != nil {
-		if err := c.cloudtasks.Close(); err != nil {
+		client := c.cloudtasks
+		c.cloudtasks = nil
+		if err := client.Close(); err != nil {
 			log.Printf("Error closing cloudtasks: %s", err.Error())
 		}
-		c.cloudtasks = nil
 	}
 
 	if c.gclogClient != nil {
-		if err := c.gclogClient.Close(); err != nil {
-			log.Printf("Error closing gclog client: %s", err.Error())
-		}
+		client := c.gclogClient
 		c.gclogClient = nil
 		c.childLogger = nil
 		c.parentLogger = nil
+		if err := client.Close(); err != nil {
+			log.Printf("Error closing gclog client: %s", err.Error())
+		}
 	}
 
 	if c.redisPool != nil {
-		if err := c.redisPool.Close(); err != nil {
+		client := c.redisPool
+		c.redisPool = nil
+		if err := client.Close(); err != nil {
 			log.Printf("Error closing redis client: %s", err.Error())
 		}
-		c.redisPool = nil
 	}
 }
 


### PR DESCRIPTION
One theory for https://github.com/googleapis/google-cloud-go/issues/3205
(and https://github.com/web-platform-tests/wpt.fyi/issues/2224)
is that the instance might receive a request when it is shutting down
(and closing the clients).

To discover and/or prevent this scenario, we
* Add a log message at the beginning of shared.Clients.Close()
* Set the clients to nil before closing them (this would cause a panic
  if a client is later used)
