### PR TITLE
Remove deprecated useReftestAnalyzer flag

### DIFF
--- a/webapp/components/test-file-results.js
+++ b/webapp/components/test-file-results.js
@@ -220,7 +220,7 @@ class TestFileResults extends WPTFlags(LoadingState(PathInfo(
             status: data && data.status,
             message: data && data.message,
           };
-          if (this.reftestAnalyzer && data && data.screenshots) {
+          if (data && data.screenshots) {
             result.screenshots = this.shuffleScreenshots(this.path, data.screenshots);
           }
           return result;

--- a/webapp/components/wpt-flags.js
+++ b/webapp/components/wpt-flags.js
@@ -48,7 +48,6 @@ Object.defineProperty(wpt, 'ClientSideFeatures', {
       'processorTab',
       'queryBuilder',
       'queryBuilderSHA',
-      'reftestAnalyzer',
       'reftestAnalyzerMockScreenshots',
       'reftestIframes',
       'searchCacheInterop',
@@ -255,11 +254,6 @@ class WPTFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ false) {
     <paper-item sub-item>
       <paper-checkbox checked="{{reftestAnalyzerMockScreenshots}}">
         Use mock screenshots for all the reftests
-      </paper-checkbox>
-    </paper-item>
-    <paper-item>
-      <paper-checkbox checked="{{reftestAnalyzer}}">
-        Show the reftest analyzer for reftests
       </paper-checkbox>
     </paper-item>
     <paper-item>


### PR DESCRIPTION
The reftest analyzer has been on by default for years; we're happy with
it and don't need this flag.