### PR TITLE
Match auto-formatted style of Go code

### DIFF
--- a/api/azure/mock_azure/api_mock.go
+++ b/api/azure/mock_azure/api_mock.go
@@ -5,35 +5,36 @@
 package mock_azure
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	azure "github.com/web-platform-tests/wpt.fyi/api/azure"
-	reflect "reflect"
 )
 
-// MockAPI is a mock of API interface
+// MockAPI is a mock of API interface.
 type MockAPI struct {
 	ctrl     *gomock.Controller
 	recorder *MockAPIMockRecorder
 }
 
-// MockAPIMockRecorder is the mock recorder for MockAPI
+// MockAPIMockRecorder is the mock recorder for MockAPI.
 type MockAPIMockRecorder struct {
 	mock *MockAPI
 }
 
-// NewMockAPI creates a new mock instance
+// NewMockAPI creates a new mock instance.
 func NewMockAPI(ctrl *gomock.Controller) *MockAPI {
 	mock := &MockAPI{ctrl: ctrl}
 	mock.recorder = &MockAPIMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockAPI) EXPECT() *MockAPIMockRecorder {
 	return m.recorder
 }
 
-// GetAzureArtifactsURL mocks base method
+// GetAzureArtifactsURL mocks base method.
 func (m *MockAPI) GetAzureArtifactsURL(arg0, arg1 string, arg2 int64) string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAzureArtifactsURL", arg0, arg1, arg2)
@@ -41,13 +42,13 @@ func (m *MockAPI) GetAzureArtifactsURL(arg0, arg1 string, arg2 int64) string {
 	return ret0
 }
 
-// GetAzureArtifactsURL indicates an expected call of GetAzureArtifactsURL
+// GetAzureArtifactsURL indicates an expected call of GetAzureArtifactsURL.
 func (mr *MockAPIMockRecorder) GetAzureArtifactsURL(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAzureArtifactsURL", reflect.TypeOf((*MockAPI)(nil).GetAzureArtifactsURL), arg0, arg1, arg2)
 }
 
-// GetBuild mocks base method
+// GetBuild mocks base method.
 func (m *MockAPI) GetBuild(arg0, arg1 string, arg2 int64) (*azure.Build, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBuild", arg0, arg1, arg2)
@@ -56,13 +57,13 @@ func (m *MockAPI) GetBuild(arg0, arg1 string, arg2 int64) (*azure.Build, error) 
 	return ret0, ret1
 }
 
-// GetBuild indicates an expected call of GetBuild
+// GetBuild indicates an expected call of GetBuild.
 func (mr *MockAPIMockRecorder) GetBuild(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBuild", reflect.TypeOf((*MockAPI)(nil).GetBuild), arg0, arg1, arg2)
 }
 
-// GetBuildURL mocks base method
+// GetBuildURL mocks base method.
 func (m *MockAPI) GetBuildURL(arg0, arg1 string, arg2 int64) string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBuildURL", arg0, arg1, arg2)
@@ -70,7 +71,7 @@ func (m *MockAPI) GetBuildURL(arg0, arg1 string, arg2 int64) string {
 	return ret0
 }
 
-// GetBuildURL indicates an expected call of GetBuildURL
+// GetBuildURL indicates an expected call of GetBuildURL.
 func (mr *MockAPIMockRecorder) GetBuildURL(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBuildURL", reflect.TypeOf((*MockAPI)(nil).GetBuildURL), arg0, arg1, arg2)

--- a/api/checks/mock_checks/api_mock.go
+++ b/api/checks/mock_checks/api_mock.go
@@ -6,39 +6,40 @@ package mock_checks
 
 import (
 	context "context"
-	gomock "github.com/golang/mock/gomock"
-	github "github.com/google/go-github/v33/github"
-	shared "github.com/web-platform-tests/wpt.fyi/shared"
 	http "net/http"
 	url "net/url"
 	reflect "reflect"
 	time "time"
+
+	gomock "github.com/golang/mock/gomock"
+	github "github.com/google/go-github/v33/github"
+	shared "github.com/web-platform-tests/wpt.fyi/shared"
 )
 
-// MockAPI is a mock of API interface
+// MockAPI is a mock of API interface.
 type MockAPI struct {
 	ctrl     *gomock.Controller
 	recorder *MockAPIMockRecorder
 }
 
-// MockAPIMockRecorder is the mock recorder for MockAPI
+// MockAPIMockRecorder is the mock recorder for MockAPI.
 type MockAPIMockRecorder struct {
 	mock *MockAPI
 }
 
-// NewMockAPI creates a new mock instance
+// NewMockAPI creates a new mock instance.
 func NewMockAPI(ctrl *gomock.Controller) *MockAPI {
 	mock := &MockAPI{ctrl: ctrl}
 	mock.recorder = &MockAPIMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockAPI) EXPECT() *MockAPIMockRecorder {
 	return m.recorder
 }
 
-// CancelRun mocks base method
+// CancelRun mocks base method.
 func (m *MockAPI) CancelRun(arg0, arg1, arg2 string, arg3 *github.CheckRun, arg4 *github.Installation) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CancelRun", arg0, arg1, arg2, arg3, arg4)
@@ -46,13 +47,13 @@ func (m *MockAPI) CancelRun(arg0, arg1, arg2 string, arg3 *github.CheckRun, arg4
 	return ret0
 }
 
-// CancelRun indicates an expected call of CancelRun
+// CancelRun indicates an expected call of CancelRun.
 func (mr *MockAPIMockRecorder) CancelRun(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelRun", reflect.TypeOf((*MockAPI)(nil).CancelRun), arg0, arg1, arg2, arg3, arg4)
 }
 
-// Context mocks base method
+// Context mocks base method.
 func (m *MockAPI) Context() context.Context {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Context")
@@ -60,13 +61,13 @@ func (m *MockAPI) Context() context.Context {
 	return ret0
 }
 
-// Context indicates an expected call of Context
+// Context indicates an expected call of Context.
 func (mr *MockAPIMockRecorder) Context() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockAPI)(nil).Context))
 }
 
