### PR TITLE
Remove un-needed break for test-level metadata

### DIFF
--- a/shared/metadata.go
+++ b/shared/metadata.go
@@ -144,12 +144,8 @@ func constructMetadataResponse(productSpecs ProductSpecs, includeTestLevel bool,
 			for _, result := range link.Results {
 				//TODO(kyleju): Concatenate test path on WPT Metadata repository instead of here.
 				fullTestName := GetWPTTestPath(folderPath, result.TestPath)
-
-				if link.Product.BrowserName == "" {
-					if includeTestLevel {
-						addResponseLink(fullTestName, link, result, res)
-					}
-					break
+				if link.Product.BrowserName == "" && includeTestLevel {
+					addResponseLink(fullTestName, link, result, res)
 				}
 
 				// Find any matching product for this link result (there can be at most one).


### PR DESCRIPTION
Fixed a existing bug when constructing test-level metadata. The `break` was premature and likely carried over from the old code.

The issue is surfaced in [web-platform-tests/wpt-metadata#2196 (comment).](https://github.com/web-platform-tests/wpt-metadata/pull/2196#issuecomment-977133256)