### PR TITLE
[triage] Add support for searching for test-level triage

### DIFF
--- a/api/metadata_handler.go
+++ b/api/metadata_handler.go
@@ -174,7 +174,9 @@ func (h MetadataHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	metadataResponse, err := shared.GetMetadataResponseOnProducts(productSpecs, h.logger, h.fetcher)
+	includeTestLevel := q.Get("includeTestLevel") == "true"
+
+	metadataResponse, err := shared.GetMetadataResponseOnProducts(productSpecs, includeTestLevel, h.logger, h.fetcher)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/api/metadata_handler.go
+++ b/api/metadata_handler.go
@@ -174,7 +174,8 @@ func (h MetadataHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	includeTestLevel := q.Get("includeTestLevel") == "true"
+	val, _ := shared.ParseBooleanParam(q, "includeTestLevel")
+	includeTestLevel := val != nil && *val
 
 	metadataResponse, err := shared.GetMetadataResponseOnProducts(productSpecs, includeTestLevel, h.logger, h.fetcher)
 	if err != nil {

--- a/api/query/atoms.go
+++ b/api/query/atoms.go
@@ -297,7 +297,7 @@ func (t AbstractTriaged) BindToRuns(runs ...shared.TestRun) ConcreteQuery {
 			metadataRuns := []shared.TestRun{run}
 
 			// Product being nil means that we want test-level issues.
-			if (t.Product == nil) {
+			if t.Product == nil {
 				includeTestLevel = true
 				metadataRuns = []shared.TestRun{}
 			}

--- a/api/query/atoms.go
+++ b/api/query/atoms.go
@@ -262,7 +262,8 @@ func (l AbstractLink) BindToRuns(runs ...shared.TestRun) ConcreteQuery {
 	if l.metadataFetcher == nil {
 		l.metadataFetcher = searchcacheMetadataFetcher{}
 	}
-	metadata, _ := shared.GetMetadataResponse(runs, logrus.StandardLogger(), l.metadataFetcher)
+	includeTestLevel := true
+	metadata, _ := shared.GetMetadataResponse(runs, includeTestLevel, logrus.StandardLogger(), l.metadataFetcher)
 	metadataMap := shared.PrepareLinkFilter(metadata)
 
 	return Link{
@@ -288,7 +289,14 @@ func (t AbstractTriaged) BindToRuns(runs ...shared.TestRun) ConcreteQuery {
 	}
 	for _, run := range runs {
 		if t.Product == nil || t.Product.Matches(run) {
-			metadata, _ := shared.GetMetadataResponse(runs, logrus.StandardLogger(), t.metadataFetcher)
+			includeTestLevel := false
+			metadataRuns := runs
+			// Product being nil means that we want test-level issues.
+			if (t.Product == nil) {
+				includeTestLevel = true
+				metadataRuns = make([]shared.TestRun, 0)
+			}
+			metadata, _ := shared.GetMetadataResponse(metadataRuns, includeTestLevel, logrus.StandardLogger(), t.metadataFetcher)
 			metadataMap := shared.PrepareLinkFilter(metadata)
 			cq = append(cq, Triaged{run.ID, metadataMap})
 		}

--- a/api/query/atoms_test.go
+++ b/api/query/atoms_test.go
@@ -890,10 +890,9 @@ func TestStructuredQuery_bindLink(t *testing.T) {
 		},
 	}
 
-	// AbstractLink should include test-level issues since it's about
-	// searching for links across all runs. It does not include the
-	// Chromium link because there is no run for Chromium (and thus no
-	// reason to include it, as the frontend won't show it).
+	// AbstractLink should bind test-level issues too as the pattern might match
+	// them. It should not include the Chromium link however, as there is no run
+	// for Chromium and thus no reason to include it - the frontend won't show it.
 	expect := Link{
 		Pattern: "bar",
 		Metadata: map[string][]string{
@@ -942,7 +941,7 @@ func TestStructuredQuery_bindTriaged(t *testing.T) {
 	}
 	assert.Equal(t, expect, q.BindToRuns(runs...))
 
-	// This case doesn't match, so we should get back False.
+	// This query doesn't match any of the runs, so should convert to False.
 	q = AbstractTriaged{
 		Product:         &safari,
 		metadataFetcher: mockFetcher,
@@ -976,8 +975,8 @@ func TestStructuredQuery_bindTriagedNilProduct(t *testing.T) {
 		},
 	}
 
-	// This is inefficient, but currently a nil product binds to all runs,
-	// with the same metadata in all cases.
+	// This is inefficient, but currently a nil product binds to all runs, with
+	// the same metadata in all cases.
 	expect := Or{
 		Args:[]ConcreteQuery{
 			Triaged{

--- a/api/query/atoms_test.go
+++ b/api/query/atoms_test.go
@@ -891,9 +891,9 @@ func TestStructuredQuery_bindLink(t *testing.T) {
 	}
 
 	// AbstractLink should include test-level issues since it's about
-	// searching for links across all runs.
-	// TODO: Shouldn't this also pick up the chromium link too (a.html),
-	// because link isn't meant to care about which product its for?
+	// searching for links across all runs. It does not include the
+	// Chromium link because there is no run for Chromium (and thus no
+	// reason to include it, as the frontend won't show it).
 	expect := Link{
 		Pattern: "bar",
 		Metadata: map[string][]string{
@@ -947,22 +947,7 @@ func TestStructuredQuery_bindTriaged(t *testing.T) {
 		Product:         &safari,
 		metadataFetcher: mockFetcher,
 	}
-	// TODO: This should be False{}, but we pass the entire 'runs' array to
-	// shared.GetMetadataResponse in BindToRuns, which means we return the
-	// Firefox entry even though we only matched against Safari in BindToRuns!
-	//
-	//assert.Equal(t, False{}, q.BindToRuns(runs...))
-	expect = Or{
-		Args:[]ConcreteQuery{
-			Triaged{
-				Run: 0,
-				Metadata: map[string][]string{
-					"/testB/b.html": {"bar.com"},
-				},
-			},
-		},
-	}
-	assert.Equal(t, expect, q.BindToRuns(runs...))
+	assert.Equal(t, False{}, q.BindToRuns(runs...))
 }
 
 func TestStructuredQuery_bindTriagedNilProduct(t *testing.T) {

--- a/shared/metadata.go
+++ b/shared/metadata.go
@@ -47,7 +47,10 @@ type MetadataTestResult struct {
 	Status      *TestStatus `yaml:"status,omitempty"  json:"status,omitempty"`
 }
 
-// GetMetadataResponse retrieves the response to a WPT Metadata query.
+// GetMetadataResponse retrieves the response to a WPT Metadata query. Metadata
+// is included for any product that matches a passed TestRun. Test-level
+// metadata (i.e. that is not associated with any product) may be fetched by
+// passing true for includeTestLevel.
 func GetMetadataResponse(testRuns []TestRun, includeTestLevel bool, log Logger, fetcher MetadataFetcher) (MetadataResults, error) {
 	var productSpecs = make([]ProductSpec, len(testRuns))
 	for i, run := range testRuns {
@@ -64,7 +67,10 @@ func GetMetadataResponse(testRuns []TestRun, includeTestLevel bool, log Logger, 
 	return constructMetadataResponse(productSpecs, includeTestLevel, metadata), nil
 }
 
-// GetMetadataResponseOnProducts constructs the response to a WPT Metadata query, given ProductSpecs.
+// GetMetadataResponseOnProducts constructs the response to a WPT Metadata
+// query, given ProductSpecs. Metdata is included for any product that matches
+// a passed ProductSpec. Test-level metadata (i.e. that is not associated with
+// any product) may be fetched by passing true for includeTestLevel.
 func GetMetadataResponseOnProducts(productSpecs ProductSpecs, includeTestLevel bool, log Logger, fetcher MetadataFetcher) (MetadataResults, error) {
 	// TODO(kyleju): Include the SHA information in API response;
 	// see https://github.com/web-platform-tests/wpt.fyi/issues/1938

--- a/shared/metadata.go
+++ b/shared/metadata.go
@@ -48,7 +48,7 @@ type MetadataTestResult struct {
 }
 
 // GetMetadataResponse retrieves the response to a WPT Metadata query.
-func GetMetadataResponse(testRuns []TestRun, log Logger, fetcher MetadataFetcher) (MetadataResults, error) {
+func GetMetadataResponse(testRuns []TestRun, includeTestLevel bool, log Logger, fetcher MetadataFetcher) (MetadataResults, error) {
 	var productSpecs = make([]ProductSpec, len(testRuns))
 	for i, run := range testRuns {
 		productSpecs[i] = ProductSpec{ProductAtRevision: run.ProductAtRevision, Labels: run.LabelsSet()}
@@ -61,11 +61,11 @@ func GetMetadataResponse(testRuns []TestRun, log Logger, fetcher MetadataFetcher
 		return nil, err
 	}
 
-	return constructMetadataResponse(productSpecs, metadata), nil
+	return constructMetadataResponse(productSpecs, includeTestLevel, metadata), nil
 }
 
 // GetMetadataResponseOnProducts constructs the response to a WPT Metadata query, given ProductSpecs.
-func GetMetadataResponseOnProducts(productSpecs ProductSpecs, log Logger, fetcher MetadataFetcher) (MetadataResults, error) {
+func GetMetadataResponseOnProducts(productSpecs ProductSpecs, includeTestLevel bool, log Logger, fetcher MetadataFetcher) (MetadataResults, error) {
 	// TODO(kyleju): Include the SHA information in API response;
 	// see https://github.com/web-platform-tests/wpt.fyi/issues/1938
 	_, metadata, err := GetMetadataByteMap(log, fetcher)
@@ -73,7 +73,7 @@ func GetMetadataResponseOnProducts(productSpecs ProductSpecs, log Logger, fetche
 		return nil, err
 	}
 
-	return constructMetadataResponse(productSpecs, metadata), nil
+	return constructMetadataResponse(productSpecs, includeTestLevel, metadata), nil
 }
 
 // GetMetadataByteMap collects and parses all META.yml files from
@@ -103,38 +103,52 @@ func parseMetadata(metadataByteMap map[string][]byte, log Logger) map[string]Met
 	return metadataMap
 }
 
+// addResponseLink is a helper method for constructMetadataResponse. It creates a new MetadataLink
+// object corresponding to a specific MetadataTestResult for a given test, and adds it to a
+// MetadataResults map.
+func addResponseLink(fullTestName string, link MetadataLink, result MetadataTestResult, outMap MetadataResults) {
+	newLink := MetadataLink{
+		Product: link.Product,
+		URL:     link.URL,
+	}
+	if result.SubtestName != nil || result.Status != nil {
+		newLink.Results = []MetadataTestResult{
+			{
+				SubtestName: result.SubtestName,
+				Status:      result.Status,
+				// TestPath is redundant (it's the map key in outMap)
+			},
+		}
+	}
+	if _, ok := outMap[fullTestName]; !ok {
+		outMap[fullTestName] = MetadataLinks{newLink}
+	} else {
+		outMap[fullTestName] = append(outMap[fullTestName], newLink)
+	}
+}
+
 // constructMetadataResponse constructs the response to a WPT Metadata query, given ProductSpecs.
-func constructMetadataResponse(productSpecs ProductSpecs, metadata map[string]Metadata) MetadataResults {
+func constructMetadataResponse(productSpecs ProductSpecs, includeTestLevel bool, metadata map[string]Metadata) MetadataResults {
 	res := make(MetadataResults)
 	for folderPath, data := range metadata {
 		for i := range data.Links {
 			link := data.Links[i]
 			for _, result := range link.Results {
 				//TODO(kyleju): Concatenate test path on WPT Metadata repository instead of here.
-				var fullTestName = GetWPTTestPath(folderPath, result.TestPath)
+				fullTestName := GetWPTTestPath(folderPath, result.TestPath)
+
+				if link.Product.BrowserName == "" {
+					if includeTestLevel {
+						addResponseLink(fullTestName, link, result, res)
+					}
+					break
+				}
+
+				// Find any matching product for this link result (there can be at most one).
 				for _, productSpec := range productSpecs {
-					// Matches browser type if a version is not specified.
-					if link.Product.MatchesProductSpec(productSpec) ||
-						// Matches to all browsers if product is not specified.
-						link.Product.BrowserName == "" {
-						output := MetadataLink{
-							Product: link.Product,
-							URL:     link.URL,
-						}
-						if result.SubtestName != nil || result.Status != nil {
-							output.Results = []MetadataTestResult{
-								{
-									SubtestName: result.SubtestName,
-									Status:      result.Status,
-									// TestPath is redundant (it's the map key)
-								},
-							}
-						}
-						if _, ok := res[fullTestName]; !ok {
-							res[fullTestName] = MetadataLinks{output}
-						} else {
-							res[fullTestName] = append(res[fullTestName], output)
-						}
+					// Matches on browser type if a version is not specified.
+					if link.Product.MatchesProductSpec(productSpec) {
+						addResponseLink(fullTestName, link, result, res)
 						break
 					}
 				}

--- a/shared/metadata_test.go
+++ b/shared/metadata_test.go
@@ -209,7 +209,7 @@ func TestConstructMetadataResponse_OneMatchingBrowserVersion(t *testing.T) {
 		},
 	}
 
-	MetadataResults := constructMetadataResponse(productSpecs, false,metadataMap)
+	MetadataResults := constructMetadataResponse(productSpecs, false, metadataMap)
 
 	assert.Equal(t, 1, len(MetadataResults))
 	assert.Equal(t, MetadataResults["/foo/bar/a.html"][0].URL, "https://bug.com/item")

--- a/shared/metadata_test.go
+++ b/shared/metadata_test.go
@@ -109,7 +109,7 @@ func TestConstructMetadataResponse_OneLink(t *testing.T) {
 		},
 	}
 
-	MetadataResults := constructMetadataResponse(productSpecs, metadataMap)
+	MetadataResults := constructMetadataResponse(productSpecs, false, metadataMap)
 
 	assert.Equal(t, 1, len(MetadataResults))
 	assert.Equal(t, 2, len(MetadataResults["/foo/bar/a.html"]))
@@ -145,7 +145,7 @@ func TestConstructMetadataResponse_NoMatchingLink(t *testing.T) {
 		},
 	}
 
-	MetadataResults := constructMetadataResponse(productSpecs, metadataMap)
+	MetadataResults := constructMetadataResponse(productSpecs, false, metadataMap)
 
 	assert.Equal(t, 0, len(MetadataResults))
 }
@@ -176,7 +176,7 @@ func TestConstructMetadataResponse_MultipleLinks(t *testing.T) {
 		},
 	}
 
-	MetadataResults := constructMetadataResponse(productSpecs, metadataMap)
+	MetadataResults := constructMetadataResponse(productSpecs, false, metadataMap)
 
 	assert.Equal(t, 2, len(MetadataResults))
 	assert.Equal(t, MetadataResults["/foo/bar/a.html"][0].URL, "https://bug.com/item")
@@ -209,13 +209,15 @@ func TestConstructMetadataResponse_OneMatchingBrowserVersion(t *testing.T) {
 		},
 	}
 
-	MetadataResults := constructMetadataResponse(productSpecs, metadataMap)
+	MetadataResults := constructMetadataResponse(productSpecs, false,metadataMap)
 
 	assert.Equal(t, 1, len(MetadataResults))
 	assert.Equal(t, MetadataResults["/foo/bar/a.html"][0].URL, "https://bug.com/item")
 }
 
-func TestConstructMetadataResponse_WithEmptyProductSpec(t *testing.T) {
+func TestConstructMetadataResponse_TestIssueMetadata(t *testing.T) {
+	// Metadata relating to issues with the test itself have empty product specs, and should only
+	// show up if we pass includeTestIssues=true to constructMetadataResponse.
 	productSpecs := []ProductSpec{
 		ParseProductSpecUnsafe("Firefox-54"),
 		ParseProductSpecUnsafe("Chrome"),
@@ -224,13 +226,6 @@ func TestConstructMetadataResponse_WithEmptyProductSpec(t *testing.T) {
 	metadataMap := map[string]Metadata{
 		"foo/bar": Metadata{
 			Links: []MetadataLink{
-				MetadataLink{
-					Product: ParseProductSpecUnsafe("ChrOme"),
-					URL:     "https://external.com/item",
-					Results: []MetadataTestResult{{
-						TestPath: "b.html",
-					}},
-				},
 				MetadataLink{
 					Product: ProductSpec{},
 					URL:     "https://bug.com/item",
@@ -242,13 +237,14 @@ func TestConstructMetadataResponse_WithEmptyProductSpec(t *testing.T) {
 		},
 	}
 
-	MetadataResults := constructMetadataResponse(productSpecs, metadataMap)
+	MetadataResults := constructMetadataResponse(productSpecs, true, metadataMap)
 
-	assert.Equal(t, 2, len(MetadataResults))
+	assert.Equal(t, 1, len(MetadataResults))
 	assert.Equal(t, 1, len(MetadataResults["/foo/bar/a.html"]))
 	assert.Equal(t, MetadataResults["/foo/bar/a.html"][0].URL, "https://bug.com/item")
-	assert.Equal(t, 1, len(MetadataResults["/foo/bar/b.html"]))
-	assert.Equal(t, MetadataResults["/foo/bar/b.html"][0].URL, "https://external.com/item")
+
+	MetadataResults = constructMetadataResponse(productSpecs, false, metadataMap)
+	assert.Equal(t, 0, len(MetadataResults))
 }
 
 func TestGetWPTTestPath(t *testing.T) {

--- a/webapp/components/test-search.js
+++ b/webapp/components/test-search.js
@@ -127,6 +127,7 @@ const QUERY_GRAMMAR = ohm.grammar(`
 
     triagedExp
       = caseInsensitive<"triaged"> ":" browserName
+      | caseInsensitive<"triaged"> ":" "test-issue"
 
     isExp
       = caseInsensitive<"is"> ":" metadataQualityLiteral
@@ -310,7 +311,11 @@ const QUERY_SEMANTICS = QUERY_GRAMMAR.createSemantics().addOperation('eval', {
   },
   triagedExp: (l, colon, r) => {
     const ps = r.eval();
-    return ps.length === 0 ? emptyQuery : { triaged: ps.toLowerCase() };
+    if (ps.length === 0) {
+      return emptyQuery;
+    }
+    // Test-level issues are represented on the backend as an empty product.
+    return { triaged: ps.toLowerCase().replace('test-issue', '') };
   },
   subtestExp: (l, colon, r) => {
     return { subtest: r.eval() };

--- a/webapp/components/test/test-search.html
+++ b/webapp/components/test/test-search.html
@@ -403,6 +403,10 @@ suite('<test-search>', () => {
       });
     });
 
+    test('test-level triaged search', () => {
+      assertQueryParse('triaged:test-issue', { exists: [{ triaged: '' }] });
+    });
+
     test('multi-root', () => {
       assertQueryParse('none(status:missing) count>0(status:!pass)', {
         and: [

--- a/webapp/components/wpt-metadata.js
+++ b/webapp/components/wpt-metadata.js
@@ -167,7 +167,7 @@ class WPTMetadata extends PathInfo(LoadingState(PolymerElement)) {
     }
 
     const url = new URL('/api/metadata', window.location);
-    url.searchParams.set('includeTestLevel', 'true');
+    url.searchParams.set('includeTestLevel', true);
     url.searchParams.set('products', productVal.join(','));
     this.load(
       window.fetch(url).then(r => r.json()).then(metadata => {

--- a/webapp/components/wpt-metadata.js
+++ b/webapp/components/wpt-metadata.js
@@ -167,6 +167,7 @@ class WPTMetadata extends PathInfo(LoadingState(PolymerElement)) {
     }
 
     const url = new URL('/api/metadata', window.location);
+    url.searchParams.set('includeTestLevel', 'true');
     url.searchParams.set('products', productVal.join(','));
     this.load(
       window.fetch(url).then(r => r.json()).then(metadata => {


### PR DESCRIPTION
This PR both adds the ability to search for test-level metadata (that is, metadata
that has no product associated with it), and stops test-level metadata showing up
for specific product searches.

To achieve this, we:

1. Expand the `triagedExp` atom on the front-end to also accept `test-issue` and
    to convert it to an empty product.
2. Change `shared.GetMetadataResponse` to invert its handling of empty-product
    metadata from matching any product to matching no products.

This does mean that for a request like: `"query":{"exists":[{"triaged":"test-issue"}]}` we
create N identical `query.Triaged` objects, one for each test-run in the query. This is
inefficient (because `triaged:test-issue` should not be bound to multiple runs), but is an
artifact of how `AbstractExists` works and is identical to the behavior for `link` today.

Fixes https://github.com/web-platform-tests/wpt.fyi/issues/2421

To test: open deployed instance, try searching for `triaged:test-issue` (should get a
handful of results), and for `triaged:chrome` (should get slightly less results than on
wpt.fyi). You can also try hitting `/api/metadata?product=chrome` on the deployed
instance and note that it no longer has entries for the test-level triaged tests.