### PR TITLE
Fix name of query parameter in /api/search payload

### DIFF
--- a/api/query/README.md
+++ b/api/query/README.md
@@ -189,7 +189,7 @@ The `/api/search` endpoint takes an HTTP `POST` method, where the body is of the
 
     {
       "run_ids": [123, 456, ...],
-      "q": {
+      "query": {
         [Structured query]
       }
     }


### PR DESCRIPTION
Just "q" has no effect, and is not what the wpt.fyi frontend uses.
