### PR TITLE
Unlink Interop 2022 from navigation and say it will launch soon

### DIFF
--- a/webapp/components/interop-2022.js
+++ b/webapp/components/interop-2022.js
@@ -467,6 +467,12 @@ class Interop2022 extends PolymerElement {
       </style>
       <h1>Interop 2022 Dashboard</h1>
       <p class="prose">
+        <i>Interop 2022 will launch soon, please wait for an announcement.</i>
+      </p>
+
+      <hr>
+
+      <p class="prose">
         These scores represent how browser engines are doing in 15 focus areas
         and 3 joint investigation efforts.
       </p>

--- a/webapp/components/wpt-header.js
+++ b/webapp/components/wpt-header.js
@@ -63,7 +63,7 @@ class WPTHeader extends WPTFlags(PolymerElement) {
         <!-- TODO: handle onclick with wpt-results.navigate if available -->
         <a href="/">Latest Run</a>
         <a href="/runs">Recent Runs</a>
-        <a href="/interop-2022">&#10024;Interop 2022&#10024;</a>
+        <!-- <a href="/interop-2022">&#10024;Interop 2022&#10024;</a> -->
         <a href="/insights">Insights</a>
         <template is="dom-if" if="[[processorTab]]">
           <a href="/status">Processor</a>


### PR DESCRIPTION
This is in case we need to or want to a prod push, for people who find
their way to the dashboard to understand it's not live yet.
