### PR TITLE
Upgrade major version of taskcluster

### DIFF
--- a/api/taskcluster/webhook.go
+++ b/api/taskcluster/webhook.go
@@ -19,7 +19,7 @@ import (
 	mapset "github.com/deckarep/golang-set"
 	"github.com/google/go-github/v33/github"
 	tcurls "github.com/taskcluster/taskcluster-lib-urls"
-	"github.com/taskcluster/taskcluster/v41/clients/client-go/tcqueue"
+	"github.com/taskcluster/taskcluster/v42/clients/client-go/tcqueue"
 	uc "github.com/web-platform-tests/wpt.fyi/api/receiver/client"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/sirupsen/logrus v1.8.0
 	github.com/stretchr/testify v1.7.0
 	github.com/taskcluster/taskcluster-lib-urls v13.0.1+incompatible
-	github.com/taskcluster/taskcluster/v41 v41.1.0
+	github.com/taskcluster/taskcluster/v42 v42.0.0
 	github.com/tebeka/selenium v0.9.9
 	go.opencensus.io v0.23.0 // indirect
 	golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5

--- a/go.sum
+++ b/go.sum
@@ -440,8 +440,8 @@ github.com/taskcluster/slugid-go v1.1.0 h1:SWsUplliyamdYzOKVM4+lDohZKuL63fKreGkv
 github.com/taskcluster/slugid-go v1.1.0/go.mod h1:5sOAcPHjqso1UkKxSl77CkKgOwha0D9X0msBKBj0AOg=
 github.com/taskcluster/taskcluster-lib-urls v13.0.1+incompatible h1:Q3kagxQiHw7QNckRoeeBV16FDvyQC+iSmda99bJEK+U=
 github.com/taskcluster/taskcluster-lib-urls v13.0.1+incompatible/go.mod h1:ALqTgi15AmJGEGubRKM0ydlLAFatlQPrQrmal9YZpQs=
-github.com/taskcluster/taskcluster/v41 v41.1.0 h1:23RG6qhRqNTugQJRpRzPcOeCyLLzkXYx8JP0EDBpblI=
-github.com/taskcluster/taskcluster/v41 v41.1.0/go.mod h1:Be/HQPv6Y2s93FCqgxL5lsW5rImzPHFQ4JtHmPcP9vU=
+github.com/taskcluster/taskcluster/v42 v42.0.0 h1:FqEPicopsRUYfob1GfhaE/zcKGN6QNn4IGBMGD6rtSI=
+github.com/taskcluster/taskcluster/v42 v42.0.0/go.mod h1:kVXMvNlbIaxDmme1AIjXtuaYNah75Wfnb6vb/LyG/3g=
 github.com/tebeka/selenium v0.9.9 h1:cNziB+etNgyH/7KlNI7RMC1ua5aH1+5wUlFQyzeMh+w=
 github.com/tebeka/selenium v0.9.9/go.mod h1:5Fr8+pUvU6B1OiPfkdCKdXZyr5znvVkxuPd0NOdZCQc=
 github.com/tent/hawk-go v0.0.0-20161026210932-d341ea318957 h1:6Fre/uvwovW5YY4nfHZk66cAg9HjT9YdFSAJHUUgOyQ=


### PR DESCRIPTION
There appear to be no breaking changes, based on
https://github.com/taskcluster/taskcluster/releases/tag/v42.0.0
