### PR TITLE
Add support for arbitrary labeling of tests  

### DIFF
--- a/api/metadata_handler_test.go
+++ b/api/metadata_handler_test.go
@@ -196,7 +196,7 @@ func TestHandleMetadataTriage_InvalidProduct(t *testing.T) {
             {
                 "product":"foobar",
                 "url":"bugs.bar",
-                "results":[{"status":6}]
+                "results":[{"status":6, "label":labelA}]
             }
         ]}`
 	bodyReader := strings.NewReader(body)

--- a/api/query/README.md
+++ b/api/query/README.md
@@ -344,7 +344,7 @@ regardless of browsers.
 
     {"testlabel": label}
 
-Where label is a string.
+Where label is a string and case-insensitive.
 
  E.g.
 

--- a/api/query/README.md
+++ b/api/query/README.md
@@ -337,6 +337,21 @@ Search triaged Chrome tests -
 
     chrome:pass and triaged:chrome
 
+#### testlabel
+
+`testlabel` query atoms perform a search for tests that have a matching metadata label,
+regardless of browsers.
+
+    {"testlabel": label}
+
+Where label is a string.
+
+ E.g.
+
+Search triaged tests with a label interop2020 -
+
+    testlabel:interop2020
+
 #### is
 
 `is` query atoms perform a search for tests that possess some meta quality.

--- a/api/query/README.md
+++ b/api/query/README.md
@@ -337,12 +337,12 @@ Search triaged Chrome tests -
 
     chrome:pass and triaged:chrome
 
-#### testlabel
+#### label
 
-`testlabel` query atoms perform a search for tests that have a matching metadata label,
+`label` query atoms perform a search for tests that have a matching metadata label,
 regardless of browsers.
 
-    {"testlabel": label}
+    {"label": label}
 
 Where label is a string and case-insensitive.
 
@@ -350,7 +350,7 @@ Where label is a string and case-insensitive.
 
 Search triaged tests with a label interop-2022:
 
-    testlabel:interop-2022
+    label:interop-2022
 
 #### is
 

--- a/api/query/README.md
+++ b/api/query/README.md
@@ -350,7 +350,7 @@ Where label is a string.
 
 Search triaged tests with a label interop-2022:
 
-    testlabel:interop2020
+    testlabel:interop-2022
 
 #### is
 

--- a/api/query/README.md
+++ b/api/query/README.md
@@ -348,7 +348,7 @@ Where label is a string.
 
  E.g.
 
-Search triaged tests with a label interop2020 -
+Search triaged tests with a label interop-2022:
 
     testlabel:interop2020
 

--- a/api/query/atoms.go
+++ b/api/query/atoms.go
@@ -316,8 +316,8 @@ func (t AbstractTriaged) BindToRuns(runs ...shared.TestRun) ConcreteQuery {
 	return Or{cq}
 }
 
-// AbstractTestLabel is represents the root of a testlabel query, which matches Metadata
-// labels to a string.
+// AbstractTestLabel represents the root of a testlabel query, which matches test-level metadata
+// labels to a searched label.
 type AbstractTestLabel struct {
 	Label           string
 	metadataFetcher shared.MetadataFetcher

--- a/api/query/atoms.go
+++ b/api/query/atoms.go
@@ -316,6 +316,30 @@ func (t AbstractTriaged) BindToRuns(runs ...shared.TestRun) ConcreteQuery {
 	return Or{cq}
 }
 
+// AbstractTestLabel is represents the root of a testlabel query, which matches Metadata
+// labels to a string.
+type AbstractTestLabel struct {
+	Label           string
+	metadataFetcher shared.MetadataFetcher
+}
+
+// BindToRuns for AbstractTestLabel fetches test-level metadata; it is independent of test runs.
+func (t AbstractTestLabel) BindToRuns(runs ...shared.TestRun) ConcreteQuery {
+	if t.metadataFetcher == nil {
+		t.metadataFetcher = searchcacheMetadataFetcher{}
+	}
+
+	includeTestLevel := true
+	// Passing []shared.TestRun{} means that we want test-level issues.
+	metadata, _ := shared.GetMetadataResponse([]shared.TestRun{}, includeTestLevel, logrus.StandardLogger(), t.metadataFetcher)
+	metadataMap := shared.PrepareTestLabelFilter(metadata)
+
+	return TestLabel{
+		Label:    t.Label,
+		Metadata: metadataMap,
+	}
+}
+
 // MetadataQuality represents the root of an "is" query, which asserts known
 // metadata qualities to the results
 type MetadataQuality int
@@ -906,6 +930,26 @@ func (l *AbstractLink) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// UnmarshalJSON for AbstractTestLabel attempts to interpret a query atom as
+// {"testlabel":<label string>}.
+func (t *AbstractTestLabel) UnmarshalJSON(b []byte) error {
+	var data map[string]*json.RawMessage
+	if err := json.Unmarshal(b, &data); err != nil {
+		return err
+	}
+	labelMsg, ok := data["testlabel"]
+	if !ok {
+		return errors.New(`Missing testlabel pattern property: "testlabel"`)
+	}
+	var label string
+	if err := json.Unmarshal(*labelMsg, &label); err != nil {
+		return errors.New(`Missing testlabel pattern property "label" is not a string`)
+	}
+
+	t.Label = label
+	return nil
+}
+
 // UnmarshalJSON for AbstractTriaged attempts to interpret a query atom as
 // {"triaged":<browser name>}.
 func (t *AbstractTriaged) UnmarshalJSON(b []byte) error {
@@ -1075,6 +1119,12 @@ func unmarshalQ(b []byte) (AbstractQuery, error) {
 	}
 	{
 		var t AbstractTriaged
+		if err := json.Unmarshal(b, &t); err == nil {
+			return t, nil
+		}
+	}
+	{
+		var t AbstractTestLabel
 		if err := json.Unmarshal(b, &t); err == nil {
 			return t, nil
 		}

--- a/api/query/atoms.go
+++ b/api/query/atoms.go
@@ -931,19 +931,19 @@ func (l *AbstractLink) UnmarshalJSON(b []byte) error {
 }
 
 // UnmarshalJSON for AbstractTestLabel attempts to interpret a query atom as
-// {"testlabel":<label string>}.
+// {"label":<label string>}.
 func (t *AbstractTestLabel) UnmarshalJSON(b []byte) error {
 	var data map[string]*json.RawMessage
 	if err := json.Unmarshal(b, &data); err != nil {
 		return err
 	}
-	labelMsg, ok := data["testlabel"]
+	labelMsg, ok := data["label"]
 	if !ok {
-		return errors.New(`Missing testlabel pattern property: "testlabel"`)
+		return errors.New(`Missing label pattern property: "label"`)
 	}
 	var label string
 	if err := json.Unmarshal(*labelMsg, &label); err != nil {
-		return errors.New(`Property "testlabel" is not a string`)
+		return errors.New(`Property "label" is not a string`)
 	}
 
 	t.Label = label

--- a/api/query/atoms.go
+++ b/api/query/atoms.go
@@ -943,7 +943,7 @@ func (t *AbstractTestLabel) UnmarshalJSON(b []byte) error {
 	}
 	var label string
 	if err := json.Unmarshal(*labelMsg, &label); err != nil {
-		return errors.New(`Missing testlabel pattern property "label" is not a string`)
+		return errors.New(`Property "testlabel" is not a string`)
 	}
 
 	t.Label = label

--- a/api/query/atoms_test.go
+++ b/api/query/atoms_test.go
@@ -487,7 +487,7 @@ func TestStructuredQuery_testlabel(t *testing.T) {
         "run_ids": [0, 1, 2],
         "query": {
             "exists": [{
-                "testlabel": "interop1"
+                "label": "interop1"
             }]
         }
     }`), &rq)
