### PR TITLE
[Renovate] Schedule renovate update every Monday

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,7 @@
 {
+  "schedule": [
+    "before 3am on Monday"
+  ],
   "extends": [
     "config:base",
     ":automergeMinor",


### PR DESCRIPTION
Switch renovate to batch updates every Monday. Currently Renovate sends updates whenever there is one available.

See the [schedule](https://docs.renovatebot.com/presets-schedule/#scheduleearlymondays) syntax