### PR TITLE
Rename all Memcache to Redis

### DIFF
--- a/api/bsf_handler.go
+++ b/api/bsf_handler.go
@@ -24,7 +24,7 @@ func apiBSFHandler(w http.ResponseWriter, r *http.Request) {
 	shared.NewCachingHandler(
 		ctx,
 		BSFHandler{shared.NewFetchBSF()},
-		shared.NewGZReadWritable(shared.NewMemcacheReadWritable(ctx, 60*time.Minute)),
+		shared.NewGZReadWritable(shared.NewRedisReadWritable(ctx, 60*time.Minute)),
 		shared.AlwaysCachable,
 		shared.URLAsCacheKey,
 		shared.CacheStatusOK).ServeHTTP(w, r)

--- a/api/labels.go
+++ b/api/labels.go
@@ -24,7 +24,7 @@ type LabelsHandler struct {
 func apiLabelsHandler(w http.ResponseWriter, r *http.Request) {
 	// Serve cached with 5 minute expiry. Delegate to LabelsHandler on cache miss.
 	ctx := r.Context()
-	shared.NewCachingHandler(ctx, LabelsHandler{ctx}, shared.NewGZReadWritable(shared.NewMemcacheReadWritable(ctx, 5*time.Minute)), shared.AlwaysCachable, shared.URLAsCacheKey, shared.CacheStatusOK).ServeHTTP(w, r)
+	shared.NewCachingHandler(ctx, LabelsHandler{ctx}, shared.NewGZReadWritable(shared.NewRedisReadWritable(ctx, 5*time.Minute)), shared.AlwaysCachable, shared.URLAsCacheKey, shared.CacheStatusOK).ServeHTTP(w, r)
 }
 
 func (h LabelsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/api/manifest.go
+++ b/api/manifest.go
@@ -39,9 +39,9 @@ func apiManifestHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func getManifest(log shared.Logger, manifestAPI manifest.API, sha string, paths []string) (string, []byte, error) {
-	mc := manifestAPI.NewMemcache(time.Hour * 48)
+	mc := manifestAPI.NewRedis(time.Hour * 48)
 	// Shorter expiry for latest SHA, to keep it current.
-	latestMC := manifestAPI.NewMemcache(time.Minute * 5)
+	latestMC := manifestAPI.NewRedis(time.Minute * 5)
 
 	var body []byte
 

--- a/api/manifest/api.go
+++ b/api/manifest/api.go
@@ -25,7 +25,7 @@ var AssetRegex = regexp.MustCompile(`^MANIFEST-([0-9a-fA-F]{40}).json.gz$`)
 // API handles manifest-related fetches and caching.
 type API interface {
 	GetManifestForSHA(string) (string, []byte, error)
-	NewMemcache(duration time.Duration) shared.ReadWritable
+	NewRedis(duration time.Duration) shared.ReadWritable
 }
 
 type apiImpl struct {
@@ -104,7 +104,7 @@ func getGitHubReleaseAssetForSHA(aeAPI shared.AppEngineAPI, sha string) (fetched
 	return "", nil, fmt.Errorf("No manifest asset found for release %s", releaseTag)
 }
 
-// NewMemcache creates a new MemcacheReadWritable with the given duration.
-func (a apiImpl) NewMemcache(duration time.Duration) shared.ReadWritable {
+// NewRedis creates a new MemcacheReadWritable with the given duration.
+func (a apiImpl) NewRedis(duration time.Duration) shared.ReadWritable {
 	return shared.NewRedisReadWritable(a.ctx, duration)
 }

--- a/api/manifest/api.go
+++ b/api/manifest/api.go
@@ -104,7 +104,7 @@ func getGitHubReleaseAssetForSHA(aeAPI shared.AppEngineAPI, sha string) (fetched
 	return "", nil, fmt.Errorf("No manifest asset found for release %s", releaseTag)
 }
 
-// NewRedis creates a new MemcacheReadWritable with the given duration.
+// NewRedis creates a new redisReadWritable with the given duration.
 func (a apiImpl) NewRedis(duration time.Duration) shared.ReadWritable {
 	return shared.NewRedisReadWritable(a.ctx, duration)
 }

--- a/api/manifest/api.go
+++ b/api/manifest/api.go
@@ -106,5 +106,5 @@ func getGitHubReleaseAssetForSHA(aeAPI shared.AppEngineAPI, sha string) (fetched
 
 // NewMemcache creates a new MemcacheReadWritable with the given duration.
 func (a apiImpl) NewMemcache(duration time.Duration) shared.ReadWritable {
-	return shared.NewMemcacheReadWritable(a.ctx, duration)
+	return shared.NewRedisReadWritable(a.ctx, duration)
 }

--- a/api/manifest/mock_manifest/api_mock.go
+++ b/api/manifest/mock_manifest/api_mock.go
@@ -50,16 +50,16 @@ func (mr *MockAPIMockRecorder) GetManifestForSHA(arg0 interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetManifestForSHA", reflect.TypeOf((*MockAPI)(nil).GetManifestForSHA), arg0)
 }
 
-// NewMemcache mocks base method
-func (m *MockAPI) NewMemcache(arg0 time.Duration) shared.ReadWritable {
+// NewRedis mocks base method
+func (m *MockAPI) NewRedis(arg0 time.Duration) shared.ReadWritable {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewMemcache", arg0)
+	ret := m.ctrl.Call(m, "NewRedis", arg0)
 	ret0, _ := ret[0].(shared.ReadWritable)
 	return ret0
 }
 
-// NewMemcache indicates an expected call of NewMemcache
-func (mr *MockAPIMockRecorder) NewMemcache(arg0 interface{}) *gomock.Call {
+// NewRedis indicates an expected call of NewRedis
+func (mr *MockAPIMockRecorder) NewRedis(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewMemcache", reflect.TypeOf((*MockAPI)(nil).NewMemcache), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewRedis", reflect.TypeOf((*MockAPI)(nil).NewRedis), arg0)
 }

--- a/api/manifest_test.go
+++ b/api/manifest_test.go
@@ -40,8 +40,8 @@ func TestGetGitHubReleaseAsset_Caches(t *testing.T) {
 		mockLatestMC := sharedtest.NewMockReadWritable(mockCtrl)
 		mockLatestWC := sharedtest.NewMockWriteCloser(t)
 		manifestAPI := mock_manifest.NewMockAPI(mockCtrl)
-		manifestAPI.EXPECT().NewMemcache(time.Hour * 48).Return(mockMC)
-		manifestAPI.EXPECT().NewMemcache(time.Minute * 5).Return(mockLatestMC)
+		manifestAPI.EXPECT().NewRedis(time.Hour * 48).Return(mockMC)
+		manifestAPI.EXPECT().NewRedis(time.Minute * 5).Return(mockLatestMC)
 		gomock.InOrder(
 			mockLatestMC.EXPECT().NewReadCloser("MANIFEST-latest").Return(nil, errNotFound),
 			manifestAPI.EXPECT().GetManifestForSHA("").Return(fullSHA, data, nil),
@@ -69,8 +69,8 @@ func TestGetGitHubReleaseAsset_Caches(t *testing.T) {
 		mockLatestMC := sharedtest.NewMockReadWritable(mockCtrl)
 		mockLatestRC := sharedtest.NewMockReadCloser(t, []byte(fullSHA))
 		manifestAPI := mock_manifest.NewMockAPI(mockCtrl)
-		manifestAPI.EXPECT().NewMemcache(time.Hour * 48).AnyTimes().Return(mockMC)
-		manifestAPI.EXPECT().NewMemcache(time.Minute * 5).AnyTimes().Return(mockLatestMC)
+		manifestAPI.EXPECT().NewRedis(time.Hour * 48).AnyTimes().Return(mockMC)
+		manifestAPI.EXPECT().NewRedis(time.Minute * 5).AnyTimes().Return(mockLatestMC)
 		gomock.InOrder(
 			mockLatestMC.EXPECT().NewReadCloser("MANIFEST-latest").Return(mockLatestRC, nil),
 			mockMC.EXPECT().NewReadCloser("MANIFEST-"+fullSHA).Return(mockRC, nil),
@@ -91,8 +91,8 @@ func TestGetGitHubReleaseAsset_Caches(t *testing.T) {
 		mockRC := sharedtest.NewMockReadCloser(t, []byte(data))
 		mockLatestMC := sharedtest.NewMockReadWritable(mockCtrl)
 		manifestAPI := mock_manifest.NewMockAPI(mockCtrl)
-		manifestAPI.EXPECT().NewMemcache(time.Hour * 48).Return(mockMC)
-		manifestAPI.EXPECT().NewMemcache(time.Minute * 5).Return(mockLatestMC)
+		manifestAPI.EXPECT().NewRedis(time.Hour * 48).Return(mockMC)
+		manifestAPI.EXPECT().NewRedis(time.Minute * 5).Return(mockLatestMC)
 		mockMC.EXPECT().NewReadCloser("MANIFEST-"+fullSHA).Return(mockRC, nil)
 
 		// Load from cache without touching API.

--- a/api/metadata_cache.go
+++ b/api/metadata_cache.go
@@ -28,7 +28,7 @@ func (f webappMetadataFetcher) Fetch() (sha *string, res map[string][]byte, err 
 	log := shared.GetLogger(f.ctx)
 	mCache := shared.NewJSONObjectCache(f.ctx, shared.NewRedisReadWritable(f.ctx, metadataCacheExpiry))
 	if !f.forceUpdate {
-		sha, metadataMap, err := getMetadataFromMemcache(mCache)
+		sha, metadataMap, err := getMetadataFromRedis(mCache)
 		if err == nil {
 			return sha, metadataMap, nil
 		}
@@ -47,7 +47,7 @@ func (f webappMetadataFetcher) Fetch() (sha *string, res map[string][]byte, err 
 		return nil, nil, err
 	}
 
-	if err := fillMetadataToMemcache(mCache, *sha, res); err != nil {
+	if err := fillMetadataToRedis(mCache, *sha, res); err != nil {
 		// This is not a fatal failure.
 		log.Errorf("Error storing metadata to cache: %v", err)
 	}
@@ -55,7 +55,7 @@ func (f webappMetadataFetcher) Fetch() (sha *string, res map[string][]byte, err 
 	return sha, res, nil
 }
 
-func getMetadataFromMemcache(cache shared.ObjectCache) (sha *string, res map[string][]byte, err error) {
+func getMetadataFromRedis(cache shared.ObjectCache) (sha *string, res map[string][]byte, err error) {
 	var metadataSHAMap map[string]map[string][]byte
 	err = cache.Get(metadataCacheKey, &metadataSHAMap)
 	if err != nil {
@@ -76,7 +76,7 @@ func getMetadataFromMemcache(cache shared.ObjectCache) (sha *string, res map[str
 	return sha, metadataSHAMap[*sha], nil
 }
 
-func fillMetadataToMemcache(cache shared.ObjectCache, sha string, metadataByteMap map[string][]byte) error {
+func fillMetadataToRedis(cache shared.ObjectCache, sha string, metadataByteMap map[string][]byte) error {
 	metadataSHAMap := make(map[string]map[string][]byte)
 	metadataSHAMap[sha] = metadataByteMap
 

--- a/api/metadata_cache.go
+++ b/api/metadata_cache.go
@@ -26,7 +26,7 @@ type webappMetadataFetcher struct {
 
 func (f webappMetadataFetcher) Fetch() (sha *string, res map[string][]byte, err error) {
 	log := shared.GetLogger(f.ctx)
-	mCache := shared.NewJSONObjectCache(f.ctx, shared.NewMemcacheReadWritable(f.ctx, metadataCacheExpiry))
+	mCache := shared.NewJSONObjectCache(f.ctx, shared.NewRedisReadWritable(f.ctx, metadataCacheExpiry))
 	if !f.forceUpdate {
 		sha, metadataMap, err := getMetadataFromMemcache(mCache)
 		if err == nil {

--- a/api/query/query.go
+++ b/api/query/query.go
@@ -113,14 +113,14 @@ func (qh queryHandler) loadSummaries(testRuns shared.TestRuns) ([]summary, error
 }
 
 func (qh queryHandler) loadSummary(testRun shared.TestRun) ([]byte, error) {
-	mkey := getMemcacheKey(testRun)
+	mkey := getRedisKey(testRun)
 	url := shared.GetResultsURL(testRun, "")
 	var data []byte
 	err := qh.dataSource.Get(mkey, url, &data)
 	return data, err
 }
 
-func getMemcacheKey(testRun shared.TestRun) string {
+func getRedisKey(testRun shared.TestRun) string {
 	return "RESULTS_SUMMARY-" + strconv.FormatInt(testRun.ID, 10)
 }
 

--- a/api/query/query_test.go
+++ b/api/query/query_test.go
@@ -19,8 +19,8 @@ import (
 	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
 )
 
-func TestGetMemcacheKey(t *testing.T) {
-	assert.Equal(t, "RESULTS_SUMMARY-1", getMemcacheKey(shared.TestRun{
+func TestGetRedisKey(t *testing.T) {
+	assert.Equal(t, "RESULTS_SUMMARY-1", getRedisKey(shared.TestRun{
 		ID: 1,
 	}))
 }
@@ -44,8 +44,8 @@ func TestLoadSummaries_success(t *testing.T) {
 		},
 	}
 	keys := []string{
-		getMemcacheKey(testRuns[0]),
-		getMemcacheKey(testRuns[1]),
+		getRedisKey(testRuns[0]),
+		getRedisKey(testRuns[1]),
 	}
 
 	cachedStore := sharedtest.NewMockCachedStore(mockCtrl)
@@ -94,8 +94,8 @@ func TestLoadSummaries_fail(t *testing.T) {
 		},
 	}
 	keys := []string{
-		getMemcacheKey(testRuns[0]),
-		getMemcacheKey(testRuns[1]),
+		getRedisKey(testRuns[0]),
+		getRedisKey(testRuns[1]),
 	}
 
 	cachedStore := sharedtest.NewMockCachedStore(mockCtrl)

--- a/api/query/search.go
+++ b/api/query/search.go
@@ -53,7 +53,7 @@ func (sh searchHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ctx := sh.api.Context()
-	mc := shared.NewGZReadWritable(shared.NewMemcacheReadWritable(ctx, 48*time.Hour))
+	mc := shared.NewGZReadWritable(shared.NewRedisReadWritable(ctx, 48*time.Hour))
 	qh := queryHandler{
 		store:      shared.NewAppEngineDatastore(ctx, true),
 		dataSource: shared.NewByteCachedStore(ctx, mc, shared.NewHTTPReadable(ctx)),

--- a/api/query/search_medium_test.go
+++ b/api/query/search_medium_test.go
@@ -107,7 +107,7 @@ func TestUnstructuredSearchHandler(t *testing.T) {
 
 	// TODO: This is parroting apiSearchHandler details. Perhaps they should be
 	// abstracted and tested directly.
-	mc := shared.NewGZReadWritable(shared.NewMemcacheReadWritable(ctx, 48*time.Hour))
+	mc := shared.NewGZReadWritable(shared.NewRedisReadWritable(ctx, 48*time.Hour))
 	sh := unstructuredSearchHandler{queryHandler{
 		store:      shared.NewAppEngineDatastore(ctx, false),
 		dataSource: shared.NewByteCachedStore(ctx, mc, cache),
@@ -236,7 +236,7 @@ func TestStructuredSearchHandler_equivalentToUnstructured(t *testing.T) {
 	// TODO: This is parroting apiSearchHandler details. Perhaps they should be
 	// abstracted and tested directly.
 	api := shared.NewAppEngineAPI(ctx)
-	mc := shared.NewGZReadWritable(shared.NewMemcacheReadWritable(ctx, 48*time.Hour))
+	mc := shared.NewGZReadWritable(shared.NewRedisReadWritable(ctx, 48*time.Hour))
 	sh := structuredSearchHandler{
 		queryHandler{
 			store:      shared.NewAppEngineDatastore(ctx, false),
@@ -366,7 +366,7 @@ func TestUnstructuredSearchHandler_doNotCacheEmptyResult(t *testing.T) {
 
 	// TODO: This is parroting apiSearchHandler details. Perhaps they should be
 	// abstracted and tested directly.
-	mc := shared.NewGZReadWritable(shared.NewMemcacheReadWritable(ctx, 48*time.Hour))
+	mc := shared.NewGZReadWritable(shared.NewRedisReadWritable(ctx, 48*time.Hour))
 	sh := unstructuredSearchHandler{
 		queryHandler{
 			store:      shared.NewAppEngineDatastore(ctx, false),
@@ -463,7 +463,7 @@ func TestStructuredSearchHandler_doNotCacheEmptyResult(t *testing.T) {
 	// TODO: This is parroting apiSearchHandler details. Perhaps they should be
 	// abstracted and tested directly.
 	api := shared.NewAppEngineAPI(ctx)
-	mc := shared.NewGZReadWritable(shared.NewMemcacheReadWritable(ctx, 48*time.Hour))
+	mc := shared.NewGZReadWritable(shared.NewRedisReadWritable(ctx, 48*time.Hour))
 	sh := structuredSearchHandler{
 		queryHandler{
 			store:      shared.NewAppEngineDatastore(ctx, false),

--- a/api/shas.go
+++ b/api/shas.go
@@ -23,7 +23,7 @@ type SHAsHandler struct {
 func apiSHAsHandler(w http.ResponseWriter, r *http.Request) {
 	// Serve cached with 5 minute expiry. Delegate to SHAsHandler on cache miss.
 	ctx := r.Context()
-	shared.NewCachingHandler(ctx, SHAsHandler{ctx}, shared.NewGZReadWritable(shared.NewMemcacheReadWritable(ctx, 5*time.Minute)), shared.AlwaysCachable, shared.URLAsCacheKey, shared.CacheStatusOK).ServeHTTP(w, r)
+	shared.NewCachingHandler(ctx, SHAsHandler{ctx}, shared.NewGZReadWritable(shared.NewRedisReadWritable(ctx, 5*time.Minute)), shared.AlwaysCachable, shared.URLAsCacheKey, shared.CacheStatusOK).ServeHTTP(w, r)
 }
 
 func (h SHAsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/api/versions.go
+++ b/api/versions.go
@@ -25,7 +25,7 @@ func apiVersionsHandler(w http.ResponseWriter, r *http.Request) {
 	// Serve cached with 5 minute expiry. Delegate to VersionsHandler on cache
 	// miss.
 	ctx := r.Context()
-	shared.NewCachingHandler(ctx, VersionsHandler{ctx}, shared.NewGZReadWritable(shared.NewMemcacheReadWritable(ctx, 5*time.Minute)), shared.AlwaysCachable, shared.URLAsCacheKey, shared.CacheStatusOK).ServeHTTP(w, r)
+	shared.NewCachingHandler(ctx, VersionsHandler{ctx}, shared.NewGZReadWritable(shared.NewRedisReadWritable(ctx, 5*time.Minute)), shared.AlwaysCachable, shared.URLAsCacheKey, shared.CacheStatusOK).ServeHTTP(w, r)
 }
 
 func (h VersionsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/shared/cache.go
+++ b/shared/cache.go
@@ -20,13 +20,13 @@ import (
 )
 
 var (
-	errNewReadCloserExpectedString        = errors.New("NewReadCloser(arg) expected arg string")
-	errMemcacheWriteCloserWriteAfterClose = errors.New("memcacheWriteCloser: Write() after Close()")
-	errMemcacheInvalidResponseType        = errors.New("memcache: type received from GET is not []byte")
-	errByteCachedStoreExpectedByteSlice   = errors.New("contextualized byte CachedStore expected []byte output arg")
-	errDatastoreObjectStoreExpectedInt64  = errors.New("datastore ObjectStore expected int64 ID")
-	errCacheMiss                          = errors.New("cache miss")
-	errNoRedis                            = errors.New("not connected to redis")
+	errNewReadCloserExpectedString       = errors.New("NewReadCloser(arg) expected arg string")
+	errRedisWriteCloserWriteAfterClose   = errors.New("redisWriteCloser: Write() after Close()")
+	errRedisInvalidResponseType          = errors.New("redis: type received from GET is not []byte")
+	errByteCachedStoreExpectedByteSlice  = errors.New("contextualized byte CachedStore expected []byte output arg")
+	errDatastoreObjectStoreExpectedInt64 = errors.New("datastore ObjectStore expected int64 ID")
+	errCacheMiss                         = errors.New("cache miss")
+	errNoRedis                           = errors.New("not connected to redis")
 )
 
 // Readable is a provider interface for an io.ReadCloser.
@@ -146,20 +146,20 @@ func NewGZReadWritable(delegate ReadWritable) ReadWritable {
 	return gzipReadWritable{delegate}
 }
 
-type memcacheReadWritable struct {
+type redisReadWritable struct {
 	ctx    context.Context
 	expiry time.Duration
 }
 
-type memcacheWriteCloser struct {
-	rw         memcacheReadWritable
+type redisWriteCloser struct {
+	rw         redisReadWritable
 	key        string
 	b          bytes.Buffer
 	hasWritten bool
 	isClosed   bool
 }
 
-func (mc memcacheReadWritable) NewReadCloser(iKey interface{}) (io.ReadCloser, error) {
+func (mc redisReadWritable) NewReadCloser(iKey interface{}) (io.ReadCloser, error) {
 	key, ok := iKey.(string)
 	if !ok {
 		return nil, errNewReadCloserExpectedString
@@ -179,28 +179,28 @@ func (mc memcacheReadWritable) NewReadCloser(iKey interface{}) (io.ReadCloser, e
 	}
 	b, ok := result.([]byte)
 	if !ok {
-		return nil, errMemcacheInvalidResponseType
+		return nil, errRedisInvalidResponseType
 	}
 	return ioutil.NopCloser(bytes.NewReader(b)), nil
 }
 
-func (mc memcacheReadWritable) NewWriteCloser(iKey interface{}) (io.WriteCloser, error) {
+func (mc redisReadWritable) NewWriteCloser(iKey interface{}) (io.WriteCloser, error) {
 	key, ok := iKey.(string)
 	if !ok {
 		return nil, errNewReadCloserExpectedString
 	}
-	return &memcacheWriteCloser{mc, key, bytes.Buffer{}, false, false}, nil
+	return &redisWriteCloser{mc, key, bytes.Buffer{}, false, false}, nil
 }
 
-func (mw *memcacheWriteCloser) Write(p []byte) (n int, err error) {
+func (mw *redisWriteCloser) Write(p []byte) (n int, err error) {
 	mw.hasWritten = true
 	if mw.isClosed {
-		return 0, errMemcacheWriteCloserWriteAfterClose
+		return 0, errRedisWriteCloserWriteAfterClose
 	}
 	return mw.b.Write(p)
 }
 
-func (mw *memcacheWriteCloser) Close() error {
+func (mw *redisWriteCloser) Close() error {
 	mw.isClosed = true
 	if Clients.redisPool == nil || !mw.hasWritten {
 		return nil
@@ -213,10 +213,10 @@ func (mw *memcacheWriteCloser) Close() error {
 	return err
 }
 
-// NewMemcacheReadWritable produces a ReadWritable that performs read/write
-// operations via the App Engine memcache API through the input context.Context.
-func NewMemcacheReadWritable(ctx context.Context, expiry time.Duration) ReadWritable {
-	return memcacheReadWritable{ctx, expiry}
+// NewRedisReadWritable produces a ReadWritable that performs read/write
+// operations via the App Engine redis API through the input context.Context.
+func NewRedisReadWritable(ctx context.Context, expiry time.Duration) ReadWritable {
+	return redisReadWritable{ctx, expiry}
 }
 
 // CachedStore is a read-only interface that attempts to read from a cache, and

--- a/shared/datastore_cached.go
+++ b/shared/datastore_cached.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-// testRunCacheTTL is the expiration for each test run in Memcache.
+// testRunCacheTTL is the expiration for each test run in Redis.
 var testRunCacheTTL = 48 * time.Hour
 
 type cachedDatastore struct {
@@ -27,7 +27,7 @@ func (d cachedDatastore) Get(k Key, dst interface{}) error {
 		d.ctx,
 		NewJSONObjectCache(d.ctx, NewRedisReadWritable(d.ctx, testRunCacheTTL)),
 		testRunObjectStore{d})
-	return cs.Get(getTestRunMemcacheKey(k.IntID()), k.IntID(), dst)
+	return cs.Get(getTestRunRedisKey(k.IntID()), k.IntID(), dst)
 }
 
 func (d cachedDatastore) GetMulti(keys []Key, dst interface{}) error {

--- a/shared/datastore_cached.go
+++ b/shared/datastore_cached.go
@@ -25,7 +25,7 @@ func (d cachedDatastore) Get(k Key, dst interface{}) error {
 
 	cs := NewObjectCachedStore(
 		d.ctx,
-		NewJSONObjectCache(d.ctx, NewMemcacheReadWritable(d.ctx, testRunCacheTTL)),
+		NewJSONObjectCache(d.ctx, NewRedisReadWritable(d.ctx, testRunCacheTTL)),
 		testRunObjectStore{d})
 	return cs.Get(getTestRunMemcacheKey(k.IntID()), k.IntID(), dst)
 }

--- a/shared/datastore_cloud.go
+++ b/shared/datastore_cloud.go
@@ -29,7 +29,7 @@ func (k cloudKey) Kind() string {
 }
 
 // NewAppEngineDatastore creates a Datastore implementation, or a Datastore
-// implementation with Memcache in front to cache all TestRun reads if cached
+// implementation with Redis in front to cache all TestRun reads if cached
 // is true.
 //
 // Both variants (cached or not) are backed by Cloud Datastore SDK, using

--- a/shared/request_caching.go
+++ b/shared/request_caching.go
@@ -166,7 +166,7 @@ func AlwaysCachable(r *http.Request) bool {
 }
 
 // URLAsCacheKey is a helper for returning the request's full URL as a cache key.
-// If this string is too long to be a memcache key then writes to memcache will fail,
+// If this string is too long to be a redis key then writes to redis will fail,
 // but that is not a big concern; it simply means that requests for cacheable long
 // URLs will not be cached.
 func URLAsCacheKey(r *http.Request) interface{} {

--- a/shared/test_run_query.go
+++ b/shared/test_run_query.go
@@ -416,6 +416,6 @@ func VersionPrefix(query Query, fieldName, versionPrefix string, desc bool) Quer
 		Filter(fieldName+" <=", fmt.Sprintf("%s.%c", versionPrefix, '9'+1))
 }
 
-func getTestRunMemcacheKey(id int64) string {
+func getTestRunRedisKey(id int64) string {
 	return "TEST_RUN-" + strconv.FormatInt(id, 10)
 }


### PR DESCRIPTION
Since go 1.14 migration, we have migrated from Memcache to Redis. Rename all occurrences of memcache to redis.