### PR TITLE
Fix Docker environment after #2252

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ web_components_test: xvfb firefox chrome webapp_node_modules_all psmisc
 lighthouse: chrome webapp_node_modules_all
 	cd webapp; npx lhci autorun --failOnUploadFailure
 
-dev_appserver_deps: gcloud-app-engine-python gcloud-app-engine-go gcloud-cloud-datastore-emulator pip-grpcio
+dev_appserver_deps: gcloud-app-engine-python gcloud-app-engine-go gcloud-cloud-datastore-emulator java pip-grpcio
 
 chrome: wget
 	# Pinned to Chrome 84 to workaround https://github.com/web-platform-tests/wpt.fyi/issues/2128

--- a/api/interop.go
+++ b/api/interop.go
@@ -121,10 +121,9 @@ func loadFallbackInteropRun(ctx context.Context, filters shared.TestRunFilter) (
 	}
 
 	// Iterate until we find interop data where its TestRunIDs match the query.
-	var interop metrics.PassRateMetadataLegacy
 	it := query.Run(store)
-	found := false
 	for {
+		var interop metrics.PassRateMetadataLegacy
 		_, err := it.Next(&interop)
 		if err == store.Done() {
 			return nil, nil
@@ -134,13 +133,10 @@ func loadFallbackInteropRun(ctx context.Context, filters shared.TestRunFilter) (
 		if keysChecker != nil && !keysChecker(interop.TestRunIDs) {
 			continue
 		}
-		found = true
+		result = &interop
 		break
 	}
-	if !found {
-		return nil, nil
-	}
-	return &interop, nil
+	return result, nil
 }
 
 func checkKeysAreAligned(shaKeys map[string]shared.KeysByProduct) func(shared.TestRunIDs) bool {

--- a/util/docker-dev/dev_data.sh
+++ b/util/docker-dev/dev_data.sh
@@ -4,4 +4,4 @@ DOCKER_DIR=$(dirname $0)
 source "${DOCKER_DIR}/../commands.sh"
 
 # Run util/populate_dev_data.go (via make) in the docker environment.
-wptd_exec make dev_data FLAGS=\"$@\"
+wptd_exec make dev_data FLAGS=\"-project=wptdashboard-local -remote_host=staging.wpt.fyi -datastore_host=localhost:8001\"

--- a/util/docker-dev/web_server.sh
+++ b/util/docker-dev/web_server.sh
@@ -48,6 +48,9 @@ wptd_exec_it dev_appserver.py \
    --admin_port=8000 \
    --api_host=$WPTD_CONTAINER_HOST \
    --api_port=9999 \
-   -A=wptdashboard \
+   --support_datastore_emulator=true \
+   --datastore_consistency_policy=consistent \
+   --datastore_emulator_port=8001 \
+   -A=wptdashboard-local \
    /home/user/wpt.fyi/webapp/web/app.dev.yaml
 


### PR DESCRIPTION
Fixes #2259.

Make sure we start Cloud Datastore emulator in Docker as well, and plumb
the necessary flags (e.g. the port number) around.

Drive-by: fix a flaky WebDriver test. In api/interop.go, we use
`it.Next` to load the next entity into a struct that may not be zero,
in which case Datastore library will not zero it out first and may leave
stale data in the struct (e.g. if a slice field already has N items but
the entity to be loaded only has N-1 items in that field, the last item
will not be removed from the struct). The issue only surfaced after
PR #2252 as the IDs in Datastore emulator are no longer sequential.