@@ -507,7 +507,7 @@ func TestStructuredQuery_combinedTestlabel(t *testing.T) {
         "query": {
             "exists": [
                 {"pattern": "cssom"},
-                {"testlabel": "interop"}
+                {"label": "interop"}
             ]
         }
     }`), &rq)
@@ -522,8 +522,8 @@ func TestStructuredQuery_andTestLabels(t *testing.T) {
 		"run_ids": [0, 1, 2],
 		"query": {
 			"and": [
-				{"testlabel": "interop1"},
-				{"testlabel": "interop2"}
+				{"label": "interop1"},
+				{"label": "interop2"}
 			]
 		}
 	}`), &rq)

--- a/api/query/atoms_test.go
+++ b/api/query/atoms_test.go
@@ -25,18 +25,18 @@ func TestStructuredQuery_empty(t *testing.T) {
 func TestStructuredQuery_missingRunIDs(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-		"query": {
-			"pattern": "/2dcontext/"
-		}
-	}`), &rq)
+        "query": {
+            "pattern": "/2dcontext/"
+        }
+    }`), &rq)
 	assert.NotNil(t, err)
 }
 
 func TestStructuredQuery_missingQuery(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-		"run_ids": [0, 1, 2]
-	}`), &rq)
+        "run_ids": [0, 1, 2]
+    }`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2}, AbstractQuery: True{}}, rq)
 }
@@ -44,22 +44,22 @@ func TestStructuredQuery_missingQuery(t *testing.T) {
 func TestStructuredQuery_emptyRunIDs(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-		"run_ids": [],
-		"query": {
-			"pattern": "/2dcontext/"
-		}
-	}`), &rq)
+        "run_ids": [],
+        "query": {
+            "pattern": "/2dcontext/"
+        }
+    }`), &rq)
 	assert.NotNil(t, err)
 }
 
 func TestStructuredQuery_emptyBrowserName(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-		"run_ids": [0, 1, 2],
-		"query": {
-			"status": "PASS"
-		}
-	}`), &rq)
+        "run_ids": [0, 1, 2],
+        "query": {
+            "status": "PASS"
+        }
+    }`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2}, AbstractQuery: TestStatusEq{Status: shared.TestStatusValueFromString("PASS")}}, rq)
 }
@@ -67,34 +67,34 @@ func TestStructuredQuery_emptyBrowserName(t *testing.T) {
 func TestStructuredQuery_missingStatus(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-		"run_ids": [0, 1, 2],
-		"query": {
-			"product": "chrome"
-		}
-	}`), &rq)
+        "run_ids": [0, 1, 2],
+        "query": {
+            "product": "chrome"
+        }
+    }`), &rq)
 	assert.NotNil(t, err)
 }
 
 func TestStructuredQuery_badStatus(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-		"run_ids": [0, 1, 2],
-		"query": {
-			"product": "chrome",
-			"status": "NOT_A_REAL_STATUS"
-		}
-	}`), &rq)
+        "run_ids": [0, 1, 2],
+        "query": {
+            "product": "chrome",
+            "status": "NOT_A_REAL_STATUS"
+        }
+    }`), &rq)
 	assert.NotNil(t, err)
 }
 func TestStructuredQuery_unknownStatus(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-		"run_ids": [0, 1, 2],
-		"query": {
-			"product": "chrome",
-			"status": "UNKNOWN"
-		}
-	}`), &rq)
+        "run_ids": [0, 1, 2],
+        "query": {
+            "product": "chrome",
+            "status": "UNKNOWN"
+        }
+    }`), &rq)
 	assert.Nil(t, err)
 	p := shared.ParseProductSpecUnsafe("chrome")
 	assert.Equal(t, RunQuery{
@@ -106,20 +106,20 @@ func TestStructuredQuery_unknownStatus(t *testing.T) {
 func TestStructuredQuery_missingPattern(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-		"run_ids": [0, 1, 2],
-		"query": {}
-	}`), &rq)
+        "run_ids": [0, 1, 2],
+        "query": {}
+    }`), &rq)
 	assert.NotNil(t, err)
 }
 
 func TestStructuredQuery_emptyPattern(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-		"run_ids": [0, 1, 2],
-		"query": {
-			"pattern": ""
-		}
-	}`), &rq)
+        "run_ids": [0, 1, 2],
+        "query": {
+            "pattern": ""
+        }
+    }`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2}, AbstractQuery: TestNamePattern{""}}, rq)
 }
@@ -127,11 +127,11 @@ func TestStructuredQuery_emptyPattern(t *testing.T) {
 func TestStructuredQuery_pattern(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-		"run_ids": [0, 1, 2],
-		"query": {
-			"pattern": "/2dcontext/"
-		}
-	}`), &rq)
+        "run_ids": [0, 1, 2],
+        "query": {
+            "pattern": "/2dcontext/"
+        }
+    }`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2}, AbstractQuery: TestNamePattern{"/2dcontext/"}}, rq)
 }
@@ -139,11 +139,11 @@ func TestStructuredQuery_pattern(t *testing.T) {
 func TestStructuredQuery_subtest(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-		"run_ids": [0, 1, 2],
-		"query": {
-			"subtest": "Subtest name"
-		}
-	}`), &rq)
+        "run_ids": [0, 1, 2],
+        "query": {
+            "subtest": "Subtest name"
+        }
+    }`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2}, AbstractQuery: SubtestNamePattern{"Subtest name"}}, rq)
 }
@@ -151,11 +151,11 @@ func TestStructuredQuery_subtest(t *testing.T) {
 func TestStructuredQuery_path(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-		"run_ids": [0, 1, 2],
-		"query": {
-			"path": "/2dcontext/"
-		}
-	}`), &rq)
+        "run_ids": [0, 1, 2],
+        "query": {
+            "path": "/2dcontext/"
+        }
+    }`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2}, AbstractQuery: TestPath{"/2dcontext/"}}, rq)
 }
@@ -163,12 +163,12 @@ func TestStructuredQuery_path(t *testing.T) {
 func TestStructuredQuery_legacyBrowserName(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-		"run_ids": [0, 1, 2],
-		"query": {
-			"browser_name": "FiReFoX",
-			"status": "PaSs"
-		}
-	}`), &rq)
+        "run_ids": [0, 1, 2],
+        "query": {
+            "browser_name": "FiReFoX",
+            "status": "PaSs"
+        }
+    }`), &rq)
 	assert.Nil(t, err)
 	p := shared.ParseProductSpecUnsafe("firefox")
 	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2},
@@ -179,12 +179,12 @@ func TestStructuredQuery_legacyBrowserName(t *testing.T) {
 func TestStructuredQuery_status(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-		"run_ids": [0, 1, 2],
-		"query": {
-			"product": "FiReFoX",
-			"status": "PaSs"
-		}
-	}`), &rq)
+        "run_ids": [0, 1, 2],
+        "query": {
+            "product": "FiReFoX",
+            "status": "PaSs"
+        }
+    }`), &rq)
 	assert.Nil(t, err)
 	p := shared.ParseProductSpecUnsafe("firefox")
 	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2},
@@ -195,12 +195,12 @@ func TestStructuredQuery_status(t *testing.T) {
 func TestStructuredQuery_statusNeq(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-		"run_ids": [0, 1, 2],
-		"query": {
-			"product": "FiReFoX",
-			"status": {"not": "PaSs"}
-		}
-	}`), &rq)
+        "run_ids": [0, 1, 2],
+        "query": {
+            "product": "FiReFoX",
+            "status": {"not": "PaSs"}
+        }
+    }`), &rq)
 	assert.Nil(t, err)
 	p := shared.ParseProductSpecUnsafe("firefox")
 	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2},
@@ -211,25 +211,25 @@ func TestStructuredQuery_statusNeq(t *testing.T) {
 func TestStructuredQuery_statusUnsupportedAbstractNot(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-		"run_ids": [0, 1, 2],
-		"query": {
-			"product": "FiReFoX",
-			"status": {"not": {"pattern": "cssom"}}
-		}
-	}`), &rq)
+        "run_ids": [0, 1, 2],
+        "query": {
+            "product": "FiReFoX",
+            "status": {"not": {"pattern": "cssom"}}
+        }
+    }`), &rq)
 	assert.NotNil(t, err)
 }
 
 func TestStructuredQuery_not(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-		"run_ids": [0, 1, 2],
-		"query": {
-			"not": {
-				"pattern": "cssom"
-			}
-		}
-	}`), &rq)
+        "run_ids": [0, 1, 2],
+        "query": {
+            "not": {
+                "pattern": "cssom"
+            }
+        }
+    }`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2}, AbstractQuery: AbstractNot{TestNamePattern{"cssom"}}}, rq)
 }
