### PR TITLE
[BSF] Fix axis title display issues

### DIFF
--- a/webapp/components/wpt-flags.js
+++ b/webapp/components/wpt-flags.js
@@ -36,8 +36,6 @@ Object.defineProperty(wpt, 'ClientSideFeatures', {
       'reftestAnalyzerMockScreenshots',
       'reftestIframes',
       'searchCacheInterop',
-      // TODO(kyleju): paper-checkbox is removed for this flag.
-      // This is disable until GitHub issue #2349 is fixed.
       'showBSF',
       'showTestType',
       'showTestRefURL',
@@ -269,6 +267,11 @@ class WPTFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ false) {
     <paper-item>
       <paper-checkbox checked="{{githubLogin}}">
         Enable GitHub OAuth login
+      </paper-checkbox>
+    </paper-item>
+    <paper-item>
+      <paper-checkbox checked="{{showBSF}}">
+        Enable Browser Specific Failures graph
       </paper-checkbox>
     </paper-item>
 `;

--- a/webapp/views/wpt-app.js
+++ b/webapp/views/wpt-app.js
@@ -122,9 +122,11 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
             <paper-icon-button src="[[getCollapseIcon(isBSFCollapsed)]]" onclick="[[handleCollapse]]"></paper-icon-button>
             [[bsfBannerMessage]]
           </info-banner>
-          <iron-collapse opened="[[!isBSFCollapsed]]">
-            <wpt-bsf is-interacting="{{isInteracting}}"></wpt-bsf>
-          </iron-collapse>
+          <template is="dom-if" if="[[!isBSFCollapsed]]">
+            <iron-collapse opened="[[!isBSFCollapsed]]">
+              <wpt-bsf is-interacting="{{isInteracting}}"></wpt-bsf>
+            </iron-collapse>
+          </template>
         </div>
       </template>
 


### PR DESCRIPTION
Fix https://github.com/web-platform-tests/wpt.fyi/issues/2349. 

This fix wraps the `iron-collapse` with `dom-if` so BSF graphs are only loaded when it is shown. The cause I suspect is that [`iron-collapse adjusts the max-height/max-width of the collapsible element to show/hide the content`](https://www.webcomponents.org/element/@polymer/iron-collapse), which messes up the calculation of axis width when hide.