### PR TITLE
Tweak Metadata label field and support multiple labels

### DIFF
--- a/api/query/atoms_test.go
+++ b/api/query/atoms_test.go
@@ -1340,11 +1340,11 @@ func getMetadataTestData() map[string][]byte {
 	// A test-level issue, which has no product associated with it.
 	metadataMap["testC"] = []byte(`
     links:
-      - url: baz.com
+      - label: labelA
+        url: baz.com
         results:
         - test: c.html
           status: FAIL
-          label: labelA
     `)
 
 	return metadataMap

--- a/api/query/cache/index/index_filter_test.go
+++ b/api/query/cache/index/index_filter_test.go
@@ -658,6 +658,7 @@ func TestBindExecute_QueryAndTestLabel(t *testing.T) {
 		"/d/e/f":          {""},
 	}
 
+	// It is equivalent to searching "label:interop1 & label:interop2".
 	testlabel := query.And{[]query.ConcreteQuery{query.TestLabel{Label: "interop2", Metadata: metadata}, query.TestLabel{Label: "interop1", Metadata: metadata}}}
 	plan, err := idx.Bind(runs, testlabel)
 	assert.Nil(t, err)
@@ -712,6 +713,7 @@ func TestBindExecute_QueryOrTestLabel(t *testing.T) {
 		"/d/e/f":          {"interop1"},
 	}
 
+	// It is equivalent to searching "label:interop1 | label:interop2".
 	testlabel := query.Or{[]query.ConcreteQuery{query.TestLabel{Label: "interop2", Metadata: metadata}, query.TestLabel{Label: "interop1", Metadata: metadata}}}
 	plan, err := idx.Bind(runs, testlabel)
 	assert.Nil(t, err)

--- a/api/query/cache/index/index_filter_test.go
+++ b/api/query/cache/index/index_filter_test.go
@@ -627,6 +627,126 @@ func TestBindExecute_TriagedWildcards(t *testing.T) {
 	assert.Equal(t, expectedResult, srs[0])
 }
 
+func TestBindExecute_QueryAndTestLabel(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	loader := NewMockReportLoader(ctrl)
+	idx, err := NewShardedWPTIndex(loader, testNumShards)
+	assert.Nil(t, err)
+
+	matchingTestName := "/a/b/c"
+	runs := mockTestRuns(loader, idx, []testRunData{
+		testRunData{
+			shared.TestRun{ID: 1},
+			&metrics.TestResultsReport{
+				Results: []*metrics.TestResults{
+					&metrics.TestResults{
+						Test:   matchingTestName,
+						Status: "PASS",
+					},
+					&metrics.TestResults{
+						Test:   "/d/e/f",
+						Status: "FAIL",
+					},
+				},
+			},
+		},
+	})
+	metadata := map[string][]string{
+		"/foo/bar/b.html": {"random"},
+		matchingTestName:  {"interop1", "INTEROP2"},
+		"/d/e/f":          {""},
+	}
+
+	testlabel := query.And{[]query.ConcreteQuery{query.TestLabel{Label: "interop2", Metadata: metadata}, query.TestLabel{Label: "interop1", Metadata: metadata}}}
+	plan, err := idx.Bind(runs, testlabel)
+	assert.Nil(t, err)
+
+	res := plan.Execute(runs, query.AggregationOpts{})
+	srs, ok := res.([]shared.SearchResult)
+	assert.True(t, ok)
+
+	assert.Equal(t, 1, len(srs))
+	expectedResult := shared.SearchResult{
+		Test: matchingTestName,
+		LegacyStatus: []shared.LegacySearchRunResult{
+			shared.LegacySearchRunResult{
+				// Only matching test passes.
+				Passes: 1,
+				Total:  1,
+			},
+		},
+	}
+
+	assert.Equal(t, expectedResult, srs[0])
+}
+
+func TestBindExecute_QueryOrTestLabel(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	loader := NewMockReportLoader(ctrl)
+	idx, err := NewShardedWPTIndex(loader, testNumShards)
+	assert.Nil(t, err)
+
+	matchingTestName := "/a/b/c"
+	runs := mockTestRuns(loader, idx, []testRunData{
+		testRunData{
+			shared.TestRun{ID: 1},
+			&metrics.TestResultsReport{
+				Results: []*metrics.TestResults{
+					&metrics.TestResults{
+						Test:   matchingTestName,
+						Status: "PASS",
+					},
+					&metrics.TestResults{
+						Test:   "/d/e/f",
+						Status: "PASS",
+					},
+				},
+			},
+		},
+	})
+	metadata := map[string][]string{
+		"/foo/bar/b.html": {"random"},
+		matchingTestName:  {"INTEROP2"},
+		"/d/e/f":          {"interop1"},
+	}
+
+	testlabel := query.Or{[]query.ConcreteQuery{query.TestLabel{Label: "interop2", Metadata: metadata}, query.TestLabel{Label: "interop1", Metadata: metadata}}}
+	plan, err := idx.Bind(runs, testlabel)
+	assert.Nil(t, err)
+
+	res := plan.Execute(runs, query.AggregationOpts{})
+	srs, ok := res.([]shared.SearchResult)
+	assert.True(t, ok)
+
+	assert.Equal(t, 2, len(srs))
+	expectedResult := shared.SearchResult{
+		Test: matchingTestName,
+		LegacyStatus: []shared.LegacySearchRunResult{
+			shared.LegacySearchRunResult{
+				// Only matching test passes.
+				Passes: 1,
+				Total:  1,
+			},
+		},
+	}
+
+	expectedResult1 := shared.SearchResult{
+		Test: "/d/e/f",
+		LegacyStatus: []shared.LegacySearchRunResult{
+			shared.LegacySearchRunResult{
+				// Only matching test passes.
+				Passes: 1,
+				Total:  1,
+			},
+		},
+	}
+
+	assert.Equal(t, expectedResult1, srs[0])
+	assert.Equal(t, expectedResult, srs[1])
+}
+
 func TestBindExecute_TestLabel(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
Tweak Metadata label format per https://github.com/web-platform-tests/wpt-metadata/pull/2186. A follow-up for https://github.com/web-platform-tests/wpt.fyi/pull/2678. This PR includes
- Move metadata `label` field to a level above in the `link`
- Support multiple labels per test
- Add tests for `&` and '|` testlabel search logic for searchcache