### PR TITLE
Revert "Update dependency @vaadin/vaadin-context-menu to v20"

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1857,72 +1857,19 @@
       }
     },
     "@vaadin/vaadin-context-menu": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-context-menu/-/vaadin-context-menu-20.0.0.tgz",
-      "integrity": "sha512-gFnI/cOi6K1M1D+iCA3s+vycCuei6mhpoL1ME8NaNQjZPUHjSPVUHve9KgZiUrWXcXF9lQbKFr/tjYm+il/Lng==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-context-menu/-/vaadin-context-menu-4.5.0.tgz",
+      "integrity": "sha512-iYQ+xpfWBDV+z7zEXRAoggs+SGNE08KpQ1/LAqRBGvrsVaTCF0CqC845DMQ1mcGd26IqpyABv8JvM4a3XtNR0A==",
       "requires": {
         "@polymer/iron-media-query": "^3.0.0",
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/vaadin-element-mixin": "^20.0.0",
-        "@vaadin/vaadin-item": "^20.0.0",
-        "@vaadin/vaadin-list-box": "^20.0.0",
-        "@vaadin/vaadin-lumo-styles": "^20.0.0",
-        "@vaadin/vaadin-material-styles": "^20.0.0",
-        "@vaadin/vaadin-overlay": "^20.0.0",
-        "@vaadin/vaadin-themable-mixin": "^20.0.0"
-      },
-      "dependencies": {
-        "@vaadin/vaadin-element-mixin": {
-          "version": "20.0.0",
-          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-element-mixin/-/vaadin-element-mixin-20.0.0.tgz",
-          "integrity": "sha512-4Y2ycyB2ZCXndYjWkNtd6kCM417T3l1pkeTdAAsrC/jnZyB8WrR+ld8F+OpnTV968PqhYGvmJRYKOZHtdaDSIA==",
-          "requires": {
-            "@polymer/polymer": "^3.0.0",
-            "@vaadin/vaadin-development-mode-detector": "^2.0.0",
-            "@vaadin/vaadin-usage-statistics": "^2.1.0"
-          }
-        },
-        "@vaadin/vaadin-lumo-styles": {
-          "version": "20.0.0",
-          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-20.0.0.tgz",
-          "integrity": "sha512-FF7uGRfPizLzt0aoIzxBeSarfGyHjKbbeVKbjTQ9+MtSGeQwe5oNcCNqdiafTFEggoPizLhVzXT4MeLLgp0tUw==",
-          "requires": {
-            "@polymer/iron-icon": "^3.0.0",
-            "@polymer/iron-iconset-svg": "^3.0.0",
-            "@polymer/polymer": "^3.0.0",
-            "@vaadin/vaadin-themable-mixin": "^20.0.0"
-          }
-        },
-        "@vaadin/vaadin-material-styles": {
-          "version": "20.0.0",
-          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-material-styles/-/vaadin-material-styles-20.0.0.tgz",
-          "integrity": "sha512-Bq1as93LVYPxhQLmcZyW44QuwAI+E9WYyvsEPe38SVMvP/Z3l6DdYCNoWn9dRSI4gwedDIdDc0XV+pKbxQSP7Q==",
-          "requires": {
-            "@polymer/polymer": "^3.0.0",
-            "@vaadin/vaadin-themable-mixin": "^20.0.0"
-          }
-        },
-        "@vaadin/vaadin-overlay": {
-          "version": "20.0.0",
-          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-overlay/-/vaadin-overlay-20.0.0.tgz",
-          "integrity": "sha512-3EXQOW79Nko9uHE8tIjDXTFXjzTCNfyCiiWanNBGI1LCIdCrFG6YSnKBz/nuk4IvOIEnnhxd7h+0BC/yuBEvKQ==",
-          "requires": {
-            "@polymer/polymer": "^3.0.0",
-            "@vaadin/vaadin-element-mixin": "^20.0.0",
-            "@vaadin/vaadin-lumo-styles": "^20.0.0",
-            "@vaadin/vaadin-material-styles": "^20.0.0",
-            "@vaadin/vaadin-themable-mixin": "^20.0.0"
-          }
-        },
-        "@vaadin/vaadin-themable-mixin": {
-          "version": "20.0.0",
-          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-20.0.0.tgz",
-          "integrity": "sha512-T7p7//jC7434g9vjttdHYXGF9qQMWyAELyogYW91iyqtSH+WZ7nIBxs/gZGwxMi56FsEF2v8BKE20+OEG4QNHA==",
-          "requires": {
-            "@polymer/polymer": "^3.0.0",
-            "lit-element": "^2.0.0"
-          }
-        }
+        "@vaadin/vaadin-element-mixin": "^2.4.1",
+        "@vaadin/vaadin-item": "^2.3.0",
+        "@vaadin/vaadin-list-box": "^1.4.0",
+        "@vaadin/vaadin-lumo-styles": "^1.6.0",
+        "@vaadin/vaadin-material-styles": "^1.3.2",
+        "@vaadin/vaadin-overlay": "^3.5.0",
+        "@vaadin/vaadin-themable-mixin": "^1.6.1"
       }
     },
     "@vaadin/vaadin-control-state-mixin": {
@@ -2047,132 +1994,38 @@
       }
     },
     "@vaadin/vaadin-item": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-item/-/vaadin-item-20.0.0.tgz",
