### PR TITLE
Revert "Update dependency @vaadin/vaadin-grid to v20"

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -1795,65 +1795,16 @@
       }
     },
     "@vaadin/vaadin-checkbox": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-checkbox/-/vaadin-checkbox-20.0.0.tgz",
-      "integrity": "sha512-VWA1JMJZg6bk6Vdk40RPFxPCT2iILfUgC5C/gLXAJ64kP7szSmGM/Lo8KSXdxhtW3joKMiCfpS5Y9pxlngU9Vw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-checkbox/-/vaadin-checkbox-2.5.0.tgz",
+      "integrity": "sha512-56DsET7CTvqVsVPNKuGdUuCY+uxyUydRZSf6V6yyaRSNFA3zKWJQ6ixzIxiXSR91fnpVXA75j1+GnLsnVfvV3A==",
       "requires": {
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/vaadin-control-state-mixin": "^20.0.0",
-        "@vaadin/vaadin-element-mixin": "^20.0.0",
-        "@vaadin/vaadin-lumo-styles": "^20.0.0",
-        "@vaadin/vaadin-material-styles": "^20.0.0",
-        "@vaadin/vaadin-themable-mixin": "^20.0.0"
-      },
-      "dependencies": {
-        "@vaadin/vaadin-control-state-mixin": {
-          "version": "20.0.0",
-          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-control-state-mixin/-/vaadin-control-state-mixin-20.0.0.tgz",
-          "integrity": "sha512-ePsXrlzRnbQiWQElfiRJXVVpWm+DB8D5w/fE3mKtjlmatsx+oYY/PvMSlfaYkuhUyTPHbkV8lhNFHpWUmkgKVg==",
-          "requires": {
-            "@polymer/polymer": "^3.0.0"
-          }
-        },
-        "@vaadin/vaadin-element-mixin": {
-          "version": "20.0.0",
-          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-element-mixin/-/vaadin-element-mixin-20.0.0.tgz",
-          "integrity": "sha512-4Y2ycyB2ZCXndYjWkNtd6kCM417T3l1pkeTdAAsrC/jnZyB8WrR+ld8F+OpnTV968PqhYGvmJRYKOZHtdaDSIA==",
-          "requires": {
-            "@polymer/polymer": "^3.0.0",
-            "@vaadin/vaadin-development-mode-detector": "^2.0.0",
-            "@vaadin/vaadin-usage-statistics": "^2.1.0"
-          }
-        },
-        "@vaadin/vaadin-lumo-styles": {
-          "version": "20.0.0",
-          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-20.0.0.tgz",
-          "integrity": "sha512-FF7uGRfPizLzt0aoIzxBeSarfGyHjKbbeVKbjTQ9+MtSGeQwe5oNcCNqdiafTFEggoPizLhVzXT4MeLLgp0tUw==",
-          "requires": {
-            "@polymer/iron-icon": "^3.0.0",
-            "@polymer/iron-iconset-svg": "^3.0.0",
-            "@polymer/polymer": "^3.0.0",
-            "@vaadin/vaadin-themable-mixin": "^20.0.0"
-          }
-        },
-        "@vaadin/vaadin-material-styles": {
-          "version": "20.0.0",
-          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-material-styles/-/vaadin-material-styles-20.0.0.tgz",
-          "integrity": "sha512-Bq1as93LVYPxhQLmcZyW44QuwAI+E9WYyvsEPe38SVMvP/Z3l6DdYCNoWn9dRSI4gwedDIdDc0XV+pKbxQSP7Q==",
-          "requires": {
-            "@polymer/polymer": "^3.0.0",
-            "@vaadin/vaadin-themable-mixin": "^20.0.0"
-          }
-        },
-        "@vaadin/vaadin-themable-mixin": {
-          "version": "20.0.0",
-          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-20.0.0.tgz",
-          "integrity": "sha512-T7p7//jC7434g9vjttdHYXGF9qQMWyAELyogYW91iyqtSH+WZ7nIBxs/gZGwxMi56FsEF2v8BKE20+OEG4QNHA==",
-          "requires": {
-            "@polymer/polymer": "^3.0.0",
-            "lit-element": "^2.0.0"
-          }
-        }
+        "@vaadin/vaadin-control-state-mixin": "^2.2.1",
+        "@vaadin/vaadin-element-mixin": "^2.4.1",
+        "@vaadin/vaadin-lumo-styles": "^1.4.1",
+        "@vaadin/vaadin-material-styles": "^1.2.0",
+        "@vaadin/vaadin-themable-mixin": "^1.6.1"
       }
     },
     "@vaadin/vaadin-context-menu": {
@@ -1969,81 +1920,21 @@
       }
     },
     "@vaadin/vaadin-grid": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-grid/-/vaadin-grid-20.0.0.tgz",
