### PR TITLE
[Triage Metadata] Fix incorrectly matched path prefix

### DIFF
--- a/webapp/components/test/wpt-metadata.html
+++ b/webapp/components/test/wpt-metadata.html
@@ -44,6 +44,28 @@ suite('<wpt-metadata>', () => {
       assert.equal(appFixture.displayedMetadata[0].url, 'https://bug1');
       assert.equal(appFixture.displayedMetadata[0].product, 'chrome');
     });
+    test('simple case with subfolders', () => {
+      appFixture.searchResults = [{ test: '/abc.html' }, { test: '/ab/foo.html' }];
+      appFixture.metadata = {
+        '/ab/foo.html': [
+          {
+            url: 'bug1',
+            product: 'chrome'
+          }
+        ],
+        '/abc.html': [
+          {
+            url: 'bug2',
+            product: 'chrome'
+          }
+        ]
+      };
+      appFixture.path = '/ab';
+      assert.equal(appFixture.displayedMetadata.length, 1);
+      assert.equal(appFixture.displayedMetadata[0].test, '/ab/foo.html');
+      assert.equal(appFixture.displayedMetadata[0].url, 'https://bug1');
+      assert.equal(appFixture.displayedMetadata[0].product, 'chrome');
+    });
     test('simple case with same URLs', () => {
       appFixture.searchResults = [{ test: '/foo.html' }];
       appFixture.metadata = {

--- a/webapp/components/test/wpt-metadata.html
+++ b/webapp/components/test/wpt-metadata.html
@@ -129,9 +129,9 @@ suite('<wpt-metadata>', () => {
       assert.equal(appFixture.displayedMetadata.length, 0);
     });
     test('exclude path', () => {
-      appFixture.searchResults = [{ test: '/foo.html' }, { test: '/bar/f.html' }];
+      appFixture.searchResults = [{ test: '/foo/foo1.html' }, { test: '/bar/f.html' }];
       appFixture.metadata = {
-        '/foo.html': [
+        '/foo/foo1.html': [
           {
             url: 'bug1',
             product: 'chrome'
@@ -146,13 +146,13 @@ suite('<wpt-metadata>', () => {
       };
       appFixture.path = '/foo';
       assert.equal(appFixture.displayedMetadata.length, 1);
-      assert.equal(appFixture.displayedMetadata[0].test, '/foo.html');
+      assert.equal(appFixture.displayedMetadata[0].test, '/foo/foo1.html');
       assert.equal(appFixture.displayedMetadata[0].url, 'https://bug1');
     });
     test('complex case', () => {
-      appFixture.searchResults = [{ test: '/foo.html' }, { test: '/foo/bar.html' }, { test: '/foo/bar/foo1.html' }, { test: '/bar/foo.html' }];
+      appFixture.searchResults = [{ test: '/foo/foo1.html' }, { test: '/foo/bar.html' }, { test: '/foo/bar/foo1.html' }, { test: '/bar/foo.html' }];
       appFixture.metadata = {
-        '/foo.html': [
+        '/foo/foo1.html': [
           {
             url: 'bug1',
             product: 'chrome'
@@ -183,7 +183,7 @@ suite('<wpt-metadata>', () => {
       };
       appFixture.path = '/foo';
       assert.equal(appFixture.displayedMetadata.length, 4);
-      assert.equal(appFixture.displayedMetadata[0].test, '/foo.html');
+      assert.equal(appFixture.displayedMetadata[0].test, '/foo/foo1.html');
       assert.equal(appFixture.displayedMetadata[0].url, 'https://bug1');
       assert.equal(appFixture.displayedMetadata[1].test, '/foo/bar.html');
       assert.equal(appFixture.displayedMetadata[1].url, 'http://bug2');
@@ -284,9 +284,9 @@ suite('<wpt-metadata>', () => {
       assert.equal(subtestMap['b'], 'https://bug2');
     });
     test('complex case for metadataMap', () => {
-      appFixture.searchResults = [{ test: '/foo.html' }, { test: '/foo/bar.html' }];
+      appFixture.searchResults = [{ test: '/foo/foo1.html' }, { test: '/foo/bar.html' }];
       appFixture.metadata = {
-        '/foo.html': [
+        '/foo/foo1.html': [
           { url: 'bug1', product: 'chrome', results: [{ subtest: 'a' }, { subtest: 'c' }] },
           { url: 'bug2', product: 'chrome', results: [{ subtest: 'b' }] },
           { url: 'bug3', product: 'chrome', results: [{ status: 'FAIL' }] },
@@ -298,7 +298,7 @@ suite('<wpt-metadata>', () => {
       appFixture.path = '/foo';
 
       assert.equal(Object.keys(appFixture.metadataMap).length, 2);
-      const fooSubtestMap = appFixture.metadataMap['/foo.htmlchrome'];
+      const fooSubtestMap = appFixture.metadataMap['/foo/foo1.htmlchrome'];
       assert.equal(Object.keys(fooSubtestMap).length, 4);
       assert.equal(fooSubtestMap['a'], 'https://bug1');
       assert.equal(fooSubtestMap['c'], 'https://bug1');

--- a/webapp/components/wpt-metadata.js
+++ b/webapp/components/wpt-metadata.js
@@ -277,11 +277,12 @@ class WPTMetadata extends PathInfo(LoadingState(PolymerElement)) {
   }
 
   shouldShowMetadata(metadataTestName, path, testResultSet) {
+    let curPath = path;
+    if (this.pathIsASubfolder) {
+      curPath = curPath + '/';
+    }
+
     if (metadataTestName.endsWith('/*')) {
-      let curPath = path;
-      if (this.pathIsASubfolder) {
-        curPath = curPath + '/';
-      }
       const metadataDirname = metadataTestName.substring(0, metadataTestName.length - 1);
       const metadataDirnameWithoutSlash = metadataTestName.substring(0, metadataTestName.length - 2);
       return (
@@ -291,7 +292,7 @@ class WPTMetadata extends PathInfo(LoadingState(PolymerElement)) {
         (this.isParentDir(curPath, metadataDirname) && testResultSet.has(metadataDirnameWithoutSlash))
       );
     }
-    return metadataTestName.startsWith(path) && testResultSet.has(metadataTestName);
+    return metadataTestName.startsWith(curPath) && testResultSet.has(metadataTestName);
   }
 }
 window.customElements.define(WPTMetadata.is, WPTMetadata);


### PR DESCRIPTION
Fix #2355. When `path` is a subfolder, add a `/` for correct prefix matching.

## Test
See [here](https://fix-metadata-matching-dot-wptdashboard-staging.uk.r.appspot.com/results/css/cssom?label=experimental&label=master&aligned)