### PR TITLE
[Triage Metadata] Validate URL prefix

### DIFF
--- a/webapp/components/wpt-amend-metadata.js
+++ b/webapp/components/wpt-amend-metadata.js
@@ -163,7 +163,7 @@ class AmendMetadata extends LoadingState(PathInfo(ProductInfo(PolymerElement))) 
             <div class="metadata-entry">
               <img class="browser" src="[[displayMetadataLogo(node.product)]]">
               :
-              <paper-input label="Bug URL" value="{{node.url}}" autofocus></paper-input>
+              <paper-input label="Bug URL" value="{{node.url}}" auto-validate pattern="^((http|https):\/\/)[\w.-]+" error-message="Missing http(s):// prefix" autofocus></paper-input>
             </div>
             <template is="dom-repeat" items="[[node.tests]]" as="test">
               <li>


### PR DESCRIPTION
Fix https://github.com/web-platform-tests/wpt.fyi/issues/2215. This change will check if an URL starts `http(s)://`. 

This will also help avoid manually normalizing URLs, e.g. https://github.com/web-platform-tests/wpt-metadata/pull/777