### PR TITLE
[webdriver-tests] Disable shm usage for Chrome

### DIFF
--- a/webdriver/chrome.go
+++ b/webdriver/chrome.go
@@ -34,7 +34,7 @@ func ChromeWebDriver(port int, options []selenium.ServiceOption) (*selenium.Serv
 	}
 
 	ChromeCapabilities := chrome.Capabilities{
-		Args: []string{"no-sandbox"},
+		Args: []string{"no-sandbox", "disable-dev-shm-usage"},
 	}
 	chromeAbsPath, err := filepath.Abs(*chromePath)
 	if err != nil {


### PR DESCRIPTION
This works around failures in go_chrome_test when running in docker locally.
The failures appear to stem from Chrome failing to load resources from the
network (net::ERR_INSUFFICIENT_RESOURCE), which some googling implies
may be caused by trying to use shm and hitting memory limits.

Note that puppeteer specifically suggests to do this:
https://developers.google.com/web/tools/puppeteer/troubleshooting#tips