-      "integrity": "sha512-43PZLx07irAO104nvAfUmOi4i3J46ioAVHELx2Vtgd+5b9hxQz7DFEoukTf0/eByFxDQz+OyfhkKnufjZrzHlw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-item/-/vaadin-item-2.3.0.tgz",
+      "integrity": "sha512-hG1MQ8cLaFlsoqSZFm8bqXrHxMry6vtkJrpiXArxpaZXMwPkJnfrUT3D6Qm/NG/rZHvOzZa5U/1k5+dyledlHA==",
       "requires": {
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/vaadin-element-mixin": "^20.0.0",
-        "@vaadin/vaadin-lumo-styles": "^20.0.0",
-        "@vaadin/vaadin-material-styles": "^20.0.0",
-        "@vaadin/vaadin-themable-mixin": "^20.0.0"
-      },
-      "dependencies": {
-        "@vaadin/vaadin-element-mixin": {
-          "version": "20.0.0",
-          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-element-mixin/-/vaadin-element-mixin-20.0.0.tgz",
-          "integrity": "sha512-4Y2ycyB2ZCXndYjWkNtd6kCM417T3l1pkeTdAAsrC/jnZyB8WrR+ld8F+OpnTV968PqhYGvmJRYKOZHtdaDSIA==",
-          "requires": {
-            "@polymer/polymer": "^3.0.0",
-            "@vaadin/vaadin-development-mode-detector": "^2.0.0",
-            "@vaadin/vaadin-usage-statistics": "^2.1.0"
-          }
-        },
-        "@vaadin/vaadin-lumo-styles": {
-          "version": "20.0.0",
-          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-20.0.0.tgz",
-          "integrity": "sha512-FF7uGRfPizLzt0aoIzxBeSarfGyHjKbbeVKbjTQ9+MtSGeQwe5oNcCNqdiafTFEggoPizLhVzXT4MeLLgp0tUw==",
-          "requires": {
-            "@polymer/iron-icon": "^3.0.0",
-            "@polymer/iron-iconset-svg": "^3.0.0",
-            "@polymer/polymer": "^3.0.0",
-            "@vaadin/vaadin-themable-mixin": "^20.0.0"
-          }
-        },
-        "@vaadin/vaadin-material-styles": {
-          "version": "20.0.0",
-          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-material-styles/-/vaadin-material-styles-20.0.0.tgz",
-          "integrity": "sha512-Bq1as93LVYPxhQLmcZyW44QuwAI+E9WYyvsEPe38SVMvP/Z3l6DdYCNoWn9dRSI4gwedDIdDc0XV+pKbxQSP7Q==",
-          "requires": {
-            "@polymer/polymer": "^3.0.0",
-            "@vaadin/vaadin-themable-mixin": "^20.0.0"
-          }
-        },
-        "@vaadin/vaadin-themable-mixin": {
-          "version": "20.0.0",
-          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-20.0.0.tgz",
-          "integrity": "sha512-T7p7//jC7434g9vjttdHYXGF9qQMWyAELyogYW91iyqtSH+WZ7nIBxs/gZGwxMi56FsEF2v8BKE20+OEG4QNHA==",
-          "requires": {
-            "@polymer/polymer": "^3.0.0",
-            "lit-element": "^2.0.0"
-          }
-        }
+        "@vaadin/vaadin-element-mixin": "^2.4.1",
+        "@vaadin/vaadin-lumo-styles": "^1.1.0",
+        "@vaadin/vaadin-material-styles": "^1.1.0",
+        "@vaadin/vaadin-themable-mixin": "^1.6.1"
       }
     },
     "@vaadin/vaadin-list-box": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-list-box/-/vaadin-list-box-20.0.0.tgz",