-// CreateWPTCheckSuite mocks base method
+// CreateWPTCheckSuite mocks base method.
 func (m *MockAPI) CreateWPTCheckSuite(arg0, arg1 int64, arg2 string, arg3 ...int) (bool, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
@@ -79,14 +80,14 @@ func (m *MockAPI) CreateWPTCheckSuite(arg0, arg1 int64, arg2 string, arg3 ...int
 	return ret0, ret1
 }
 
-// CreateWPTCheckSuite indicates an expected call of CreateWPTCheckSuite
+// CreateWPTCheckSuite indicates an expected call of CreateWPTCheckSuite.
 func (mr *MockAPIMockRecorder) CreateWPTCheckSuite(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateWPTCheckSuite", reflect.TypeOf((*MockAPI)(nil).CreateWPTCheckSuite), varargs...)
 }
 
-// GetGitHubClient mocks base method
+// GetGitHubClient mocks base method.
 func (m *MockAPI) GetGitHubClient() (*github.Client, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetGitHubClient")
@@ -95,13 +96,13 @@ func (m *MockAPI) GetGitHubClient() (*github.Client, error) {
 	return ret0, ret1
 }
 
-// GetGitHubClient indicates an expected call of GetGitHubClient
+// GetGitHubClient indicates an expected call of GetGitHubClient.
 func (mr *MockAPIMockRecorder) GetGitHubClient() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGitHubClient", reflect.TypeOf((*MockAPI)(nil).GetGitHubClient))
 }
 
-// GetHTTPClient mocks base method
+// GetHTTPClient mocks base method.
 func (m *MockAPI) GetHTTPClient() *http.Client {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHTTPClient")
@@ -109,13 +110,13 @@ func (m *MockAPI) GetHTTPClient() *http.Client {
 	return ret0
 }
 
-// GetHTTPClient indicates an expected call of GetHTTPClient
+// GetHTTPClient indicates an expected call of GetHTTPClient.
 func (mr *MockAPIMockRecorder) GetHTTPClient() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHTTPClient", reflect.TypeOf((*MockAPI)(nil).GetHTTPClient))
 }
 
-// GetHTTPClientWithTimeout mocks base method
+// GetHTTPClientWithTimeout mocks base method.
 func (m *MockAPI) GetHTTPClientWithTimeout(arg0 time.Duration) *http.Client {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHTTPClientWithTimeout", arg0)
@@ -123,13 +124,13 @@ func (m *MockAPI) GetHTTPClientWithTimeout(arg0 time.Duration) *http.Client {
 	return ret0
 }
 
-// GetHTTPClientWithTimeout indicates an expected call of GetHTTPClientWithTimeout
+// GetHTTPClientWithTimeout indicates an expected call of GetHTTPClientWithTimeout.
 func (mr *MockAPIMockRecorder) GetHTTPClientWithTimeout(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHTTPClientWithTimeout", reflect.TypeOf((*MockAPI)(nil).GetHTTPClientWithTimeout), arg0)
 }
 
-// GetHostname mocks base method
+// GetHostname mocks base method.
 func (m *MockAPI) GetHostname() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHostname")
@@ -137,13 +138,13 @@ func (m *MockAPI) GetHostname() string {
 	return ret0
 }
 
-// GetHostname indicates an expected call of GetHostname
+// GetHostname indicates an expected call of GetHostname.
 func (mr *MockAPIMockRecorder) GetHostname() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHostname", reflect.TypeOf((*MockAPI)(nil).GetHostname))
 }
 
-// GetResultsURL mocks base method
+// GetResultsURL mocks base method.
 func (m *MockAPI) GetResultsURL(arg0 shared.TestRunFilter) *url.URL {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetResultsURL", arg0)
@@ -151,13 +152,13 @@ func (m *MockAPI) GetResultsURL(arg0 shared.TestRunFilter) *url.URL {
 	return ret0
 }
 
-// GetResultsURL indicates an expected call of GetResultsURL
+// GetResultsURL indicates an expected call of GetResultsURL.
 func (mr *MockAPIMockRecorder) GetResultsURL(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResultsURL", reflect.TypeOf((*MockAPI)(nil).GetResultsURL), arg0)
 }
 
-// GetResultsUploadURL mocks base method
+// GetResultsUploadURL mocks base method.
 func (m *MockAPI) GetResultsUploadURL() *url.URL {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetResultsUploadURL")
@@ -165,13 +166,13 @@ func (m *MockAPI) GetResultsUploadURL() *url.URL {
 	return ret0
 }
 
-// GetResultsUploadURL indicates an expected call of GetResultsUploadURL
+// GetResultsUploadURL indicates an expected call of GetResultsUploadURL.
 func (mr *MockAPIMockRecorder) GetResultsUploadURL() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResultsUploadURL", reflect.TypeOf((*MockAPI)(nil).GetResultsUploadURL))
 }
 
-// GetRunsURL mocks base method
+// GetRunsURL mocks base method.
 func (m *MockAPI) GetRunsURL(arg0 shared.TestRunFilter) *url.URL {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRunsURL", arg0)
@@ -179,13 +180,13 @@ func (m *MockAPI) GetRunsURL(arg0 shared.TestRunFilter) *url.URL {
 	return ret0
 }
 
-// GetRunsURL indicates an expected call of GetRunsURL
+// GetRunsURL indicates an expected call of GetRunsURL.
 func (mr *MockAPIMockRecorder) GetRunsURL(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRunsURL", reflect.TypeOf((*MockAPI)(nil).GetRunsURL), arg0)
 }
 
-// GetServiceHostname mocks base method
+// GetServiceHostname mocks base method.
 func (m *MockAPI) GetServiceHostname(arg0 string) string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetServiceHostname", arg0)
@@ -193,13 +194,13 @@ func (m *MockAPI) GetServiceHostname(arg0 string) string {
 	return ret0
 }
 
-// GetServiceHostname indicates an expected call of GetServiceHostname
+// GetServiceHostname indicates an expected call of GetServiceHostname.
 func (mr *MockAPIMockRecorder) GetServiceHostname(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceHostname", reflect.TypeOf((*MockAPI)(nil).GetServiceHostname), arg0)
 }
 
-// GetSuitesForSHA mocks base method
+// GetSuitesForSHA mocks base method.
 func (m *MockAPI) GetSuitesForSHA(arg0 string) ([]shared.CheckSuite, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSuitesForSHA", arg0)
@@ -208,13 +209,13 @@ func (m *MockAPI) GetSuitesForSHA(arg0 string) ([]shared.CheckSuite, error) {
 	return ret0, ret1
 }
 
-// GetSuitesForSHA indicates an expected call of GetSuitesForSHA
+// GetSuitesForSHA indicates an expected call of GetSuitesForSHA.
 func (mr *MockAPIMockRecorder) GetSuitesForSHA(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSuitesForSHA", reflect.TypeOf((*MockAPI)(nil).GetSuitesForSHA), arg0)
 }
 
-// GetUploader mocks base method
+// GetUploader mocks base method.
 func (m *MockAPI) GetUploader(arg0 string) (shared.Uploader, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUploader", arg0)
@@ -223,13 +224,13 @@ func (m *MockAPI) GetUploader(arg0 string) (shared.Uploader, error) {
 	return ret0, ret1
 }
 
-// GetUploader indicates an expected call of GetUploader
+// GetUploader indicates an expected call of GetUploader.
 func (mr *MockAPIMockRecorder) GetUploader(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUploader", reflect.TypeOf((*MockAPI)(nil).GetUploader), arg0)
 }
 
-// GetVersion mocks base method
+// GetVersion mocks base method.
 func (m *MockAPI) GetVersion() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetVersion")
@@ -237,13 +238,13 @@ func (m *MockAPI) GetVersion() string {
 	return ret0
 }
 
-// GetVersion indicates an expected call of GetVersion
+// GetVersion indicates an expected call of GetVersion.
 func (mr *MockAPIMockRecorder) GetVersion() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVersion", reflect.TypeOf((*MockAPI)(nil).GetVersion))
 }
 
-// GetVersionedHostname mocks base method
+// GetVersionedHostname mocks base method.
 func (m *MockAPI) GetVersionedHostname() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetVersionedHostname")
@@ -251,13 +252,13 @@ func (m *MockAPI) GetVersionedHostname() string {
 	return ret0
 }
 
-// GetVersionedHostname indicates an expected call of GetVersionedHostname
+// GetVersionedHostname indicates an expected call of GetVersionedHostname.
 func (mr *MockAPIMockRecorder) GetVersionedHostname() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVersionedHostname", reflect.TypeOf((*MockAPI)(nil).GetVersionedHostname))
 }
 
-// GetWPTRepoAppInstallationIDs mocks base method
+// GetWPTRepoAppInstallationIDs mocks base method.
 func (m *MockAPI) GetWPTRepoAppInstallationIDs() (int64, int64) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetWPTRepoAppInstallationIDs")
@@ -266,13 +267,13 @@ func (m *MockAPI) GetWPTRepoAppInstallationIDs() (int64, int64) {
 	return ret0, ret1
 }
 
-// GetWPTRepoAppInstallationIDs indicates an expected call of GetWPTRepoAppInstallationIDs
+// GetWPTRepoAppInstallationIDs indicates an expected call of GetWPTRepoAppInstallationIDs.
 func (mr *MockAPIMockRecorder) GetWPTRepoAppInstallationIDs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWPTRepoAppInstallationIDs", reflect.TypeOf((*MockAPI)(nil).GetWPTRepoAppInstallationIDs))
 }
 
-// IgnoreFailure mocks base method
+// IgnoreFailure mocks base method.
 func (m *MockAPI) IgnoreFailure(arg0, arg1, arg2 string, arg3 *github.CheckRun, arg4 *github.Installation) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IgnoreFailure", arg0, arg1, arg2, arg3, arg4)
@@ -280,13 +281,13 @@ func (m *MockAPI) IgnoreFailure(arg0, arg1, arg2 string, arg3 *github.CheckRun, 
 	return ret0
 }
 
-// IgnoreFailure indicates an expected call of IgnoreFailure
+// IgnoreFailure indicates an expected call of IgnoreFailure.
 func (mr *MockAPIMockRecorder) IgnoreFailure(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IgnoreFailure", reflect.TypeOf((*MockAPI)(nil).IgnoreFailure), arg0, arg1, arg2, arg3, arg4)
 }
 
-// IsFeatureEnabled mocks base method
+// IsFeatureEnabled mocks base method.
 func (m *MockAPI) IsFeatureEnabled(arg0 string) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsFeatureEnabled", arg0)
@@ -294,13 +295,13 @@ func (m *MockAPI) IsFeatureEnabled(arg0 string) bool {
 	return ret0
 }
 
-// IsFeatureEnabled indicates an expected call of IsFeatureEnabled
+// IsFeatureEnabled indicates an expected call of IsFeatureEnabled.
 func (mr *MockAPIMockRecorder) IsFeatureEnabled(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsFeatureEnabled", reflect.TypeOf((*MockAPI)(nil).IsFeatureEnabled), arg0)
 }
 
-// ScheduleResultsProcessing mocks base method
+// ScheduleResultsProcessing mocks base method.
 func (m *MockAPI) ScheduleResultsProcessing(arg0 string, arg1 shared.ProductSpec) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ScheduleResultsProcessing", arg0, arg1)
@@ -308,13 +309,13 @@ func (m *MockAPI) ScheduleResultsProcessing(arg0 string, arg1 shared.ProductSpec
 	return ret0
 }
 
-// ScheduleResultsProcessing indicates an expected call of ScheduleResultsProcessing
+// ScheduleResultsProcessing indicates an expected call of ScheduleResultsProcessing.
 func (mr *MockAPIMockRecorder) ScheduleResultsProcessing(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScheduleResultsProcessing", reflect.TypeOf((*MockAPI)(nil).ScheduleResultsProcessing), arg0, arg1)
 }
 
-// ScheduleTask mocks base method
+// ScheduleTask mocks base method.
 func (m *MockAPI) ScheduleTask(arg0, arg1, arg2 string, arg3 url.Values) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ScheduleTask", arg0, arg1, arg2, arg3)
@@ -323,7 +324,7 @@ func (m *MockAPI) ScheduleTask(arg0, arg1, arg2 string, arg3 url.Values) (string
 	return ret0, ret1
 }
 
-// ScheduleTask indicates an expected call of ScheduleTask
+// ScheduleTask indicates an expected call of ScheduleTask.
 func (mr *MockAPIMockRecorder) ScheduleTask(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScheduleTask", reflect.TypeOf((*MockAPI)(nil).ScheduleTask), arg0, arg1, arg2, arg3)

--- a/api/manifest/mock_manifest/api_mock.go
+++ b/api/manifest/mock_manifest/api_mock.go
@@ -5,36 +5,37 @@
 package mock_manifest
 
 import (
-	gomock "github.com/golang/mock/gomock"
-	shared "github.com/web-platform-tests/wpt.fyi/shared"
 	reflect "reflect"
 	time "time"
+
+	gomock "github.com/golang/mock/gomock"
+	shared "github.com/web-platform-tests/wpt.fyi/shared"
 )
 
-// MockAPI is a mock of API interface
+// MockAPI is a mock of API interface.
 type MockAPI struct {
 	ctrl     *gomock.Controller
 	recorder *MockAPIMockRecorder
 }
 
-// MockAPIMockRecorder is the mock recorder for MockAPI
+// MockAPIMockRecorder is the mock recorder for MockAPI.
 type MockAPIMockRecorder struct {
 	mock *MockAPI
 }
 
-// NewMockAPI creates a new mock instance
+// NewMockAPI creates a new mock instance.
 func NewMockAPI(ctrl *gomock.Controller) *MockAPI {
 	mock := &MockAPI{ctrl: ctrl}
 	mock.recorder = &MockAPIMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockAPI) EXPECT() *MockAPIMockRecorder {
 	return m.recorder
 }
 
-// GetManifestForSHA mocks base method
+// GetManifestForSHA mocks base method.
 func (m *MockAPI) GetManifestForSHA(arg0 string) (string, []byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetManifestForSHA", arg0)
@@ -44,13 +45,13 @@ func (m *MockAPI) GetManifestForSHA(arg0 string) (string, []byte, error) {
 	return ret0, ret1, ret2
 }
 
-// GetManifestForSHA indicates an expected call of GetManifestForSHA
+// GetManifestForSHA indicates an expected call of GetManifestForSHA.
 func (mr *MockAPIMockRecorder) GetManifestForSHA(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetManifestForSHA", reflect.TypeOf((*MockAPI)(nil).GetManifestForSHA), arg0)
 }
 
-// NewRedis mocks base method
+// NewRedis mocks base method.
 func (m *MockAPI) NewRedis(arg0 time.Duration) shared.ReadWritable {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewRedis", arg0)
@@ -58,7 +59,7 @@ func (m *MockAPI) NewRedis(arg0 time.Duration) shared.ReadWritable {
 	return ret0
 }
 
-// NewRedis indicates an expected call of NewRedis
+// NewRedis indicates an expected call of NewRedis.
 func (mr *MockAPIMockRecorder) NewRedis(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewRedis", reflect.TypeOf((*MockAPI)(nil).NewRedis), arg0)

--- a/api/receiver/mock_receiver/api_mock.go
+++ b/api/receiver/mock_receiver/api_mock.go
@@ -6,40 +6,41 @@ package mock_receiver
 
 import (
 	context "context"
-	gomock "github.com/golang/mock/gomock"
-	github "github.com/google/go-github/v33/github"
-	shared "github.com/web-platform-tests/wpt.fyi/shared"
 	io "io"
 	http "net/http"
 	url "net/url"
 	reflect "reflect"
 	time "time"
+
+	gomock "github.com/golang/mock/gomock"
+	github "github.com/google/go-github/v33/github"
+	shared "github.com/web-platform-tests/wpt.fyi/shared"
 )
 
-// MockAPI is a mock of API interface
+// MockAPI is a mock of API interface.
 type MockAPI struct {
 	ctrl     *gomock.Controller
 	recorder *MockAPIMockRecorder
 }
 
-// MockAPIMockRecorder is the mock recorder for MockAPI
+// MockAPIMockRecorder is the mock recorder for MockAPI.
 type MockAPIMockRecorder struct {
 	mock *MockAPI
 }
 
-// NewMockAPI creates a new mock instance
+// NewMockAPI creates a new mock instance.
 func NewMockAPI(ctrl *gomock.Controller) *MockAPI {
 	mock := &MockAPI{ctrl: ctrl}
 	mock.recorder = &MockAPIMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockAPI) EXPECT() *MockAPIMockRecorder {
 	return m.recorder
 }
 
-// AddTestRun mocks base method
+// AddTestRun mocks base method.
 func (m *MockAPI) AddTestRun(arg0 *shared.TestRun) (shared.Key, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddTestRun", arg0)
@@ -48,13 +49,13 @@ func (m *MockAPI) AddTestRun(arg0 *shared.TestRun) (shared.Key, error) {
 	return ret0, ret1
 }
 
-// AddTestRun indicates an expected call of AddTestRun
+// AddTestRun indicates an expected call of AddTestRun.
 func (mr *MockAPIMockRecorder) AddTestRun(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddTestRun", reflect.TypeOf((*MockAPI)(nil).AddTestRun), arg0)
 }
 
-// Context mocks base method
+// Context mocks base method.
 func (m *MockAPI) Context() context.Context {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Context")
@@ -62,13 +63,13 @@ func (m *MockAPI) Context() context.Context {
 	return ret0
 }
 
-// Context indicates an expected call of Context
+// Context indicates an expected call of Context.
 func (mr *MockAPIMockRecorder) Context() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockAPI)(nil).Context))
 }
 
-// GetGitHubClient mocks base method
+// GetGitHubClient mocks base method.
 func (m *MockAPI) GetGitHubClient() (*github.Client, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetGitHubClient")
@@ -77,13 +78,13 @@ func (m *MockAPI) GetGitHubClient() (*github.Client, error) {
 	return ret0, ret1
 }
 
-// GetGitHubClient indicates an expected call of GetGitHubClient
+// GetGitHubClient indicates an expected call of GetGitHubClient.
 func (mr *MockAPIMockRecorder) GetGitHubClient() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGitHubClient", reflect.TypeOf((*MockAPI)(nil).GetGitHubClient))
 }
 
-// GetHTTPClient mocks base method
+// GetHTTPClient mocks base method.
 func (m *MockAPI) GetHTTPClient() *http.Client {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHTTPClient")
@@ -91,13 +92,13 @@ func (m *MockAPI) GetHTTPClient() *http.Client {
 	return ret0
 }
 
-// GetHTTPClient indicates an expected call of GetHTTPClient
+// GetHTTPClient indicates an expected call of GetHTTPClient.
 func (mr *MockAPIMockRecorder) GetHTTPClient() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHTTPClient", reflect.TypeOf((*MockAPI)(nil).GetHTTPClient))
 }
 
-// GetHTTPClientWithTimeout mocks base method
+// GetHTTPClientWithTimeout mocks base method.
 func (m *MockAPI) GetHTTPClientWithTimeout(arg0 time.Duration) *http.Client {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHTTPClientWithTimeout", arg0)
@@ -105,13 +106,13 @@ func (m *MockAPI) GetHTTPClientWithTimeout(arg0 time.Duration) *http.Client {
 	return ret0
 }
 
-// GetHTTPClientWithTimeout indicates an expected call of GetHTTPClientWithTimeout
+// GetHTTPClientWithTimeout indicates an expected call of GetHTTPClientWithTimeout.
 func (mr *MockAPIMockRecorder) GetHTTPClientWithTimeout(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHTTPClientWithTimeout", reflect.TypeOf((*MockAPI)(nil).GetHTTPClientWithTimeout), arg0)
 }
 
-// GetHostname mocks base method
+// GetHostname mocks base method.
 func (m *MockAPI) GetHostname() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHostname")
@@ -119,13 +120,13 @@ func (m *MockAPI) GetHostname() string {
 	return ret0
 }
 
-// GetHostname indicates an expected call of GetHostname
+// GetHostname indicates an expected call of GetHostname.
 func (mr *MockAPIMockRecorder) GetHostname() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHostname", reflect.TypeOf((*MockAPI)(nil).GetHostname))
 }
 
-// GetResultsURL mocks base method
+// GetResultsURL mocks base method.
 func (m *MockAPI) GetResultsURL(arg0 shared.TestRunFilter) *url.URL {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetResultsURL", arg0)
@@ -133,13 +134,13 @@ func (m *MockAPI) GetResultsURL(arg0 shared.TestRunFilter) *url.URL {
 	return ret0
 }
 
-// GetResultsURL indicates an expected call of GetResultsURL
+// GetResultsURL indicates an expected call of GetResultsURL.
 func (mr *MockAPIMockRecorder) GetResultsURL(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResultsURL", reflect.TypeOf((*MockAPI)(nil).GetResultsURL), arg0)
 }
 
-// GetResultsUploadURL mocks base method
+// GetResultsUploadURL mocks base method.
 func (m *MockAPI) GetResultsUploadURL() *url.URL {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetResultsUploadURL")
@@ -147,13 +148,13 @@ func (m *MockAPI) GetResultsUploadURL() *url.URL {
 	return ret0
 }
 
-// GetResultsUploadURL indicates an expected call of GetResultsUploadURL
+// GetResultsUploadURL indicates an expected call of GetResultsUploadURL.
 func (mr *MockAPIMockRecorder) GetResultsUploadURL() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResultsUploadURL", reflect.TypeOf((*MockAPI)(nil).GetResultsUploadURL))
 }
 
-// GetRunsURL mocks base method
+// GetRunsURL mocks base method.
 func (m *MockAPI) GetRunsURL(arg0 shared.TestRunFilter) *url.URL {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRunsURL", arg0)
@@ -161,13 +162,13 @@ func (m *MockAPI) GetRunsURL(arg0 shared.TestRunFilter) *url.URL {
 	return ret0
 }
 
-// GetRunsURL indicates an expected call of GetRunsURL
+// GetRunsURL indicates an expected call of GetRunsURL.
 func (mr *MockAPIMockRecorder) GetRunsURL(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRunsURL", reflect.TypeOf((*MockAPI)(nil).GetRunsURL), arg0)
 }
 
-// GetServiceHostname mocks base method
+// GetServiceHostname mocks base method.
 func (m *MockAPI) GetServiceHostname(arg0 string) string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetServiceHostname", arg0)
@@ -175,13 +176,13 @@ func (m *MockAPI) GetServiceHostname(arg0 string) string {
 	return ret0
 }
 
-// GetServiceHostname indicates an expected call of GetServiceHostname
+// GetServiceHostname indicates an expected call of GetServiceHostname.
 func (mr *MockAPIMockRecorder) GetServiceHostname(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceHostname", reflect.TypeOf((*MockAPI)(nil).GetServiceHostname), arg0)
 }
 
-// GetUploader mocks base method
+// GetUploader mocks base method.
 func (m *MockAPI) GetUploader(arg0 string) (shared.Uploader, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUploader", arg0)
@@ -190,13 +191,13 @@ func (m *MockAPI) GetUploader(arg0 string) (shared.Uploader, error) {
 	return ret0, ret1
 }
 
-// GetUploader indicates an expected call of GetUploader
+// GetUploader indicates an expected call of GetUploader.
 func (mr *MockAPIMockRecorder) GetUploader(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUploader", reflect.TypeOf((*MockAPI)(nil).GetUploader), arg0)
 }
 
-// GetVersion mocks base method
+// GetVersion mocks base method.
 func (m *MockAPI) GetVersion() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetVersion")
@@ -204,13 +205,13 @@ func (m *MockAPI) GetVersion() string {
 	return ret0
 }
 
-// GetVersion indicates an expected call of GetVersion
+// GetVersion indicates an expected call of GetVersion.
 func (mr *MockAPIMockRecorder) GetVersion() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVersion", reflect.TypeOf((*MockAPI)(nil).GetVersion))
 }
 
-// GetVersionedHostname mocks base method
+// GetVersionedHostname mocks base method.
 func (m *MockAPI) GetVersionedHostname() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetVersionedHostname")
@@ -218,13 +219,13 @@ func (m *MockAPI) GetVersionedHostname() string {
 	return ret0
 }
 
-// GetVersionedHostname indicates an expected call of GetVersionedHostname
+// GetVersionedHostname indicates an expected call of GetVersionedHostname.
 func (mr *MockAPIMockRecorder) GetVersionedHostname() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVersionedHostname", reflect.TypeOf((*MockAPI)(nil).GetVersionedHostname))
 }
 
-// IsAdmin mocks base method
+// IsAdmin mocks base method.
 func (m *MockAPI) IsAdmin(arg0 *http.Request) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsAdmin", arg0)
@@ -232,13 +233,13 @@ func (m *MockAPI) IsAdmin(arg0 *http.Request) bool {
 	return ret0
 }
 
-// IsAdmin indicates an expected call of IsAdmin
+// IsAdmin indicates an expected call of IsAdmin.
 func (mr *MockAPIMockRecorder) IsAdmin(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsAdmin", reflect.TypeOf((*MockAPI)(nil).IsAdmin), arg0)
 }
 
-// IsFeatureEnabled mocks base method
+// IsFeatureEnabled mocks base method.
 func (m *MockAPI) IsFeatureEnabled(arg0 string) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsFeatureEnabled", arg0)
@@ -246,13 +247,13 @@ func (m *MockAPI) IsFeatureEnabled(arg0 string) bool {
 	return ret0
 }
 
-// IsFeatureEnabled indicates an expected call of IsFeatureEnabled
+// IsFeatureEnabled indicates an expected call of IsFeatureEnabled.
 func (mr *MockAPIMockRecorder) IsFeatureEnabled(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsFeatureEnabled", reflect.TypeOf((*MockAPI)(nil).IsFeatureEnabled), arg0)
 }
 
-// ScheduleResultsTask mocks base method
+// ScheduleResultsTask mocks base method.
 func (m *MockAPI) ScheduleResultsTask(arg0 string, arg1, arg2 []string, arg3 map[string]string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ScheduleResultsTask", arg0, arg1, arg2, arg3)
@@ -261,13 +262,13 @@ func (m *MockAPI) ScheduleResultsTask(arg0 string, arg1, arg2 []string, arg3 map
 	return ret0, ret1
 }
 
-// ScheduleResultsTask indicates an expected call of ScheduleResultsTask
+// ScheduleResultsTask indicates an expected call of ScheduleResultsTask.
 func (mr *MockAPIMockRecorder) ScheduleResultsTask(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScheduleResultsTask", reflect.TypeOf((*MockAPI)(nil).ScheduleResultsTask), arg0, arg1, arg2, arg3)
 }
 
-// ScheduleTask mocks base method
+// ScheduleTask mocks base method.
 func (m *MockAPI) ScheduleTask(arg0, arg1, arg2 string, arg3 url.Values) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ScheduleTask", arg0, arg1, arg2, arg3)
@@ -276,13 +277,13 @@ func (m *MockAPI) ScheduleTask(arg0, arg1, arg2 string, arg3 url.Values) (string
 	return ret0, ret1
 }
 
-// ScheduleTask indicates an expected call of ScheduleTask
+// ScheduleTask indicates an expected call of ScheduleTask.
 func (mr *MockAPIMockRecorder) ScheduleTask(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScheduleTask", reflect.TypeOf((*MockAPI)(nil).ScheduleTask), arg0, arg1, arg2, arg3)
 }
 
-// UpdatePendingTestRun mocks base method
+// UpdatePendingTestRun mocks base method.
 func (m *MockAPI) UpdatePendingTestRun(arg0 shared.PendingTestRun) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdatePendingTestRun", arg0)
@@ -290,13 +291,13 @@ func (m *MockAPI) UpdatePendingTestRun(arg0 shared.PendingTestRun) error {
 	return ret0
 }
 
-// UpdatePendingTestRun indicates an expected call of UpdatePendingTestRun
+// UpdatePendingTestRun indicates an expected call of UpdatePendingTestRun.
 func (mr *MockAPIMockRecorder) UpdatePendingTestRun(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePendingTestRun", reflect.TypeOf((*MockAPI)(nil).UpdatePendingTestRun), arg0)
 }
 
-// UploadToGCS mocks base method
+// UploadToGCS mocks base method.
 func (m *MockAPI) UploadToGCS(arg0 string, arg1 io.Reader, arg2 bool) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UploadToGCS", arg0, arg1, arg2)
@@ -304,7 +305,7 @@ func (m *MockAPI) UploadToGCS(arg0 string, arg1 io.Reader, arg2 bool) error {
 	return ret0
 }
 
-// UploadToGCS indicates an expected call of UploadToGCS
+// UploadToGCS indicates an expected call of UploadToGCS.
 func (mr *MockAPIMockRecorder) UploadToGCS(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadToGCS", reflect.TypeOf((*MockAPI)(nil).UploadToGCS), arg0, arg1, arg2)

--- a/api/taskcluster/mock_taskcluster/webhook_mock.go
+++ b/api/taskcluster/mock_taskcluster/webhook_mock.go
@@ -5,36 +5,37 @@
 package mock_taskcluster
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	github "github.com/google/go-github/v33/github"
 	taskcluster "github.com/web-platform-tests/wpt.fyi/api/taskcluster"
-	reflect "reflect"
 )
 
-// MockAPI is a mock of API interface
+// MockAPI is a mock of API interface.
 type MockAPI struct {
 	ctrl     *gomock.Controller
 	recorder *MockAPIMockRecorder
 }
 
-// MockAPIMockRecorder is the mock recorder for MockAPI
+// MockAPIMockRecorder is the mock recorder for MockAPI.
 type MockAPIMockRecorder struct {
 	mock *MockAPI
 }
 
-// NewMockAPI creates a new mock instance
+// NewMockAPI creates a new mock instance.
 func NewMockAPI(ctrl *gomock.Controller) *MockAPI {
 	mock := &MockAPI{ctrl: ctrl}
 	mock.recorder = &MockAPIMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockAPI) EXPECT() *MockAPIMockRecorder {
 	return m.recorder
 }
 
-// GetTaskGroupInfo mocks base method
+// GetTaskGroupInfo mocks base method.
 func (m *MockAPI) GetTaskGroupInfo(arg0, arg1 string) (*taskcluster.TaskGroupInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTaskGroupInfo", arg0, arg1)
@@ -43,13 +44,13 @@ func (m *MockAPI) GetTaskGroupInfo(arg0, arg1 string) (*taskcluster.TaskGroupInf
 	return ret0, ret1
 }
 
-// GetTaskGroupInfo indicates an expected call of GetTaskGroupInfo
+// GetTaskGroupInfo indicates an expected call of GetTaskGroupInfo.
 func (mr *MockAPIMockRecorder) GetTaskGroupInfo(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTaskGroupInfo", reflect.TypeOf((*MockAPI)(nil).GetTaskGroupInfo), arg0, arg1)
 }
 
-// ListCheckRuns mocks base method
+// ListCheckRuns mocks base method.
 func (m *MockAPI) ListCheckRuns(arg0, arg1 string, arg2 int64) ([]*github.CheckRun, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListCheckRuns", arg0, arg1, arg2)
@@ -58,7 +59,7 @@ func (m *MockAPI) ListCheckRuns(arg0, arg1 string, arg2 int64) ([]*github.CheckR
 	return ret0, ret1
 }
 
-// ListCheckRuns indicates an expected call of ListCheckRuns
+// ListCheckRuns indicates an expected call of ListCheckRuns.
 func (mr *MockAPIMockRecorder) ListCheckRuns(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCheckRuns", reflect.TypeOf((*MockAPI)(nil).ListCheckRuns), arg0, arg1, arg2)

--- a/shared/sharedtest/appengine_mock.go
+++ b/shared/sharedtest/appengine_mock.go
@@ -6,39 +6,40 @@ package sharedtest
 
 import (
 	context "context"
-	gomock "github.com/golang/mock/gomock"
-	github "github.com/google/go-github/v33/github"
-	shared "github.com/web-platform-tests/wpt.fyi/shared"
 	http "net/http"
 	url "net/url"
 	reflect "reflect"
 	time "time"
+
+	gomock "github.com/golang/mock/gomock"
+	github "github.com/google/go-github/v33/github"
+	shared "github.com/web-platform-tests/wpt.fyi/shared"
 )
 
-// MockAppEngineAPI is a mock of AppEngineAPI interface
+// MockAppEngineAPI is a mock of AppEngineAPI interface.
 type MockAppEngineAPI struct {
 	ctrl     *gomock.Controller
 	recorder *MockAppEngineAPIMockRecorder
 }
 
-// MockAppEngineAPIMockRecorder is the mock recorder for MockAppEngineAPI
+// MockAppEngineAPIMockRecorder is the mock recorder for MockAppEngineAPI.
 type MockAppEngineAPIMockRecorder struct {
 	mock *MockAppEngineAPI
 }
 
-// NewMockAppEngineAPI creates a new mock instance
+// NewMockAppEngineAPI creates a new mock instance.
 func NewMockAppEngineAPI(ctrl *gomock.Controller) *MockAppEngineAPI {
 	mock := &MockAppEngineAPI{ctrl: ctrl}
 	mock.recorder = &MockAppEngineAPIMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockAppEngineAPI) EXPECT() *MockAppEngineAPIMockRecorder {
 	return m.recorder
 }
 
-// Context mocks base method
+// Context mocks base method.
 func (m *MockAppEngineAPI) Context() context.Context {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Context")
@@ -46,13 +47,13 @@ func (m *MockAppEngineAPI) Context() context.Context {
 	return ret0
 }
 
-// Context indicates an expected call of Context
+// Context indicates an expected call of Context.
 func (mr *MockAppEngineAPIMockRecorder) Context() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockAppEngineAPI)(nil).Context))
 }
 
-// GetGitHubClient mocks base method
+// GetGitHubClient mocks base method.
 func (m *MockAppEngineAPI) GetGitHubClient() (*github.Client, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetGitHubClient")
@@ -61,13 +62,13 @@ func (m *MockAppEngineAPI) GetGitHubClient() (*github.Client, error) {
 	return ret0, ret1
 }
 
-// GetGitHubClient indicates an expected call of GetGitHubClient
+// GetGitHubClient indicates an expected call of GetGitHubClient.
 func (mr *MockAppEngineAPIMockRecorder) GetGitHubClient() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGitHubClient", reflect.TypeOf((*MockAppEngineAPI)(nil).GetGitHubClient))
 }
 
-// GetHTTPClient mocks base method
+// GetHTTPClient mocks base method.
 func (m *MockAppEngineAPI) GetHTTPClient() *http.Client {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHTTPClient")
@@ -75,13 +76,13 @@ func (m *MockAppEngineAPI) GetHTTPClient() *http.Client {
 	return ret0
 }
 
-// GetHTTPClient indicates an expected call of GetHTTPClient
+// GetHTTPClient indicates an expected call of GetHTTPClient.
 func (mr *MockAppEngineAPIMockRecorder) GetHTTPClient() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHTTPClient", reflect.TypeOf((*MockAppEngineAPI)(nil).GetHTTPClient))
 }
 
-// GetHTTPClientWithTimeout mocks base method
+// GetHTTPClientWithTimeout mocks base method.
 func (m *MockAppEngineAPI) GetHTTPClientWithTimeout(arg0 time.Duration) *http.Client {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHTTPClientWithTimeout", arg0)
@@ -89,13 +90,13 @@ func (m *MockAppEngineAPI) GetHTTPClientWithTimeout(arg0 time.Duration) *http.Cl
 	return ret0
 }
 
-// GetHTTPClientWithTimeout indicates an expected call of GetHTTPClientWithTimeout
+// GetHTTPClientWithTimeout indicates an expected call of GetHTTPClientWithTimeout.
 func (mr *MockAppEngineAPIMockRecorder) GetHTTPClientWithTimeout(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHTTPClientWithTimeout", reflect.TypeOf((*MockAppEngineAPI)(nil).GetHTTPClientWithTimeout), arg0)
 }
 
-// GetHostname mocks base method
+// GetHostname mocks base method.
 func (m *MockAppEngineAPI) GetHostname() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHostname")
@@ -103,13 +104,13 @@ func (m *MockAppEngineAPI) GetHostname() string {
 	return ret0
 }
 
-// GetHostname indicates an expected call of GetHostname
+// GetHostname indicates an expected call of GetHostname.
 func (mr *MockAppEngineAPIMockRecorder) GetHostname() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHostname", reflect.TypeOf((*MockAppEngineAPI)(nil).GetHostname))
 }
 
-// GetResultsURL mocks base method
+// GetResultsURL mocks base method.
 func (m *MockAppEngineAPI) GetResultsURL(arg0 shared.TestRunFilter) *url.URL {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetResultsURL", arg0)
@@ -117,13 +118,13 @@ func (m *MockAppEngineAPI) GetResultsURL(arg0 shared.TestRunFilter) *url.URL {
 	return ret0
 }
 
-// GetResultsURL indicates an expected call of GetResultsURL
+// GetResultsURL indicates an expected call of GetResultsURL.
 func (mr *MockAppEngineAPIMockRecorder) GetResultsURL(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResultsURL", reflect.TypeOf((*MockAppEngineAPI)(nil).GetResultsURL), arg0)
 }
 
-// GetResultsUploadURL mocks base method
+// GetResultsUploadURL mocks base method.
 func (m *MockAppEngineAPI) GetResultsUploadURL() *url.URL {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetResultsUploadURL")
@@ -131,13 +132,13 @@ func (m *MockAppEngineAPI) GetResultsUploadURL() *url.URL {
 	return ret0
 }
 
-// GetResultsUploadURL indicates an expected call of GetResultsUploadURL
+// GetResultsUploadURL indicates an expected call of GetResultsUploadURL.
 func (mr *MockAppEngineAPIMockRecorder) GetResultsUploadURL() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResultsUploadURL", reflect.TypeOf((*MockAppEngineAPI)(nil).GetResultsUploadURL))
 }
 
-// GetRunsURL mocks base method
+// GetRunsURL mocks base method.
 func (m *MockAppEngineAPI) GetRunsURL(arg0 shared.TestRunFilter) *url.URL {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRunsURL", arg0)
@@ -145,13 +146,13 @@ func (m *MockAppEngineAPI) GetRunsURL(arg0 shared.TestRunFilter) *url.URL {
 	return ret0
 }
 
-// GetRunsURL indicates an expected call of GetRunsURL
+// GetRunsURL indicates an expected call of GetRunsURL.
 func (mr *MockAppEngineAPIMockRecorder) GetRunsURL(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRunsURL", reflect.TypeOf((*MockAppEngineAPI)(nil).GetRunsURL), arg0)
 }
 
-// GetServiceHostname mocks base method
+// GetServiceHostname mocks base method.
 func (m *MockAppEngineAPI) GetServiceHostname(arg0 string) string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetServiceHostname", arg0)
@@ -159,13 +160,13 @@ func (m *MockAppEngineAPI) GetServiceHostname(arg0 string) string {
 	return ret0
 }
 
-// GetServiceHostname indicates an expected call of GetServiceHostname
+// GetServiceHostname indicates an expected call of GetServiceHostname.
 func (mr *MockAppEngineAPIMockRecorder) GetServiceHostname(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceHostname", reflect.TypeOf((*MockAppEngineAPI)(nil).GetServiceHostname), arg0)
 }
 
-// GetUploader mocks base method
+// GetUploader mocks base method.
 func (m *MockAppEngineAPI) GetUploader(arg0 string) (shared.Uploader, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUploader", arg0)
@@ -174,13 +175,13 @@ func (m *MockAppEngineAPI) GetUploader(arg0 string) (shared.Uploader, error) {
 	return ret0, ret1
 }
 
-// GetUploader indicates an expected call of GetUploader
+// GetUploader indicates an expected call of GetUploader.
 func (mr *MockAppEngineAPIMockRecorder) GetUploader(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUploader", reflect.TypeOf((*MockAppEngineAPI)(nil).GetUploader), arg0)
 }
 
-// GetVersion mocks base method
+// GetVersion mocks base method.
 func (m *MockAppEngineAPI) GetVersion() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetVersion")
@@ -188,13 +189,13 @@ func (m *MockAppEngineAPI) GetVersion() string {
 	return ret0
 }
 
-// GetVersion indicates an expected call of GetVersion
+// GetVersion indicates an expected call of GetVersion.
 func (mr *MockAppEngineAPIMockRecorder) GetVersion() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVersion", reflect.TypeOf((*MockAppEngineAPI)(nil).GetVersion))
 }
 
-// GetVersionedHostname mocks base method
+// GetVersionedHostname mocks base method.
 func (m *MockAppEngineAPI) GetVersionedHostname() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetVersionedHostname")
@@ -202,13 +203,13 @@ func (m *MockAppEngineAPI) GetVersionedHostname() string {
 	return ret0
 }
 
-// GetVersionedHostname indicates an expected call of GetVersionedHostname
+// GetVersionedHostname indicates an expected call of GetVersionedHostname.
 func (mr *MockAppEngineAPIMockRecorder) GetVersionedHostname() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVersionedHostname", reflect.TypeOf((*MockAppEngineAPI)(nil).GetVersionedHostname))
 }
 
-// IsFeatureEnabled mocks base method
+// IsFeatureEnabled mocks base method.
 func (m *MockAppEngineAPI) IsFeatureEnabled(arg0 string) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsFeatureEnabled", arg0)
@@ -216,13 +217,13 @@ func (m *MockAppEngineAPI) IsFeatureEnabled(arg0 string) bool {
 	return ret0
 }
 
-// IsFeatureEnabled indicates an expected call of IsFeatureEnabled
+// IsFeatureEnabled indicates an expected call of IsFeatureEnabled.
 func (mr *MockAppEngineAPIMockRecorder) IsFeatureEnabled(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsFeatureEnabled", reflect.TypeOf((*MockAppEngineAPI)(nil).IsFeatureEnabled), arg0)
 }
 
-// ScheduleTask mocks base method
+// ScheduleTask mocks base method.
 func (m *MockAppEngineAPI) ScheduleTask(arg0, arg1, arg2 string, arg3 url.Values) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ScheduleTask", arg0, arg1, arg2, arg3)
@@ -231,7 +232,7 @@ func (m *MockAppEngineAPI) ScheduleTask(arg0, arg1, arg2 string, arg3 url.Values
 	return ret0, ret1
 }
 
-// ScheduleTask indicates an expected call of ScheduleTask
+// ScheduleTask indicates an expected call of ScheduleTask.
 func (mr *MockAppEngineAPIMockRecorder) ScheduleTask(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScheduleTask", reflect.TypeOf((*MockAppEngineAPI)(nil).ScheduleTask), arg0, arg1, arg2, arg3)

--- a/shared/sharedtest/cache_mock.go
+++ b/shared/sharedtest/cache_mock.go
@@ -5,35 +5,36 @@
 package sharedtest
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	io "io"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockCachedStore is a mock of CachedStore interface
+// MockCachedStore is a mock of CachedStore interface.
 type MockCachedStore struct {
 	ctrl     *gomock.Controller
 	recorder *MockCachedStoreMockRecorder
 }
 
-// MockCachedStoreMockRecorder is the mock recorder for MockCachedStore
+// MockCachedStoreMockRecorder is the mock recorder for MockCachedStore.
 type MockCachedStoreMockRecorder struct {
 	mock *MockCachedStore
 }
 
-// NewMockCachedStore creates a new mock instance
+// NewMockCachedStore creates a new mock instance.
 func NewMockCachedStore(ctrl *gomock.Controller) *MockCachedStore {
 	mock := &MockCachedStore{ctrl: ctrl}
 	mock.recorder = &MockCachedStoreMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockCachedStore) EXPECT() *MockCachedStoreMockRecorder {
 	return m.recorder
 }
 
-// Get mocks base method
+// Get mocks base method.
 func (m *MockCachedStore) Get(arg0, arg1, arg2 interface{}) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", arg0, arg1, arg2)
@@ -41,36 +42,36 @@ func (m *MockCachedStore) Get(arg0, arg1, arg2 interface{}) error {
 	return ret0
 }
 
-// Get indicates an expected call of Get
+// Get indicates an expected call of Get.
 func (mr *MockCachedStoreMockRecorder) Get(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockCachedStore)(nil).Get), arg0, arg1, arg2)
 }
 
-// MockObjectCache is a mock of ObjectCache interface
+// MockObjectCache is a mock of ObjectCache interface.
 type MockObjectCache struct {
 	ctrl     *gomock.Controller
 	recorder *MockObjectCacheMockRecorder
 }
 
-// MockObjectCacheMockRecorder is the mock recorder for MockObjectCache
+// MockObjectCacheMockRecorder is the mock recorder for MockObjectCache.
 type MockObjectCacheMockRecorder struct {
 	mock *MockObjectCache
 }
 
-// NewMockObjectCache creates a new mock instance
+// NewMockObjectCache creates a new mock instance.
 func NewMockObjectCache(ctrl *gomock.Controller) *MockObjectCache {
 	mock := &MockObjectCache{ctrl: ctrl}
 	mock.recorder = &MockObjectCacheMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockObjectCache) EXPECT() *MockObjectCacheMockRecorder {
 	return m.recorder
 }
 
-// Get mocks base method
+// Get mocks base method.
 func (m *MockObjectCache) Get(arg0, arg1 interface{}) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", arg0, arg1)
@@ -78,13 +79,13 @@ func (m *MockObjectCache) Get(arg0, arg1 interface{}) error {
 	return ret0
 }
 
-// Get indicates an expected call of Get
+// Get indicates an expected call of Get.
 func (mr *MockObjectCacheMockRecorder) Get(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockObjectCache)(nil).Get), arg0, arg1)
 }
 
-// Put mocks base method
+// Put mocks base method.
 func (m *MockObjectCache) Put(arg0, arg1 interface{}) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Put", arg0, arg1)
@@ -92,36 +93,36 @@ func (m *MockObjectCache) Put(arg0, arg1 interface{}) error {
 	return ret0
 }
 
-// Put indicates an expected call of Put
+// Put indicates an expected call of Put.
 func (mr *MockObjectCacheMockRecorder) Put(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockObjectCache)(nil).Put), arg0, arg1)
 }
 
