### PR TITLE
[Triage Metadata] wrong order of getSearchURL params

### DIFF
--- a/webapp/components/wpt-amend-metadata.js
+++ b/webapp/components/wpt-amend-metadata.js
@@ -166,7 +166,7 @@ class AmendMetadata extends LoadingState(PathInfo(ProductInfo(PolymerElement))) 
               <li>
                 <div class="list"> [[test]] </div>
                 <template is="dom-if" if="[[hasSearchURL(node.product)]]">
-                  <a href="[[getSearchURL(node.product, test)]]" target="_blank"> [Search for bug] </a>
+                  <a href="[[getSearchURL(test, node.product)]]" target="_blank"> [Search for bug] </a>
                 </template>
               </li>
             </template>


### PR DESCRIPTION
A follow-up fix for https://github.com/web-platform-tests/wpt.fyi/pull/2222#issuecomment-761100542 as it is breaking the staging instance