### PR TITLE
Remove deprecated experimentalByDefault and experimentalAligned flags

### DIFF
--- a/shared/test_run_filter.go
+++ b/shared/test_run_filter.go
@@ -94,6 +94,10 @@ func (filter TestRunFilter) IsDefaultQuery() bool {
 // OrDefault returns the current filter, or, if it is a default query, returns
 // the query used by default in wpt.fyi.
 func (filter TestRunFilter) OrDefault() TestRunFilter {
+	// TODO(smcgruer): OrAlignedStableRuns is not the default query in
+	// wpt.fyi, and has not been for many years (ever since the
+	// experimentalByDefault flag was turned on). Usage of this method
+	// should be audited.
 	return filter.OrAlignedStableRuns()
 }
 

--- a/util/populate_dev_data.go
+++ b/util/populate_dev_data.go
@@ -165,8 +165,6 @@ func main() {
 	addFlag(store, "queryBuilder", enabledFlag)
 	addFlag(store, "diffFilter", enabledFlag)
 	addFlag(store, "diffFromAPI", enabledFlag)
-	addFlag(store, "experimentalByDefault", enabledFlag)
-	addFlag(store, "experimentalAligned", enabledFlag)
 	addFlag(store, "structuredQueries", enabledFlag)
 	addFlag(store, "diffRenames", enabledFlag)
 	addFlag(store, "paginationTokens", enabledFlag)

--- a/webapp/components/wpt-flags.js
+++ b/webapp/components/wpt-flags.js
@@ -40,8 +40,6 @@ Object.defineProperty(wpt, 'ClientSideFeatures', {
       'colorHomepage',
       'diffFromAPI',
       'displayMetadata',
-      'experimentalByDefault',
-      'experimentalAligned',
       'fetchManifestForTestList',
       'githubCommitLinks',
       'githubLogin',
@@ -336,16 +334,6 @@ class WPTEnvironmentFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ tr
     <paper-item>
       <paper-checkbox checked="{{diffRenames}}">
         Compute renames in diffs with the GitHub API
-      </paper-checkbox>
-    </paper-item>
-    <paper-item>
-      <paper-checkbox checked="{{experimentalByDefault}}">
-        Fetch experimental runs as the default (homepage) query
-      </paper-checkbox>
-    </paper-item>
-    <paper-item sub-item>
-      <paper-checkbox checked="{{experimentalAligned}}">
-        Align the default experimental runs
       </paper-checkbox>
     </paper-item>
     <paper-item>

--- a/webapp/test_results_handler.go
+++ b/webapp/test_results_handler.go
@@ -82,8 +82,6 @@ func populateHomepageData(r *http.Request) (data homepageData, err error) {
 	if err != nil {
 		return data, err
 	}
-	ctx := r.Context()
-	aeAPI := shared.NewAppEngineAPI(ctx)
 
 	var pr *int
 	pr, err = shared.ParsePRParam(q)
@@ -104,15 +102,9 @@ func populateHomepageData(r *http.Request) (data homepageData, err error) {
 		data.TestRunIDs = string(marshalled)
 	} else {
 		if pr == nil && testRunFilter.IsDefaultQuery() {
-			if aeAPI.IsFeatureEnabled("experimentalByDefault") {
-				testRunFilter = testRunFilter.OrExperimentalRuns()
-				if aeAPI.IsFeatureEnabled("experimentalAligned") || true {
-					aligned := true
-					testRunFilter.Aligned = &aligned
-				}
-			} else {
-				testRunFilter = testRunFilter.OrAlignedStableRuns()
-			}
+			testRunFilter = testRunFilter.OrExperimentalRuns()
+			aligned := true
+			testRunFilter.Aligned = &aligned
 			testRunFilter = testRunFilter.MasterOnly()
 		}
 		data.testRunUIFilter = convertTestRunUIFilter(testRunFilter)


### PR DESCRIPTION
Both of these flags have been default-on in wpt.fyi for many years, and
we are exceedingly unlikely to change them to be false at any point.
Removing them clarifies the intent of the code - and has also revealed
an existing inconsistency in our codebase (see Default() in
shared/test_run_filter.go).