### PR TITLE
[WIP] [docker-dev] Increase shm to 256m

### DIFF
--- a/util/docker-dev/run.sh
+++ b/util/docker-dev/run.sh
@@ -96,6 +96,7 @@ if [[ "${INSPECT_STATUS}" != 0 ]] || [[ "${PR}" == "r" ]]; then
       -p "${WPTD_HOST_GCD_PORT}:8001" \
       --workdir "/home/user/wpt.fyi" \
       --name "${DOCKER_INSTANCE}" \
+      --shm-size=256m \
       ${DOCKER_IMAGE}
   info "Setting up local user"
   wptd_useradd


### PR DESCRIPTION
This appears to workaround failures in go_chrome_test when running in
docker locally. The failures appear to stem from Chrome failing to load
resources from the network (net::ERR_INSUFFICIENT_RESOURCE), which some
googling implies may be caused by memory limits.

Testing this PR to see if it (somehow!) affects GitHub actions.