### PR TITLE
Bump searchcache to Go 1.14 as well

### DIFF
--- a/api/query/cache/service/Dockerfile
+++ b/api/query/cache/service/Dockerfile
@@ -1,7 +1,7 @@
 # Production deployment spec for query cache service.
 
-# Base golang 1.12 image.
-FROM gcr.io/gcp-runtimes/go1-builder:1.12 as builder
+# Base golang 1.14 image.
+FROM gcr.io/gcp-runtimes/go1-builder:1.14 as builder
 
 RUN apt-get update
 RUN apt-get install -qy --no-install-suggests git


### PR DESCRIPTION
missed in #2271