@@ -237,14 +237,14 @@ func TestStructuredQuery_not(t *testing.T) {
 func TestStructuredQuery_or(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-		"run_ids": [0, 1, 2],
-		"query": {
-			"or": [
-				{"pattern": "cssom"},
-				{"pattern": "html"}
-			]
-		}
-	}`), &rq)
+        "run_ids": [0, 1, 2],
+        "query": {
+            "or": [
+                {"pattern": "cssom"},
+                {"pattern": "html"}
+            ]
+        }
+    }`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2}, AbstractQuery: AbstractOr{[]AbstractQuery{TestNamePattern{"cssom"}, TestNamePattern{"html"}}}}, rq)
 }
@@ -252,14 +252,14 @@ func TestStructuredQuery_or(t *testing.T) {
 func TestStructuredQuery_and(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-		"run_ids": [0, 1, 2],
-		"query": {
-			"and": [
-				{"pattern": "cssom"},
-				{"pattern": "html"}
-			]
-		}
-	}`), &rq)
+        "run_ids": [0, 1, 2],
+        "query": {
+            "and": [
+                {"pattern": "cssom"},
+                {"pattern": "html"}
+            ]
+        }
+    }`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2}, AbstractQuery: AbstractAnd{[]AbstractQuery{TestNamePattern{"cssom"}, TestNamePattern{"html"}}}}, rq)
 }
@@ -267,14 +267,14 @@ func TestStructuredQuery_and(t *testing.T) {
 func TestStructuredQuery_exists(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-		"run_ids": [0, 1, 2],
-		"query": {
-			"exists": [
-				{"pattern": "cssom"},
-				{"pattern": "html"}
-			]
-		}
-	}`), &rq)
+        "run_ids": [0, 1, 2],
+        "query": {
+            "exists": [
+                {"pattern": "cssom"},
+                {"pattern": "html"}
+            ]
+        }
+    }`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2}, AbstractQuery: AbstractExists{[]AbstractQuery{TestNamePattern{"cssom"}, TestNamePattern{"html"}}}}, rq)
 }
