### PR TITLE
Fix alignment of test results page

### DIFF
--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -183,7 +183,7 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
         <table>
           <thead>
             <tr>
-              <th colspan="2">Path</th>
+              <th>Path</th>
               <template is="dom-repeat" items="{{testRuns}}" as="testRun">
                 <!-- Repeats for as many different browser test runs are available -->
                 <th><test-run test-run="[[testRun]]" show-source show-platform></test-run></th>


### PR DESCRIPTION
In cf18d4857908847293741223559193b4755a019c, we removed the unused
manifest code. However we overlooked that there was an invisible
zero-width table column in existence for this unused feature, and when
it was removed the 'path' cell stretched too far.

Fix this by making the path column single-wide, not double.