### PR TITLE
[compat2021] Add an initial `/compat2021` page

### DIFF
--- a/webapp/compat_2021_handler.go
+++ b/webapp/compat_2021_handler.go
@@ -1,0 +1,18 @@
+// Copyright 2021 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package webapp
+
+import (
+	"net/http"
+)
+
+// compat2021Handler handles GET requests to /compat2021
+func compat2021Handler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "GET" {
+		http.Error(w, "Only GET is supported.", http.StatusMethodNotAllowed)
+		return
+	}
+	RenderTemplate(w, r, "compat-2021.html", nil)
+}

--- a/webapp/components/compat-2021.js
+++ b/webapp/components/compat-2021.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2021 The WPT Dashboard Project. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+import { html, PolymerElement } from '../node_modules/@polymer/polymer/polymer-element.js';
+
+// Compat2021 is a custom element that holds the overall compat-2021 dashboard.
+// The dashboard breaks down into top-level summary scores, a small description,
+// graphs per feature, and a table of currently tracked tests.
+class Compat2021 extends PolymerElement {
+  static get template() {
+    return html`
+      <h1>2021 DevSat Compat Dashboard</h1>
+      <p>TODO: Summary scores</p>
+      <p>
+        These scores represent how well browser engines are doing on the 2021
+        Compat Focus Areas, as measured by wpt.fyi test results. Each feature
+        contributes up to 20 points to the score, based on passing-test
+        percentage, giving a maximum possible score of 100 for each browser.
+      </p>
+      <p>
+        The set of tests used is derived from the full wpt.fyi test suite for
+        each feature, filtered by believed importance to web developers.
+        <span id="experimentalResultsText">The results shown here are from
+        developer preview builds with experimental features enabled.</span>
+      </p>
+      <p>TODO: Individual feature graph</p>
+      <p>TODO: Test results table</p>
+`;
+  }
+
+  static get is() {
+    return 'compat-2021';
+  }
+}
+window.customElements.define(Compat2021.is, Compat2021);
+

--- a/webapp/components/compat-2021.js
+++ b/webapp/components/compat-2021.js
@@ -12,7 +12,7 @@ import { html, PolymerElement } from '../node_modules/@polymer/polymer/polymer-e
 class Compat2021 extends PolymerElement {
   static get template() {
     return html`
-      <h1>2021 DevSat Compat Dashboard</h1>
+      <h1>Compat 2021 Dashboard</h1>
       <p>TODO: Summary scores</p>
       <p>
         These scores represent how well browser engines are doing on the 2021
@@ -36,4 +36,3 @@ class Compat2021 extends PolymerElement {
   }
 }
 window.customElements.define(Compat2021.is, Compat2021);
-

--- a/webapp/routes.go
+++ b/webapp/routes.go
@@ -41,6 +41,9 @@ func RegisterRoutes() {
 	shared.AddRoute("/runs", "test-runs", testRunsHandler)
 	shared.AddRoute("/test-runs", "test-runs", testRunsHandler) // Legacy name
 
+	// Dashboard for the compat-2021 effort.
+	shared.AddRoute("/compat2021", "compat-2021", compat2021Handler)
+
 	// Admin-only manual results upload.
 	shared.AddRoute("/admin/results/upload", "admin-results-upload", adminUploadHandler)
 

--- a/webapp/templates/compat-2021.html
+++ b/webapp/templates/compat-2021.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+{{ template "_head_common.html" . }}
+<script type="module" src="/components/compat-2021.js"></script>
+</head>
+<body>
+<div id="content">
+  <wpt-header {{if .User}}user="{{.User.GitHubHandle}}"{{end}}></wpt-header>
+  <compat-2021></compat-2021>
+</div>
+</body>
+</html>


### PR DESCRIPTION
This adds a (very) incomplete version of https://ecosystem-infra.github.io/wpt-results-analysis/compat
to wpt.fyi, at `wpt.fyi/compat2021`. The page currently is just static text, and is not yet exposed via
any UI. Later PRs will add the summary numbers, graph, and test list.