### PR TITLE
Cleanup helpers and timeouts WebDriver tests

### DIFF
--- a/webdriver/builder_test.go
+++ b/webdriver/builder_test.go
@@ -9,7 +9,6 @@ package webdriver
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	mapset "github.com/deckarep/golang-set"
 	"github.com/stretchr/testify/assert"
@@ -38,7 +37,7 @@ func TestQueryBuilder_MasterCheckedForMasterLabelQuery(t *testing.T) {
 			}
 			return e != nil, nil
 		}
-		if err := wd.WaitWithTimeout(loaded, time.Second*10); err != nil {
+		if err := wd.WaitWithTimeout(loaded, LongTimeout); err != nil {
 			assert.FailNow(t, fmt.Sprintf("Error waiting for test runs: %s", err.Error()))
 		}
 
@@ -55,7 +54,7 @@ func TestQueryBuilder_MasterCheckedForMasterLabelQuery(t *testing.T) {
 			}
 			return cb != nil, nil
 		}
-		if err := wd.WaitWithTimeout(expanded, time.Second*10); err != nil {
+		if err := wd.WaitWithTimeout(expanded, LongTimeout); err != nil {
 			assert.FailNow(t, fmt.Sprintf("Error waiting for builder to expand: %s", err.Error()))
 		}
 		// NOTE: 'checked' is a property on the class, but not an attr in the HTML.

--- a/webdriver/label_test.go
+++ b/webdriver/label_test.go
@@ -89,22 +89,6 @@ func testLabel(
 	}
 }
 
-func getTestRunElements(wd selenium.WebDriver, element string) ([]selenium.WebElement, error) {
-	e, err := wd.FindElement(selenium.ByCSSSelector, "wpt-app")
-	if err != nil {
-		return nil, err
-	}
-	return FindShadowElements(wd, e, element, "test-run")
-}
-
-func getTabElements(wd selenium.WebDriver) ([]selenium.WebElement, error) {
-	e, err := wd.FindElement(selenium.ByCSSSelector, "wpt-app")
-	if err != nil {
-		return nil, err
-	}
-	return FindShadowElements(wd, e, "results-tabs", "paper-tab")
-}
-
 func assertAligned(t *testing.T, wd selenium.WebDriver, testRuns []selenium.WebElement) {
 	if len(testRuns) < 2 {
 		return

--- a/webdriver/label_test.go
+++ b/webdriver/label_test.go
@@ -5,7 +5,6 @@ package webdriver
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	mapset "github.com/deckarep/golang-set"
 
@@ -62,7 +61,7 @@ func testLabel(
 		}
 		return len(testRuns) > 0, nil
 	}
-	if err := wd.WaitWithTimeout(runsLoadedCondition, time.Second*10); err != nil {
+	if err := wd.WaitWithTimeout(runsLoadedCondition, LongTimeout); err != nil {
 		assert.FailNow(t, fmt.Sprintf("Error waiting for test runs: %s", err.Error()))
 	}
 

--- a/webdriver/path_test.go
+++ b/webdriver/path_test.go
@@ -5,7 +5,6 @@ package webdriver
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/tebeka/selenium"
@@ -44,7 +43,7 @@ func testPath(t *testing.T, app AppServer, wd selenium.WebDriver, path, elementN
 		"canvas_complexshapes_arcto_001.htm",
 		"canvas_complexshapes_beziercurveto_001.htm",
 	}
-	err := wd.WaitWithTimeout(resultsLoadedCondition, time.Second*10)
+	err := wd.WaitWithTimeout(resultsLoadedCondition, LongTimeout)
 	assert.Nil(t, err)
 	assertListIsFiltered(t, wd, elementName, paths...)
 }

--- a/webdriver/product_test.go
+++ b/webdriver/product_test.go
@@ -133,11 +133,11 @@ func assertProducts(t *testing.T, wd selenium.WebDriver, testRuns []selenium.Web
 	for i, product := range products {
 		args := []interface{}{testRuns[i]}
 		browserNameBytes, _ := wd.ExecuteScriptRaw("return arguments[0].testRun.browser_name", args)
-		browserName, _ := extractScriptRawValue(browserNameBytes, "value")
+		browserName, _ := ExtractScriptRawValue(browserNameBytes, "value")
 		assert.Equal(t, product.BrowserName, browserName.(string))
 		if product.Labels != nil {
 			labelBytes, _ := wd.ExecuteScriptRaw("return arguments[0].testRun.labels", args)
-			labels, _ := extractScriptRawValue(labelBytes, "value")
+			labels, _ := ExtractScriptRawValue(labelBytes, "value")
 			for label := range product.Labels.Iter() {
 				assert.Contains(t, labels, label)
 			}

--- a/webdriver/product_test.go
+++ b/webdriver/product_test.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"strings"
 	"testing"
-	"time"
 
 	mapset "github.com/deckarep/golang-set"
 	"github.com/stretchr/testify/assert"
@@ -78,7 +77,7 @@ func testProducts(
 		}
 		return len(testRuns) > 0, nil
 	}
-	if err := wd.WaitWithTimeout(runsLoadedCondition, time.Second*10); err != nil {
+	if err := wd.WaitWithTimeout(runsLoadedCondition, LongTimeout); err != nil {
 		assert.FailNow(t, fmt.Sprintf("Error waiting for test runs: %s", err.Error()))
 	}
 
@@ -121,7 +120,7 @@ func testProducts(
 		}
 		return len(pathParts) > 0, nil
 	}
-	err = wd.WaitWithTimeout(resultsLoadedCondition, time.Second*10)
+	err = wd.WaitWithTimeout(resultsLoadedCondition, LongTimeout)
 	assert.Nil(t, err)
 }
 

--- a/webdriver/search_test.go
+++ b/webdriver/search_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/tebeka/selenium"
@@ -43,7 +42,7 @@ func testSearch(t *testing.T, wd selenium.WebDriver, app AppServer, path, elemen
 			if err := wd.Get(app.GetWebappURL(path)); err != nil {
 				assert.FailNow(t, fmt.Sprintf("Error navigating to homepage: %s", err.Error()))
 			}
-			err := wd.WaitWithTimeout(resultsLoadedCondition, time.Second*10)
+			err := wd.WaitWithTimeout(resultsLoadedCondition, LongTimeout)
 			assert.Nil(t, err)
 
 			// Type the search.
@@ -63,7 +62,7 @@ func testSearch(t *testing.T, wd selenium.WebDriver, app AppServer, path, elemen
 			assert.FailNow(t, fmt.Sprintf("Error navigating to homepage: %s", err.Error()))
 		}
 
-		err := wd.WaitWithTimeout(resultsLoadedCondition, time.Second*10)
+		err := wd.WaitWithTimeout(resultsLoadedCondition, LongTimeout)
 		assert.Nil(t, err)
 		assertListIsFiltered(t, wd, elementName, folder+"/")
 	})
@@ -79,7 +78,7 @@ func assertListIsFiltered(t *testing.T, wd selenium.WebDriver, elementName strin
 		}
 		return len(pathParts) == len(paths), nil
 	}
