### PR TITLE
Revert "Link to more documentation of /api/search"

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -435,8 +435,9 @@ over which to search. IDs associated with runs can be obtained by querying the
 `/api/runs` API. Defaults to the default runs returned by `/api/runs`. NOTE:
 This is not the same set of runs as is shown on wpt.fyi by default.
 
-__`query`__: (Optional) See [search query](./query/README.md#apisearch)
-documentaton for the structure of this parameter.
+__`q`__: (Optional) A query string for search. Only results data for tests that
+contain the `q` value as a substring of the test name will be returned. Defaults
+to the empty string, which will yield all test results for the selected runs.
 
 #### Examples
 


### PR DESCRIPTION
Reverts web-platform-tests/wpt.fyi#2284

Turns out we were confused by structured (POST) vs. unstructured (GET) queries. `q` does still work for unstructured queries.