### PR TITLE
Add skipSeleniumInstall and turn on verbose

### DIFF
--- a/webapp/wct.conf.json
+++ b/webapp/wct.conf.json
@@ -4,6 +4,7 @@
   ],
   "plugins": {
     "local": {
+      "skipSeleniumInstall": true,
       "browserOptions": {
         "chrome": [
           "headless",
@@ -20,6 +21,6 @@
   "compile": "never",
   "npm": true,
   "expanded": true,
-  "verbose": false,
+  "verbose": true,
   "testTimeout": 300000
 }


### PR DESCRIPTION
Fix https://github.com/web-platform-tests/wpt.fyi/issues/2677. `wct --local chrome && wct --local firefox` isn't able to detect already installed selenium. To avoid that, turn off the selenium Installation check. 

To find out the root cause, we might need to file an issue. But no one seems to maintain https://github.com/Polymer/tools/tree/master/packages/web-component-tester any more. 

