### PR TITLE
[Triage Metadata] Links not shown when metadata entries have same URLs

### DIFF
--- a/webapp/components/test/wpt-metadata.html
+++ b/webapp/components/test/wpt-metadata.html
@@ -44,6 +44,29 @@ suite('<wpt-metadata>', () => {
       assert.equal(appFixture.displayedMetadata[0].url, 'https://bug1');
       assert.equal(appFixture.displayedMetadata[0].product, 'chrome');
     });
+    test('simple case with same URLs', () => {
+      appFixture.searchResults = [{ test: '/foo.html' }];
+      appFixture.metadata = {
+        '/foo.html': [
+          {
+            url: 'github1',
+            product: 'chrome'
+          },
+          {
+            url: 'github1',
+            product: 'edge'
+          }
+        ]
+      };
+      appFixture.path = '/';
+      assert.equal(appFixture.displayedMetadata.length, 2);
+      assert.equal(appFixture.displayedMetadata[0].test, '/foo.html');
+      assert.equal(appFixture.displayedMetadata[0].url, 'https://github1');
+      assert.equal(appFixture.displayedMetadata[0].product, 'chrome');
+      assert.equal(appFixture.displayedMetadata[1].test, '/foo.html');
+      assert.equal(appFixture.displayedMetadata[1].url, 'https://github1');
+      assert.equal(appFixture.displayedMetadata[1].product, 'edge');
+    });
     test('simple case with wildcard', () => {
       appFixture.searchResults = [{ test: '/foo/bar.html' }];
       appFixture.metadata = {
@@ -87,10 +110,16 @@ suite('<wpt-metadata>', () => {
       appFixture.searchResults = [{ test: '/foo.html' }, { test: '/bar/f.html' }];
       appFixture.metadata = {
         '/foo.html': [
-          { url: 'bug1' }
+          {
+            url: 'bug1',
+            product: 'chrome'
+          }
         ],
         '/bar/f.html': [
-          { url: 'bug2' }
+          {
+            url: 'bug2',
+            product: 'chrome'
+          }
         ]
       };
       appFixture.path = '/foo';
@@ -102,17 +131,32 @@ suite('<wpt-metadata>', () => {
       appFixture.searchResults = [{ test: '/foo.html' }, { test: '/foo/bar.html' }, { test: '/foo/bar/foo1.html' }, { test: '/bar/foo.html' }];
       appFixture.metadata = {
         '/foo.html': [
-          { url: 'bug1' }
+          {
+            url: 'bug1',
+            product: 'chrome'
+          }
         ],
         '/foo/bar.html': [
-          { url: 'http://bug2' },
-          { url: 'safari1' }
+          {
+            url: 'http://bug2',
+            product: 'safari'
+          },
+          {
+            url: 'safari1',
+            product: 'safari'
+          }
         ],
         '/foo/bar/foo1.html': [
-          { url: 'https://bug3' }
+          {
+            url: 'https://bug3',
+            product: 'chrome'
+          }
         ],
         '/bar/foo.html': [
-          { url: 'bug4' }
+          {
+            url: 'bug4',
+            product: 'chrome'
+          }
         ]
       };
       appFixture.path = '/foo';
@@ -130,14 +174,14 @@ suite('<wpt-metadata>', () => {
       appFixture.searchResults = [{ test: '/foo.html' }, { test: '/bar.html' }];
       appFixture.metadata = {
         '/foo.html': [
-          { url: 'bug1' },
-          { url: 'bug1' },
-          { url: 'bug1' }
+          { url: 'bug1', product: 'chrome' },
+          { url: 'bug1', product: 'chrome' },
+          { url: 'bug1', product: 'chrome' }
         ],
         '/bar.html': [
-          { url: '' },
-          { url: 'bug2' },
-          { url: '' }
+          { url: '', product: 'chrome' },
+          { url: 'bug2', product: 'chrome' },
+          { url: '', product: 'chrome' }
         ],
       };
       appFixture.path = '/';
@@ -151,17 +195,17 @@ suite('<wpt-metadata>', () => {
       appFixture.searchResults = [{ test: '/foo/bar/foo1.html' }];
       appFixture.metadata = {
         '/foo.html': [
-          { url: 'bug1' }
+          { url: 'bug1', product: 'chrome' }
         ],
         '/foo/bar.html': [
-          { url: 'bug2' },
-          { url: 'safari1' }
+          { url: 'bug2', product: 'chrome' },
+          { url: 'safari1', product: 'chrome' }
         ],
         '/foo/bar/foo1.html': [
-          { url: 'bug3' }
+          { url: 'bug3', product: 'chrome' }
         ],
         '/bar/foo.html': [
-          { url: 'bug4' }
+          { url: 'bug4', product: 'chrome' }
         ]
       };
       appFixture.path = '/foo';

--- a/webapp/components/wpt-metadata.js
+++ b/webapp/components/wpt-metadata.js
@@ -201,13 +201,13 @@ class WPTMetadata extends PathInfo(LoadingState(PolymerElement)) {
     let metadataMap = {};
     let displayedMetadata = [];
     for (const test of Object.keys(metadata).filter(k => this.shouldShowMetadata(k, path, testResultSet))) {
-      const seenURLs = new Set();
+      const seenProductURLs = new Set();
       for (const link of metadata[test]) {
-        const serializedURL = link.product.trim() + link.url.trim();
-        if (link.url === '' || seenURLs.has(serializedURL)) {
+        const serializedProductURL = link.product.trim() + '_' + link.url.trim();
+        if (link.url === '' || seenProductURLs.has(serializedProductURL)) {
           continue;
         }
-        seenURLs.add(serializedURL);
+        seenProductURLs.add(serializedProductURL);
         const urlHref = this.getUrlHref(link.url);
         const subtestMap = {};
         if ('results' in link) {

--- a/webapp/components/wpt-metadata.js
+++ b/webapp/components/wpt-metadata.js
@@ -202,12 +202,12 @@ class WPTMetadata extends PathInfo(LoadingState(PolymerElement)) {
     let displayedMetadata = [];
     for (const test of Object.keys(metadata).filter(k => this.shouldShowMetadata(k, path, testResultSet))) {
       const seenURLs = new Set();
-      seenURLs.add(''); // Avoids accepting empty URLs.
       for (const link of metadata[test]) {
-        if (seenURLs.has(link.url)) {
+        const serializedURL = link.product.trim() + link.url.trim();
+        if (link.url === '' || seenURLs.has(serializedURL)) {
           continue;
         }
-        seenURLs.add(link.url);
+        seenURLs.add(serializedURL);
         const urlHref = this.getUrlHref(link.url);
         const subtestMap = {};
         if ('results' in link) {


### PR DESCRIPTION
Fix #2216; verify [here](https://ui-link-not-shown-dot-wptdashboard-staging.uk.r.appspot.com/results/css/css-flexbox?label=master&label=experimental&product=chrome&product=edge&product=firefox&product=safari&product=webkitgtk&aligned&q=triaged%3Awebkitgtk)