### PR TITLE
Document run_ids as non-optional for /api/search

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -430,11 +430,10 @@ Search for test results over some set of test runs.
 
 __Parameters__
 
-__`run_ids`__ : (Optional) A comma-separated list of numerical ids associated
-with the runs over which to search. IDs associated with runs can be obtained by
-querying the `/api/runs` API. Defaults to the default runs returned by
-`/api/runs`. NOTE: This is not the same set of runs as is shown on wpt.fyi by
-default.
+__`run_ids`__ : A comma-separated list of numerical ids associated with the runs
+over which to search. IDs associated with runs can be obtained by querying the
+`/api/runs` API. Defaults to the default runs returned by `/api/runs`. NOTE:
+This is not the same set of runs as is shown on wpt.fyi by default.
 
 __`query`__: (Optional) See [search query](./query/README.md#apisearch)
 documentaton for the structure of this parameter.

--- a/api/query/README.md
+++ b/api/query/README.md
@@ -194,10 +194,6 @@ The `/api/search` endpoint takes an HTTP `POST` method, where the body is of the
       }
     }
 
-> NOTE: If, rather than a specific set of runs, the user wishes to query for the latest
-> results for a set of products, the `/api/search` endpoint supports the same query
-> parameters as /api/runs, outlined [in the API docs](../README.md)
-
 ### Structured query objects
 
 Structured query objects are produced by the syntax parser on wpt.fyi.


### PR DESCRIPTION
https://github.com/web-platform-tests/wpt.fyi/blob/f8d9beebe98a4d254d1ae0d0283c4fe7cef3196e/api/query/atoms.go#L437