@@ -282,13 +282,13 @@ func TestStructuredQuery_exists(t *testing.T) {
 func TestStructuredQuery_all(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-		"run_ids": [0, 1, 2],
-		"query": {
-			"all": [
-				{"pattern": "cssom"}
-			]
-		}
-	}`), &rq)
+        "run_ids": [0, 1, 2],
+        "query": {
+            "all": [
+                {"pattern": "cssom"}
+            ]
+        }
+    }`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(t, RunQuery{
 		RunIDs:        []int64{0, 1, 2},
@@ -299,13 +299,13 @@ func TestStructuredQuery_all(t *testing.T) {
 func TestStructuredQuery_none(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-		"run_ids": [0, 1, 2],
-		"query": {
-			"none": [
-				{"pattern": "cssom"}
-			]
-		}
-	}`), &rq)
+        "run_ids": [0, 1, 2],
+        "query": {
+            "none": [
+                {"pattern": "cssom"}
+            ]
+        }
+    }`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(t, RunQuery{
 		RunIDs:        []int64{0, 1, 2},
@@ -316,16 +316,16 @@ func TestStructuredQuery_none(t *testing.T) {
 func TestStructuredQuery_sequential(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-		"run_ids": [0, 1, 2],
-		"query": {
-			"exists": [
-				{ "sequential":[
-					{"or":[{"status":"PASS"},{"status":"OK"}]},
-					{"and":[{"status":{"not":"PASS"}},{"status":{"not":"OK"}},{"status":{"not":"UNKNOWN"}}]}
-				]}
-			]
-		}
-	}`), &rq)
+        "run_ids": [0, 1, 2],
+        "query": {
+            "exists": [
+                { "sequential":[
+                    {"or":[{"status":"PASS"},{"status":"OK"}]},
+                    {"and":[{"status":{"not":"PASS"}},{"status":{"not":"OK"}},{"status":{"not":"UNKNOWN"}}]}
+                ]}
+            ]
+        }
+    }`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(
 		t,
@@ -348,16 +348,16 @@ func TestStructuredQuery_sequential(t *testing.T) {
 func TestStructuredQuery_count(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-		"run_ids": [0, 1, 2],
-		"query": {
-			"exists": [{
-				"count": 3,
-				"where": {
-					"or": [{"status":"PASS"},{"status":"OK"}]
-				}
-			}]
-		}
-	}`), &rq)
+        "run_ids": [0, 1, 2],
+        "query": {
+            "exists": [{
+                "count": 3,
+                "where": {
+                    "or": [{"status":"PASS"},{"status":"OK"}]
+                }
+            }]
+        }
+    }`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(
 		t,
@@ -376,14 +376,14 @@ func TestStructuredQuery_count(t *testing.T) {
 func TestStructuredQuery_moreThan(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-		"run_ids": [0, 1, 2],
-		"query": {
-			"exists": [{
-				"moreThan": 3,
-				"where": {"status":"PASS"}
-			}]
-		}
-	}`), &rq)
+        "run_ids": [0, 1, 2],
+        "query": {
+            "exists": [{
+                "moreThan": 3,
+                "where": {"status":"PASS"}
+            }]
+        }
+    }`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(
 		t,
@@ -401,14 +401,14 @@ func TestStructuredQuery_moreThan(t *testing.T) {
 func TestStructuredQuery_lessThan(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-		"run_ids": [0, 1, 2],
-		"query": {
-			"exists": [{
-				"lessThan": 2,
-				"where": {"status":"PASS"}
-			}]
-		}
-	}`), &rq)
+        "run_ids": [0, 1, 2],
+        "query": {
+            "exists": [{
+                "lessThan": 2,
+                "where": {"status":"PASS"}
+            }]
+        }
+    }`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(
 		t,
@@ -426,13 +426,13 @@ func TestStructuredQuery_lessThan(t *testing.T) {
 func TestStructuredQuery_link(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-		"run_ids": [0, 1, 2],
-		"query": {
-			"exists": [{
-				"link": "chromium.bug.com/abc"
-			}]
-		}
-	}`), &rq)
+        "run_ids": [0, 1, 2],
+        "query": {
+            "exists": [{
+                "link": "chromium.bug.com/abc"
+            }]
+        }
+    }`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2},
 		AbstractQuery: AbstractExists{[]AbstractQuery{
@@ -446,13 +446,13 @@ func TestStructuredQuery_triaged(t *testing.T) {
 	p := shared.ParseProductSpecUnsafe("Chrome")
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-		"run_ids": [0, 1, 2],
-		"query": {
-			"exists": [{
-				"triaged": "chrome"
-			}]
-		}
-	}`), &rq)
+        "run_ids": [0, 1, 2],
+        "query": {
+            "exists": [{
+                "triaged": "chrome"
+            }]
+        }
+    }`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2},
 		AbstractQuery: AbstractExists{[]AbstractQuery{
@@ -462,16 +462,51 @@ func TestStructuredQuery_triaged(t *testing.T) {
 		}}, rq)
 }
 
+func TestStructuredQuery_testlabel(t *testing.T) {
+	var rq RunQuery
+	err := json.Unmarshal([]byte(`{
+        "run_ids": [0, 1, 2],
+        "query": {
+            "exists": [{
+                "testlabel": "interop1"
+            }]
+        }
+    }`), &rq)
+	assert.Nil(t, err)
+	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2},
+		AbstractQuery: AbstractExists{[]AbstractQuery{
+			AbstractTestLabel{
+				Label: "interop1",
+			}},
+		}}, rq)
+}
+
+func TestStructuredQuery_combinedTestlabel(t *testing.T) {
+	var rq RunQuery
+	err := json.Unmarshal([]byte(`{
+        "run_ids": [0, 1, 2],
+        "query": {
+            "exists": [
+                {"pattern": "cssom"},
+                {"testlabel": "interop"}
+            ]
+        }
+    }`), &rq)
+	assert.Nil(t, err)
+	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2},
+		AbstractQuery: AbstractExists{[]AbstractQuery{TestNamePattern{"cssom"}, AbstractTestLabel{Label: "interop"}}}}, rq)
+}
+
 func TestStructuredQuery_triagedEmptyProduct(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-		"run_ids": [0, 1, 2],
-		"query": {
-			"exists": [{
-				"triaged": ""
-			}]
-		}
-	}`), &rq)
+        "run_ids": [0, 1, 2],
+        "query": {
+            "exists": [{
+                "triaged": ""
+            }]
+        }
+    }`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2},
 		AbstractQuery: AbstractExists{[]AbstractQuery{
@@ -484,13 +519,13 @@ func TestStructuredQuery_triagedEmptyProduct(t *testing.T) {
 func TestStructuredQuery_isDifferent(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-		"run_ids": [0, 1, 2],
-		"query": {
-			"exists": [{
-				"is": "different"
-			}]
-		}
-	}`), &rq)
+        "run_ids": [0, 1, 2],
+        "query": {
+            "exists": [{
+                "is": "different"
+            }]
+        }
+    }`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(t, RunQuery{
 		RunIDs: []int64{0, 1, 2},
@@ -503,13 +538,13 @@ func TestStructuredQuery_isDifferent(t *testing.T) {
 func TestStructuredQuery_isTentative(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-		"run_ids": [0, 1, 2],
-		"query": {
-			"exists": [{
-				"is": "tentative"
-			}]
-		}
-	}`), &rq)
+        "run_ids": [0, 1, 2],
+        "query": {
+            "exists": [{
+                "is": "tentative"
+            }]
+        }
+    }`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(t, RunQuery{
 		RunIDs: []int64{0, 1, 2},
@@ -522,13 +557,13 @@ func TestStructuredQuery_isTentative(t *testing.T) {
 func TestStructuredQuery_isOptional(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-		"run_ids": [0, 1, 2],
-		"query": {
-			"exists": [{
-				"is": "optional"
-			}]
-		}
-	}`), &rq)
+        "run_ids": [0, 1, 2],
+        "query": {
+            "exists": [{
+                "is": "optional"
+            }]
+        }
+    }`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(t, RunQuery{
 		RunIDs: []int64{0, 1, 2},
@@ -541,14 +576,14 @@ func TestStructuredQuery_isOptional(t *testing.T) {
 func TestStructuredQuery_combinedlink(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-		"run_ids": [0, 1, 2],
-		"query": {
-			"exists": [
-				{"pattern": "cssom"},
-				{"link": "chromium"}
-			]
-		}
-	}`), &rq)
+        "run_ids": [0, 1, 2],
+        "query": {
+            "exists": [
+                {"pattern": "cssom"},
+                {"link": "chromium"}
+            ]
+        }
+    }`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2},
 		AbstractQuery: AbstractExists{[]AbstractQuery{TestNamePattern{"cssom"}, AbstractLink{Pattern: "chromium"}}}}, rq)
@@ -557,18 +592,18 @@ func TestStructuredQuery_combinedlink(t *testing.T) {
 func TestStructuredQuery_combinednotlink(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-		"run_ids": [0, 1, 2],
-		"query": {
-			"exists": [
-				{"and": [
-					{"pattern": "cssom"},
-					{"not": {"link": "chromium.bug"}
-					}
-				  ]
-				}
-			]
-		}
-	}`), &rq)
+        "run_ids": [0, 1, 2],
+        "query": {
+            "exists": [
+                {"and": [
+                    {"pattern": "cssom"},
+                    {"not": {"link": "chromium.bug"}
+                    }
+                  ]
+                }
+            ]
+        }
+    }`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2},
 		AbstractQuery: AbstractExists{Args: []AbstractQuery{AbstractAnd{Args: []AbstractQuery{TestNamePattern{Pattern: "cssom"}, AbstractNot{Arg: AbstractLink{Pattern: "chromium.bug"}}}}}}}, rq)
@@ -577,22 +612,22 @@ func TestStructuredQuery_combinednotlink(t *testing.T) {
 func TestStructuredQuery_nested(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-		"run_ids": [0, 1, 2],
-		"query": {
-			"or": [
-				{
-					"and": [
-						{"not": {"pattern": "cssom"}},
-						{"pattern": "html"}
-					]
-				},
-				{
-					"product": "eDgE",
-					"status": "tImEoUt"
-				}
-			]
-		}
-	}`), &rq)
+        "run_ids": [0, 1, 2],
+        "query": {
+            "or": [
+                {
+                    "and": [
+                        {"not": {"pattern": "cssom"}},
+                        {"pattern": "html"}
+                    ]
+                },
+                {
+                    "product": "eDgE",
+                    "status": "tImEoUt"
+                }
+            ]
+        }
+    }`), &rq)
 	assert.Nil(t, err)
 	p := shared.ParseProductSpecUnsafe("edge")
 	assert.Equal(t, RunQuery{
@@ -930,7 +965,7 @@ func TestStructuredQuery_bindTriaged(t *testing.T) {
 	}
 
 	expect := Or{
-		Args:[]ConcreteQuery{
+		Args: []ConcreteQuery{
 			Triaged{
 				Run: 1,
 				Metadata: map[string][]string{
@@ -978,7 +1013,7 @@ func TestStructuredQuery_bindTriagedNilProduct(t *testing.T) {
 	// This is inefficient, but currently a nil product binds to all runs, with
 	// the same metadata in all cases.
 	expect := Or{
-		Args:[]ConcreteQuery{
+		Args: []ConcreteQuery{
 			Triaged{
 				Run: 0,
 				Metadata: map[string][]string{
@@ -991,6 +1026,41 @@ func TestStructuredQuery_bindTriagedNilProduct(t *testing.T) {
 					"/testC/c.html": {"baz.com"},
 				},
 			},
+		},
+	}
+	assert.Equal(t, expect, q.BindToRuns(runs...))
+}
+
+func TestStructuredQuery_bindTestLabel(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	sha := "sha"
+	mockFetcher := sharedtest.NewMockMetadataFetcher(mockCtrl)
+	mockFetcher.EXPECT().Fetch().Return(&sha, getMetadataTestData(), nil).AnyTimes()
+
+	safari := shared.ParseProductSpecUnsafe("safari")
+	firefox := shared.ParseProductSpecUnsafe("firefox")
+	q := AbstractTestLabel{
+		Label:           "interop",
+		metadataFetcher: mockFetcher,
+	}
+
+	runs := shared.TestRuns{
+		{
+			ID:                int64(0),
+			ProductAtRevision: safari.ProductAtRevision,
+		},
+		{
+			ID:                int64(1),
+			ProductAtRevision: firefox.ProductAtRevision,
+		},
+	}
+
+	expect := TestLabel{
+		Label: "interop",
+		Metadata: map[string][]string{
+			"/testC/c.html": {"labelA"},
 		},
 	}
 	assert.Equal(t, expect, q.BindToRuns(runs...))
@@ -1259,6 +1329,7 @@ func getMetadataTestData() map[string][]byte {
         results:
         - test: c.html
           status: FAIL
+          label: labelA
     `)
 
 	return metadataMap

--- a/api/query/atoms_test.go
+++ b/api/query/atoms_test.go
@@ -516,6 +516,21 @@ func TestStructuredQuery_combinedTestlabel(t *testing.T) {
 		AbstractQuery: AbstractExists{[]AbstractQuery{TestNamePattern{"cssom"}, AbstractTestLabel{Label: "interop"}}}}, rq)
 }
 
+func TestStructuredQuery_andTestLabels(t *testing.T) {
+	var rq RunQuery
+	err := json.Unmarshal([]byte(`{
+		"run_ids": [0, 1, 2],
+		"query": {
+			"and": [
+				{"testlabel": "interop1"},
+				{"testlabel": "interop2"}
+			]
+		}
+	}`), &rq)
+	assert.Nil(t, err)
+	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2}, AbstractQuery: AbstractAnd{[]AbstractQuery{AbstractTestLabel{Label: "interop1"}, AbstractTestLabel{Label: "interop2"}}}}, rq)
+}
+
 func TestStructuredQuery_isDifferent(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{

--- a/api/query/atoms_test.go
+++ b/api/query/atoms_test.go
@@ -25,18 +25,18 @@ func TestStructuredQuery_empty(t *testing.T) {
 func TestStructuredQuery_missingRunIDs(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-        "query": {
-            "pattern": "/2dcontext/"
-        }
-    }`), &rq)
+		"query": {
+			"pattern": "/2dcontext/"
+		}
+	}`), &rq)
 	assert.NotNil(t, err)
 }
 
 func TestStructuredQuery_missingQuery(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-        "run_ids": [0, 1, 2]
-    }`), &rq)
+		"run_ids": [0, 1, 2]
+	}`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2}, AbstractQuery: True{}}, rq)
 }
@@ -44,22 +44,22 @@ func TestStructuredQuery_missingQuery(t *testing.T) {
 func TestStructuredQuery_emptyRunIDs(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-        "run_ids": [],
-        "query": {
-            "pattern": "/2dcontext/"
-        }
-    }`), &rq)
+		"run_ids": [],
+		"query": {
+			"pattern": "/2dcontext/"
+		}
+	}`), &rq)
 	assert.NotNil(t, err)
 }
 
 func TestStructuredQuery_emptyBrowserName(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-        "run_ids": [0, 1, 2],
-        "query": {
-            "status": "PASS"
-        }
-    }`), &rq)
+		"run_ids": [0, 1, 2],
+		"query": {
+			"status": "PASS"
+		}
+	}`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2}, AbstractQuery: TestStatusEq{Status: shared.TestStatusValueFromString("PASS")}}, rq)
 }
@@ -67,34 +67,34 @@ func TestStructuredQuery_emptyBrowserName(t *testing.T) {
 func TestStructuredQuery_missingStatus(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-        "run_ids": [0, 1, 2],
-        "query": {
-            "product": "chrome"
-        }
-    }`), &rq)
+		"run_ids": [0, 1, 2],
+		"query": {
+			"product": "chrome"
+		}
+	}`), &rq)
 	assert.NotNil(t, err)
 }
 
 func TestStructuredQuery_badStatus(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-        "run_ids": [0, 1, 2],
-        "query": {
-            "product": "chrome",
-            "status": "NOT_A_REAL_STATUS"
-        }
-    }`), &rq)
+		"run_ids": [0, 1, 2],
+		"query": {
+			"product": "chrome",
+			"status": "NOT_A_REAL_STATUS"
+		}
+	}`), &rq)
 	assert.NotNil(t, err)
 }
 func TestStructuredQuery_unknownStatus(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-        "run_ids": [0, 1, 2],
-        "query": {
-            "product": "chrome",
-            "status": "UNKNOWN"
-        }
-    }`), &rq)
+		"run_ids": [0, 1, 2],
+		"query": {
+			"product": "chrome",
+			"status": "UNKNOWN"
+		}
+	}`), &rq)
 	assert.Nil(t, err)
 	p := shared.ParseProductSpecUnsafe("chrome")
 	assert.Equal(t, RunQuery{
@@ -106,20 +106,20 @@ func TestStructuredQuery_unknownStatus(t *testing.T) {
 func TestStructuredQuery_missingPattern(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-        "run_ids": [0, 1, 2],
-        "query": {}
-    }`), &rq)
+		"run_ids": [0, 1, 2],
+		"query": {}
+	}`), &rq)
 	assert.NotNil(t, err)
 }
 
 func TestStructuredQuery_emptyPattern(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-        "run_ids": [0, 1, 2],
-        "query": {
-            "pattern": ""
-        }
-    }`), &rq)
+		"run_ids": [0, 1, 2],
+		"query": {
+			"pattern": ""
+		}
+	}`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2}, AbstractQuery: TestNamePattern{""}}, rq)
 }
@@ -127,11 +127,11 @@ func TestStructuredQuery_emptyPattern(t *testing.T) {
 func TestStructuredQuery_pattern(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-        "run_ids": [0, 1, 2],
-        "query": {
-            "pattern": "/2dcontext/"
-        }
-    }`), &rq)
+		"run_ids": [0, 1, 2],
+		"query": {
+			"pattern": "/2dcontext/"
+		}
+	}`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2}, AbstractQuery: TestNamePattern{"/2dcontext/"}}, rq)
 }
@@ -139,11 +139,11 @@ func TestStructuredQuery_pattern(t *testing.T) {
 func TestStructuredQuery_subtest(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-        "run_ids": [0, 1, 2],
-        "query": {
-            "subtest": "Subtest name"
-        }
-    }`), &rq)
+		"run_ids": [0, 1, 2],
+		"query": {
+			"subtest": "Subtest name"
+		}
+	}`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2}, AbstractQuery: SubtestNamePattern{"Subtest name"}}, rq)
 }
@@ -151,11 +151,11 @@ func TestStructuredQuery_subtest(t *testing.T) {
 func TestStructuredQuery_path(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-        "run_ids": [0, 1, 2],
-        "query": {
-            "path": "/2dcontext/"
-        }
-    }`), &rq)
+		"run_ids": [0, 1, 2],
+		"query": {
+			"path": "/2dcontext/"
+		}
+	}`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2}, AbstractQuery: TestPath{"/2dcontext/"}}, rq)
 }
@@ -163,12 +163,12 @@ func TestStructuredQuery_path(t *testing.T) {
 func TestStructuredQuery_legacyBrowserName(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-        "run_ids": [0, 1, 2],
-        "query": {
-            "browser_name": "FiReFoX",
-            "status": "PaSs"
-        }
-    }`), &rq)
+		"run_ids": [0, 1, 2],
+		"query": {
+			"browser_name": "FiReFoX",
+			"status": "PaSs"
+		}
+	}`), &rq)
 	assert.Nil(t, err)
 	p := shared.ParseProductSpecUnsafe("firefox")
 	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2},
@@ -179,12 +179,12 @@ func TestStructuredQuery_legacyBrowserName(t *testing.T) {
 func TestStructuredQuery_status(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-        "run_ids": [0, 1, 2],
-        "query": {
-            "product": "FiReFoX",
-            "status": "PaSs"
-        }
-    }`), &rq)
+		"run_ids": [0, 1, 2],
+		"query": {
+			"product": "FiReFoX",
+			"status": "PaSs"
+		}
+	}`), &rq)
 	assert.Nil(t, err)
 	p := shared.ParseProductSpecUnsafe("firefox")
 	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2},
@@ -195,12 +195,12 @@ func TestStructuredQuery_status(t *testing.T) {
 func TestStructuredQuery_statusNeq(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-        "run_ids": [0, 1, 2],
-        "query": {
-            "product": "FiReFoX",
-            "status": {"not": "PaSs"}
-        }
-    }`), &rq)
+		"run_ids": [0, 1, 2],
+		"query": {
+			"product": "FiReFoX",
+			"status": {"not": "PaSs"}
+		}
+	}`), &rq)
 	assert.Nil(t, err)
 	p := shared.ParseProductSpecUnsafe("firefox")
 	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2},
@@ -211,25 +211,25 @@ func TestStructuredQuery_statusNeq(t *testing.T) {
 func TestStructuredQuery_statusUnsupportedAbstractNot(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-        "run_ids": [0, 1, 2],
-        "query": {
-            "product": "FiReFoX",
-            "status": {"not": {"pattern": "cssom"}}
-        }
-    }`), &rq)
+		"run_ids": [0, 1, 2],
+		"query": {
+			"product": "FiReFoX",
+			"status": {"not": {"pattern": "cssom"}}
+		}
+	}`), &rq)
 	assert.NotNil(t, err)
 }
 
 func TestStructuredQuery_not(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-        "run_ids": [0, 1, 2],
-        "query": {
-            "not": {
-                "pattern": "cssom"
-            }
-        }
-    }`), &rq)
+		"run_ids": [0, 1, 2],
+		"query": {
+			"not": {
+				"pattern": "cssom"
+			}
+		}
+	}`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2}, AbstractQuery: AbstractNot{TestNamePattern{"cssom"}}}, rq)
 }
@@ -237,14 +237,14 @@ func TestStructuredQuery_not(t *testing.T) {
 func TestStructuredQuery_or(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-        "run_ids": [0, 1, 2],
-        "query": {
-            "or": [
-                {"pattern": "cssom"},
-                {"pattern": "html"}
-            ]
-        }
-    }`), &rq)
+		"run_ids": [0, 1, 2],
+		"query": {
+			"or": [
+				{"pattern": "cssom"},
+				{"pattern": "html"}
+			]
+		}
+	}`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2}, AbstractQuery: AbstractOr{[]AbstractQuery{TestNamePattern{"cssom"}, TestNamePattern{"html"}}}}, rq)
 }
@@ -252,14 +252,14 @@ func TestStructuredQuery_or(t *testing.T) {
 func TestStructuredQuery_and(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-        "run_ids": [0, 1, 2],
-        "query": {
-            "and": [
-                {"pattern": "cssom"},
-                {"pattern": "html"}
-            ]
-        }
-    }`), &rq)
+		"run_ids": [0, 1, 2],
+		"query": {
+			"and": [
+				{"pattern": "cssom"},
+				{"pattern": "html"}
+			]
+		}
+	}`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2}, AbstractQuery: AbstractAnd{[]AbstractQuery{TestNamePattern{"cssom"}, TestNamePattern{"html"}}}}, rq)
 }
@@ -267,14 +267,14 @@ func TestStructuredQuery_and(t *testing.T) {
 func TestStructuredQuery_exists(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-        "run_ids": [0, 1, 2],
-        "query": {
-            "exists": [
-                {"pattern": "cssom"},
-                {"pattern": "html"}
-            ]
-        }
-    }`), &rq)
+		"run_ids": [0, 1, 2],
+		"query": {
+			"exists": [
+				{"pattern": "cssom"},
+				{"pattern": "html"}
+			]
+		}
+	}`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2}, AbstractQuery: AbstractExists{[]AbstractQuery{TestNamePattern{"cssom"}, TestNamePattern{"html"}}}}, rq)
 }
@@ -282,13 +282,13 @@ func TestStructuredQuery_exists(t *testing.T) {
 func TestStructuredQuery_all(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-        "run_ids": [0, 1, 2],
-        "query": {
-            "all": [
-                {"pattern": "cssom"}
-            ]
-        }
-    }`), &rq)
+		"run_ids": [0, 1, 2],
+		"query": {
+			"all": [
+				{"pattern": "cssom"}
+			]
+		}
+	}`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(t, RunQuery{
 		RunIDs:        []int64{0, 1, 2},
@@ -299,13 +299,13 @@ func TestStructuredQuery_all(t *testing.T) {
 func TestStructuredQuery_none(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-        "run_ids": [0, 1, 2],
-        "query": {
-            "none": [
-                {"pattern": "cssom"}
-            ]
-        }
-    }`), &rq)
+		"run_ids": [0, 1, 2],
+		"query": {
+			"none": [
+				{"pattern": "cssom"}
+			]
+		}
+	}`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(t, RunQuery{
 		RunIDs:        []int64{0, 1, 2},
@@ -316,16 +316,16 @@ func TestStructuredQuery_none(t *testing.T) {
 func TestStructuredQuery_sequential(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-        "run_ids": [0, 1, 2],
-        "query": {
-            "exists": [
-                { "sequential":[
-                    {"or":[{"status":"PASS"},{"status":"OK"}]},
-                    {"and":[{"status":{"not":"PASS"}},{"status":{"not":"OK"}},{"status":{"not":"UNKNOWN"}}]}
-                ]}
-            ]
-        }
-    }`), &rq)
+		"run_ids": [0, 1, 2],
+		"query": {
+			"exists": [
+				{ "sequential":[
+					{"or":[{"status":"PASS"},{"status":"OK"}]},
+					{"and":[{"status":{"not":"PASS"}},{"status":{"not":"OK"}},{"status":{"not":"UNKNOWN"}}]}
+				]}
+			]
+		}
+	}`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(
 		t,
@@ -348,16 +348,16 @@ func TestStructuredQuery_sequential(t *testing.T) {
 func TestStructuredQuery_count(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-        "run_ids": [0, 1, 2],
-        "query": {
-            "exists": [{
-                "count": 3,
-                "where": {
-                    "or": [{"status":"PASS"},{"status":"OK"}]
-                }
-            }]
-        }
-    }`), &rq)
+		"run_ids": [0, 1, 2],
+		"query": {
+			"exists": [{
+				"count": 3,
+				"where": {
+					"or": [{"status":"PASS"},{"status":"OK"}]
+				}
+			}]
+		}
+	}`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(
 		t,
@@ -376,14 +376,14 @@ func TestStructuredQuery_count(t *testing.T) {
 func TestStructuredQuery_moreThan(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-        "run_ids": [0, 1, 2],
-        "query": {
-            "exists": [{
-                "moreThan": 3,
-                "where": {"status":"PASS"}
-            }]
-        }
-    }`), &rq)
+		"run_ids": [0, 1, 2],
+		"query": {
+			"exists": [{
+				"moreThan": 3,
+				"where": {"status":"PASS"}
+			}]
+		}
+	}`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(
 		t,
@@ -401,14 +401,14 @@ func TestStructuredQuery_moreThan(t *testing.T) {
 func TestStructuredQuery_lessThan(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-        "run_ids": [0, 1, 2],
-        "query": {
-            "exists": [{
-                "lessThan": 2,
-                "where": {"status":"PASS"}
-            }]
-        }
-    }`), &rq)
+		"run_ids": [0, 1, 2],
+		"query": {
+			"exists": [{
+				"lessThan": 2,
+				"where": {"status":"PASS"}
+			}]
+		}
+	}`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(
 		t,
@@ -426,13 +426,13 @@ func TestStructuredQuery_lessThan(t *testing.T) {
 func TestStructuredQuery_link(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-        "run_ids": [0, 1, 2],
-        "query": {
-            "exists": [{
-                "link": "chromium.bug.com/abc"
-            }]
-        }
-    }`), &rq)
+		"run_ids": [0, 1, 2],
+		"query": {
+			"exists": [{
+				"link": "chromium.bug.com/abc"
+			}]
+		}
+	}`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2},
 		AbstractQuery: AbstractExists{[]AbstractQuery{
@@ -446,18 +446,37 @@ func TestStructuredQuery_triaged(t *testing.T) {
 	p := shared.ParseProductSpecUnsafe("Chrome")
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-        "run_ids": [0, 1, 2],
-        "query": {
-            "exists": [{
-                "triaged": "chrome"
-            }]
-        }
-    }`), &rq)
+		"run_ids": [0, 1, 2],
+		"query": {
+			"exists": [{
+				"triaged": "chrome"
+			}]
+		}
+	}`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2},
 		AbstractQuery: AbstractExists{[]AbstractQuery{
 			AbstractTriaged{
 				Product: &p,
+			}},
+		}}, rq)
+}
+
+func TestStructuredQuery_triagedEmptyProduct(t *testing.T) {
+	var rq RunQuery
+	err := json.Unmarshal([]byte(`{
+		"run_ids": [0, 1, 2],
+		"query": {
+			"exists": [{
+				"triaged": ""
+			}]
+		}
+	}`), &rq)
+	assert.Nil(t, err)
+	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2},
+		AbstractQuery: AbstractExists{[]AbstractQuery{
+			AbstractTriaged{
+				Product: nil,
 			}},
 		}}, rq)
 }
@@ -497,35 +516,16 @@ func TestStructuredQuery_combinedTestlabel(t *testing.T) {
 		AbstractQuery: AbstractExists{[]AbstractQuery{TestNamePattern{"cssom"}, AbstractTestLabel{Label: "interop"}}}}, rq)
 }
 
-func TestStructuredQuery_triagedEmptyProduct(t *testing.T) {
-	var rq RunQuery
-	err := json.Unmarshal([]byte(`{
-        "run_ids": [0, 1, 2],
-        "query": {
-            "exists": [{
-                "triaged": ""
-            }]
-        }
-    }`), &rq)
-	assert.Nil(t, err)
-	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2},
-		AbstractQuery: AbstractExists{[]AbstractQuery{
-			AbstractTriaged{
-				Product: nil,
-			}},
-		}}, rq)
-}
-
 func TestStructuredQuery_isDifferent(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-        "run_ids": [0, 1, 2],
-        "query": {
-            "exists": [{
-                "is": "different"
-            }]
-        }
-    }`), &rq)
+		"run_ids": [0, 1, 2],
+		"query": {
+			"exists": [{
+				"is": "different"
+			}]
+		}
+	}`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(t, RunQuery{
 		RunIDs: []int64{0, 1, 2},
@@ -538,13 +538,13 @@ func TestStructuredQuery_isDifferent(t *testing.T) {
 func TestStructuredQuery_isTentative(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-        "run_ids": [0, 1, 2],
-        "query": {
-            "exists": [{
-                "is": "tentative"
-            }]
-        }
-    }`), &rq)
+		"run_ids": [0, 1, 2],
+		"query": {
+			"exists": [{
+				"is": "tentative"
+			}]
+		}
+	}`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(t, RunQuery{
 		RunIDs: []int64{0, 1, 2},
@@ -557,13 +557,13 @@ func TestStructuredQuery_isTentative(t *testing.T) {
 func TestStructuredQuery_isOptional(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-        "run_ids": [0, 1, 2],
-        "query": {
-            "exists": [{
-                "is": "optional"
-            }]
-        }
-    }`), &rq)
+		"run_ids": [0, 1, 2],
+		"query": {
+			"exists": [{
+				"is": "optional"
+			}]
+		}
+	}`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(t, RunQuery{
 		RunIDs: []int64{0, 1, 2},
@@ -576,14 +576,14 @@ func TestStructuredQuery_isOptional(t *testing.T) {
 func TestStructuredQuery_combinedlink(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-        "run_ids": [0, 1, 2],
-        "query": {
-            "exists": [
-                {"pattern": "cssom"},
-                {"link": "chromium"}
-            ]
-        }
-    }`), &rq)
+		"run_ids": [0, 1, 2],
+		"query": {
+			"exists": [
+				{"pattern": "cssom"},
+				{"link": "chromium"}
+			]
+		}
+	}`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2},
 		AbstractQuery: AbstractExists{[]AbstractQuery{TestNamePattern{"cssom"}, AbstractLink{Pattern: "chromium"}}}}, rq)
@@ -592,18 +592,18 @@ func TestStructuredQuery_combinedlink(t *testing.T) {
 func TestStructuredQuery_combinednotlink(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-        "run_ids": [0, 1, 2],
-        "query": {
-            "exists": [
-                {"and": [
-                    {"pattern": "cssom"},
-                    {"not": {"link": "chromium.bug"}
-                    }
-                  ]
-                }
-            ]
-        }
-    }`), &rq)
+		"run_ids": [0, 1, 2],
+		"query": {
+			"exists": [
+				{"and": [
+					{"pattern": "cssom"},
+					{"not": {"link": "chromium.bug"}
+					}
+				  ]
+				}
+			]
+		}
+	}`), &rq)
 	assert.Nil(t, err)
 	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2},
 		AbstractQuery: AbstractExists{Args: []AbstractQuery{AbstractAnd{Args: []AbstractQuery{TestNamePattern{Pattern: "cssom"}, AbstractNot{Arg: AbstractLink{Pattern: "chromium.bug"}}}}}}}, rq)
@@ -612,22 +612,22 @@ func TestStructuredQuery_combinednotlink(t *testing.T) {
 func TestStructuredQuery_nested(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
-        "run_ids": [0, 1, 2],
-        "query": {
-            "or": [
-                {
-                    "and": [
-                        {"not": {"pattern": "cssom"}},
-                        {"pattern": "html"}
-                    ]
-                },
-                {
-                    "product": "eDgE",
-                    "status": "tImEoUt"
-                }
-            ]
-        }
-    }`), &rq)
+		"run_ids": [0, 1, 2],
+		"query": {
+			"or": [
+				{
+					"and": [
+						{"not": {"pattern": "cssom"}},
+						{"pattern": "html"}
+					]
+				},
+				{
+					"product": "eDgE",
+					"status": "tImEoUt"
+				}
+			]
+		}
+	}`), &rq)
 	assert.Nil(t, err)
 	p := shared.ParseProductSpecUnsafe("edge")
 	assert.Equal(t, RunQuery{

--- a/api/query/cache/index/index_filter_test.go
+++ b/api/query/cache/index/index_filter_test.go
@@ -627,6 +627,60 @@ func TestBindExecute_TriagedWildcards(t *testing.T) {
 	assert.Equal(t, expectedResult, srs[0])
 }
 
+func TestBindExecute_TestLabel(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	loader := NewMockReportLoader(ctrl)
+	idx, err := NewShardedWPTIndex(loader, testNumShards)
+	assert.Nil(t, err)
+
+	matchingTestName := "/a/b/c"
+	runs := mockTestRuns(loader, idx, []testRunData{
+		testRunData{
+			shared.TestRun{ID: 1},
+			&metrics.TestResultsReport{
+				Results: []*metrics.TestResults{
+					&metrics.TestResults{
+						Test:   matchingTestName,
+						Status: "PASS",
+					},
+					&metrics.TestResults{
+						Test:   "/d/e/f",
+						Status: "FAIL",
+					},
+				},
+			},
+		},
+	})
+	metadata := map[string][]string{
+		"/foo/bar/b.html": {"random"},
+		matchingTestName:  {"interop1", "INTEROP2"},
+		"/d/e/f":          {""},
+	}
+
+	link := query.Or{Args: []query.ConcreteQuery{query.TestLabel{Label: "interop2", Metadata: metadata}}}
+	plan, err := idx.Bind(runs, link)
+	assert.Nil(t, err)
+
+	res := plan.Execute(runs, query.AggregationOpts{})
+	srs, ok := res.([]shared.SearchResult)
+	assert.True(t, ok)
+
+	assert.Equal(t, 1, len(srs))
+	expectedResult := shared.SearchResult{
+		Test: matchingTestName,
+		LegacyStatus: []shared.LegacySearchRunResult{
+			shared.LegacySearchRunResult{
+				// Only matching test passes.
+				Passes: 1,
+				Total:  1,
+			},
+		},
+	}
+
+	assert.Equal(t, expectedResult, srs[0])
+}
+
 func TestBindExecute_IsDifferent(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/api/query/cache/index/index_filter_test.go
+++ b/api/query/cache/index/index_filter_test.go
@@ -658,8 +658,8 @@ func TestBindExecute_TestLabel(t *testing.T) {
 		"/d/e/f":          {""},
 	}
 
-	link := query.Or{Args: []query.ConcreteQuery{query.TestLabel{Label: "interop2", Metadata: metadata}}}
-	plan, err := idx.Bind(runs, link)
+	testlabel := query.TestLabel{Label: "interop2", Metadata: metadata}
+	plan, err := idx.Bind(runs, testlabel)
 	assert.Nil(t, err)
 
 	res := plan.Execute(runs, query.AggregationOpts{})

--- a/api/query/concrete_query.go
+++ b/api/query/concrete_query.go
@@ -75,6 +75,12 @@ type Triaged struct {
 	Metadata map[string][]string
 }
 
+// TestLabel is a ConcreteQuery of AbstractTestLabel.
+type TestLabel struct {
+	Label    string
+	Metadata map[string][]string
+}
+
 // RunTestStatusEq constrains search results to include only test results from a
 // particular run that have a particular test status value. Run IDs are those
 // values automatically assigned to shared.TestRun instances by Datastore.
@@ -135,6 +141,10 @@ func (Link) Size() int { return 1 }
 // Size of Triaged is 1: servicing such a query requires a single
 // lookup in a test run result mapping per test
 func (Triaged) Size() int { return 1 }
+
+// Size of TestLabel has a size of 1: servicing such a query requires a
+// label match per Metadata Link Node.
+func (TestLabel) Size() int { return 1 }
 
 // Size of Count is the sum of the sizes of its constituent ConcretQuery instances.
 func (c Count) Size() int { return size(c.Args) }

--- a/shared/metadata_test.go
+++ b/shared/metadata_test.go
@@ -334,7 +334,6 @@ func TestGetMetadataFilePath(t *testing.T) {
 }
 
 func TestPrepareLinkFilter(t *testing.T) {
-	label := "labelA"
 	subtestName := "Something should happen"
 	fail := TestStatusFail
 	metadataResults := map[string]MetadataLinks{
@@ -344,7 +343,6 @@ func TestPrepareLinkFilter(t *testing.T) {
 				Results: []MetadataTestResult{{
 					SubtestName: &subtestName,
 					Status:      &fail,
-					Label:       &label,
 				}},
 			},
 		},
@@ -360,14 +358,12 @@ func TestPrepareLinkFilter(t *testing.T) {
 func TestPrepareTestLabelFilter(t *testing.T) {
 	label := "labelA"
 	labelb := "labelB"
-	subtestName := "Something should happen"
-	fail := TestStatusFail
 	metadataResults := map[string]MetadataLinks{
 		"/foo/bar/a.html": []MetadataLink{
 			{
 				Product: ProductSpec{},
 				URL:     "https://bug.com/item",
-				Results: []MetadataTestResult{{SubtestName: &subtestName, Status: &fail, Label: &label}, {SubtestName: &subtestName, Status: &fail, Label: &labelb}},
+				Results: []MetadataTestResult{{Label: &label}, {Label: &labelb}},
 			},
 		},
 	}

--- a/shared/metadata_test.go
+++ b/shared/metadata_test.go
@@ -22,6 +22,8 @@ links:
     results:
     - test: a.html
       label: labelA
+    - test: a.html
+      label: labelB
   - product: firefox-2
     url: https://bug.com/item
     results:
@@ -357,6 +359,7 @@ func TestPrepareLinkFilter(t *testing.T) {
 
 func TestPrepareTestLabelFilter(t *testing.T) {
 	label := "labelA"
+	labelb := "labelB"
 	subtestName := "Something should happen"
 	fail := TestStatusFail
 	metadataResults := map[string]MetadataLinks{
@@ -364,7 +367,7 @@ func TestPrepareTestLabelFilter(t *testing.T) {
 			{
 				Product: ProductSpec{},
 				URL:     "https://bug.com/item",
-				Results: []MetadataTestResult{{SubtestName: &subtestName, Status: &fail, Label: &label}},
+				Results: []MetadataTestResult{{SubtestName: &subtestName, Status: &fail, Label: &label}, {SubtestName: &subtestName, Status: &fail, Label: &labelb}},
 			},
 		},
 	}
@@ -372,6 +375,7 @@ func TestPrepareTestLabelFilter(t *testing.T) {
 	metaddataMap := PrepareTestLabelFilter(metadataResults)
 
 	assert.Equal(t, 1, len(metaddataMap))
-	assert.Equal(t, 1, len(metaddataMap["/foo/bar/a.html"]))
+	assert.Equal(t, 2, len(metaddataMap["/foo/bar/a.html"]))
 	assert.Equal(t, "labelA", metaddataMap["/foo/bar/a.html"][0])
+	assert.Equal(t, "labelB", metaddataMap["/foo/bar/a.html"][1])
 }

--- a/webapp/components/test-search.js
+++ b/webapp/components/test-search.js
@@ -105,7 +105,7 @@ const QUERY_GRAMMAR = ohm.grammar(`
       | linkExp
       | isExp
       | triagedExp
