### PR TITLE
Make /interop-2022 just the "will launch soon" box

### DIFF
--- a/webapp/components/interop-2022.js
+++ b/webapp/components/interop-2022.js
@@ -470,7 +470,7 @@ class Interop2022 extends PolymerElement {
       -->
       <div class="table-card">
         <p class="prose" style="font-size: 36px">
-          Interop 2022 will launch soon,<br>please wait for an announcement.
+          Interop 2022 will launch soon
         </p>
       </div>
 

--- a/webapp/components/interop-2022.js
+++ b/webapp/components/interop-2022.js
@@ -465,13 +465,16 @@ class Interop2022 extends PolymerElement {
         //   }
         // }
       </style>
+      <!--
       <h1>Interop 2022 Dashboard</h1>
+      -->
       <div class="table-card">
         <p class="prose" style="font-size: 36px">
           Interop 2022 will launch soon,<br>please wait for an announcement.
         </p>
       </div>
 
+      <!--
       <p class="prose">
         These scores represent how browser engines are doing in 15 focus areas
         and 3 joint investigation efforts.
@@ -491,7 +494,6 @@ class Interop2022 extends PolymerElement {
           The more tests that pass, the higher the score.
         </p>
 
-        <!-- TODO: replace with paper-dropdown-menu -->
         <div class="focus-area">
           <select id="featureSelect">
             <option value="summary">Summary</option>
@@ -636,6 +638,7 @@ class Interop2022 extends PolymerElement {
         <a href="https://app.element.io/#/room/#interop2022:matrix.org" target="_blank">join
         the conversation on Matrix</a>!</p>
       </footer>
+      -->
 `;
   }
 


### PR DESCRIPTION
As it turns out, https://wpt.fyi/interop-2022 has been live with first
copy-pasted version of the dashboard since Feb 2:
https://github.com/web-platform-tests/wpt.fyi/issues/2741
https://github.com/web-platform-tests/wpt.fyi/pull/2735

Since the URL has been linked in at least one place, empty the page to
avoid confusion.

Removing the route entirely would be another option, but then it would
just redirect to /results/interop-2022, which is not good either.
