### PR TITLE
 Increase app_start_timeout_sec in processor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -245,7 +245,7 @@ deploy_staging: git apt-get-jq
 deploy_staging: BRANCH_NAME := $$(git rev-parse --abbrev-ref HEAD)
 deploy_staging: deployment_state var-BRANCH_NAME
 	gcloud config set project wptdashboard-staging
-	if [[ "$(BRANCH_NAME)" == "main" ]]; then \
+	if [[ "$(BRANCH_NAME)" == "refs/heads/main" ]]; then \
 		util/deploy.sh -q -r -p $(APP_PATH); \
 	else \
 		util/deploy.sh -q -b $(BRANCH_NAME) $(APP_PATH); \

--- a/results-processor/app.yaml
+++ b/results-processor/app.yaml
@@ -14,4 +14,4 @@ liveness_check:
 
 readiness_check:
   path: "/_ah/readiness_check"
-  app_start_timeout_sec: 60
+  app_start_timeout_sec: 300

--- a/util/deploy-staging.sh
+++ b/util/deploy-staging.sh
@@ -4,7 +4,7 @@
 # from GitHub Actions. Also see deploy.sh
 
 usage() {
-  USAGE="Usage: travis-staging-deploy.sh [-f] [app path]
+  USAGE="Usage: deploy-staging.sh [-f] [app path]
     -f : Always deploy (even if no changes detected)
     app path: wpt.fyi relative path for the app, e.g. \"webapp\""
   echo "${USAGE}"

--- a/util/deploy-staging.sh
+++ b/util/deploy-staging.sh
@@ -51,8 +51,9 @@ docker exec -t -u $(id -u $USER):$(id -g $USER) "${DOCKER_INSTANCE}" \
 if [ "${EXIT_CODE:=${PIPESTATUS[0]}}" != "0" ]; then exit ${EXIT_CODE}; fi
 DEPLOYED_URL=$(tr -d "\r" < ${TEMP_FILE} | sed -ne 's/^Deployed service.*to \[\(.*\)\]$/\1/p')
 
+# TODO(kyle): Fix deploy-comment.sh; rewrite to GitHub Actions equivalent.
 # Add a GitHub comment to the PR (if there is a PR).
-if [[ -n "${GITHUB_HEAD_REF}" ]];
-then
-  ${UTIL_DIR}/deploy-comment.sh -e "${APP_PATH}" "${DEPLOYED_URL}";
-fi
+#if [[ -n "${GITHUB_HEAD_REF}" ]];
+#then
+#  ${UTIL_DIR}/deploy-comment.sh -e "${APP_PATH}" "${DEPLOYED_URL}";
+#fi


### PR DESCRIPTION
Follow up for #2560. Increase the timeout to 300 seconds according to [the official doc](https://cloud.google.com/endpoints/docs/openapi/troubleshoot-aeflex-deployment)

[Latest processor deployment] has errors:

ERROR: (gcloud.app.deploy) Error Response: [4] Flex operation projects/wptdashboard-staging/regions/us-east4/operations/7aaf2005-f08f-469b-a1fc-8bdbd82b318d error [DEADLINE_EXCEEDED]: An internal error occurred while processing task /app-engine-flex/flex_await_healthy/flex_await_healthy>2021-06-30T03:13:09.949Z3699.xi.0: Your deployment has failed to become healthy in the allotted time and therefore was rolled back. If you believe this was an error, try adjusting the 'app_start_timeout_sec' setting in the 'readiness_check' section.

Also fix the deployment VERSION on the main branch. It should compare `refs/heads/main` instead. See [here](https://github.com/web-platform-tests/wpt.fyi/runs/2948394952#step:10:220)