-	err = wd.WaitWithTimeout(filteredPathPartsCondition, time.Second*120)
+	err = wd.WaitWithTimeout(filteredPathPartsCondition, LongTimeout)
 	if err != nil {
 		assert.Fail(t, fmt.Sprintf("Expected exactly %v results", len(paths)))
 		return

--- a/webdriver/search_test.go
+++ b/webdriver/search_test.go
@@ -106,11 +106,3 @@ func getSearchElement(wd selenium.WebDriver) (selenium.WebElement, error) {
 	}
 	return inputs[0], err
 }
-
-func getPathPartElements(wd selenium.WebDriver, element string) ([]selenium.WebElement, error) {
-	e, err := wd.FindElement(selenium.ByTagName, "wpt-app")
-	if err != nil {
-		return nil, err
-	}
-	return FindShadowElements(wd, e, element, "path-part")
-}

--- a/webdriver/test_runs_test.go
+++ b/webdriver/test_runs_test.go
@@ -5,7 +5,6 @@ package webdriver
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/tebeka/selenium"
@@ -26,7 +25,7 @@ func TestTestRuns(t *testing.T) {
 			}
 			return len(rows) > 1, nil
 		}
-		err := wd.WaitWithTimeout(runsLoadedCondition, time.Second*10)
+		err := wd.WaitWithTimeout(runsLoadedCondition, LongTimeout)
 		assert.Nil(t, err)
 	})
 }

--- a/webdriver/webdriver.go
+++ b/webdriver/webdriver.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/phayes/freeport"
 	"github.com/tebeka/selenium"
@@ -19,6 +20,13 @@ var (
 	debug            = flag.Bool("debug", false, "Turn on debug logging")
 	browser          = flag.String("browser", "firefox", "Which browser to run the tests with")
 	startFrameBuffer = flag.Bool("frame_buffer", frameBufferDefault(), "Whether to use a frame buffer")
+)
+
+const (
+	// LongTimeout is the timeout for waiting the full page to load, with
+	// data coming from Datastore. You may not need this if you only need
+	// to wait for the initial Polymer rendering.
+	LongTimeout = time.Second * 30
 )
 
 func frameBufferDefault() bool {


### PR DESCRIPTION
The main motivation is to extend the timeout everywhere as we started to see timeouts more often since the Go 1.12 migration (which is presumably caused by the slower Datastore emulator), but I took the chance to do some other cleanup as well.