### PR TITLE
[Triage Metadata] Unskip metadataMap from seenProductURLs

### DIFF
--- a/webapp/components/test/wpt-metadata.html
+++ b/webapp/components/test/wpt-metadata.html
@@ -237,7 +237,12 @@ suite('<wpt-metadata>', () => {
           {
             url: 'bug1',
             product: 'chrome',
-            results: [{ subtest: 'a' }]
+            results: [{ subtest: 'a' }, { subtest: 'd' }]
+          },
+          {
+            url: 'bug1',
+            product: 'chrome',
+            results: [{ subtest: 'c' }]
           },
           {
             url: 'bug2',
@@ -250,8 +255,10 @@ suite('<wpt-metadata>', () => {
 
       assert.equal(Object.keys(appFixture.metadataMap).length, 1);
       const subtestMap = appFixture.metadataMap['/foo.htmlchrome'];
-      assert.equal(Object.keys(subtestMap).length, 2);
+      assert.equal(Object.keys(subtestMap).length, 4);
       assert.equal(subtestMap['a'], 'https://bug1');
+      assert.equal(subtestMap['c'], 'https://bug1');
+      assert.equal(subtestMap['d'], 'https://bug1');
       assert.equal(subtestMap['b'], 'https://bug2');
     });
     test('complex case for metadataMap', () => {

--- a/webapp/components/wpt-metadata.js
+++ b/webapp/components/wpt-metadata.js
@@ -203,11 +203,9 @@ class WPTMetadata extends PathInfo(LoadingState(PolymerElement)) {
     for (const test of Object.keys(metadata).filter(k => this.shouldShowMetadata(k, path, testResultSet))) {
       const seenProductURLs = new Set();
       for (const link of metadata[test]) {
-        const serializedProductURL = link.product.trim() + '_' + link.url.trim();
-        if (link.url === '' || seenProductURLs.has(serializedProductURL)) {
+        if (link.url === '') {
           continue;
         }
-        seenProductURLs.add(serializedProductURL);
         const urlHref = this.getUrlHref(link.url);
         const subtestMap = {};
         if ('results' in link) {
@@ -229,6 +227,11 @@ class WPTMetadata extends PathInfo(LoadingState(PolymerElement)) {
         } else {
           metadataMap[metadataMapKey] = Object.assign(metadataMap[metadataMapKey], subtestMap);
         }
+        const serializedProductURL = link.product.trim() + '_' + link.url.trim();
+        if (seenProductURLs.has(serializedProductURL)) {
+          continue;
+        }
+        seenProductURLs.add(serializedProductURL);
         const wptMetadataNode = {
           test,
           url: urlHref,

--- a/webapp/components/wpt-metadata.js
+++ b/webapp/components/wpt-metadata.js
@@ -198,6 +198,9 @@ class WPTMetadata extends PathInfo(LoadingState(PolymerElement)) {
       return;
     }
 
+    // This loop constructs both the metadataMap, which is used to show inline
+    // bug icons in the test results, and displayedMetdata, which is the list of
+    // metadata links shown at the bottom of the page.
     let metadataMap = {};
     let displayedMetadata = [];
     for (const test of Object.keys(metadata).filter(k => this.shouldShowMetadata(k, path, testResultSet))) {
@@ -227,6 +230,8 @@ class WPTMetadata extends PathInfo(LoadingState(PolymerElement)) {
         } else {
           metadataMap[metadataMapKey] = Object.assign(metadataMap[metadataMapKey], subtestMap);
         }
+
+        // Avoid showing duplicate bug links in the list of metadata shown at the bottom of the page.
         const serializedProductURL = link.product.trim() + '_' + link.url.trim();
         if (seenProductURLs.has(serializedProductURL)) {
           continue;


### PR DESCRIPTION
Fix  #2333. Don't skip `metadataMap` from `seenProductURLs` . 

`metadataMap` stores metadata for all triaged tests and is used to show inline icons. `displayedMetadata` displays the metadata on the bottom of test results view and only show metadata on the test-file level. 

## Test
See [here](https://fix-subtest-missing-dot-wptdashboard-staging.uk.r.appspot.com/results/css/selectors/attribute-selectors/attribute-case/semantics.html?label=experimental&label=master&aligned)