### PR TITLE
[compat2021] Add an embedded mode

### DIFF
--- a/webapp/compat_2021_handler.go
+++ b/webapp/compat_2021_handler.go
@@ -6,7 +6,12 @@ package webapp
 
 import (
 	"net/http"
+	"github.com/web-platform-tests/wpt.fyi/shared"
 )
+
+type compat2021Data struct {
+	Embedded bool
+}
 
 // compat2021Handler handles GET requests to /compat2021
 func compat2021Handler(w http.ResponseWriter, r *http.Request) {
@@ -14,5 +19,16 @@ func compat2021Handler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Only GET is supported.", http.StatusMethodNotAllowed)
 		return
 	}
-	RenderTemplate(w, r, "compat-2021.html", nil)
+
+	q := r.URL.Query()
+	embedded, err := shared.ParseBooleanParam(q, "embedded")
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	data := compat2021Data{
+		Embedded: embedded != nil && *embedded,
+	}
+	RenderTemplate(w, r, "compat-2021.html", data)
 }

--- a/webapp/components/compat-2021.js
+++ b/webapp/components/compat-2021.js
@@ -112,6 +112,7 @@ class Compat2021 extends PolymerElement {
 
   static get properties() {
     return {
+      embedded: Boolean,
       stable: Boolean,
       feature: String,
     };
@@ -119,7 +120,7 @@ class Compat2021 extends PolymerElement {
 
   static get observers() {
     return [
-      'updateUrlParams(stable, feature)',
+      'updateUrlParams(embedded, stable, feature)',
     ];
   }
 
@@ -127,6 +128,7 @@ class Compat2021 extends PolymerElement {
     super.ready();
 
     const params = (new URL(document.location)).searchParams;
+    this.embedded = params.get('embedded') !== null;
     this.stable = params.get('stable') !== null;
     this.feature = params.get('feature');
 
@@ -136,7 +138,7 @@ class Compat2021 extends PolymerElement {
     });
   }
 
-  updateUrlParams(stable, feature) {
+  updateUrlParams(embedded, stable, feature) {
     // Our observer may be called before the feature is set, so debounce that.
     if (feature === undefined) {
       return;
@@ -148,6 +150,9 @@ class Compat2021 extends PolymerElement {
     }
     if (stable) {
       params.push('stable');
+    }
+    if (embedded) {
+      params.push('embedded');
     }
 
     let url = location.pathname;

--- a/webapp/templates/compat-2021.html
+++ b/webapp/templates/compat-2021.html
@@ -6,7 +6,9 @@
 </head>
 <body>
 <div id="content">
-  <wpt-header {{if .User}}user="{{.User.GitHubHandle}}"{{end}}></wpt-header>
+  {{if not .Data.Embedded}}
+    <wpt-header {{if .User}}user="{{.User.GitHubHandle}}"{{end}}></wpt-header>
+  {{end}}
   <compat-2021></compat-2021>
 </div>
 </body>


### PR DESCRIPTION
When 'embedded' is passed as a param, don't include the wpt.fyi header.
This is intended to be used for iframing the dashboard.