-      "integrity": "sha512-wrdrf/8D+R1WgalxrNs2YWIiiH8ovSR3hdNtjO2mzq1xDO4xOgD+U6TtH6bcsGfwdallaYm1wGOcmqqah34pcA==",
+      "version": "5.7.13",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-grid/-/vaadin-grid-5.7.13.tgz",
+      "integrity": "sha512-pkbN2BWefGWayc+bp3C1Vhoz/NvE9TWvARaS4BgoW8j2GgRA9wLY2ldjUgwXou2Awjh9Ow/LBNrqIoZgkhYOHA==",
       "requires": {
+        "@polymer/iron-a11y-announcer": "^3.0.0",
+        "@polymer/iron-a11y-keys-behavior": "^3.0.0",
         "@polymer/iron-resizable-behavior": "^3.0.0",
         "@polymer/iron-scroll-target-behavior": "^3.0.0",
         "@polymer/polymer": "^3.0.0",
-        "@vaadin/vaadin-checkbox": "^20.0.0",
-        "@vaadin/vaadin-element-mixin": "^20.0.0",
-        "@vaadin/vaadin-lumo-styles": "^20.0.0",
-        "@vaadin/vaadin-material-styles": "^20.0.0",
-        "@vaadin/vaadin-text-field": "^20.0.0",
-        "@vaadin/vaadin-themable-mixin": "^20.0.0"
-      },
-      "dependencies": {
-        "@vaadin/vaadin-control-state-mixin": {
-          "version": "20.0.0",
-          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-control-state-mixin/-/vaadin-control-state-mixin-20.0.0.tgz",
-          "integrity": "sha512-ePsXrlzRnbQiWQElfiRJXVVpWm+DB8D5w/fE3mKtjlmatsx+oYY/PvMSlfaYkuhUyTPHbkV8lhNFHpWUmkgKVg==",
-          "requires": {
-            "@polymer/polymer": "^3.0.0"
-          }
-        },
-        "@vaadin/vaadin-element-mixin": {
-          "version": "20.0.0",
-          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-element-mixin/-/vaadin-element-mixin-20.0.0.tgz",
-          "integrity": "sha512-4Y2ycyB2ZCXndYjWkNtd6kCM417T3l1pkeTdAAsrC/jnZyB8WrR+ld8F+OpnTV968PqhYGvmJRYKOZHtdaDSIA==",
-          "requires": {
-            "@polymer/polymer": "^3.0.0",
-            "@vaadin/vaadin-development-mode-detector": "^2.0.0",
-            "@vaadin/vaadin-usage-statistics": "^2.1.0"
-          }
-        },
-        "@vaadin/vaadin-lumo-styles": {
-          "version": "20.0.0",
-          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-20.0.0.tgz",
-          "integrity": "sha512-FF7uGRfPizLzt0aoIzxBeSarfGyHjKbbeVKbjTQ9+MtSGeQwe5oNcCNqdiafTFEggoPizLhVzXT4MeLLgp0tUw==",
-          "requires": {
-            "@polymer/iron-icon": "^3.0.0",
-            "@polymer/iron-iconset-svg": "^3.0.0",
-            "@polymer/polymer": "^3.0.0",
-            "@vaadin/vaadin-themable-mixin": "^20.0.0"
-          }
-        },
-        "@vaadin/vaadin-material-styles": {
-          "version": "20.0.0",
-          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-material-styles/-/vaadin-material-styles-20.0.0.tgz",
-          "integrity": "sha512-Bq1as93LVYPxhQLmcZyW44QuwAI+E9WYyvsEPe38SVMvP/Z3l6DdYCNoWn9dRSI4gwedDIdDc0XV+pKbxQSP7Q==",
-          "requires": {
-            "@polymer/polymer": "^3.0.0",
-            "@vaadin/vaadin-themable-mixin": "^20.0.0"
-          }
-        },
-        "@vaadin/vaadin-text-field": {
-          "version": "20.0.0",
-          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-text-field/-/vaadin-text-field-20.0.0.tgz",
-          "integrity": "sha512-CAm+vbwtu1+z55PgZhJWKnleWlV/y7kIR+qSRFKwDOZNezRlgjJoR2laCuS/fRsGcrMWpUMhImfQRxW1yfuJHw==",
-          "requires": {
-            "@polymer/polymer": "^3.0.0",
-            "@vaadin/vaadin-control-state-mixin": "^20.0.0",
-            "@vaadin/vaadin-element-mixin": "^20.0.0",
-            "@vaadin/vaadin-lumo-styles": "^20.0.0",
-            "@vaadin/vaadin-material-styles": "^20.0.0",
-            "@vaadin/vaadin-themable-mixin": "^20.0.0"
-          }
-        },
-        "@vaadin/vaadin-themable-mixin": {
-          "version": "20.0.0",
-          "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-20.0.0.tgz",
-          "integrity": "sha512-T7p7//jC7434g9vjttdHYXGF9qQMWyAELyogYW91iyqtSH+WZ7nIBxs/gZGwxMi56FsEF2v8BKE20+OEG4QNHA==",
-          "requires": {
-            "@polymer/polymer": "^3.0.0",
-            "lit-element": "^2.0.0"
-          }
-        }
+        "@vaadin/vaadin-checkbox": "^2.4.0",
+        "@vaadin/vaadin-element-mixin": "^2.4.1",
+        "@vaadin/vaadin-lumo-styles": "^1.6.0",
+        "@vaadin/vaadin-material-styles": "^1.3.2",
+        "@vaadin/vaadin-text-field": "^2.7.0",
+        "@vaadin/vaadin-themable-mixin": "^1.6.1"
       }
     },
     "@vaadin/vaadin-item": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -70,7 +70,7 @@
     "@polymer/polymer": "3.4.1",
     "@vaadin/vaadin-context-menu": "20.0.0",
     "@vaadin/vaadin-date-picker": "4.4.1",
-    "@vaadin/vaadin-grid": "20.0.0",
+    "@vaadin/vaadin-grid": "5.7.13",
     "@webcomponents/webcomponentsjs": "2.5.0",
     "pluralize": "8.0.0"
   }


### PR DESCRIPTION
Reverts web-platform-tests/wpt.fyi#2551. Fix #2411. This upgrade causes the following error on the status page

Uncaught TypeError: Failed to resolve module specifier "lit-element". Relative references must start with either "/", "./", or "../".