### PR TITLE
[code health] Tidy up the lru code

### DIFF
--- a/api/query/cache/lru/lru_test.go
+++ b/api/query/cache/lru/lru_test.go
@@ -58,7 +58,9 @@ func TestRepeatAccess(t *testing.T) {
 	l.Access(1)
 	l.Access(2)
 	l.Access(1)
-	removed := l.EvictLRU(0.5)
+	// Remove slightly over half of the items to avoid floating point
+	// errors in the case that 0.5 * 2 is < 1.
+	removed := l.EvictLRU(0.51)
 	assert.Equal(t, []int64{int64(2)}, removed)
 }
 


### PR DESCRIPTION
This PR tidies up the lru code a bit:

1. Correct the interface documentation to correctly describe its behavior.
2. Fully generalizes the naming to remove the assumption that the values
   are run IDs (previously it was half general, half specific).
3. Extracts a variable to make the code clearer.
4. Fixes a test that was inherently flaky, as it relied on 0.5 * 2.0
   being >= 1 when by floating point it could be slightly less than 1.