### PR TITLE
Replace realpath with git rev-parse --show-toplevel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,6 @@
 SHELL := /bin/bash
 # WPTD_PATH will have a trailing slash, e.g. /home/user/wpt.fyi/
 WPTD_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
-WPT_PATH := $(dir $(WPTD_PATH)../)
 NODE_SELENIUM_PATH := $(WPTD_PATH)webapp/node_modules/selenium-standalone/.selenium/
 FIREFOX_PATH := /usr/bin/firefox
 CHROME_PATH := /usr/bin/google-chrome

--- a/git/hooks/pre-push
+++ b/git/hooks/pre-push
@@ -1,10 +1,8 @@
 #!/bin/bash
 
-HOOKS_DIR=$(dirname "$0")
-REPO_DIR="${HOOKS_DIR}/../.."
+REPO_DIR="$(git rev-parse --show-toplevel)"
 source "${REPO_DIR}/util/logging.sh"
 source "${REPO_DIR}/util/commands.sh"
-WPTD_PATH=${WPTD_PATH:-$(realpath "${REPO_DIR}")}
 
 DOCKER_INSTANCE="${DOCKER_INSTANCE:-wptd-dev-instance}"
 

--- a/util/commands.sh
+++ b/util/commands.sh
@@ -5,8 +5,7 @@ DOCKER_IMAGE=${DOCKER_IMAGE:-"webplatformtests/wpt.fyi:latest"}
 DOCKER_INSTANCE=${DOCKER_INSTANCE:-"wptd-dev-instance"}
 WPTD_HOST_WEB_PORT=${WPTD_HOST_WEB_PORT:-"8080"}
 WPTD_HOST_GCD_PORT=${WPTD_HOST_GCD_PORT:-"8001"}
-WPT_PATH=${WPT_PATH:-$(realpath "${DOCKER_DIR}/../../..")}
-WPTD_PATH="${WPT_PATH}/wpt.fyi"
+WPTD_PATH="$(git rev-parse --show-toplevel)"
 
 function wptd_chown() {
   docker exec -u 0:0 "${DOCKER_INSTANCE}" chown -R $(id -u $USER):$(id -g $USER) $1

--- a/util/deploy.sh
+++ b/util/deploy.sh
@@ -2,9 +2,9 @@
 
 # Helper script for using a standardized version flag when deploying.
 
-REPO_DIR="$(dirname "${BASH_SOURCE[0]}")/.."
+REPO_DIR="$(git rev-parse --show-toplevel)"
 source "${REPO_DIR}/util/logging.sh"
-WPTD_PATH=${WPTD_PATH:-$(realpath "${REPO_DIR}")}
+WPTD_PATH=${WPTD_PATH:-"${REPO_DIR}"}
 
 usage() {
   USAGE="Usage: deploy.sh [-p] [-r] [-q] [-b] [-h] [app path]
@@ -48,7 +48,7 @@ esac
 
 # Ensure dependencies are installed.
 if [[ -z "${QUIET}" ]]; then info "Installing dependencies..."; fi
-cd ${WPTD_PATH}
+cd "${WPTD_PATH}"
 if [[ "${APP_PATH}" == "webapp" ]]; then
   make deployment_state || fatal "Error installing deps"
 fi


### PR DESCRIPTION
`realpath` was used in three places to get an absolute path to the repo
directory. We can use `git rev-parse --show-toplevel` for this instead
and avoid the dependency.

WPT_PATH was never used anywhere, and therefore removed.

In the pre-push script, commands.sh is sourced, so that will define
WPTD_PATH, so the redefinition can just be dropped.

Fixes https://github.com/web-platform-tests/wpt.fyi/issues/2743.