### PR TITLE
Remove the never-launched manifest frontend code

### DIFF
--- a/webapp/components/test-file-results.js
+++ b/webapp/components/test-file-results.js
@@ -199,15 +199,7 @@ class TestFileResults extends WPTFlags(LoadingState(PathInfo(
     if (!response.ok) {
       return null;
     }
-    if (!this.reftestAnalyzerMockScreenshots) {
-      return response.json();
-    }
-    // Use some arbitrary screenshots for any without them.
-    const screenshots = {};
-    screenshots[this.path] = 'sha1:000c495e8f587dac40894d0cacb5a7ca769410c6';
-    screenshots[this.path.replace(/.html$/, '-ref.html')] = 'sha1:000c495e8f587dac40894d0cacb5a7ca769410c6';
-    return response.json()
-      .then(r => Object.assign({ screenshots }, r));
+    return response.json();
   }
 
   resultsTableHeaders(resultsPerTestRun) {

--- a/webapp/components/wpt-flags.js
+++ b/webapp/components/wpt-flags.js
@@ -40,7 +40,6 @@ Object.defineProperty(wpt, 'ClientSideFeatures', {
       'colorHomepage',
       'diffFromAPI',
       'displayMetadata',
-      'fetchManifestForTestList',
       'githubCommitLinks',
       'githubLogin',
       'interopScoreColumn',
@@ -48,12 +47,8 @@ Object.defineProperty(wpt, 'ClientSideFeatures', {
       'processorTab',
       'queryBuilder',
       'queryBuilderSHA',
-      'reftestAnalyzerMockScreenshots',
-      'reftestIframes',
       'searchCacheInterop',
       'showBSF',
-      'showTestType',
-      'showTestRefURL',
       'structuredQueries',
       'triageMetadataUI',
       'webPlatformTestsLive',
@@ -228,31 +223,6 @@ class WPTFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ false) {
     <paper-item sub-item>
       <paper-checkbox checked="{{searchCacheInterop}}">
         Compute interop results the fly, using the searchcache
-      </paper-checkbox>
-    </paper-item>
-    <paper-item>
-      <paper-checkbox checked="{{fetchManifestForTestList}}">
-        Fetch a manifest for a complete (expected) list of tests.
-      </paper-checkbox>
-    </paper-item>
-    <paper-item sub-item>
-      <paper-checkbox checked="{{showTestType}}">
-        Display test types
-      </paper-checkbox>
-    </paper-item>
-    <paper-item sub-item>
-      <paper-checkbox checked="{{showTestRefURL}}">
-        Display link to ref (for reftests)
-      </paper-checkbox>
-    </paper-item>
-    <paper-item sub-item>
-      <paper-checkbox checked="{{reftestIframes}}">
-        Display comparitive iframes for reftests
-      </paper-checkbox>
-    </paper-item>
-    <paper-item sub-item>
-      <paper-checkbox checked="{{reftestAnalyzerMockScreenshots}}">
-        Use mock screenshots for all the reftests
       </paper-checkbox>
     </paper-item>
     <paper-item>


### PR DESCRIPTION
The use of the manifest in the frontend never shipped, and the flags are
off in prod and staging. This code is non-trivial and removing it makes
the code easier to understand.

The /api/manifest endpoint is not removed because it is still [used by
Bikeshed](https://github.com/tabatkins/bikeshed/blob/e797b9548c0bd140c9b1500809869b09f50f7d99/bikeshed/update/updateWpt.py)
and the [GitHub checks in wpt-metadata](https://github.com/web-platform-tests/wpt-metadata/blob/557b49eb329670395d90744b084869e848b268ac/test_paths_test.go#L30)

Updates #56