### PR TITLE
Revert "Update dependency @vaadin/vaadin-context-menu to v5"

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -2081,40 +2081,19 @@
       }
     },
     "@vaadin/vaadin-context-menu": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-context-menu/-/vaadin-context-menu-5.0.0.tgz",
-      "integrity": "sha512-+OIFseHPRy1QraQFLUT/jxCKlvsOVg/NaaHhfonTZdwrO31CTpKGZFCDB0Gvos2W9WdXa6WI12DRJLZF7Wcr0g==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-context-menu/-/vaadin-context-menu-4.5.0.tgz",
+      "integrity": "sha512-iYQ+xpfWBDV+z7zEXRAoggs+SGNE08KpQ1/LAqRBGvrsVaTCF0CqC845DMQ1mcGd26IqpyABv8JvM4a3XtNR0A==",
       "requires": {
         "@polymer/iron-media-query": "^3.0.0",
         "@polymer/polymer": "^3.0.0",
         "@vaadin/vaadin-element-mixin": "^2.4.1",
-        "@vaadin/vaadin-item": "^3.0.0",
-        "@vaadin/vaadin-list-box": "^2.0.0",
-        "@vaadin/vaadin-lumo-styles": "^1.6.1",
+        "@vaadin/vaadin-item": "^2.3.0",
+        "@vaadin/vaadin-list-box": "^1.4.0",
+        "@vaadin/vaadin-lumo-styles": "^1.6.0",
         "@vaadin/vaadin-material-styles": "^1.3.2",
         "@vaadin/vaadin-overlay": "^3.5.0",
-        "@vaadin/vaadin-themable-mixin": "^1.6.2"
-      },
-      "dependencies": {
-        "@vaadin/vaadin-lumo-styles": {
-          "version": "1.6.1",
-          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-1.6.1.tgz",
-          "integrity": "sha512-Yh9ZcekpY7byXP1QJnfx94rVvK71xHBEspsVV7LL7YMvqXU4EAYuzQGYsljryV4PGS9PFPD6sqbGqhEkIhHPnQ==",
-          "requires": {
-            "@polymer/iron-icon": "^3.0.0",
-            "@polymer/iron-iconset-svg": "^3.0.0",
-            "@polymer/polymer": "^3.0.0"
-          }
-        },
-        "@vaadin/vaadin-themable-mixin": {
-          "version": "1.6.2",
-          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-1.6.2.tgz",
-          "integrity": "sha512-PZZOZnke3KUlZsDrRVbWxAGEeFBPRyRayNRCvip0XnQK+Zs3cLuRgdgbdro3Ir9LZ3Izsw6HqA6XNMKffEP67A==",
-          "requires": {
-            "@polymer/polymer": "^3.0.0",
-            "lit-element": "^2.0.0"
-          }
-        }
+        "@vaadin/vaadin-themable-mixin": "^1.6.1"
       }
     },
     "@vaadin/vaadin-control-state-mixin": {
@@ -2213,68 +2192,35 @@
       }
     },
     "@vaadin/vaadin-item": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-item/-/vaadin-item-3.0.0.tgz",
-      "integrity": "sha512-AcSqaOd2LJr51JWT3j7GcdbU54oBHAE8xlfeN0O5OdCcsAQJLekkNJ3uxt8Kr3ZP99nnEFTZ1WKcQtEufSAVhA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-item/-/vaadin-item-2.3.0.tgz",
+      "integrity": "sha512-hG1MQ8cLaFlsoqSZFm8bqXrHxMry6vtkJrpiXArxpaZXMwPkJnfrUT3D6Qm/NG/rZHvOzZa5U/1k5+dyledlHA==",
       "requires": {
         "@polymer/polymer": "^3.0.0",
         "@vaadin/vaadin-element-mixin": "^2.4.1",
-        "@vaadin/vaadin-lumo-styles": "^1.6.1",
-        "@vaadin/vaadin-material-styles": "^1.3.2",
-        "@vaadin/vaadin-themable-mixin": "^1.6.2"
-      },
-      "dependencies": {
-        "@vaadin/vaadin-lumo-styles": {
-          "version": "1.6.1",
-          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-1.6.1.tgz",
-          "integrity": "sha512-Yh9ZcekpY7byXP1QJnfx94rVvK71xHBEspsVV7LL7YMvqXU4EAYuzQGYsljryV4PGS9PFPD6sqbGqhEkIhHPnQ==",
-          "requires": {
-            "@polymer/iron-icon": "^3.0.0",
-            "@polymer/iron-iconset-svg": "^3.0.0",
-            "@polymer/polymer": "^3.0.0"
-          }
-        },
-        "@vaadin/vaadin-themable-mixin": {
-          "version": "1.6.2",
-          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-1.6.2.tgz",
-          "integrity": "sha512-PZZOZnke3KUlZsDrRVbWxAGEeFBPRyRayNRCvip0XnQK+Zs3cLuRgdgbdro3Ir9LZ3Izsw6HqA6XNMKffEP67A==",
-          "requires": {
-            "@polymer/polymer": "^3.0.0",
-            "lit-element": "^2.0.0"
-          }
-        }
+        "@vaadin/vaadin-lumo-styles": "^1.1.0",
+        "@vaadin/vaadin-material-styles": "^1.1.0",
+        "@vaadin/vaadin-themable-mixin": "^1.6.1"
       }
     },
     "@vaadin/vaadin-list-box": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-list-box/-/vaadin-list-box-2.0.0.tgz",
