### PR TITLE
Revert "[compat2021] Add disclaimer for STP version (#2679)"

### DIFF
--- a/webapp/components/compat-2021.js
+++ b/webapp/components/compat-2021.js
@@ -214,14 +214,6 @@ class Compat2021 extends PolymerElement {
       </style>
       <h1>Compat 2021 Dashboard</h1>
       <compat-2021-summary stable="[[stable]]"></compat-2021-summary>
-      <template is="dom-if" if="[[showSTPWarning]]">
-        <info-banner>
-          <em>NOTE:</em> Due to an <a
-          href="https://github.com/web-platform-tests/wpt/issues/31147">
-          infrastructure issue</a>, the version of Safari Technology Preview
-          used here is significantly out of date.
-        </info-banner>
-      </template>
       <p>
         These scores represent how well browser engines are doing on the 2021
         Compat Focus Areas, as measured by wpt.fyi test results. Each feature
@@ -296,10 +288,6 @@ class Compat2021 extends PolymerElement {
       stable: Boolean,
       feature: String,
       dataManager: Object,
-      showSTPWarning: {
-        type: Boolean,
-        computed: 'computeShowSTPWarning(stable, useWebKitGTK)',
-      },
     };
   }
 
@@ -383,10 +371,6 @@ class Compat2021 extends PolymerElement {
 
   getTestListHref(feature) {
     return `${GITHUB_URL_PREFIX}/main/compat-2021/${feature}-tests.txt`;
-  }
-
-  computeShowSTPWarning(stable, useWebKitGTK) {
-    return !stable && !useWebKitGTK;
   }
 }
 window.customElements.define(Compat2021.is, Compat2021);


### PR DESCRIPTION
STP is no longer blocked on WPT, so we now have up-to-date data.

See https://github.com/web-platform-tests/wpt/pull/30256

This reverts commit 9078a92d4e1c44cc360ffc146f24337aef36da71.