### PR TITLE
Link to Interop 2022 in header navigation

### DIFF
--- a/webapp/components/wpt-header.js
+++ b/webapp/components/wpt-header.js
@@ -76,9 +76,8 @@ class WPTHeader extends WPTFlags(PolymerElement) {
         <!-- TODO: handle onclick with wpt-results.navigate if available -->
         <a href="/">Latest Run</a>
         <a href="/runs">Recent Runs</a>
+        <a href="/interop-2022">&#10024;Interop 2022&#10024;</a>
         <a href="/insights">Insights</a>
-        <a href="/compat2021">&#10024;Compat 2021&#10024;</a>
-        <a href="/interop[[path]]?[[query]]">Interoperability</a>
         <template is="dom-if" if="[[processorTab]]">
           <a href="/status">Processor</a>
         </template>


### PR DESCRIPTION
At the same time, remove the link to the interop view, since this could
now easily be confused with Interop 2022. The view itself isn't removed,
but it hasn't been as valuable since we added the search cache and can
filter to different combinations of pass and fail directly.