### PR TITLE
[Searchcache] Increase memory_gb to 12.5

### DIFF
--- a/api/query/cache/service/app.staging.yaml
+++ b/api/query/cache/service/app.staging.yaml
@@ -7,7 +7,7 @@ service: searchcache
 
 resources:
   cpu: 2
-  memory_gb: 10
+  memory_gb: 12.5
 
 manual_scaling:
   instances: 1


### PR DESCRIPTION
Increase memory_gb to 12.5 (FloorToNearest to the nearest 256MB)

The max available memory_gb is cpu * [0.9 - 6.5] - 0.4 = 2*6.5 - 0.4 = 12.6GB.