### PR TITLE
Display test totals information on subtest and directory views

### DIFF
--- a/webapp/components/test-file-results-table.js
+++ b/webapp/components/test-file-results-table.js
@@ -359,8 +359,8 @@ class TestFileResultsTable extends WPTFlags(Pluralizer(AmendMetadataMixin(WPTCol
     if (rows.length <= 2) {
       return [];
     }
-    // keep a total for each for each browser.
-    let totals = new Array(rows[2].results.length);
+    // Keep a total for each browser.
+    const totals = new Array(rows[2].results.length);
     for (let i = 0; i < totals.length; i++) {
       totals[i] = {passes: 0, total: 0};
     }

--- a/webapp/components/test-file-results-table.js
+++ b/webapp/components/test-file-results-table.js
@@ -107,6 +107,10 @@ class TestFileResultsTable extends WPTFlags(Pluralizer(AmendMetadataMixin(WPTCol
     width: -moz-max-content;
     width: max-content;
   }
+  .totals-row {
+    border-top: 8px solid white;
+    padding: 8px;
+  }
   .view-triage {
     margin-left: 30px;
   }
@@ -165,7 +169,16 @@ class TestFileResultsTable extends WPTFlags(Pluralizer(AmendMetadataMixin(WPTCol
         </template>
       </tr>
     </template>
-
+    <template is="dom-if" if="[[shouldShowTotals(totals)]]">
+      <tr class="totals-row">
+        <td class="sub-test-name"><code>Total</code></td>
+        <template is="dom-repeat" items="[[totals]]" as="totals">
+          <td class$="[[ totalsColorClass(totals.passes, totals.total) ]]">
+            <code>[[ totals.passes ]]/[[ totals.total ]]</code>
+          </td>
+        </template>
+      </tr>
+    </template>
     <template is="dom-if" if="[[verbose]]">
       <template is="dom-if" if="[[anyScreenshots(firstRow)]]">
         <tr>
@@ -218,6 +231,10 @@ class TestFileResultsTable extends WPTFlags(Pluralizer(AmendMetadataMixin(WPTCol
       displayedProducts: {
         type: Array,
         computed: 'computeDisplayedProducts(testRuns)',
+      },
+      totals: {
+        type: Array,
+        computed: 'computeTotals(rows)'
       },
       metadataMap: Object,
       matchers: {
@@ -335,13 +352,50 @@ class TestFileResultsTable extends WPTFlags(Pluralizer(AmendMetadataMixin(WPTCol
     return rows && rows.length && rows[0];
   }
 
+  computeTotals(rows) {
+    // The first two rows display TestHarness status and duration,
+    // so we don't need to count them. If only these rows exist,
+    // there is no need to show totals.
+    if (rows.length <= 2) {
+      return [];
+    }
+    // keep a total for each for each browser.
+    let totals = new Array(rows[2].results.length);
+    for (let i = 0; i < totals.length; i++) {
+      totals[i] = {passes: 0, total: 0};
+    }
+
+    // Tally the number of passes and total tests.
+    for (let i = 2; i < rows.length; i++) {
+      rows[i].results.forEach((result, index) => {
+        if (result.status === 'PASS') {
+          totals[index].passes++;
+        }
+        // If the test status is missing, it's not counted toward the total.
+        if (result.status) {
+          totals[index].total++;
+        }
+      });
+    }
+    return totals;
+  }
+
   colorClass(status) {
     if (['PASS'].includes(status)) {
       return this.passRateClass(1, 1);
-    } else if (['FAIL', 'ERROR'].includes(status)) {
+    } else if (['FAIL', 'ERROR', 'TIMEOUT', 'NOTRUN'].includes(status)) {
       return this.passRateClass(0, 1);
     }
     return 'result';
+  }
+
+  totalsColorClass(passes, total) {
+    // Gray cell color if no tests were run.
+    if (total === 0) {
+      return 'result';
+    }
+    // If tests were run, choose a color based on the % of tests passed.
+    return this.passRateClass(passes, total);
   }
 
   parseFailureMessage(result) {
@@ -445,6 +499,10 @@ class TestFileResultsTable extends WPTFlags(Pluralizer(AmendMetadataMixin(WPTCol
     }
 
     return this.displayMetadata && this.getMetadataUrlForSubtest(index, subtestname, metadataMap) !== '';
+  }
+
+  shouldShowTotals(totals) {
+    return totals && totals.length > 0;
   }
 
   getMetadataUrlForSubtest(index, subtestname, metadataMap) {

--- a/webapp/components/test-file-results.js
+++ b/webapp/components/test-file-results.js
@@ -84,7 +84,7 @@ class TestFileResults extends WPTFlags(LoadingState(PathInfo(
         type: Array,
         computed: 'computeRows(resultsTable, onlyShowDifferences)'
       },
-      subtestRows: {
+      subtestRowCount: {
         type: Number,
         value: 0,
         notify: true
@@ -293,18 +293,25 @@ class TestFileResults extends WPTFlags(LoadingState(PathInfo(
   }
 
   computeRows(resultsTable, onlyShowDifferences) {
+    let rows;
     if (!resultsTable || !resultsTable.length || !onlyShowDifferences) {
-      // If displaying subtests of a single test, the first two rows will
-      // reflect TestHarness status and duration, so we don't count them
-      // when displaying the number of subtests in the blue banner.
-      this.subtestRows = (resultsTable && resultsTable.length - 2 > 0) ? resultsTable.length - 2 : 0;
-      return resultsTable;
+      rows = resultsTable;
+    } else {
+      const [first, ...others] = resultsTable;
+      const rows = [first, ...others.filter(r => {
+        return r.results[0].status !== r.results[1].status;
+      })];
     }
-    const [first, ...others] = resultsTable;
-    const rows = [first, ...others.filter(r => {
-      return r.results[0].status !== r.results[1].status;
-    })];
-    this.subtestRows = (rows.length - 2 > 0) ? resultsTable.length - 2 : 0;
+    
+    // If displaying subtests of a single test, the first two rows will
+    // reflect TestHarness status and duration, so we count them as 1 subtest
+    // when displaying the number of subtests in the blue banner.
+    if (rows.length >= 2 && rows[1].name === 'Duration') {
+      this.subtestRowCount = rows.length - 1;
+    } else {
+      this.subtestRowCount = rows.length;
+    }
+
     return rows;
   }
 }

--- a/webapp/components/test-file-results.js
+++ b/webapp/components/test-file-results.js
@@ -84,6 +84,11 @@ class TestFileResults extends WPTFlags(LoadingState(PathInfo(
         type: Array,
         computed: 'computeRows(resultsTable, onlyShowDifferences)'
       },
+      subtestRows: {
+        type: Number,
+        value: 0,
+        notify: true
+      },
       isTriageMode: Boolean,
       metadataMap: Object,
     };
@@ -289,12 +294,18 @@ class TestFileResults extends WPTFlags(LoadingState(PathInfo(
 
   computeRows(resultsTable, onlyShowDifferences) {
     if (!resultsTable || !resultsTable.length || !onlyShowDifferences) {
+      // If displaying subtests of a single test, the first two rows will
+      // reflect TestHarness status and duration, so we don't count them
+      // when displaying the number of subtests in the blue banner.
+      this.subtestRows = (resultsTable && resultsTable.length - 2 > 0) ? resultsTable.length - 2 : 0;
       return resultsTable;
     }
     const [first, ...others] = resultsTable;
-    return [first, ...others.filter(r => {
+    const rows = [first, ...others.filter(r => {
       return r.results[0].status !== r.results[1].status;
     })];
+    this.subtestRows = (rows.length - 2 > 0) ? resultsTable.length - 2 : 0;
+    return rows;
   }
 }
 

--- a/webapp/components/test-file-results.js
+++ b/webapp/components/test-file-results.js
@@ -298,11 +298,11 @@ class TestFileResults extends WPTFlags(LoadingState(PathInfo(
       rows = resultsTable;
     } else {
       const [first, ...others] = resultsTable;
-      const rows = [first, ...others.filter(r => {
+      rows = [first, ...others.filter(r => {
         return r.results[0].status !== r.results[1].status;
       })];
     }
-    
+
     // If displaying subtests of a single test, the first two rows will
     // reflect TestHarness status and duration, so we count them as 1 subtest
     // when displaying the number of subtests in the blue banner.

--- a/webapp/components/test/test-file-results-table.html
+++ b/webapp/components/test/test-file-results-table.html
@@ -49,9 +49,10 @@ suite('TestFileResultsTable', () => {
       test('Fail and error are colored identically', () => {
         assert.equal(tfrt.colorClass('FAIL'), tfrt.colorClass('ERROR'));
       });
-      test('Harness status is not equivalent to pass', () => {
-        // OK is used for harness status and should not be colored green.
-        assert.notEqual(tfrt.colorClass('OK'), tfrt.colorClass('PASS'));
+      test('Harness status OK is equivalent to pass', () => {
+        // Harness status is currently counted as a passable subtest and affects
+        // the total count of passing or failing tests, so OK will be shown as green.
+        assert.equal(tfrt.colorClass('OK'), tfrt.colorClass('PASS'));
       });
     });
 

--- a/webapp/views/wpt-app.js
+++ b/webapp/views/wpt-app.js
@@ -153,7 +153,7 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
                      test-runs="{{testRuns}}"
                      test-paths="{{testPaths}}"
                      search-results="{{searchResults}}"
-                     subtest-rows={{subtestRows}}
+                     subtest-row-count={{subtestRowCount}}
                      is-triage-mode="[[isTriageMode]]"></wpt-results>
 
         <wpt-404 name="404" ></wpt-404>
@@ -192,9 +192,9 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
       searchResults: Array,
       resultsTotalsRangeMessage: {
         type: String,
-        computed: 'computeResultsTotalsRangeMessage(page, path, searchResults, shas, productSpecs, to, from, maxCount, labels, master, runIds, subtestRows)',
+        computed: 'computeResultsTotalsRangeMessage(page, path, searchResults, shas, productSpecs, to, from, maxCount, labels, master, runIds, subtestRowCount)',
       },
-      subtestRows: Number,
+      subtestRowCount: Number,
       bsfBannerMessage: {
         type: String,
         computed: 'computeBSFBannerMessage(isBSFCollapsed)',
@@ -384,16 +384,16 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
     return true;
   }
 
-  computeResultsTotalsRangeMessage(page, path, searchResults, shas, productSpecs, from, to, maxCount, labels, master, runIds, subtestRows) {
+  computeResultsTotalsRangeMessage(page, path, searchResults, shas, productSpecs, from, to, maxCount, labels, master, runIds, subtestRowCount) {
     const msg = super.computeResultsRangeMessage(shas, productSpecs, from, to, maxCount, labels, master, runIds);
     if (page === 'results' && searchResults) {
       // If the view is displaying subtests of a single test,
-      // we show the number of rows excluding TestHarness rows.
+      // we show the number of rows excluding Harness duration.
       if (this.computePathIsATestFile(path)) {
-        if (!subtestRows || subtestRows === 1) {
+        if (!subtestRowCount || subtestRowCount === 1) {
           return msg;
         }
-        return msg.replace('Showing ', `Showing ${subtestRows} subtests from `);
+        return msg.replace('Showing ', `Showing ${subtestRowCount} subtests from `);
       }
       let subtests = 0, tests = 0;
       for (const r of searchResults) {

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -173,7 +173,7 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
     <template is="dom-if" if="[[testRuns]]">
       <template is="dom-if" if="{{ pathIsATestFile }}">
         <test-file-results test-runs="[[testRuns]]"
-                           subtest-rows={{subtestRows}}
+                           subtest-row-count={{subtestRowCount}}
                            path="[[path]]"
                            structured-search="[[structuredSearch]]"
                            labels="[[labels]]"
@@ -257,11 +257,11 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
                 <td>
                   <code><strong>Total</strong></code>
                 </td>
-                <template is="dom-repeat" items="[[displayedTotals]]" as="totals">
-                  <td class\$="numbers [[ testTotalsClass(totals.passes, totals.total) ]]">
-                    <span class\$="passes [[ testTotalsClass(totals.passes, totals.total) ]]">[[ totals.passes ]]</span>
+                <template is="dom-repeat" items="[[displayedTotals]]" as="columnTotal">
+                  <td class\$="numbers [[ testTotalsClass(columnTotal.passes, columnTotal.total) ]]">
+                    <span class\$="passes [[ testTotalsClass(columnTotal.passes, columnTotal.total) ]]">[[ columnTotal.passes ]]</span>
                     /
-                    <span class\$="total [[ testTotalsClass(totals.passes, totals.total) ]]">[[ totals.total ]]</span>
+                    <span class\$="total [[ testTotalsClass(columnTotal.passes, columnTotal.total) ]]">[[ columnTotal.total ]]</span>
                   </td>
                 </template>
               </tr>
@@ -348,7 +348,7 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
         value: [],
         notify: true,
       },
-      subtestRows: {
+      subtestRowCount: {
         type: Number,
         notify: true
       },

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -169,6 +169,7 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
     <template is="dom-if" if="[[testRuns]]">
       <template is="dom-if" if="{{ pathIsATestFile }}">
         <test-file-results test-runs="[[testRuns]]"
+                           subtest-rows={{subtestRows}}
                            path="[[path]]"
                            structured-search="[[structuredSearch]]"
                            labels="[[labels]]"
@@ -328,6 +329,10 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
         type: Array,
         value: [],
         notify: true,
+      },
+      subtestRows: {
+        type: Number,
+        notify: true
       },
       testPaths: {
         type: Set,
@@ -566,16 +571,6 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
     this.refreshDisplayedNodes();
   }
 
-  nodeSort(a, b) {
-    if (a.path < b.path) {
-      return -1;
-    }
-    if (a.path > b.path) {
-      return 1;
-    }
-    return 0;
-  }
-
   refreshDisplayedNodes() {
     if (!this.searchResults || !this.searchResults.length) {
       this.displayedNodes = [];
@@ -670,9 +665,7 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
           return true;
         }
         return row.diff;
-      })
-      // TODO(markdittmer): Is this still necessary?
-      .sort(this.nodeSort);
+      });
   }
 
   computeDifferences(before, after) {

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -103,6 +103,10 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
       td[selected] {
         border: 2px solid #000000;
       }
+      .totals-row {
+        border-top: 4px solid white;
+        padding: 4px;
+      }
       .yellow-button {
         color: var(--paper-yellow-500);
         margin-left: 32px;
@@ -248,6 +252,20 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
               </tr>
             </template>
 
+            <template is="dom-if" if="[[ shouldDisplayTotals(displayedTotals, diffRun) ]]">
+              <tr class="totals-row">
+                <td>
+                  <code><strong>Total</strong></code>
+                </td>
+                <template is="dom-repeat" items="[[displayedTotals]]" as="totals">
+                  <td class\$="numbers [[ testTotalsClass(totals.passes, totals.total) ]]">
+                    <span class\$="passes [[ testTotalsClass(totals.passes, totals.total) ]]">[[ totals.passes ]]</span>
+                    /
+                    <span class\$="total [[ testTotalsClass(totals.passes, totals.total) ]]">[[ totals.total ]]</span>
+                  </td>
+                </template>
+              </tr>
+            </template>
           </tbody>
         </table>
 
@@ -346,6 +364,10 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
       displayedTests: {
         type: Array,
         computed: 'computeDisplayedTests(path, searchResults)',
+      },
+      displayedTotals: {
+        type: Array,
+        value: [],
       },
       metadataMap: Object,
       labelMap: Object,
@@ -477,6 +499,7 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
     }
     this.testRuns = [];
     this.searchResults = [];
+    this.displayedTotals = [];
     this.refreshDisplayedNodes();
     this.loadData();
   }
@@ -625,7 +648,14 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
           return nodes;
         }
         const row = nodes[name];
+        
+        // Keep track of overall total.
+        if (!nodes.hasOwnProperty('totals')) {
+          nodes['totals'] = this.testRuns.map(() => ({passes: 0, total: 0}));
+        }
         for (let i = 0; i < rs.length; i++) {
+          nodes.totals[i].passes += rs[i].passes;
+          nodes.totals[i].total += rs[i].total;
           row.results[i].passes += rs[i].passes;
           row.results[i].total += rs[i].total;
         }
@@ -659,6 +689,12 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
         }
         return nodes;
       }, {});
+    
+    // Take the calculated totals to be displayed at bottom of results page.
+    // Delete key after reassignment.
+    this.displayedTotals = resultsByPath.totals;
+    delete resultsByPath.totals;
+
     this.displayedNodes = Object.values(resultsByPath)
       .filter(row => {
         if (!this.onlyShowDifferences) {
@@ -742,6 +778,13 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
       }
       return this.passRateClass(result.passes, result.total);
     }
+  }
+
+  testTotalsClass(passes, total) {
+    if ((this.path === '/' && !this.colorHomepage) || total === 0) {
+      return 'top'
+    }
+    return this.passRateClass(passes, total);
   }
 
   getDiffDelta(node, prop) {
@@ -894,6 +937,10 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
 
   shouldDisplayTestLabel(testname, labelMap) {
     return !this.pathIsRootDir && this.displayMetadata && this.getTestLabel(testname, labelMap) !== '';
+  }
+
+  shouldDisplayTotals(displayedTotals, diffRun) {
+    return !diffRun && displayedTotals && displayedTotals.length > 0;
   }
 
   getTestLabelTitle(testname, labelMap) {


### PR DESCRIPTION
<!--
Thanks for the PR, you probably worked hard on it! Before you submit it for review, please make sure you read our guidelines for contributing to this repository. 

Try to make the job easy for your reviewer! Below is a template you can use as a guide for what context your reviewer might need.  
If you changed any dev procedures, consider also updating the README.
-->

## Description
fixes #2759 and #2667

This is a fix to ensure that the number of subtests shown in the blue banner matches of single test views will accurately represent the number of rows displayed to the user. Additionally, a "Total" row is added to subtest and directory views to display the aggregation of pass/total values of all of the tests numbers in the respective column.

~~**NOTE:** Issue #62 is still a problem for the aggregate number of subtests shown in levels higher than the subtest view, so this total will not match higher-level views by 1 in most instances.~~
Edit: This is a separate issue and this implementation has been removed from this PR.


<!-- A detailed description explaining what your code accomplishes, and why this work is taking place. If this affects an open issue, please make sure to properly reference it. -->

## Changes
- The top blue banner now correctly displays the number of subtests being displayed in the subtest view.
- A row displaying the fraction of passes/total for tests in a directory or subtests within a test is displayed.
  - If a set of subtests for a browser has no data (all "MISSING"), the total row will show `0/0` with a gray background.
  - Tests that have no subtests and only display the Test Harness status and duration will not display a totals row.

Some additional small changes have been made (and can be removed if they are not correct):
- An additional sort for rows shown based on the test path name has been removed, as it had the (seemingly unintended) effect of sorting test paths with capital letter titles first.

- "TIMEOUT" and "NOTRUN" test status results show with a red background, as they are being considered failing anyway.
- "OK" test status results show with a green background, as they are being considered passing anyway.
<!-- Highlight the files that have changed and group them into concepts, or issues being solved -->


## Visual changes
### Subtests view (before)
![Screen Shot 2022-04-20 at 10 01 41 AM](https://user-images.githubusercontent.com/56164590/164285915-3ffcbdc4-5e40-4854-86b6-bad18ed3b7b1.png)

### Subtests view (after)
![Screen Shot 2022-04-20 at 10 01 49 AM](https://user-images.githubusercontent.com/56164590/164285945-93a0ba88-0a45-42f8-92bf-ba84d70175f6.png)


### Directory view (before)
![Screen Shot 2022-04-20 at 2 39 46 PM](https://user-images.githubusercontent.com/56164590/164327561-7a68dfb4-7f62-433c-b8af-f4781b478146.png)


### Directory view (after)
![Screen Shot 2022-04-20 at 2 39 39 PM](https://user-images.githubusercontent.com/56164590/164327602-74f1b770-0b88-424f-956e-ddbdd05c3cf3.png)

### Totals with 0 tests will display with a gray background
![Screen Shot 2022-04-20 at 2 43 41 PM](https://user-images.githubusercontent.com/56164590/164328259-ff08c406-6207-4dac-aefb-e45c319877f8.png)

### Totals displayed in the root test directory will display with a gray background
![Screen Shot 2022-04-20 at 2 44 59 PM](https://user-images.githubusercontent.com/56164590/164328590-32d44fc1-c56a-4755-9d2f-6cb457f957c6.png)
