### PR TITLE
Update more links to point to main branch instead of master (follow up #2497)

### DIFF
--- a/shared/triage_metadata.go
+++ b/shared/triage_metadata.go
@@ -80,7 +80,7 @@ func getWptmetadataGitHubInfo(ctx context.Context, client *github.Client) wptmet
 		prRepo:        SourceRepo,
 		prBranch:      baseBranch,
 		prSubject:     "Automatically Triage New Metadata",
-		prDescription: "This metadata PR was generated via the wpt.fyi `/api/metadata/triage` endpoint. See [the documentation](https://github.com/web-platform-tests/wpt.fyi/tree/master/api#apimetadatatriage) for more information about how to use this service."}
+		prDescription: "This metadata PR was generated via the wpt.fyi `/api/metadata/triage` endpoint. See [the documentation](https://github.com/web-platform-tests/wpt.fyi/tree/main/api#apimetadatatriage) for more information about how to use this service."}
 }
 
 func (tm triageMetadata) getCommitBranchRef(sha *string) (ref *github.Reference, err error) {

--- a/util/docker-dev/run.sh
+++ b/util/docker-dev/run.sh
@@ -79,7 +79,7 @@ set -e
 # -v "${WPTD_PATH}":/wpt.fyi             Mount the repository
 # -u $(id -u $USER)                      Run as current user
 # --cap-add=SYS_ADMIN                    Allow Chrome to use sandbox:
-#   https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md
+#   https://github.com/GoogleChrome/puppeteer/blob/main/docs/troubleshooting.md
 # -p "${WPTD_HOST_WEB_PORT}:8080"        Expose web server port
 # --name "${DOCKER_INSTANCE}"            Name the instance
 # wptd-dev                               Identify image to use


### PR DESCRIPTION
Skipping the PR template this time, sorry 0:-)

Following up #2497, finally.

Checked the [other five](https://github.com/web-platform-tests/wpt.fyi/search?q=%22blob%2Fmaster%22&type=) (as mentioned in https://github.com/web-platform-tests/wpt.fyi/pull/2497#issuecomment-805999071) as well, but those are currently still correct and without redirect. [`"tree/master"`](https://github.com/web-platform-tests/wpt.fyi/search?q=%22tree%2Fmaster%22) was only one.

Guess I was a bit eager because for some reason I thought there would be a lot more.

---

However I found hardcoded `master` while searching. I didn't dig in if thats correct or not (probably is currently correct, since otherwise you surely would have noticed because of failings builds or the like). Maybe just a heads up for the future if you don't already know:

https://github.com/web-platform-tests/wpt.fyi/blob/3f39d6d4eeae8bf9d0ebf2f6d5f2c57bd221fa10/api/azure/api.go#L56-L59

https://github.com/web-platform-tests/wpt.fyi/blob/3f39d6d4eeae8bf9d0ebf2f6d5f2c57bd221fa10/webapp/components/test-runs-query-builder.js#L93

https://github.com/web-platform-tests/wpt.fyi/blob/4fba59edb14eec0ab875429f49128fcdaf5a4ab4/api/checks/summaries/completed.go#L17

And more: <https://github.com/web-platform-tests/wpt.fyi/search?q=master>