### PR TITLE
Switch to the new location of BSF / Compat 2021 / Interop 2022 metrics

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -344,8 +344,8 @@ The high-level structure of the `v4` manifest is as follows:
 Uploads a wptreport to the dashboard to create the test run.
 
 This endpoint only accepts POST requests. Requests need to be authenticated via HTTP basic auth.
-Please contact [Ecosystem Infra](mailto:ecosystem-infra@chromium.org) if you want to register as a
-"test runner", to upload results.
+Please [file an issue](https://github.com/web-platform-tests/wpt.fyi/issues/new) if you want to
+register as a "test runner", to upload results.
 
 #### File payload
 

--- a/shared/fetch_bsf.go
+++ b/shared/fetch_bsf.go
@@ -16,10 +16,10 @@ import (
 const (
 	// experimentalBSFURL is the GitHub URL for fetching the experimental BSF data
 	// for Chrome, Firefox and Safari.
-	experimentalBSFURL = "https://raw.githubusercontent.com/Ecosystem-Infra/wpt-results-analysis/gh-pages/data/experimental-browser-specific-failures.csv"
+	experimentalBSFURL = "https://raw.githubusercontent.com/web-platform-tests/results-analysis/gh-pages/data/experimental-browser-specific-failures.csv"
 	// stableBSFURL is the GitHub URL for fetching the stable BSF data
 	// for Chrome, Firefox and Safari.
-	stableBSFURL = "https://raw.githubusercontent.com/Ecosystem-Infra/wpt-results-analysis/gh-pages/data/stable-browser-specific-failures.csv"
+	stableBSFURL = "https://raw.githubusercontent.com/web-platform-tests/results-analysis/gh-pages/data/stable-browser-specific-failures.csv"
 )
 
 // BSFData stores BSF data of the latest WPT revision.

--- a/webapp/components/compat-2021.js
+++ b/webapp/components/compat-2021.js
@@ -11,7 +11,7 @@ import '../node_modules/@polymer/paper-input/paper-input.js';
 import '../node_modules/@polymer/polymer/lib/elements/dom-if.js';
 import { html, PolymerElement } from '../node_modules/@polymer/polymer/polymer-element.js';
 
-const GITHUB_URL_PREFIX = 'https://raw.githubusercontent.com/Ecosystem-Infra/wpt-results-analysis';
+const GITHUB_URL_PREFIX = 'https://raw.githubusercontent.com/web-platform-tests/results-analysis';
 const DATA_BRANCH = 'gh-pages';
 // Support a 'use_webkitgtk' query parameter to substitute WebKitGTK in for
 // Safari, to deal with the ongoing lack of new STP versions on wpt.fyi.

--- a/webapp/components/interop-2022.js
+++ b/webapp/components/interop-2022.js
@@ -12,7 +12,7 @@ import '../node_modules/@polymer/polymer/lib/elements/dom-if.js';
 import { html, PolymerElement } from '../node_modules/@polymer/polymer/polymer-element.js';
 import {CountUp} from 'https://unpkg.com/countup.js@2.0.8/dist/countUp.js';
 
-const GITHUB_URL_PREFIX = 'https://raw.githubusercontent.com/Ecosystem-Infra/wpt-results-analysis/gh-pages/data/interop-2022';
+const GITHUB_URL_PREFIX = 'https://raw.githubusercontent.com/web-platform-tests/results-analysis/gh-pages/data/interop-2022';
 
 const SUMMARY_FEATURE_NAME = 'summary';
 


### PR DESCRIPTION
Part of https://github.com/web-platform-tests/rfcs/pull/106.