-      | testlabelExp
+      | labelExp
       | statusExp
       | subtestExp
       | pathExp
@@ -130,8 +130,8 @@ const QUERY_GRAMMAR = ohm.grammar(`
       = caseInsensitive<"triaged"> ":" browserName
       | caseInsensitive<"triaged"> ":" "test-issue"
 
-    testlabelExp
-      = caseInsensitive<"testlabel"> ":" nameFragment
+    labelExp
+      = caseInsensitive<"label"> ":" nameFragment
 
     isExp
       = caseInsensitive<"is"> ":" metadataQualityLiteral
@@ -321,9 +321,9 @@ const QUERY_SEMANTICS = QUERY_GRAMMAR.createSemantics().addOperation('eval', {
     // Test-level issues are represented on the backend as an empty product.
     return { triaged: ps.toLowerCase().replace('test-issue', '') };
   },
-  testlabelExp: (l, colon, r) => {
+  labelExp: (l, colon, r) => {
     const ps = r.eval();
-    return ps.length === 0 ? emptyQuery : {testlabel: ps };
+    return ps.length === 0 ? emptyQuery : {label: ps };
   },
   subtestExp: (l, colon, r) => {
     return { subtest: r.eval() };

--- a/webapp/components/test-search.js
+++ b/webapp/components/test-search.js
@@ -105,6 +105,7 @@ const QUERY_GRAMMAR = ohm.grammar(`
       | linkExp
       | isExp
       | triagedExp
+      | testlabelExp
       | statusExp
       | subtestExp
       | pathExp
@@ -128,6 +129,9 @@ const QUERY_GRAMMAR = ohm.grammar(`
     triagedExp
       = caseInsensitive<"triaged"> ":" browserName
       | caseInsensitive<"triaged"> ":" "test-issue"
+
+    testlabelExp
+      = caseInsensitive<"testlabel"> ":" nameFragment
 
     isExp
       = caseInsensitive<"is"> ":" metadataQualityLiteral
@@ -316,6 +320,10 @@ const QUERY_SEMANTICS = QUERY_GRAMMAR.createSemantics().addOperation('eval', {
     }
     // Test-level issues are represented on the backend as an empty product.
     return { triaged: ps.toLowerCase().replace('test-issue', '') };
+  },
+  testlabelExp: (l, colon, r) => {
+    const ps = r.eval();
+    return ps.length === 0 ? emptyQuery : {testlabel: ps };
   },
   subtestExp: (l, colon, r) => {
     return { subtest: r.eval() };

--- a/webapp/components/test/test-search.html
+++ b/webapp/components/test/test-search.html
@@ -407,8 +407,8 @@ suite('<test-search>', () => {
       assertQueryParse('triaged:test-issue', { exists: [{ triaged: '' }] });
     });
 
-    test('test label search', () => {
-      assertQueryParse('testlabel:interop123', { exists: [{ testlabel: 'interop123' }] });
+    test('metadata label search', () => {
+      assertQueryParse('label:interop123', { exists: [{ label: 'interop123' }] });
     });
 
     test('multi-root', () => {

--- a/webapp/components/test/test-search.html
+++ b/webapp/components/test/test-search.html
@@ -407,6 +407,10 @@ suite('<test-search>', () => {
       assertQueryParse('triaged:test-issue', { exists: [{ triaged: '' }] });
     });
 
+    test('test label search', () => {
+      assertQueryParse('testlabel:interop123', { exists: [{ testlabel: 'interop123' }] });
+    });
+
     test('multi-root', () => {
       assertQueryParse('none(status:missing) count>0(status:!pass)', {
         and: [


### PR DESCRIPTION
Add test labelling support for https://github.com/web-platform-tests/wpt.fyi/issues/1491.

- Add an optional `label` entry in Metadata `Link`.
- Add the ability to search triaged tests based on its `labels`. The label exists at the test-level (that is, metadata
that has no product associated with it), regardless of browsers. One test can associate with multiple labels.

### How to test
On the [staging instance](https://metadata-label-dot-wptdashboard-staging.uk.r.appspot.com/results/css/css-align/gaps?q=testlabel%3Aexample-label1&run_id=5312968510144512), search `label:example-label1`, which should show a dummy data `gap-animation-001.html`

### Follow-up
Support multiple labels