### PR TITLE
Remove Edge as a default product, but add breadcrumb link

### DIFF
--- a/api/query/atoms.go
+++ b/api/query/atoms.go
@@ -45,8 +45,6 @@ import (
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
-var browsers = shared.GetDefaultBrowserNames()
-
 // AbstractQuery is an intermetidate representation of a test results query that
 //  has not been bound to specific shared.TestRun specs for processing.
 type AbstractQuery interface {

--- a/api/test_runs_medium_test.go
+++ b/api/test_runs_medium_test.go
@@ -210,7 +210,7 @@ func TestGetTestRuns_SHA(t *testing.T) {
 	body, _ = ioutil.ReadAll(resp.Result().Body)
 	assert.Equal(t, http.StatusOK, resp.Code)
 	json.Unmarshal(body, &results)
-	assert.Equal(t, 4, len(results))
+	assert.Equal(t, 3, len(results))
 	assert.Equal(t, "1111111111", results[0].Revision)
 }
 

--- a/shared/browsers.go
+++ b/shared/browsers.go
@@ -9,12 +9,12 @@ import (
 // A list of browsers that are shown on the homepage by default.
 // (Must be sorted alphabetically!)
 var defaultBrowsers = []string{
-	"chrome", "edge", "firefox", "safari",
+	"chrome", "firefox", "safari",
 }
 
 // An extra list of known browsers.
 var extraBrowsers = []string{
-	"android_webview", "epiphany", "servo", "uc", "webkitgtk",
+	"android_webview", "edge", "epiphany", "servo", "uc", "webkitgtk",
 }
 
 var allBrowsers mapset.Set

--- a/webapp/components/product-info.js
+++ b/webapp/components/product-info.js
@@ -42,7 +42,9 @@ const AllBrowserNames = Object.freeze(['chrome', 'edge', 'firefox', 'safari', 's
 // The list of default browsers used in cases where the user has not otherwise
 // chosen a set of browsers (e.g. which browsers to show runs for). Stored as
 // an ordered list so that the first entry can be used as a consistent default.
-const DefaultBrowserNames = Object.freeze(['chrome', 'edge', 'firefox', 'safari']);
+//
+// This should be kept in sync with defaultBrowsers in shared/browsers.go
+const DefaultBrowserNames = Object.freeze(['chrome', 'firefox', 'safari']);
 const DefaultProductSpecs = DefaultBrowserNames;
 
 // The above sets, encoded as product objects. This avoids repeatedly calling

--- a/webapp/views/wpt-app.js
+++ b/webapp/views/wpt-app.js
@@ -1,4 +1,5 @@
 import { PathInfo } from '../components/path.js';
+import { DefaultBrowserNames } from '../components/product-info.js';
 import '../components/test-runs-query-builder.js';
 import { TestRunsUIBase } from '../components/test-runs.js';
 import '../components/test-search.js';
@@ -129,6 +130,9 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
           [[resultsTotalsRangeMessage]]
           <template is="dom-if" if="[[!editable]]">
             <a href="javascript:window.location.search='';"> (switch to the default product set instead)</a>
+          </template>
+          <template is="dom-if" if="[[showAddEdgeBackLink(queryParams)]]">
+            <a href='#' on-click="addEdgeBack"> (add Microsoft Edge back)</a>
           </template>
           <wpt-permalinks path="[[path]]"
                           path-prefix="/[[page]]/"
@@ -384,6 +388,21 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
       return false;
     }
     return true;
+  }
+
+  showAddEdgeBackLink(queryParams) {
+    // We only show the 'add edge' link when the user has originally gone to
+    // the main page (e.g. just https://wpt.fyi/results). We can detect that by
+    // checking that no products were specified.
+    return queryParams.product === undefined;
+  }
+
+  addEdgeBack() {
+    // Attempt to put Edge back in the place it used to go (next to Chrome),
+    // but also allow for some change in the default browser set.
+    const newProducts = [DefaultBrowserNames[0], 'edge', ...DefaultBrowserNames.slice(1)];
+    this.queryParams.product = newProducts;
+    this.updateQueryParams(this.queryParams);
   }
 
   computeResultsTotalsRangeMessage(page, path, searchResults, shas, productSpecs, from, to, maxCount, labels, master, runIds) {

--- a/webdriver/builder_test.go
+++ b/webdriver/builder_test.go
@@ -9,12 +9,93 @@ package webdriver
 import (
 	"fmt"
 	"testing"
+	"strings"
 
 	mapset "github.com/deckarep/golang-set"
 	"github.com/stretchr/testify/assert"
 	"github.com/tebeka/selenium"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
+
+func TestQueryBuilder_AddEdgeAnchor(t* testing.T) {
+	// Tests that the 'add Edge' button added for
+	// https://github.com/web-platform-tests/wpt.fyi/issues/1519 is shown
+	// when expected, and that clicking it has the desired effect.
+	runWebdriverTest(t, func(t *testing.T, app AppServer, wd selenium.WebDriver) {
+		t.Run("Shown", func(t* testing.T) {
+			testEdgeAnchor(t, app, wd, true)
+		})
+
+		t.Run("Hidden", func(t* testing.T) {
+			testEdgeAnchor(t, app, wd, false)
+		})
+	})
+}
+
+func testEdgeAnchor(t *testing.T, app AppServer, wd selenium.WebDriver, shouldBeShown bool) {
+	// Navigate to the wpt.fyi homepage.
+	url := "/results"
+	if !shouldBeShown {
+		url += "?product=chrome&product=firefox"
+	}
+
+	var err error
+	if err = wd.Get(app.GetWebappURL(url)); err != nil {
+		assert.FailNow(t, fmt.Sprintf("Failed to load %s: %s", url, err.Error()))
+	}
+
+	// Wait for the page to load.
+	var e selenium.WebElement
+	loaded := func(wd selenium.WebDriver) (bool, error) {
+		e, err = wd.FindElement(selenium.ByTagName, "wpt-app")
+		if err != nil {
+			return false, err
+		}
+		return e != nil, nil
+	}
+	if err = wd.WaitWithTimeout(loaded, LongTimeout); err != nil {
+		assert.FailNow(t, fmt.Sprintf("Error waiting for wpt-app to load: %s", err.Error()))
+	}
+
+	// Find the 'add Edge' anchor.
+	anchors, err := FindShadowElements(wd, e, "info-banner > a")
+	if err != nil {
+		assert.FailNow(t, fmt.Sprintf("Error when locating info-banner anchors: %s", err.Error()))
+	}
+	var edgeAnchor selenium.WebElement
+	foundEdgeAnchor := false
+	for _, anchor := range anchors {
+		text, err := anchor.Text()
+		if err != nil {
+			assert.FailNow(t, fmt.Sprintf("Error when loading Text() for element: %s", err.Error()))
+		}
+
+		if strings.Contains(text, "add Microsoft Edge back") {
+			edgeAnchor = anchor
+			foundEdgeAnchor = true
+			break
+		}
+	}
+
+	// Verify that it either is or is not shown depending on expectation.
+	if !shouldBeShown {
+		assert.False(t, foundEdgeAnchor)
+		return
+	}
+	assert.True(t, foundEdgeAnchor)
+
+	// Now click on the anchor and make sure it loads the page with params.
+	err = edgeAnchor.Click()
+	if err != nil {
+		assert.FailNow(t, fmt.Sprintf("Error when clicking on anchor: %s", err.Error()))
+	}
+
+	newUrl, err := wd.CurrentURL()
+	if err != nil {
+		assert.FailNow(t, fmt.Sprintf("Error when getting current url: %s", err.Error()))
+	}
+	assert.Contains(t, newUrl, "product=edge")
+}
 
 func TestQueryBuilder_MasterCheckedForMasterLabelQuery(t *testing.T) {
 	runWebdriverTest(t, func(t *testing.T, app AppServer, wd selenium.WebDriver) {

--- a/webdriver/label_test.go
+++ b/webdriver/label_test.go
@@ -16,7 +16,7 @@ import (
 func TestLabelParam_Results(t *testing.T) {
 	runWebdriverTest(t, func(t *testing.T, app AppServer, wd selenium.WebDriver) {
 		aligned := false
-		testLabel(t, wd, app, "/", "experimental", "wpt-results", 4, aligned)
+		testLabel(t, wd, app, "/", "experimental", "wpt-results", 3, aligned)
 	})
 
 }


### PR DESCRIPTION
After a lot of discussion, we have decided to remove Edge as a default
product from wpt.fyi due to overlap in browser engine between Chrome and
Edge. In a perfect world we would invest in per-user default products,
but there is no resourcing for that currently.

To try to minimize the disruption, we add a breadcrumb link back to
easily let users get Edge back on the page.

See https://github.com/web-platform-tests/wpt.fyi/issues/1519