-      "integrity": "sha512-q8hEUe2Rs6GY0Ic9Y6LxJoxDkt/Fpg4/OOknP1j1u8Sx7oihG5GFZvDpacPHRgOQ3CmPhzCpcPisxnKirwnaTQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-list-box/-/vaadin-list-box-1.4.0.tgz",
+      "integrity": "sha512-G/BT1CYmZ+8AmQN2koNAxdPmw9iQkYxurN0V5VV/W0/rTfZY54hSpaIOIUpzXvkyS/oayClC3Cpe7bfR8W5Ueg==",
       "requires": {
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/vaadin-element-mixin": "^20.0.0",
-        "@vaadin/vaadin-item": "^20.0.0",
-        "@vaadin/vaadin-list-mixin": "^20.0.0",
-        "@vaadin/vaadin-lumo-styles": "^20.0.0",
-        "@vaadin/vaadin-material-styles": "^20.0.0",
-        "@vaadin/vaadin-themable-mixin": "^20.0.0"
-      },
-      "dependencies": {
-        "@vaadin/vaadin-element-mixin": {
-          "version": "20.0.0",
-          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-element-mixin/-/vaadin-element-mixin-20.0.0.tgz",
-          "integrity": "sha512-4Y2ycyB2ZCXndYjWkNtd6kCM417T3l1pkeTdAAsrC/jnZyB8WrR+ld8F+OpnTV968PqhYGvmJRYKOZHtdaDSIA==",
-          "requires": {
-            "@polymer/polymer": "^3.0.0",
-            "@vaadin/vaadin-development-mode-detector": "^2.0.0",
-            "@vaadin/vaadin-usage-statistics": "^2.1.0"
-          }
-        },
-        "@vaadin/vaadin-lumo-styles": {
-          "version": "20.0.0",
-          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-20.0.0.tgz",
-          "integrity": "sha512-FF7uGRfPizLzt0aoIzxBeSarfGyHjKbbeVKbjTQ9+MtSGeQwe5oNcCNqdiafTFEggoPizLhVzXT4MeLLgp0tUw==",
-          "requires": {
-            "@polymer/iron-icon": "^3.0.0",
-            "@polymer/iron-iconset-svg": "^3.0.0",
-            "@polymer/polymer": "^3.0.0",
-            "@vaadin/vaadin-themable-mixin": "^20.0.0"
-          }
-        },
-        "@vaadin/vaadin-material-styles": {
-          "version": "20.0.0",
-          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-material-styles/-/vaadin-material-styles-20.0.0.tgz",
-          "integrity": "sha512-Bq1as93LVYPxhQLmcZyW44QuwAI+E9WYyvsEPe38SVMvP/Z3l6DdYCNoWn9dRSI4gwedDIdDc0XV+pKbxQSP7Q==",
-          "requires": {
-            "@polymer/polymer": "^3.0.0",
-            "@vaadin/vaadin-themable-mixin": "^20.0.0"
-          }
-        },
-        "@vaadin/vaadin-themable-mixin": {
-          "version": "20.0.0",
-          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-20.0.0.tgz",
-          "integrity": "sha512-T7p7//jC7434g9vjttdHYXGF9qQMWyAELyogYW91iyqtSH+WZ7nIBxs/gZGwxMi56FsEF2v8BKE20+OEG4QNHA==",
-          "requires": {
-            "@polymer/polymer": "^3.0.0",
-            "lit-element": "^2.0.0"
-          }
-        }
+        "@vaadin/vaadin-element-mixin": "^2.4.1",
+        "@vaadin/vaadin-item": "^2.3.0",
+        "@vaadin/vaadin-list-mixin": "^2.5.0",
+        "@vaadin/vaadin-lumo-styles": "^1.1.0",
+        "@vaadin/vaadin-material-styles": "^1.1.0",
+        "@vaadin/vaadin-themable-mixin": "^1.6.1"
       }
     },
     "@vaadin/vaadin-list-mixin": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-list-mixin/-/vaadin-list-mixin-20.0.0.tgz",
-      "integrity": "sha512-vVKq6K90UtotAXLLjP9FuInp1DAY1Uy0W2eC1zo2ymf2zdZtdtI5vV/bbeivk2irbiHjNP/abvymQhV2E4FHhQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-list-mixin/-/vaadin-list-mixin-2.5.0.tgz",
+      "integrity": "sha512-NyQMJZ4sQ35gQxCOdoeBbGW2ou+MfqZRc9DSWotVgJheusRCV7wMHqUmKU/KyFa/IQ8ZoxWbVPdap8I9hyMKfA==",
       "requires": {
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/vaadin-element-mixin": "^20.0.0"
-      },
-      "dependencies": {
-        "@vaadin/vaadin-element-mixin": {
-          "version": "20.0.0",
-          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-element-mixin/-/vaadin-element-mixin-20.0.0.tgz",
-          "integrity": "sha512-4Y2ycyB2ZCXndYjWkNtd6kCM417T3l1pkeTdAAsrC/jnZyB8WrR+ld8F+OpnTV968PqhYGvmJRYKOZHtdaDSIA==",
-          "requires": {
-            "@polymer/polymer": "^3.0.0",
-            "@vaadin/vaadin-development-mode-detector": "^2.0.0",
-            "@vaadin/vaadin-usage-statistics": "^2.1.0"
-          }
-        }
+        "@vaadin/vaadin-element-mixin": "^2.4.1"
       }
     },
     "@vaadin/vaadin-lumo-styles": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -68,7 +68,7 @@
     "@polymer/paper-toggle-button": "3.0.1",
     "@polymer/paper-tooltip": "3.0.1",
     "@polymer/polymer": "3.4.1",
-    "@vaadin/vaadin-context-menu": "20.0.0",
+    "@vaadin/vaadin-context-menu": "4.5.0",
     "@vaadin/vaadin-date-picker": "4.4.1",
     "@vaadin/vaadin-grid": "20.0.0",
     "@webcomponents/webcomponentsjs": "2.5.0",


### PR DESCRIPTION
Reverts web-platform-tests/wpt.fyi#2549. Fix #2411. This upgrade causes the following error on the status page

Uncaught TypeError: Failed to resolve module specifier "lit-element". Relative references must start with either "/", "./", or "../".