### PR TITLE
Update three links to point to main branch instead of master, removing the redirect

### DIFF
--- a/api/receiver/client/client.go
+++ b/api/receiver/client/client.go
@@ -50,7 +50,7 @@ func (c client) CreateRun(
 	resultURLs []string,
 	screenshotURLs []string,
 	labels []string) error {
-	// https://github.com/web-platform-tests/wpt.fyi/blob/master/api/README.md#url-payload
+	// https://github.com/web-platform-tests/wpt.fyi/blob/main/api/README.md#url-payload
 	payload := make(url.Values)
 	// Not to be confused with `revision` in the wpt.fyi TestRun model, this
 	// parameter is the full revision hash.

--- a/webapp/components/test-search.js
+++ b/webapp/components/test-search.js
@@ -360,7 +360,7 @@ class TestSearch extends WPTFlags(PolymerElement) {
              value="{{ queryInput::input }}" placeholder="[[placeholder]]"
              onchange="[[onChange]]" onkeyup="[[onKeyUp]]" onkeydown="[[onKeyDown]]" onfocus="[[onFocus]]" onblur="[[onBlur]]">
       <span class="help">
-        For information on the search syntax, <a href="https://github.com/web-platform-tests/wpt.fyi/blob/master/api/query/README.md">view the search documentation</a>
+        For information on the search syntax, <a href="https://github.com/web-platform-tests/wpt.fyi/blob/main/api/query/README.md">view the search documentation</a>
       </span>
 
       <!-- TODO(markdittmer): Static id will break multiple search components. -->

--- a/webapp/components/wpt-flags.js
+++ b/webapp/components/wpt-flags.js
@@ -312,7 +312,7 @@ class WPTEnvironmentFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ tr
     <paper-item sub-item>
       <paper-checkbox checked="{{onlyChangesAsRegressions}}">
         Only treat C (changed) differences as possible regressions.
-        (<a href="https://github.com/web-platform-tests/wpt.fyi/blob/master/api/README.md#apidiff">See docs for definition</a>)
+        (<a href="https://github.com/web-platform-tests/wpt.fyi/blob/main/api/README.md#apidiff">See docs for definition</a>)
       </paper-checkbox>
     </paper-item>
     <paper-item>


### PR DESCRIPTION
## Description

<!-- A detailed description explaining what your code accomplishes, and why this work is taking place. If this affects an open issue, please make sure to properly reference it. -->

On <https://wpt.fyi/results/> I've noticed when clicking on "[`view the search documentation`](https://github.com/web-platform-tests/wpt.fyi/blob/master/api/query/README.md)" you'll be taken to the documentation, but a banner from GitHub distracts you, telling you've been redirected to the default branch. This PR removes the redirect by directly linking to the main branch (which is the default). I've also changed two other occurrences. The redirect was acknowledged in https://github.com/web-platform-tests/wpt.fyi/issues/2280#issuecomment-737269724, but I thought it would be nicer without it.

There are more links containing master linking to other repos. If you want me to I can check and change those too.

## Review Information

<!-- Provide detailed instructions for how to run the code. -->

Not applicable, code is run as before, no change.

## Changes

<!-- Highlight the files that have changed and group them into concepts, or issues being solved -->

Not really applicable. While the files differ widely, it's only a change to each link.

## Requirements

<!-- Describe any special configurations, environment requirements, or dependencies. -->

Not applicable.
