### PR TITLE
Bring back /interop-2022 without the "will launch soon" box

### DIFF
--- a/webapp/components/interop-2022.js
+++ b/webapp/components/interop-2022.js
@@ -465,16 +465,8 @@ class Interop2022 extends PolymerElement {
         //   }
         // }
       </style>
-      <!--
       <h1>Interop 2022 Dashboard</h1>
-      -->
-      <div class="table-card">
-        <p class="prose" style="font-size: 36px">
-          Interop 2022 will launch soon
-        </p>
-      </div>
 
-      <!--
       <p class="prose">
         These scores represent how browser engines are doing in 15 focus areas
         and 3 joint investigation efforts.
@@ -638,7 +630,6 @@ class Interop2022 extends PolymerElement {
         <a href="https://app.element.io/#/room/#interop2022:matrix.org" target="_blank">join
         the conversation on Matrix</a>!</p>
       </footer>
-      -->
 `;
   }
 


### PR DESCRIPTION
This is to make it easier to test the dashboard in staging.