### PR TITLE
[Triage Metadata] Clean orphaned pending metadata in searchcache polling

### DIFF
--- a/api/query/cache/service/app.staging.yaml
+++ b/api/query/cache/service/app.staging.yaml
@@ -17,3 +17,10 @@ liveness_check:
 
 readiness_check:
   path: "/_ah/readiness_check"
+
+network:
+  name: default
+
+env_variables:
+  REDISHOST: "10.171.142.203"
+  REDISPORT: "6379"

--- a/api/query/cache/service/app.yaml
+++ b/api/query/cache/service/app.yaml
@@ -21,3 +21,10 @@ liveness_check:
 
 readiness_check:
   path: "/_ah/readiness_check"
+
+network:
+  name: default
+
+env_variables:
+  REDISHOST: "10.171.142.203"
+  REDISPORT: "6379"

--- a/api/query/cache/service/main.go
+++ b/api/query/cache/service/main.go
@@ -141,10 +141,6 @@ func main() {
 	// after backfilling was started.
 	go poll.KeepRunsUpdated(store, logger, *updateInterval, *updateMaxRuns, idx)
 
-	var netClient = &http.Client{
-		Timeout: time.Second * 5,
-	}
-
 	// Initializes clients.
 	if err = shared.Clients.Init(context.Background()); err != nil {
 		logrus.Fatalf("Failed to initialize Google Cloud clients: %v", err)
@@ -152,7 +148,7 @@ func main() {
 	defer shared.Clients.Close()
 
 	// Polls Metadata update every 10 minutes.
-	go poll.KeepMetadataUpdated(netClient, logger, time.Minute*10)
+	go poll.MetadataPollingService(context.Background(), logger, time.Minute*10)
 
 	http.HandleFunc("/_ah/liveness_check", livenessCheckHandler)
 	http.HandleFunc("/_ah/readiness_check", readinessCheckHandler)

--- a/api/query/cache/service/main.go
+++ b/api/query/cache/service/main.go
@@ -148,7 +148,7 @@ func main() {
 	defer shared.Clients.Close()
 
 	// Polls Metadata update every 10 minutes.
-	go poll.MetadataPollingService(context.Background(), logger, time.Minute*10)
+	go poll.StartMetadataPollingService(context.Background(), logger, time.Minute*10)
 
 	http.HandleFunc("/_ah/liveness_check", livenessCheckHandler)
 	http.HandleFunc("/_ah/readiness_check", readinessCheckHandler)

--- a/shared/cache.go
+++ b/shared/cache.go
@@ -434,6 +434,19 @@ func FlushCache() error {
 	return err
 }
 
+// DeleteCache deletes the object stored at key in Redis.
+// A key is ignored if it does not exist.
+func DeleteCache(key string) error {
+	if Clients.redisPool == nil {
+		return errNoRedis
+	}
+	conn := Clients.redisPool.Get()
+	defer conn.Close()
+	// https://redis.io/commands/del
+	_, err := conn.Do("DEL", key)
+	return err
+}
+
 // RedisSet is an interface for an redisSetReadWritable,
 // which performs Add/Remove/GetAll operations via the App Engine Redis API.
 type RedisSet interface {

--- a/shared/metadata_util.go
+++ b/shared/metadata_util.go
@@ -27,8 +27,11 @@ const PendingMetadataCacheKey = "WPT-PENDING-METADATA"
 // stored in Redis.
 const PendingMetadataCachePrefix = "PENDING-PR-"
 
-const sourceOwner string = "web-platform-tests"
-const sourceRepo string = "wpt-metadata"
+// SourceOwner is the owner name of the wpt-metadata repo.
+const SourceOwner string = "web-platform-tests"
+
+// SourceRepo is the wpt-metadata repo.
+const SourceRepo string = "wpt-metadata"
 const baseBranch string = "master"
 
 // MetadataFetcher is an abstract interface that encapsulates the Fetch() method. Fetch() fetches metadata
@@ -39,7 +42,7 @@ type MetadataFetcher interface {
 
 // GetWPTMetadataMasterSHA returns the SHA of the master branch of the wpt-metadata repo.
 func GetWPTMetadataMasterSHA(ctx context.Context, gitHubClient *github.Client) (*string, error) {
-	baseRef, _, err := gitHubClient.Git.GetRef(ctx, sourceOwner, sourceRepo, "refs/heads/"+baseBranch)
+	baseRef, _, err := gitHubClient.Git.GetRef(ctx, SourceOwner, SourceRepo, "refs/heads/"+baseBranch)
 	if err != nil {
 		return nil, err
 	}

--- a/shared/triage_metadata.go
+++ b/shared/triage_metadata.go
@@ -68,16 +68,16 @@ func getNewCommitBranchName(ctx context.Context, client *github.Client, sourceOw
 }
 
 func getWptmetadataGitHubInfo(ctx context.Context, client *github.Client) wptmetadataGitHubInfo {
-	commitBranch := getNewCommitBranchName(ctx, client, sourceOwner, sourceRepo)
+	commitBranch := getNewCommitBranchName(ctx, client, SourceOwner, SourceRepo)
 
 	return wptmetadataGitHubInfo{
-		sourceOwner:   sourceOwner,
-		sourceRepo:    sourceRepo,
+		sourceOwner:   SourceOwner,
+		sourceRepo:    SourceRepo,
 		commitMessage: "Commit New Metadata",
 		commitBranch:  commitBranch,
 		baseBranch:    baseBranch,
-		prRepoOwner:   sourceOwner,
-		prRepo:        sourceRepo,
+		prRepoOwner:   SourceOwner,
+		prRepo:        SourceRepo,
 		prBranch:      baseBranch,
 		prSubject:     "Automatically Triage New Metadata",
 		prDescription: "This metadata PR was generated via the wpt.fyi `/api/metadata/triage` endpoint. See [the documentation](https://github.com/web-platform-tests/wpt.fyi/tree/master/api#apimetadatatriage) for more information about how to use this service."}


### PR DESCRIPTION
Set up Redis in searchcache and remove no longer PRs and their pending metadata from Redis every 10 minutes.

[Instructions to set up Redis](https://cloud.google.com/memorystore/docs/redis/connect-redis-instance-flex). It should share the same Redis memorystore as webapp. 

## Test
Checked the log in staging using https://github.com/web-platform-tests/wpt-metadata/pull/1068
<img width="1373" alt="Screen Shot 2021-03-23 at 12 00 35 AM" src="https://user-images.githubusercontent.com/8611520/112093335-9d341900-8b6f-11eb-895b-9170cb498e95.png">
