### PR TITLE
Upgrade to Go 1.14

### DIFF
--- a/.github/actions/make-in-docker/action.yml
+++ b/.github/actions/make-in-docker/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: true
 runs:
   using: docker
-  image: docker://webplatformtests/wpt.fyi:go114
+  image: docker://webplatformtests/wpt.fyi:latest
   args:
     - /usr/bin/make
     - ${{ inputs.target }}

--- a/.github/actions/make-in-docker/action.yml
+++ b/.github/actions/make-in-docker/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: true
 runs:
   using: docker
-  image: docker://webplatformtests/wpt.fyi:latest
+  image: docker://webplatformtests/wpt.fyi:go114
   args:
     - /usr/bin/make
     - ${{ inputs.target }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # vim: set expandtab sw=4
-FROM golang:1.12-buster
+FROM golang:1.14-buster
 
 # Create a non-priviledged user to run browsers as (Firefox and Chrome do not
 # like to run as root).

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/web-platform-tests/wpt.fyi
 
-go 1.12
+go 1.14
 
 require (
 	cloud.google.com/go v0.70.0
@@ -13,7 +13,6 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13
 	github.com/gobuffalo/packr/v2 v2.8.0
-	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/golang/mock v1.4.4
 	github.com/gomodule/redigo v1.8.2
 	github.com/google/go-github/v32 v32.1.0
@@ -21,9 +20,7 @@ require (
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/securecookie v1.1.1
-	github.com/hashicorp/golang-lru v0.5.1 // indirect
 	github.com/karrick/godirwalk v1.16.1 // indirect
-	github.com/konsorten/go-windows-terminal-sequences v1.0.3 // indirect
 	github.com/pborman/uuid v1.2.1 // indirect
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/rogpeppe/go-internal v1.6.2 // indirect
@@ -34,7 +31,6 @@ require (
 	github.com/taskcluster/taskcluster-lib-urls v13.0.1+incompatible
 	github.com/taskcluster/taskcluster/v37 v37.5.1
 	github.com/tebeka/selenium v0.9.9
-	golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6 // indirect
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b
 	golang.org/x/net v0.0.0-20201016165138-7b1cca2348c0 // indirect
 	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43
@@ -44,7 +40,6 @@ require (
 	google.golang.org/api v0.33.0
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20201019141844-1ed22bb0c154
-	google.golang.org/protobuf v1.25.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 )
 

--- a/webapp/web/app.staging.yaml
+++ b/webapp/web/app.staging.yaml
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-runtime: go112
+runtime: go114
 instance_class: F4_1G
 
 inbound_services:

--- a/webapp/web/app.yaml
+++ b/webapp/web/app.yaml
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-runtime: go112
+runtime: go114
 instance_class: F4_1G
 
 inbound_services:


### PR DESCRIPTION
On the language side, here's a brief changelog: https://en.wikipedia.org/wiki/Go_(programming_language)#Version_history
In short, a few minor backward-compatible additions; my favourites? [error wrapping](https://blog.golang.org/go1.13-errors) and [overlapping interface embedding](https://dave.cheney.net/2020/05/24/diamond-interface-composition-in-go-1-14)!

On the AppEngine side: https://cloud.google.com/appengine/docs/standard/go/release-notes
Again, nothing major here.