### PR TITLE
Update Node.js to version 16 (LTS)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update -qqy && apt-get install -qqy --no-install-suggests \
 RUN echo "root ALL=(ALL:ALL) ALL" > /etc/sudoers
 
 # Node LTS
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
     apt-get install -qqy nodejs
 
 # Google Cloud SDK


### PR DESCRIPTION
Node.js 10 is very old by now and not the version anyone is likely to be
using locally. Upgrade to avoid any problems this might cause in the
future.