-// MockObjectStore is a mock of ObjectStore interface
+// MockObjectStore is a mock of ObjectStore interface.
 type MockObjectStore struct {
 	ctrl     *gomock.Controller
 	recorder *MockObjectStoreMockRecorder
 }
 
-// MockObjectStoreMockRecorder is the mock recorder for MockObjectStore
+// MockObjectStoreMockRecorder is the mock recorder for MockObjectStore.
 type MockObjectStoreMockRecorder struct {
 	mock *MockObjectStore
 }
 
-// NewMockObjectStore creates a new mock instance
+// NewMockObjectStore creates a new mock instance.
 func NewMockObjectStore(ctrl *gomock.Controller) *MockObjectStore {
 	mock := &MockObjectStore{ctrl: ctrl}
 	mock.recorder = &MockObjectStoreMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockObjectStore) EXPECT() *MockObjectStoreMockRecorder {
 	return m.recorder
 }
 
-// Get mocks base method
+// Get mocks base method.
 func (m *MockObjectStore) Get(arg0, arg1 interface{}) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", arg0, arg1)
@@ -129,36 +130,36 @@ func (m *MockObjectStore) Get(arg0, arg1 interface{}) error {
 	return ret0
 }
 
-// Get indicates an expected call of Get
+// Get indicates an expected call of Get.
 func (mr *MockObjectStoreMockRecorder) Get(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockObjectStore)(nil).Get), arg0, arg1)
 }
 
