### PR TITLE
[BSF] Frontend for BSF on wpt.fyi milestone one

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -677,7 +677,9 @@ The response has three top-level fields:
 
 `lastUpdateRevision` indicates the latest WPT Revision updated in `data`.
 
-`fields` corresponds to the fields (columns) in the `data` table.
+`fields` corresponds to the fields (columns) in the `data` table and has the format of an array of:
+
+- sha, date, [product-version, product-score]+
 
 `data` returns BSF data in chronological order.
 

--- a/webapp/components/info-banner.js
+++ b/webapp/components/info-banner.js
@@ -18,7 +18,7 @@ class InfoBanner extends PolymerElement {
       :host {
         display: block;
         margin-bottom: 1em;
-        margin-top: 2em;
+        margin-top: 1em;
       }
       .banner {
         display: flex;

--- a/webapp/components/wpt-bsf.js
+++ b/webapp/components/wpt-bsf.js
@@ -73,7 +73,7 @@ class WPTBSF extends LoadingState(PolymerElement) {
             <paper-button class\$="[[stableButtonClass(isExperimental)]]" onclick="[[clickStable]]">Stable</paper-button>
             <paper-button class\$="[[experimentalButtonClass(isExperimental)]]" onclick="[[clickExperimental]]">Experimental</paper-button>
           </div>
-          <h5>Last updated GitHub SHA</h5>
+          <h5>Last updated WPT revision</h5>
           <div class="sha">
             <iron-icon class="github-icon" src="/static/github.svg"></iron-icon>
             <a class="link" href="[[githubHref]]" target="_blank"><paper-button>[[shortSHA]]</paper-button></a>

--- a/webapp/components/wpt-bsf.js
+++ b/webapp/components/wpt-bsf.js
@@ -135,7 +135,7 @@ class WPTBSF extends LoadingState(PolymerElement) {
   constructor() {
     super();
     this.clickStable = () => {
-      if (this.isExperimental === false) {
+      if (!this.isExperimental) {
         return;
       }
       this.isExperimental = false;

--- a/webapp/components/wpt-bsf.js
+++ b/webapp/components/wpt-bsf.js
@@ -142,7 +142,7 @@ class WPTBSF extends LoadingState(PolymerElement) {
       this.loadBSFData();
     };
     this.clickExperimental = () => {
-      if (this.isExperimental === true) {
+      if (this.isExperimental) {
         return;
       }
       this.isExperimental = true;

--- a/webapp/components/wpt-bsf.js
+++ b/webapp/components/wpt-bsf.js
@@ -78,7 +78,7 @@ class WPTBSF extends LoadingState(PolymerElement) {
             <iron-icon class="github-icon" src="/static/github.svg"></iron-icon>
             <a class="link" href="[[githubHref]]" target="_blank"><paper-button>[[shortSHA]]</paper-button></a>
           </div>
-          <h5>Click + drag on graphs to zoom, right click to un-zoom</h5>
+          <h5>Click + drag on graph to zoom, right click to un-zoom</h5>
         </div>
         <google-chart type="line" class="chart" data="[[data]]" options="[[chartOptions]]"></google-chart>
       </div>

--- a/webapp/components/wpt-bsf.js
+++ b/webapp/components/wpt-bsf.js
@@ -1,0 +1,215 @@
+/**
+ * Copyright 2020 The WPT Dashboard Project. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+import '../node_modules/@google-web-components/google-chart/google-chart.js';
+import '../node_modules/@polymer/polymer/lib/elements/dom-if.js';
+import '../node_modules/@polymer/polymer/lib/elements/dom-repeat.js';
+import {
+  html,
+  PolymerElement
+} from '../node_modules/@polymer/polymer/polymer-element.js';
+import { LoadingState } from './loading-state.js';
+
+class WPTBSF extends LoadingState(PolymerElement) {
+  static get template() {
+    return html`
+      <style>
+        .bsf {
+          display: inline-flex;
+        }
+        .left {
+          width: 20%;
+          margin-top: 10px;
+          margin-left: 10px;
+          font-size: 13px;
+        }
+        .chart {
+          height: 350px;
+          width: 800px;
+        }
+        .sha {
+          display: inline-flex;
+          height: 25px;
+          margin-top: 0px;
+          margin-left: 15px;
+        }
+        h5 {
+          margin-top: 20px;
+          margin-left: 8px;
+        }
+        .channel {
+          display: inline-flex;
+          height: 35px;
+          margin-top: 0px;
+        }
+        .link {
+          text-decoration: none;
+          font-size: 12px;
+        }
+        .github-icon {
+          margin-right: 35px;
+          fill: white;
+          width: 25px;
+          height: 25px;
+        }
+        .unselected {
+          background-color: white;
+        }
+        .selected{
+          background-color: var(--paper-blue-100);
+        }
+        paper-button {
+          color: black;
+          text-transform: none;
+        }
+      </style>
+      <div class="bsf">
+        <div class="left">
+          <h5>Channel tabs</h5>
+          <div class="channel">
+            <paper-button class\$="[[stableButtonClass(isExperimental)]]" onclick="[[clickStable]]">Stable</paper-button>
+            <paper-button class\$="[[experimentalButtonClass(isExperimental)]]" onclick="[[clickExperimental]]">Experimental</paper-button>
+          </div>
+          <h5>Last updated GitHub SHA</h5>
+          <div class="sha">
+            <iron-icon class="github-icon" src="/static/github.svg"></iron-icon>
+            <a class="link" href="[[githubHref]]" target="_blank"><paper-button>[[shortSHA]]</paper-button></a>
+          </div>
+          <h5>Click + drag on graphs to zoom, right click to un-zoom</h5>
+        </div>
+        <google-chart type="line" class="chart" data="[[data]]" options="[[chartOptions]]"></google-chart>
+      </div>
+    `;
+  }
+
+  static get is() {
+    return 'wpt-bsf';
+  }
+
+  static get properties() {
+    return {
+      data: Array,
+      sha: String,
+      shortSHA: {
+        type: String,
+        computed: 'computeShortSHA(sha)',
+      },
+      githubHref: {
+        type: String,
+        computed: 'computeGitHubHref(sha)',
+      },
+      isExperimental: {
+        type: Boolean,
+        value: false,
+      },
+      chartOptions: {
+        type: Object,
+        value: {
+          width: 800,
+          height: 350,
+          chartArea: {
+            height: '80%',
+          },
+          hAxis: {
+            title: 'Date',
+            format: 'MMM-YYYY',
+          },
+          vAxis: {
+            title: 'Tests that fail in exactly 1 browser',
+          },
+          explorer: {
+            actions: ['dragToZoom', 'rightClickToReset'],
+            axis: 'horizontal',
+            keepInBounds: true,
+            maxZoomIn: 4.0,
+          },
+          colors: ['#4285f4', '#ea4335', '#fbbc04'],
+        }
+      },
+    };
+  }
+
+  constructor() {
+    super();
+    this.clickStable = () => {
+      if (this.isExperimental === false) {
+        return;
+      }
+      this.isExperimental = false;
+      this.loadBSFData();
+    };
+    this.clickExperimental = () => {
+      if (this.isExperimental === true) {
+        return;
+      }
+      this.isExperimental = true;
+      this.loadBSFData();
+    };
+    this.loadBSFData();
+  }
+
+  computeGitHubHref(sha) {
+    return 'https://github.com/web-platform-tests/wpt/commit/' + sha;
+  }
+
+  computeShortSHA(sha) {
+    return sha.slice(0, 10);
+  }
+
+  stableButtonClass(isExperimental) {
+    return this.getChannelClass(!isExperimental);
+  }
+
+  experimentalButtonClass(isExperimental) {
+    return this.getChannelClass(isExperimental);
+  }
+
+  getChannelClass(isChannel) {
+    if (isChannel) {
+      return 'selected';
+    }
+    return 'unselected';
+  }
+
+  loadBSFData() {
+    const url = new URL('/api/bsf', window.location);
+    if (this.isExperimental) {
+      url.searchParams.set('experimental', true);
+    }
+
+    this.load(
+      window.fetch(url).then(r => r.json()).then(bsf => {
+        this.sha = bsf.lastUpdateRevision;
+        // Insert fields into the 0th row of the data table.
+        bsf.data.splice(0, 0, bsf.fields);
+        // BSF data's columns have the format of an array of
+        //  sha, date, [product-version, product-score]+
+        // google-chart.js only needs the date and product
+        // scores to produce the graph, so drop the other columns.
+        this.data = bsf.data.map((row, rowIdx) => {
+          // Drop the sha.
+          row = row.slice(1);
+
+          // Drop the version columns.
+          row = row.filter((c, i) => (i % 2) === 0);
+
+          if (rowIdx === 0) {
+            return row;
+          }
+
+          const dateParts = row[0].split('-').map(x => parseInt(x));
+          // Javascript Date objects take 0-indexed months, whilst the CSV is 1-indexed.
+          row[0] = new Date(dateParts[0], dateParts[1] - 1, dateParts[2]);
+          for (let i = 1; i < row.length; i++) {
+            row[i] = parseFloat(row[i]);
+          }
+          return row;
+        });
+      })
+    );
+  }
+}
+window.customElements.define(WPTBSF.is, WPTBSF);

--- a/webapp/components/wpt-bsf.js
+++ b/webapp/components/wpt-bsf.js
@@ -68,7 +68,7 @@ class WPTBSF extends LoadingState(PolymerElement) {
       </style>
       <div class="bsf">
         <div class="left">
-          <h5>Channel tabs</h5>
+          <h5>Channel</h5>
           <div class="channel">
             <paper-button class\$="[[stableButtonClass(isExperimental)]]" onclick="[[clickStable]]">Stable</paper-button>
             <paper-button class\$="[[experimentalButtonClass(isExperimental)]]" onclick="[[clickExperimental]]">Experimental</paper-button>

--- a/webapp/components/wpt-flags.js
+++ b/webapp/components/wpt-flags.js
@@ -36,6 +36,7 @@ Object.defineProperty(wpt, 'ClientSideFeatures', {
       'reftestAnalyzerMockScreenshots',
       'reftestIframes',
       'searchCacheInterop',
+      'showBSF',
       'showTestType',
       'showTestRefURL',
       'structuredQueries',
@@ -92,6 +93,18 @@ wpt.FlagsClass = (superClass, readOnly, useLocalStorage) => class extends superC
     const props = {};
     makeFeatureProperties(props, wpt.ClientSideFeatures, readOnly, useLocalStorage);
     return props;
+  }
+
+  setLocalStorageFlag(value, feature) {
+    localStorage.setItem(`features.${feature}`, JSON.stringify(value));
+  }
+
+  getLocalStorageFlag(feature) {
+    const stored = localStorage.getItem(`features.${feature}`);
+    if (stored === null) {
+      return null;
+    }
+    return JSON.parse(stored);
   }
 };
 
@@ -254,6 +267,11 @@ class WPTFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ false) {
     <paper-item>
       <paper-checkbox checked="{{githubLogin}}">
         Enable GitHub OAuth login
+      </paper-checkbox>
+    </paper-item>
+    <paper-item>
+      <paper-checkbox checked="{{showBSF}}">
+        Enable Browser Specific Failures graph
       </paper-checkbox>
     </paper-item>
 `;

--- a/webapp/static/expand_less.svg
+++ b/webapp/static/expand_less.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="black" width="48px" height="48px"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 8l-6 6 1.41 1.41L12 10.83l4.59 4.58L18 14z"/></svg>

--- a/webapp/static/expand_more.svg
+++ b/webapp/static/expand_more.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="black" width="48px" height="48px"><path d="M0 0h24v24H0z" fill="none"/><path d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"/></svg>

--- a/webapp/views/wpt-app.js
+++ b/webapp/views/wpt-app.js
@@ -61,7 +61,7 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
         }
         paper-icon-button {
           vertical-align: middle;
-          margin-right: 20px;
+          margin-right: 10px;
           padding: 0px;
           height: 28px;
         }
@@ -377,12 +377,13 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
   }
 
   computeBSFBannerMessage(isBSFCollapsed) {
-    if (isBSFCollapsed) {
-      return 'Browser Specific Failures graph (click the arrow to expand)';
-    }
-    return 'Browser Specific Failures graph (click the arrow to collapse)';
+    const actionText = isBSFCollapsed ? 'expand' : 'collapse';
+    return `Browser Specific Failures graph (click the arrow to ${actionText})`;
   }
 
+  // Currently we only have BSF data for the entirety of the WPT test suite. To avoid
+  // confusing the user, we only display the graph when they are looking at top-level
+  // test results and hide it when in a subdirectory.
   computeShowBSFGraph(pathIsRootDir, showBSF) {
     return pathIsRootDir && showBSF;
   }

--- a/webapp/views/wpt-app.js
+++ b/webapp/views/wpt-app.js
@@ -6,9 +6,12 @@ import '../components/wpt-flags.js';
 import { WPTFlags } from '../components/wpt-flags.js';
 import '../components/wpt-header.js';
 import '../components/wpt-permalinks.js';
+import '../components/wpt-bsf.js';
 import '../node_modules/@polymer/app-route/app-location.js';
 import '../node_modules/@polymer/app-route/app-route.js';
+import '../node_modules/@polymer/iron-collapse/iron-collapse.js';
 import '../node_modules/@polymer/iron-pages/iron-pages.js';
+import '../node_modules/@polymer/paper-icon-button/paper-icon-button.js';
 import '../node_modules/@polymer/polymer/lib/elements/dom-if.js';
 import { html } from '../node_modules/@polymer/polymer/polymer-element.js';
 import '../views/wpt-404.js';
@@ -55,6 +58,12 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
         }
         .query-actions paper-button {
           display: inline-block;
+        }
+        paper-icon-button {
+          vertical-align: middle;
+          margin-right: 20px;
+          padding: 0px;
+          height: 28px;
         }
       </style>
 
@@ -108,6 +117,16 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
       </section>
 
       <div class="separator"></div>
+
+      <template is="dom-if" if="[[showBSFGraph]]">
+        <info-banner>
+          <paper-icon-button src="[[getCollapseIcon(isBSFCollapsed)]]" onclick="[[handleCollapse]]"></paper-icon-button>
+          [[bsfBannerMessage]]
+        </info-banner>
+        <iron-collapse opened="[[!isBSFCollapsed]]">
+          <wpt-bsf></wpt-bsf>
+        </iron-collapse>
+      </template>
 
       <template is="dom-if" if="[[resultsTotalsRangeMessage]]">
         <info-banner>
@@ -182,6 +201,18 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
         type: String,
         computed: 'computeResultsTotalsRangeMessage(page, path, searchResults, shas, productSpecs, to, from, maxCount, labels, master, runIds)',
       },
+      bsfBannerMessage: {
+        type: String,
+        computed: 'computeBSFBannerMessage(isBSFCollapsed)',
+      },
+      showBSFGraph: {
+        type: Boolean,
+        computed: 'computeShowBSFGraph(pathIsRootDir, showBSF)',
+      },
+      isBSFCollapsed: {
+        type: Boolean,
+        computed: 'computeIsBSFCollapsed()',
+      },
       isTriageMode: {
         type: Boolean,
         value: false,
@@ -201,6 +232,10 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
     this.togglePermalinks = () => this.shadowRoot.querySelector('wpt-permalinks').open();
     this.toggleQueryEdit = () => {
       this.editingQuery = !this.editingQuery;
+    };
+    this.handleCollapse = () => {
+      this.isBSFCollapsed = !this.isBSFCollapsed;
+      this.setLocalStorageFlag(this.isBSFCollapsed, 'isBSFCollapsed');
     };
     this.submitQuery = this.handleSubmitQuery.bind(this);
     this.addMasterLabel = this.handleAddMasterLabel.bind(this);
@@ -339,6 +374,32 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
         `Showing ${testsAndSubtests} from `);
     }
     return msg;
+  }
+
+  computeBSFBannerMessage(isBSFCollapsed) {
+    if (isBSFCollapsed) {
+      return 'Browser Specific Failures graph (click the arrow to expand)';
+    }
+    return 'Browser Specific Failures graph (click the arrow to collapse)';
+  }
+
+  computeShowBSFGraph(pathIsRootDir, showBSF) {
+    return pathIsRootDir && showBSF;
+  }
+
+  computeIsBSFCollapsed() {
+    const stored = this.getLocalStorageFlag('isBSFCollapsed');
+    if (stored === null) {
+      return false;
+    }
+    return stored;
+  }
+
+  getCollapseIcon(isBSFCollapsed) {
+    if (isBSFCollapsed) {
+      return '/static/expand_more.svg';
+    }
+    return '/static/expand_less.svg';
   }
 }
 customElements.define(WPTApp.is, WPTApp);


### PR DESCRIPTION
Frontend UI for BSF on wpt.fyi [milestone one](https://docs.google.com/document/d/1YsWyovoje7rvW_u-kaCJAWvFJ2QjafvyVqWKtmafFHw/edit#heading=h.4agfzcyzhu2y).

This PR doesn't define the list of cases that hide the BSF graph on the homepage. A follow-up PR will be sent shortly for it.

## Test
To see the BSF graph, go to /flags and click on `Enable Browser Specific Failures graph`