-      "integrity": "sha512-3WU7oU3cgrp7jPet1aAjAIJSQqdVbKAqIPxOH3LsLX7QQAYnWvUwQY+UApPHiJIjpnKF0PfYiIZe1o6adqKivg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-list-box/-/vaadin-list-box-1.4.0.tgz",
+      "integrity": "sha512-G/BT1CYmZ+8AmQN2koNAxdPmw9iQkYxurN0V5VV/W0/rTfZY54hSpaIOIUpzXvkyS/oayClC3Cpe7bfR8W5Ueg==",
       "requires": {
         "@polymer/polymer": "^3.0.0",
         "@vaadin/vaadin-element-mixin": "^2.4.1",
-        "@vaadin/vaadin-item": "^3.0.0",
+        "@vaadin/vaadin-item": "^2.3.0",
         "@vaadin/vaadin-list-mixin": "^2.5.0",
-        "@vaadin/vaadin-lumo-styles": "^1.6.1",
-        "@vaadin/vaadin-material-styles": "^1.3.2",
+        "@vaadin/vaadin-lumo-styles": "^1.1.0",
+        "@vaadin/vaadin-material-styles": "^1.1.0",
         "@vaadin/vaadin-themable-mixin": "^1.6.1"
-      },
-      "dependencies": {
-        "@vaadin/vaadin-lumo-styles": {
-          "version": "1.6.1",
-          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-1.6.1.tgz",
-          "integrity": "sha512-Yh9ZcekpY7byXP1QJnfx94rVvK71xHBEspsVV7LL7YMvqXU4EAYuzQGYsljryV4PGS9PFPD6sqbGqhEkIhHPnQ==",
-          "requires": {
-            "@polymer/iron-icon": "^3.0.0",
-            "@polymer/iron-iconset-svg": "^3.0.0",
-            "@polymer/polymer": "^3.0.0"
-          }
-        }
       }
     },
     "@vaadin/vaadin-list-mixin": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-list-mixin/-/vaadin-list-mixin-2.5.1.tgz",
-      "integrity": "sha512-XcMzQ0hJnK/AAiV+bW95nwJgmMIrXUBiSDwM+uvfurcBKqPyM4pm3sj8imh8zXSTfpN4HSjMnrLWU1ZfR330vg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-list-mixin/-/vaadin-list-mixin-2.5.0.tgz",
+      "integrity": "sha512-NyQMJZ4sQ35gQxCOdoeBbGW2ou+MfqZRc9DSWotVgJheusRCV7wMHqUmKU/KyFa/IQ8ZoxWbVPdap8I9hyMKfA==",
       "requires": {
         "@polymer/polymer": "^3.0.0",
         "@vaadin/vaadin-element-mixin": "^2.4.1"

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -69,7 +69,7 @@
     "@polymer/paper-toggle-button": "3.0.1",
     "@polymer/paper-tooltip": "3.0.1",
     "@polymer/polymer": "3.4.1",
-    "@vaadin/vaadin-context-menu": "5.0.0",
+    "@vaadin/vaadin-context-menu": "4.5.0",
     "@vaadin/vaadin-date-picker": "4.4.1",
     "@vaadin/vaadin-grid": "6.0.0",
     "@webcomponents/webcomponentsjs": "2.5.0",


### PR DESCRIPTION
Reverts web-platform-tests/wpt.fyi#2381. See https://github.com/web-platform-tests/wpt.fyi/issues/2411