-// MockReadWritable is a mock of ReadWritable interface
+// MockReadWritable is a mock of ReadWritable interface.
 type MockReadWritable struct {
 	ctrl     *gomock.Controller
 	recorder *MockReadWritableMockRecorder
 }
 
-// MockReadWritableMockRecorder is the mock recorder for MockReadWritable
+// MockReadWritableMockRecorder is the mock recorder for MockReadWritable.
 type MockReadWritableMockRecorder struct {
 	mock *MockReadWritable
 }
 
-// NewMockReadWritable creates a new mock instance
+// NewMockReadWritable creates a new mock instance.
 func NewMockReadWritable(ctrl *gomock.Controller) *MockReadWritable {
 	mock := &MockReadWritable{ctrl: ctrl}
 	mock.recorder = &MockReadWritableMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockReadWritable) EXPECT() *MockReadWritableMockRecorder {
 	return m.recorder
 }
 
-// NewReadCloser mocks base method
+// NewReadCloser mocks base method.
 func (m *MockReadWritable) NewReadCloser(arg0 interface{}) (io.ReadCloser, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewReadCloser", arg0)
@@ -167,13 +168,13 @@ func (m *MockReadWritable) NewReadCloser(arg0 interface{}) (io.ReadCloser, error
 	return ret0, ret1
 }
 
-// NewReadCloser indicates an expected call of NewReadCloser
+// NewReadCloser indicates an expected call of NewReadCloser.
 func (mr *MockReadWritableMockRecorder) NewReadCloser(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewReadCloser", reflect.TypeOf((*MockReadWritable)(nil).NewReadCloser), arg0)
 }
 
-// NewWriteCloser mocks base method
+// NewWriteCloser mocks base method.
 func (m *MockReadWritable) NewWriteCloser(arg0 interface{}) (io.WriteCloser, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewWriteCloser", arg0)
@@ -182,36 +183,36 @@ func (m *MockReadWritable) NewWriteCloser(arg0 interface{}) (io.WriteCloser, err
 	return ret0, ret1
 }
 
-// NewWriteCloser indicates an expected call of NewWriteCloser
+// NewWriteCloser indicates an expected call of NewWriteCloser.
 func (mr *MockReadWritableMockRecorder) NewWriteCloser(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewWriteCloser", reflect.TypeOf((*MockReadWritable)(nil).NewWriteCloser), arg0)
 }
 
-// MockReadable is a mock of Readable interface
+// MockReadable is a mock of Readable interface.
 type MockReadable struct {
 	ctrl     *gomock.Controller
 	recorder *MockReadableMockRecorder
 }
 
-// MockReadableMockRecorder is the mock recorder for MockReadable
+// MockReadableMockRecorder is the mock recorder for MockReadable.
 type MockReadableMockRecorder struct {
 	mock *MockReadable
 }
 
-// NewMockReadable creates a new mock instance
+// NewMockReadable creates a new mock instance.
 func NewMockReadable(ctrl *gomock.Controller) *MockReadable {
 	mock := &MockReadable{ctrl: ctrl}
 	mock.recorder = &MockReadableMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockReadable) EXPECT() *MockReadableMockRecorder {
 	return m.recorder
 }
 
-// NewReadCloser mocks base method
+// NewReadCloser mocks base method.
 func (m *MockReadable) NewReadCloser(arg0 interface{}) (io.ReadCloser, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewReadCloser", arg0)
@@ -220,36 +221,36 @@ func (m *MockReadable) NewReadCloser(arg0 interface{}) (io.ReadCloser, error) {
 	return ret0, ret1
 }
 
-// NewReadCloser indicates an expected call of NewReadCloser
+// NewReadCloser indicates an expected call of NewReadCloser.
 func (mr *MockReadableMockRecorder) NewReadCloser(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewReadCloser", reflect.TypeOf((*MockReadable)(nil).NewReadCloser), arg0)
 }
 
-// MockRedisSet is a mock of RedisSet interface
+// MockRedisSet is a mock of RedisSet interface.
 type MockRedisSet struct {
 	ctrl     *gomock.Controller
 	recorder *MockRedisSetMockRecorder
 }
 
-// MockRedisSetMockRecorder is the mock recorder for MockRedisSet
+// MockRedisSetMockRecorder is the mock recorder for MockRedisSet.
 type MockRedisSetMockRecorder struct {
 	mock *MockRedisSet
 }
 
-// NewMockRedisSet creates a new mock instance
+// NewMockRedisSet creates a new mock instance.
 func NewMockRedisSet(ctrl *gomock.Controller) *MockRedisSet {
 	mock := &MockRedisSet{ctrl: ctrl}
 	mock.recorder = &MockRedisSetMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockRedisSet) EXPECT() *MockRedisSetMockRecorder {
 	return m.recorder
 }
 
-// Add mocks base method
+// Add mocks base method.
 func (m *MockRedisSet) Add(arg0, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Add", arg0, arg1)
@@ -257,13 +258,13 @@ func (m *MockRedisSet) Add(arg0, arg1 string) error {
 	return ret0
 }
 
-// Add indicates an expected call of Add
+// Add indicates an expected call of Add.
 func (mr *MockRedisSetMockRecorder) Add(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Add", reflect.TypeOf((*MockRedisSet)(nil).Add), arg0, arg1)
 }
 
-// GetAll mocks base method
+// GetAll mocks base method.
 func (m *MockRedisSet) GetAll(arg0 string) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAll", arg0)
@@ -272,13 +273,13 @@ func (m *MockRedisSet) GetAll(arg0 string) ([]string, error) {
 	return ret0, ret1
 }
 
-// GetAll indicates an expected call of GetAll
+// GetAll indicates an expected call of GetAll.
 func (mr *MockRedisSetMockRecorder) GetAll(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAll", reflect.TypeOf((*MockRedisSet)(nil).GetAll), arg0)
 }
 
-// Remove mocks base method
+// Remove mocks base method.
 func (m *MockRedisSet) Remove(arg0, arg1 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Remove", arg0, arg1)
@@ -286,7 +287,7 @@ func (m *MockRedisSet) Remove(arg0, arg1 string) error {
 	return ret0
 }
 
-// Remove indicates an expected call of Remove
+// Remove indicates an expected call of Remove.
 func (mr *MockRedisSetMockRecorder) Remove(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockRedisSet)(nil).Remove), arg0, arg1)

--- a/shared/sharedtest/datastore_mock.go
+++ b/shared/sharedtest/datastore_mock.go
@@ -6,35 +6,36 @@ package sharedtest
 
 import (
 	context "context"
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	shared "github.com/web-platform-tests/wpt.fyi/shared"
-	reflect "reflect"
 )
 
-// MockDatastore is a mock of Datastore interface
+// MockDatastore is a mock of Datastore interface.
 type MockDatastore struct {
 	ctrl     *gomock.Controller
 	recorder *MockDatastoreMockRecorder
 }
 
-// MockDatastoreMockRecorder is the mock recorder for MockDatastore
+// MockDatastoreMockRecorder is the mock recorder for MockDatastore.
 type MockDatastoreMockRecorder struct {
 	mock *MockDatastore
 }
 
-// NewMockDatastore creates a new mock instance
+// NewMockDatastore creates a new mock instance.
 func NewMockDatastore(ctrl *gomock.Controller) *MockDatastore {
 	mock := &MockDatastore{ctrl: ctrl}
 	mock.recorder = &MockDatastoreMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockDatastore) EXPECT() *MockDatastoreMockRecorder {
 	return m.recorder
 }
 
-// Context mocks base method
+// Context mocks base method.
 func (m *MockDatastore) Context() context.Context {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Context")
@@ -42,13 +43,13 @@ func (m *MockDatastore) Context() context.Context {
 	return ret0
 }
 
-// Context indicates an expected call of Context
+// Context indicates an expected call of Context.
 func (mr *MockDatastoreMockRecorder) Context() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockDatastore)(nil).Context))
 }
 
