### PR TITLE
[UI] Improve accessibility score for Lighthouse

### DIFF
--- a/webapp/components/github-login.js
+++ b/webapp/components/github-login.js
@@ -41,7 +41,7 @@ class GitHubLogin extends PolymerElement {
         <iron-icon class="help" icon="icons:help-outline" on-click="openHelpDialog"></iron-icon>
       </template>
       <paper-button class="login-button" raised on-click="handleLogIn">
-        <iron-icon class="github-icon" src="/static/github.svg" alt="GitHub icon"></iron-icon>
+        <iron-icon class="github-icon" src="/static/github.svg"></iron-icon>
           Sign in with GitHub
       </paper-button>
     </template>

--- a/webapp/components/github-login.js
+++ b/webapp/components/github-login.js
@@ -41,14 +41,14 @@ class GitHubLogin extends PolymerElement {
         <iron-icon class="help" icon="icons:help-outline" on-click="openHelpDialog"></iron-icon>
       </template>
       <paper-button class="login-button" raised on-click="handleLogIn">
-        <iron-icon class="github-icon" src="/static/github.svg"></iron-icon>
+        <iron-icon class="github-icon" src="/static/github.svg" alt="GitHub icon"></iron-icon>
           Sign in with GitHub
       </paper-button>
     </template>
     <template is="dom-if" if="[[user]]">
       <div class="logged-in">
         <template is="dom-if" if="[[showTriage]]">
-          <paper-toggle-button checked="{{isTriageMode}}"></paper-toggle-button>
+          <paper-toggle-button checked="{{isTriageMode}}" aria-label="Toggle Triage Mode"></paper-toggle-button>
           Triage Mode
         </template>
         <iron-icon class="github-icon" src="/static/github.svg"></iron-icon>

--- a/webapp/views/wpt-app.js
+++ b/webapp/views/wpt-app.js
@@ -119,7 +119,7 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
       <template is="dom-if" if="[[showBSFGraph]]">
         <div onmouseenter="[[enterBSF]]" onmouseleave="[[exitBSF]]">
           <info-banner>
-            <paper-icon-button src="[[getCollapseIcon(isBSFCollapsed)]]" onclick="[[handleCollapse]]"></paper-icon-button>
+            <paper-icon-button src="[[getCollapseIcon(isBSFCollapsed)]]" onclick="[[handleCollapse]]" aria-label="Hide BSF graph" alt=""></paper-icon-button>
             [[bsfBannerMessage]]
           </info-banner>
           <template is="dom-if" if="[[!isBSFCollapsed]]">

--- a/webapp/views/wpt-app.js
+++ b/webapp/views/wpt-app.js
@@ -119,7 +119,7 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
       <template is="dom-if" if="[[showBSFGraph]]">
         <div onmouseenter="[[enterBSF]]" onmouseleave="[[exitBSF]]">
           <info-banner>
-            <paper-icon-button src="[[getCollapseIcon(isBSFCollapsed)]]" onclick="[[handleCollapse]]" aria-label="Hide BSF graph" alt=""></paper-icon-button>
+            <paper-icon-button src="[[getCollapseIcon(isBSFCollapsed)]]" onclick="[[handleCollapse]]" aria-label="Hide BSF graph"></paper-icon-button>
             [[bsfBannerMessage]]
           </info-banner>
           <template is="dom-if" if="[[!isBSFCollapsed]]">


### PR DESCRIPTION
Fix the GitHub check failures due to a low accessibility score. The failing test expects the score to be > 90.

- [Use the `aria-label` attribute for buttons](https://web.dev/button-name/?utm_source=lighthouse&utm_medium=devtools#how-to-add-accessible-names-to-buttons)

<img width="722" alt="Screen Shot 2021-02-04 at 8 10 35 PM" src="https://user-images.githubusercontent.com/8611520/106975777-265cd100-6725-11eb-9513-e52134c958d6.png">

## Test
<img width="705" alt="Screen Shot 2021-02-04 at 11 04 21 PM" src="https://user-images.githubusercontent.com/8611520/106988291-69c33980-673d-11eb-914b-a3f4e2997ba0.png">
