### PR TITLE
[BSF] Set up Google Analytics for hover and hide actions

### DIFF
--- a/webapp/components/wpt-bsf.js
+++ b/webapp/components/wpt-bsf.js
@@ -72,7 +72,12 @@ class WPTBSF extends LoadingState(PolymerElement) {
           </div>
           <h5>Click + drag on graph to zoom, right click to un-zoom</h5>
         </div>
-        <google-chart type="line" class="chart" data="[[data]]" options="[[chartOptions]]"></google-chart>
+        <google-chart type="line"
+                      class="chart"
+                      data="[[data]]"
+                      options="[[chartOptions]]"
+                      onmouseenter="[[enterChart]]"
+                      onmouseleave="[[exitChart]]"></google-chart>
       </div>
     `;
   }
@@ -85,6 +90,10 @@ class WPTBSF extends LoadingState(PolymerElement) {
     return {
       data: Array,
       sha: String,
+      isInteracting: {
+        type: Boolean,
+        notify: true,
+      },
       shortSHA: {
         type: String,
         computed: 'computeShortSHA(sha)',
@@ -139,6 +148,12 @@ class WPTBSF extends LoadingState(PolymerElement) {
       }
       this.isExperimental = true;
       this.loadBSFData();
+    };
+    this.enterChart = () => {
+      this.isInteracting = true;
+    };
+    this.exitChart = () => {
+      this.isInteracting = false;
     };
     this.loadBSFData();
   }

--- a/webapp/views/wpt-app.js
+++ b/webapp/views/wpt-app.js
@@ -233,6 +233,17 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
     };
     this.handleCollapse = () => {
       this.isBSFCollapsed = !this.isBSFCollapsed;
+      // Record hide/open actions on the BSF graph. Currently, we only
+      // show it on the homepage.
+      if ('ga' in window) {
+        window.ga('send', {
+          hitType: 'event',
+          eventCategory: 'bsf',
+          eventAction: 'hide',
+          eventLabel: this.path,
+          eventValue: this.isBSFCollapsed ? 1 : -1
+        });
+      }
       this.setLocalStorageFlag(this.isBSFCollapsed, 'isBSFCollapsed');
     };
     this.submitQuery = this.handleSubmitQuery.bind(this);

--- a/webapp/views/wpt-app.js
+++ b/webapp/views/wpt-app.js
@@ -246,7 +246,7 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
         window.ga('send', {
           hitType: 'event',
           eventCategory: 'bsf',
-          eventAction: 'hide',
+          eventAction: 'visibility change',
           eventLabel: this.path,
           eventValue: this.isBSFCollapsed ? 1 : 0
         });
@@ -254,12 +254,18 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
       this.setLocalStorageFlag(this.isBSFCollapsed, 'isBSFCollapsed');
     };
     this.enterBSF = () => {
+      // The use of isInteracting is a workaround for a known issue,
+      // https://stackoverflow.com/questions/17244996/why-do-the-mouseenter-mouseleave-events-fire-when-entering-leaving-child-element;
+      // when users interact with the BSF chart itself, enterBSF is triggered unexpectedly.
+      // In that case, isInteracting is set to true to avoid resetting bsfStartTime.
       if (this.isInteracting) {
         return;
       }
       this.bsfStartTime = new Date();
     };
     this.exitBSF = () => {
+      // Similarly, when users interact with the BSF chart, isInteracting is set to
+      // true to avoid sending analytics prematurely in exitBSF.
       if (this.isInteracting || !this.bsfStartTime) {
         return;
       }
@@ -278,6 +284,7 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
           eventValue: duration
         });
       }
+      this.bsfStartTime = null;
     };
     this.submitQuery = this.handleSubmitQuery.bind(this);
     this.addMasterLabel = this.handleAddMasterLabel.bind(this);

--- a/webapp/views/wpt-app.js
+++ b/webapp/views/wpt-app.js
@@ -117,13 +117,15 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
       <div class="separator"></div>
 
       <template is="dom-if" if="[[showBSFGraph]]">
-        <info-banner>
-          <paper-icon-button src="[[getCollapseIcon(isBSFCollapsed)]]" onclick="[[handleCollapse]]"></paper-icon-button>
-          [[bsfBannerMessage]]
-        </info-banner>
-        <iron-collapse opened="[[!isBSFCollapsed]]">
-          <wpt-bsf></wpt-bsf>
-        </iron-collapse>
+        <div onmouseenter="[[enterBSF]]" onmouseleave="[[exitBSF]]">
+          <info-banner>
+            <paper-icon-button src="[[getCollapseIcon(isBSFCollapsed)]]" onclick="[[handleCollapse]]"></paper-icon-button>
+            [[bsfBannerMessage]]
+          </info-banner>
+          <iron-collapse opened="[[!isBSFCollapsed]]">
+            <wpt-bsf></wpt-bsf>
+          </iron-collapse>
+        </div>
       </template>
 
       <template is="dom-if" if="[[resultsTotalsRangeMessage]]">
@@ -214,6 +216,10 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
       isTriageMode: {
         type: Boolean,
         value: false,
+      },
+      bsfStartTime: {
+        type: Object,
+        value: null,
       }
     };
   }
@@ -241,10 +247,33 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
           eventCategory: 'bsf',
           eventAction: 'hide',
           eventLabel: this.path,
-          eventValue: this.isBSFCollapsed ? 1 : -1
+          eventValue: this.isBSFCollapsed ? 1 : 0
         });
       }
       this.setLocalStorageFlag(this.isBSFCollapsed, 'isBSFCollapsed');
+    };
+    this.enterBSF = () => {
+      this.bsfStartTime = new Date();
+    };
+    this.exitBSF = () => {
+      if (!this.bsfStartTime) {
+        return;
+      }
+      const diff = new Date().getTime() - this.bsfStartTime.getTime();
+      const duration = Math.round(diff / 1000);
+      if (duration <= 0) {
+        return;
+      }
+
+      if ('ga' in window) {
+        window.ga('send', {
+          hitType: 'event',
+          eventCategory: 'bsf',
+          eventAction: 'hover',
+          eventLabel: this.path,
+          eventValue: duration
+        });
+      }
     };
     this.submitQuery = this.handleSubmitQuery.bind(this);
     this.addMasterLabel = this.handleAddMasterLabel.bind(this);

--- a/webapp/views/wpt-app.js
+++ b/webapp/views/wpt-app.js
@@ -123,7 +123,7 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
             [[bsfBannerMessage]]
           </info-banner>
           <iron-collapse opened="[[!isBSFCollapsed]]">
-            <wpt-bsf></wpt-bsf>
+            <wpt-bsf is-interacting="{{isInteracting}}"></wpt-bsf>
           </iron-collapse>
         </div>
       </template>
@@ -220,7 +220,8 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
       bsfStartTime: {
         type: Object,
         value: null,
-      }
+      },
+      isInteracting: Boolean,
     };
   }
 
@@ -253,10 +254,13 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
       this.setLocalStorageFlag(this.isBSFCollapsed, 'isBSFCollapsed');
     };
     this.enterBSF = () => {
+      if (this.isInteracting) {
+        return;
+      }
       this.bsfStartTime = new Date();
     };
     this.exitBSF = () => {
-      if (!this.bsfStartTime) {
+      if (this.isInteracting || !this.bsfStartTime) {
         return;
       }
       const diff = new Date().getTime() - this.bsfStartTime.getTime();


### PR DESCRIPTION
Set up Google Analytics for hover and hide actions:

- `hover` tracks the duration spent on the general area of the BSF graph, including the banner
- `hide` tracks the number of times users hide/open the BSF graph

For the setup, see https://developers.google.com/analytics/devguides/collection/analyticsjs/events.

Also work around a [known issue](https://stackoverflow.com/questions/17244996/why-do-the-mouseenter-mouseleave-events-fire-when-entering-leaving-child-element) where the children svg (in this case Google Chart) interferes with parent's `onmouseenter` event. Use `isInteracting` to keep track of the state of interaction with the BSF chart.

Note that unlike the origin design, we can track clicks on stable/experiment through the /api/bsf endpoint usage and zoom-in/zoom-out are covered by `hover` actions.

## Test
See [Google Analytics](https://analytics.google.com/analytics/web/#/report/content-event-overview/a89387706w132586808p136568610/_u.date00=20201229&_u.date01=20201230/)