### PR TITLE
[results-processor] Make conflicts easier to debug

### DIFF
--- a/results-processor/wptreport.py
+++ b/results-processor/wptreport.py
@@ -169,16 +169,22 @@ class WPTReport(object):
         if 'run_info' in chunk:
             conflicts = []
             for key in chunk['run_info']:
+                source = cast(Dict, chunk['run_info'])
+                target = cast(Dict, self._report['run_info'])
+
+                # We clear the target value as part of update_property;
+                # record it here to be used in the conflict report if needed.
+                target_value = target[key] if key in target else ""
+
                 conflict = update_property(
-                    key,
-                    cast(Dict, chunk['run_info']),
-                    cast(Dict, self._report['run_info']),
+                    key, source, target,
                     lambda _1, _2: None,  # Set conflicting fields to None.
                 )
                 # Delay raising exceptions even when conflicts are not ignored,
                 # so that we can set as much metadata as possible.
                 if conflict and key not in IGNORED_CONFLICTS:
-                    conflicts.append(key)
+                    conflicts.append(
+                        "%s: [%s, %s]" % (key, source[key], target_value))
             if conflicts:
                 raise ConflictingDataError(', '.join(conflicts))
 

--- a/results-processor/wptreport_test.py
+++ b/results-processor/wptreport_test.py
@@ -168,8 +168,8 @@ class WPTReportTest(unittest.TestCase):
                 },
             }, f)
         with open(tmp_path, 'rb') as f:
-            with self.assertRaisesRegex(ConflictingDataError,
-                                        "product, browser_version"):
+            reg = r"product: \[chrome, firefox\], browser_version: \[70, 59\]"
+            with self.assertRaisesRegex(ConflictingDataError, reg):
                 r.load_json(f)
 
         # Fields without conflict should be preserved.


### PR DESCRIPTION
Currently conflicts reported by the processor report the field that
conflicted but not the values that it saw, e.g.:

"Conflicting 'browser_version' found in the merged report"

This change adds the values, to better help debugging what conflict
occurred. Note that we bail on the first report that fails, so it is
possible that we could have (e.g.) 5 reports with 5 different
'browser_version's, and we would only report the first two after
this change.