### PR TITLE
[Searchcache] Increase memory_gb to 10

### DIFF
--- a/api/query/cache/service/app.staging.yaml
+++ b/api/query/cache/service/app.staging.yaml
@@ -7,7 +7,7 @@ service: searchcache
 
 resources:
   cpu: 2
-  memory_gb: 8
+  memory_gb: 10
 
 manual_scaling:
   instances: 1


### PR DESCRIPTION
An attempt to fix https://github.com/web-platform-tests/wpt.fyi/issues/2617#issuecomment-930601372.

The max available memory_gb is [cpu * [0.9 - 6.5] - 0.4 = 2*6.5 - 0.4 = 12.6GB.](https://cloud.google.com/appengine/docs/flexible/nodejs/reference/app-yaml#resource-settings)