-// Done mocks base method
+// Done mocks base method.
 func (m *MockDatastore) Done() interface{} {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Done")
@@ -56,13 +57,13 @@ func (m *MockDatastore) Done() interface{} {
 	return ret0
 }
 
-// Done indicates an expected call of Done
+// Done indicates an expected call of Done.
 func (mr *MockDatastoreMockRecorder) Done() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Done", reflect.TypeOf((*MockDatastore)(nil).Done))
 }
 
-// Get mocks base method
+// Get mocks base method.
 func (m *MockDatastore) Get(arg0 shared.Key, arg1 interface{}) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", arg0, arg1)
@@ -70,13 +71,13 @@ func (m *MockDatastore) Get(arg0 shared.Key, arg1 interface{}) error {
 	return ret0
 }
 
-// Get indicates an expected call of Get
+// Get indicates an expected call of Get.
 func (mr *MockDatastoreMockRecorder) Get(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockDatastore)(nil).Get), arg0, arg1)
 }
 
-// GetAll mocks base method
+// GetAll mocks base method.
 func (m *MockDatastore) GetAll(arg0 shared.Query, arg1 interface{}) ([]shared.Key, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAll", arg0, arg1)
@@ -85,13 +86,13 @@ func (m *MockDatastore) GetAll(arg0 shared.Query, arg1 interface{}) ([]shared.Ke
 	return ret0, ret1
 }
 
-// GetAll indicates an expected call of GetAll
+// GetAll indicates an expected call of GetAll.
 func (mr *MockDatastoreMockRecorder) GetAll(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAll", reflect.TypeOf((*MockDatastore)(nil).GetAll), arg0, arg1)
 }
 
-// GetMulti mocks base method
+// GetMulti mocks base method.
 func (m *MockDatastore) GetMulti(arg0 []shared.Key, arg1 interface{}) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMulti", arg0, arg1)
@@ -99,13 +100,13 @@ func (m *MockDatastore) GetMulti(arg0 []shared.Key, arg1 interface{}) error {
 	return ret0
 }
 
-// GetMulti indicates an expected call of GetMulti
+// GetMulti indicates an expected call of GetMulti.
 func (mr *MockDatastoreMockRecorder) GetMulti(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMulti", reflect.TypeOf((*MockDatastore)(nil).GetMulti), arg0, arg1)
 }
 
-// Insert mocks base method
+// Insert mocks base method.
 func (m *MockDatastore) Insert(arg0 shared.Key, arg1 interface{}) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Insert", arg0, arg1)
@@ -113,13 +114,13 @@ func (m *MockDatastore) Insert(arg0 shared.Key, arg1 interface{}) error {
 	return ret0
 }
 
-// Insert indicates an expected call of Insert
+// Insert indicates an expected call of Insert.
 func (mr *MockDatastoreMockRecorder) Insert(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Insert", reflect.TypeOf((*MockDatastore)(nil).Insert), arg0, arg1)
 }
 
-// NewIDKey mocks base method
+// NewIDKey mocks base method.
 func (m *MockDatastore) NewIDKey(arg0 string, arg1 int64) shared.Key {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewIDKey", arg0, arg1)
@@ -127,13 +128,13 @@ func (m *MockDatastore) NewIDKey(arg0 string, arg1 int64) shared.Key {
 	return ret0
 }
 
-// NewIDKey indicates an expected call of NewIDKey
+// NewIDKey indicates an expected call of NewIDKey.
 func (mr *MockDatastoreMockRecorder) NewIDKey(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewIDKey", reflect.TypeOf((*MockDatastore)(nil).NewIDKey), arg0, arg1)
 }
 
-// NewIncompleteKey mocks base method
+// NewIncompleteKey mocks base method.
 func (m *MockDatastore) NewIncompleteKey(arg0 string) shared.Key {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewIncompleteKey", arg0)
@@ -141,13 +142,13 @@ func (m *MockDatastore) NewIncompleteKey(arg0 string) shared.Key {
 	return ret0
 }
 
-// NewIncompleteKey indicates an expected call of NewIncompleteKey
+// NewIncompleteKey indicates an expected call of NewIncompleteKey.
 func (mr *MockDatastoreMockRecorder) NewIncompleteKey(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewIncompleteKey", reflect.TypeOf((*MockDatastore)(nil).NewIncompleteKey), arg0)
 }
 
-// NewNameKey mocks base method
+// NewNameKey mocks base method.
 func (m *MockDatastore) NewNameKey(arg0, arg1 string) shared.Key {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewNameKey", arg0, arg1)
@@ -155,13 +156,13 @@ func (m *MockDatastore) NewNameKey(arg0, arg1 string) shared.Key {
 	return ret0
 }
 
-// NewNameKey indicates an expected call of NewNameKey
+// NewNameKey indicates an expected call of NewNameKey.
 func (mr *MockDatastoreMockRecorder) NewNameKey(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewNameKey", reflect.TypeOf((*MockDatastore)(nil).NewNameKey), arg0, arg1)
 }
 
-// NewQuery mocks base method
+// NewQuery mocks base method.
 func (m *MockDatastore) NewQuery(arg0 string) shared.Query {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewQuery", arg0)
@@ -169,13 +170,13 @@ func (m *MockDatastore) NewQuery(arg0 string) shared.Query {
 	return ret0
 }
 
-// NewQuery indicates an expected call of NewQuery
+// NewQuery indicates an expected call of NewQuery.
 func (mr *MockDatastoreMockRecorder) NewQuery(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewQuery", reflect.TypeOf((*MockDatastore)(nil).NewQuery), arg0)
 }
 
-// Put mocks base method
+// Put mocks base method.
 func (m *MockDatastore) Put(arg0 shared.Key, arg1 interface{}) (shared.Key, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Put", arg0, arg1)
@@ -184,13 +185,13 @@ func (m *MockDatastore) Put(arg0 shared.Key, arg1 interface{}) (shared.Key, erro
 	return ret0, ret1
 }
 
-// Put indicates an expected call of Put
+// Put indicates an expected call of Put.
 func (mr *MockDatastoreMockRecorder) Put(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockDatastore)(nil).Put), arg0, arg1)
 }
 
-// PutMulti mocks base method
+// PutMulti mocks base method.
 func (m *MockDatastore) PutMulti(arg0 []shared.Key, arg1 interface{}) ([]shared.Key, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutMulti", arg0, arg1)
@@ -199,13 +200,13 @@ func (m *MockDatastore) PutMulti(arg0 []shared.Key, arg1 interface{}) ([]shared.
 	return ret0, ret1
 }
 
-// PutMulti indicates an expected call of PutMulti
+// PutMulti indicates an expected call of PutMulti.
 func (mr *MockDatastoreMockRecorder) PutMulti(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutMulti", reflect.TypeOf((*MockDatastore)(nil).PutMulti), arg0, arg1)
 }
 
-// ReserveID mocks base method
+// ReserveID mocks base method.
 func (m *MockDatastore) ReserveID(arg0 string) (shared.Key, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReserveID", arg0)
@@ -214,13 +215,13 @@ func (m *MockDatastore) ReserveID(arg0 string) (shared.Key, error) {
 	return ret0, ret1
 }
 
-// ReserveID indicates an expected call of ReserveID
+// ReserveID indicates an expected call of ReserveID.
 func (mr *MockDatastoreMockRecorder) ReserveID(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReserveID", reflect.TypeOf((*MockDatastore)(nil).ReserveID), arg0)
 }
 
-// TestRunQuery mocks base method
+// TestRunQuery mocks base method.
 func (m *MockDatastore) TestRunQuery() shared.TestRunQuery {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TestRunQuery")
@@ -228,13 +229,13 @@ func (m *MockDatastore) TestRunQuery() shared.TestRunQuery {
 	return ret0
 }
 
-// TestRunQuery indicates an expected call of TestRunQuery
+// TestRunQuery indicates an expected call of TestRunQuery.
 func (mr *MockDatastoreMockRecorder) TestRunQuery() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TestRunQuery", reflect.TypeOf((*MockDatastore)(nil).TestRunQuery))
 }
 
-// Update mocks base method
+// Update mocks base method.
 func (m *MockDatastore) Update(arg0 shared.Key, arg1 interface{}, arg2 func(interface{}) error) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Update", arg0, arg1, arg2)
@@ -242,7 +243,7 @@ func (m *MockDatastore) Update(arg0 shared.Key, arg1 interface{}, arg2 func(inte
 	return ret0
 }
 
-// Update indicates an expected call of Update
+// Update indicates an expected call of Update.
 func (mr *MockDatastoreMockRecorder) Update(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockDatastore)(nil).Update), arg0, arg1, arg2)

--- a/shared/sharedtest/fetch_bsf_mock.go
+++ b/shared/sharedtest/fetch_bsf_mock.go
@@ -5,34 +5,35 @@
 package sharedtest
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockFetchBSF is a mock of FetchBSF interface
+// MockFetchBSF is a mock of FetchBSF interface.
 type MockFetchBSF struct {
 	ctrl     *gomock.Controller
 	recorder *MockFetchBSFMockRecorder
 }
 
-// MockFetchBSFMockRecorder is the mock recorder for MockFetchBSF
+// MockFetchBSFMockRecorder is the mock recorder for MockFetchBSF.
 type MockFetchBSFMockRecorder struct {
 	mock *MockFetchBSF
 }
 
-// NewMockFetchBSF creates a new mock instance
+// NewMockFetchBSF creates a new mock instance.
 func NewMockFetchBSF(ctrl *gomock.Controller) *MockFetchBSF {
 	mock := &MockFetchBSF{ctrl: ctrl}
 	mock.recorder = &MockFetchBSFMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockFetchBSF) EXPECT() *MockFetchBSFMockRecorder {
 	return m.recorder
 }
 
-// Fetch mocks base method
+// Fetch mocks base method.
 func (m *MockFetchBSF) Fetch(arg0 bool) ([][]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Fetch", arg0)
@@ -41,7 +42,7 @@ func (m *MockFetchBSF) Fetch(arg0 bool) ([][]string, error) {
 	return ret0, ret1
 }
 
-// Fetch indicates an expected call of Fetch
+// Fetch indicates an expected call of Fetch.
 func (mr *MockFetchBSFMockRecorder) Fetch(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Fetch", reflect.TypeOf((*MockFetchBSF)(nil).Fetch), arg0)

--- a/shared/sharedtest/github_oauth_mock.go
+++ b/shared/sharedtest/github_oauth_mock.go
@@ -6,37 +6,38 @@ package sharedtest
 
 import (
 	context "context"
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	github "github.com/google/go-github/v33/github"
 	shared "github.com/web-platform-tests/wpt.fyi/shared"
 	oauth2 "golang.org/x/oauth2"
-	reflect "reflect"
 )
 
-// MockGitHubOAuth is a mock of GitHubOAuth interface
+// MockGitHubOAuth is a mock of GitHubOAuth interface.
 type MockGitHubOAuth struct {
 	ctrl     *gomock.Controller
 	recorder *MockGitHubOAuthMockRecorder
 }
 
-// MockGitHubOAuthMockRecorder is the mock recorder for MockGitHubOAuth
+// MockGitHubOAuthMockRecorder is the mock recorder for MockGitHubOAuth.
 type MockGitHubOAuthMockRecorder struct {
 	mock *MockGitHubOAuth
 }
 
-// NewMockGitHubOAuth creates a new mock instance
+// NewMockGitHubOAuth creates a new mock instance.
 func NewMockGitHubOAuth(ctrl *gomock.Controller) *MockGitHubOAuth {
 	mock := &MockGitHubOAuth{ctrl: ctrl}
 	mock.recorder = &MockGitHubOAuthMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockGitHubOAuth) EXPECT() *MockGitHubOAuthMockRecorder {
 	return m.recorder
 }
 
-// Context mocks base method
+// Context mocks base method.
 func (m *MockGitHubOAuth) Context() context.Context {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Context")
@@ -44,13 +45,13 @@ func (m *MockGitHubOAuth) Context() context.Context {
 	return ret0
 }
 
-// Context indicates an expected call of Context
+// Context indicates an expected call of Context.
 func (mr *MockGitHubOAuthMockRecorder) Context() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockGitHubOAuth)(nil).Context))
 }
 
-// Datastore mocks base method
+// Datastore mocks base method.
 func (m *MockGitHubOAuth) Datastore() shared.Datastore {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Datastore")
@@ -58,13 +59,13 @@ func (m *MockGitHubOAuth) Datastore() shared.Datastore {
 	return ret0
 }
 
-// Datastore indicates an expected call of Datastore
+// Datastore indicates an expected call of Datastore.
 func (mr *MockGitHubOAuthMockRecorder) Datastore() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Datastore", reflect.TypeOf((*MockGitHubOAuth)(nil).Datastore))
 }
 
-// GetAccessToken mocks base method
+// GetAccessToken mocks base method.
 func (m *MockGitHubOAuth) GetAccessToken() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAccessToken")
@@ -72,13 +73,13 @@ func (m *MockGitHubOAuth) GetAccessToken() string {
 	return ret0
 }
 
-// GetAccessToken indicates an expected call of GetAccessToken
+// GetAccessToken indicates an expected call of GetAccessToken.
 func (mr *MockGitHubOAuthMockRecorder) GetAccessToken() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAccessToken", reflect.TypeOf((*MockGitHubOAuth)(nil).GetAccessToken))
 }
 
-// GetAuthCodeURL mocks base method
+// GetAuthCodeURL mocks base method.
 func (m *MockGitHubOAuth) GetAuthCodeURL(arg0 string, arg1 ...oauth2.AuthCodeOption) string {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
@@ -90,14 +91,14 @@ func (m *MockGitHubOAuth) GetAuthCodeURL(arg0 string, arg1 ...oauth2.AuthCodeOpt
 	return ret0
 }
 
-// GetAuthCodeURL indicates an expected call of GetAuthCodeURL
+// GetAuthCodeURL indicates an expected call of GetAuthCodeURL.
 func (mr *MockGitHubOAuthMockRecorder) GetAuthCodeURL(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAuthCodeURL", reflect.TypeOf((*MockGitHubOAuth)(nil).GetAuthCodeURL), varargs...)
 }
 
-// GetUser mocks base method
+// GetUser mocks base method.
 func (m *MockGitHubOAuth) GetUser(arg0 *github.Client) (*github.User, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUser", arg0)
@@ -106,13 +107,13 @@ func (m *MockGitHubOAuth) GetUser(arg0 *github.Client) (*github.User, error) {
 	return ret0, ret1
 }
 
-// GetUser indicates an expected call of GetUser
+// GetUser indicates an expected call of GetUser.
 func (mr *MockGitHubOAuthMockRecorder) GetUser(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUser", reflect.TypeOf((*MockGitHubOAuth)(nil).GetUser), arg0)
 }
 
-// NewClient mocks base method
+// NewClient mocks base method.
 func (m *MockGitHubOAuth) NewClient(arg0 string) (*github.Client, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewClient", arg0)
@@ -121,48 +122,48 @@ func (m *MockGitHubOAuth) NewClient(arg0 string) (*github.Client, error) {
 	return ret0, ret1
 }
 
-// NewClient indicates an expected call of NewClient
+// NewClient indicates an expected call of NewClient.
 func (mr *MockGitHubOAuthMockRecorder) NewClient(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewClient", reflect.TypeOf((*MockGitHubOAuth)(nil).NewClient), arg0)
 }
 
-// SetRedirectURL mocks base method
+// SetRedirectURL mocks base method.
 func (m *MockGitHubOAuth) SetRedirectURL(arg0 string) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetRedirectURL", arg0)
 }
 
-// SetRedirectURL indicates an expected call of SetRedirectURL
+// SetRedirectURL indicates an expected call of SetRedirectURL.
 func (mr *MockGitHubOAuthMockRecorder) SetRedirectURL(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRedirectURL", reflect.TypeOf((*MockGitHubOAuth)(nil).SetRedirectURL), arg0)
 }
 
-// MockGitHubAccessControl is a mock of GitHubAccessControl interface
+// MockGitHubAccessControl is a mock of GitHubAccessControl interface.
 type MockGitHubAccessControl struct {
 	ctrl     *gomock.Controller
 	recorder *MockGitHubAccessControlMockRecorder
 }
 
-// MockGitHubAccessControlMockRecorder is the mock recorder for MockGitHubAccessControl
+// MockGitHubAccessControlMockRecorder is the mock recorder for MockGitHubAccessControl.
 type MockGitHubAccessControlMockRecorder struct {
 	mock *MockGitHubAccessControl
 }
 
-// NewMockGitHubAccessControl creates a new mock instance
+// NewMockGitHubAccessControl creates a new mock instance.
 func NewMockGitHubAccessControl(ctrl *gomock.Controller) *MockGitHubAccessControl {
 	mock := &MockGitHubAccessControl{ctrl: ctrl}
 	mock.recorder = &MockGitHubAccessControlMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockGitHubAccessControl) EXPECT() *MockGitHubAccessControlMockRecorder {
 	return m.recorder
 }
 
-// IsValidAdmin mocks base method
+// IsValidAdmin mocks base method.
 func (m *MockGitHubAccessControl) IsValidAdmin() (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsValidAdmin")
@@ -171,13 +172,13 @@ func (m *MockGitHubAccessControl) IsValidAdmin() (bool, error) {
 	return ret0, ret1
 }
 
-// IsValidAdmin indicates an expected call of IsValidAdmin
+// IsValidAdmin indicates an expected call of IsValidAdmin.
 func (mr *MockGitHubAccessControlMockRecorder) IsValidAdmin() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsValidAdmin", reflect.TypeOf((*MockGitHubAccessControl)(nil).IsValidAdmin))
 }
 
-// IsValidWPTMember mocks base method
+// IsValidWPTMember mocks base method.
 func (m *MockGitHubAccessControl) IsValidWPTMember() (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsValidWPTMember")
@@ -186,7 +187,7 @@ func (m *MockGitHubAccessControl) IsValidWPTMember() (bool, error) {
 	return ret0, ret1
 }
 
-// IsValidWPTMember indicates an expected call of IsValidWPTMember
+// IsValidWPTMember indicates an expected call of IsValidWPTMember.
 func (mr *MockGitHubAccessControlMockRecorder) IsValidWPTMember() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsValidWPTMember", reflect.TypeOf((*MockGitHubAccessControl)(nil).IsValidWPTMember))

--- a/shared/sharedtest/metadata_util_mock.go
+++ b/shared/sharedtest/metadata_util_mock.go
@@ -5,34 +5,35 @@
 package sharedtest
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockMetadataFetcher is a mock of MetadataFetcher interface
+// MockMetadataFetcher is a mock of MetadataFetcher interface.
 type MockMetadataFetcher struct {
 	ctrl     *gomock.Controller
 	recorder *MockMetadataFetcherMockRecorder
 }
 
-// MockMetadataFetcherMockRecorder is the mock recorder for MockMetadataFetcher
+// MockMetadataFetcherMockRecorder is the mock recorder for MockMetadataFetcher.
 type MockMetadataFetcherMockRecorder struct {
 	mock *MockMetadataFetcher
 }
 
-// NewMockMetadataFetcher creates a new mock instance
+// NewMockMetadataFetcher creates a new mock instance.
 func NewMockMetadataFetcher(ctrl *gomock.Controller) *MockMetadataFetcher {
 	mock := &MockMetadataFetcher{ctrl: ctrl}
 	mock.recorder = &MockMetadataFetcherMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockMetadataFetcher) EXPECT() *MockMetadataFetcherMockRecorder {
 	return m.recorder
 }
 
-// Fetch mocks base method
+// Fetch mocks base method.
 func (m *MockMetadataFetcher) Fetch() (*string, map[string][]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Fetch")
@@ -42,7 +43,7 @@ func (m *MockMetadataFetcher) Fetch() (*string, map[string][]byte, error) {
 	return ret0, ret1, ret2
 }
 
-// Fetch indicates an expected call of Fetch
+// Fetch indicates an expected call of Fetch.
 func (mr *MockMetadataFetcherMockRecorder) Fetch() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Fetch", reflect.TypeOf((*MockMetadataFetcher)(nil).Fetch))

--- a/shared/sharedtest/run_diff_mock.go
+++ b/shared/sharedtest/run_diff_mock.go
@@ -5,37 +5,38 @@
 package sharedtest
 
 import (
+	url "net/url"
+	reflect "reflect"
+
 	mapset "github.com/deckarep/golang-set"
 	gomock "github.com/golang/mock/gomock"
 	shared "github.com/web-platform-tests/wpt.fyi/shared"
-	url "net/url"
-	reflect "reflect"
 )
 
-// MockDiffAPI is a mock of DiffAPI interface
+// MockDiffAPI is a mock of DiffAPI interface.
 type MockDiffAPI struct {
 	ctrl     *gomock.Controller
 	recorder *MockDiffAPIMockRecorder
 }
 
-// MockDiffAPIMockRecorder is the mock recorder for MockDiffAPI
+// MockDiffAPIMockRecorder is the mock recorder for MockDiffAPI.
 type MockDiffAPIMockRecorder struct {
 	mock *MockDiffAPI
 }
 
-// NewMockDiffAPI creates a new mock instance
+// NewMockDiffAPI creates a new mock instance.
 func NewMockDiffAPI(ctrl *gomock.Controller) *MockDiffAPI {
 	mock := &MockDiffAPI{ctrl: ctrl}
 	mock.recorder = &MockDiffAPIMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockDiffAPI) EXPECT() *MockDiffAPIMockRecorder {
 	return m.recorder
 }
 
-// GetDiffURL mocks base method
+// GetDiffURL mocks base method.
 func (m *MockDiffAPI) GetDiffURL(arg0, arg1 shared.TestRun, arg2 *shared.DiffFilterParam) *url.URL {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDiffURL", arg0, arg1, arg2)
@@ -43,13 +44,13 @@ func (m *MockDiffAPI) GetDiffURL(arg0, arg1 shared.TestRun, arg2 *shared.DiffFil
 	return ret0
 }
 
-// GetDiffURL indicates an expected call of GetDiffURL
+// GetDiffURL indicates an expected call of GetDiffURL.
 func (mr *MockDiffAPIMockRecorder) GetDiffURL(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDiffURL", reflect.TypeOf((*MockDiffAPI)(nil).GetDiffURL), arg0, arg1, arg2)
 }
 
-// GetMasterDiffURL mocks base method
+// GetMasterDiffURL mocks base method.
 func (m *MockDiffAPI) GetMasterDiffURL(arg0 shared.TestRun, arg1 *shared.DiffFilterParam) *url.URL {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMasterDiffURL", arg0, arg1)
@@ -57,13 +58,13 @@ func (m *MockDiffAPI) GetMasterDiffURL(arg0 shared.TestRun, arg1 *shared.DiffFil
 	return ret0
 }
 
-// GetMasterDiffURL indicates an expected call of GetMasterDiffURL
+// GetMasterDiffURL indicates an expected call of GetMasterDiffURL.
 func (mr *MockDiffAPIMockRecorder) GetMasterDiffURL(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMasterDiffURL", reflect.TypeOf((*MockDiffAPI)(nil).GetMasterDiffURL), arg0, arg1)
 }
 
-// GetRunsDiff mocks base method
+// GetRunsDiff mocks base method.
 func (m *MockDiffAPI) GetRunsDiff(arg0, arg1 shared.TestRun, arg2 shared.DiffFilterParam, arg3 mapset.Set) (shared.RunDiff, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRunsDiff", arg0, arg1, arg2, arg3)
@@ -72,7 +73,7 @@ func (m *MockDiffAPI) GetRunsDiff(arg0, arg1 shared.TestRun, arg2 shared.DiffFil
 	return ret0, ret1
 }
 
-// GetRunsDiff indicates an expected call of GetRunsDiff
+// GetRunsDiff indicates an expected call of GetRunsDiff.
 func (mr *MockDiffAPIMockRecorder) GetRunsDiff(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRunsDiff", reflect.TypeOf((*MockDiffAPI)(nil).GetRunsDiff), arg0, arg1, arg2, arg3)

--- a/shared/sharedtest/test_run_query_mock.go
+++ b/shared/sharedtest/test_run_query_mock.go
@@ -5,37 +5,38 @@
 package sharedtest
 
 import (
+	reflect "reflect"
+	time "time"
+
 	mapset "github.com/deckarep/golang-set"
 	gomock "github.com/golang/mock/gomock"
 	shared "github.com/web-platform-tests/wpt.fyi/shared"
-	reflect "reflect"
-	time "time"
 )
 
-// MockTestRunQuery is a mock of TestRunQuery interface
+// MockTestRunQuery is a mock of TestRunQuery interface.
 type MockTestRunQuery struct {
 	ctrl     *gomock.Controller
 	recorder *MockTestRunQueryMockRecorder
 }
 
-// MockTestRunQueryMockRecorder is the mock recorder for MockTestRunQuery
+// MockTestRunQueryMockRecorder is the mock recorder for MockTestRunQuery.
 type MockTestRunQueryMockRecorder struct {
 	mock *MockTestRunQuery
 }
 
-// NewMockTestRunQuery creates a new mock instance
+// NewMockTestRunQuery creates a new mock instance.
 func NewMockTestRunQuery(ctrl *gomock.Controller) *MockTestRunQuery {
 	mock := &MockTestRunQuery{ctrl: ctrl}
 	mock.recorder = &MockTestRunQueryMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockTestRunQuery) EXPECT() *MockTestRunQueryMockRecorder {
 	return m.recorder
 }
 
-// GetAlignedRunSHAs mocks base method
+// GetAlignedRunSHAs mocks base method.
 func (m *MockTestRunQuery) GetAlignedRunSHAs(arg0 shared.ProductSpecs, arg1 mapset.Set, arg2, arg3 *time.Time, arg4, arg5 *int) ([]string, map[string]shared.KeysByProduct, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAlignedRunSHAs", arg0, arg1, arg2, arg3, arg4, arg5)
@@ -45,13 +46,13 @@ func (m *MockTestRunQuery) GetAlignedRunSHAs(arg0 shared.ProductSpecs, arg1 maps
 	return ret0, ret1, ret2
 }
 
-// GetAlignedRunSHAs indicates an expected call of GetAlignedRunSHAs
+// GetAlignedRunSHAs indicates an expected call of GetAlignedRunSHAs.
 func (mr *MockTestRunQueryMockRecorder) GetAlignedRunSHAs(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAlignedRunSHAs", reflect.TypeOf((*MockTestRunQuery)(nil).GetAlignedRunSHAs), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
-// LoadTestRunKeys mocks base method
+// LoadTestRunKeys mocks base method.
 func (m *MockTestRunQuery) LoadTestRunKeys(arg0 []shared.ProductSpec, arg1 mapset.Set, arg2 []string, arg3, arg4 *time.Time, arg5, arg6 *int) (shared.KeysByProduct, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LoadTestRunKeys", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
@@ -60,13 +61,13 @@ func (m *MockTestRunQuery) LoadTestRunKeys(arg0 []shared.ProductSpec, arg1 mapse
 	return ret0, ret1
 }
 
-// LoadTestRunKeys indicates an expected call of LoadTestRunKeys
+// LoadTestRunKeys indicates an expected call of LoadTestRunKeys.
 func (mr *MockTestRunQueryMockRecorder) LoadTestRunKeys(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadTestRunKeys", reflect.TypeOf((*MockTestRunQuery)(nil).LoadTestRunKeys), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
-// LoadTestRuns mocks base method
+// LoadTestRuns mocks base method.
 func (m *MockTestRunQuery) LoadTestRuns(arg0 []shared.ProductSpec, arg1 mapset.Set, arg2 []string, arg3, arg4 *time.Time, arg5, arg6 *int) (shared.TestRunsByProduct, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LoadTestRuns", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
@@ -75,13 +76,13 @@ func (m *MockTestRunQuery) LoadTestRuns(arg0 []shared.ProductSpec, arg1 mapset.S
 	return ret0, ret1
 }
 
-// LoadTestRuns indicates an expected call of LoadTestRuns
+// LoadTestRuns indicates an expected call of LoadTestRuns.
 func (mr *MockTestRunQueryMockRecorder) LoadTestRuns(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadTestRuns", reflect.TypeOf((*MockTestRunQuery)(nil).LoadTestRuns), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
-// LoadTestRunsByKeys mocks base method
+// LoadTestRunsByKeys mocks base method.
 func (m *MockTestRunQuery) LoadTestRunsByKeys(arg0 shared.KeysByProduct) (shared.TestRunsByProduct, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LoadTestRunsByKeys", arg0)
@@ -90,7 +91,7 @@ func (m *MockTestRunQuery) LoadTestRunsByKeys(arg0 shared.KeysByProduct) (shared
 	return ret0, ret1
 }
 
-// LoadTestRunsByKeys indicates an expected call of LoadTestRunsByKeys
+// LoadTestRunsByKeys indicates an expected call of LoadTestRunsByKeys.
 func (mr *MockTestRunQueryMockRecorder) LoadTestRunsByKeys(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadTestRunsByKeys", reflect.TypeOf((*MockTestRunQuery)(nil).LoadTestRunsByKeys), arg0)

--- a/shared/sharedtest/triage_metadata_mock.go
+++ b/shared/sharedtest/triage_metadata_mock.go
@@ -5,35 +5,36 @@
 package sharedtest
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	shared "github.com/web-platform-tests/wpt.fyi/shared"
-	reflect "reflect"
 )
 
-// MockTriageMetadata is a mock of TriageMetadata interface
+// MockTriageMetadata is a mock of TriageMetadata interface.
 type MockTriageMetadata struct {
 	ctrl     *gomock.Controller
 	recorder *MockTriageMetadataMockRecorder
 }
 
-// MockTriageMetadataMockRecorder is the mock recorder for MockTriageMetadata
+// MockTriageMetadataMockRecorder is the mock recorder for MockTriageMetadata.
 type MockTriageMetadataMockRecorder struct {
 	mock *MockTriageMetadata
 }
 
-// NewMockTriageMetadata creates a new mock instance
+// NewMockTriageMetadata creates a new mock instance.
 func NewMockTriageMetadata(ctrl *gomock.Controller) *MockTriageMetadata {
 	mock := &MockTriageMetadata{ctrl: ctrl}
 	mock.recorder = &MockTriageMetadataMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockTriageMetadata) EXPECT() *MockTriageMetadataMockRecorder {
 	return m.recorder
 }
 
-// Triage mocks base method
+// Triage mocks base method.
 func (m *MockTriageMetadata) Triage(arg0 shared.MetadataResults) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Triage", arg0)
@@ -42,7 +43,7 @@ func (m *MockTriageMetadata) Triage(arg0 shared.MetadataResults) (string, error)
 	return ret0, ret1
 }
 
-// Triage indicates an expected call of Triage
+// Triage indicates an expected call of Triage.
 func (mr *MockTriageMetadataMockRecorder) Triage(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Triage", reflect.TypeOf((*MockTriageMetadata)(nil).Triage), arg0)


### PR DESCRIPTION
Running `./util/docker-dev/web_server.sh` produces these changes, which
are changing import order and adding punctuation. Commit these to get
fewer local changes in development.
