### PR TITLE
Use percentages when displaying results

### DIFF
--- a/webapp/components/test-file-results.js
+++ b/webapp/components/test-file-results.js
@@ -194,7 +194,7 @@ class TestFileResults extends WPTFlags(LoadingState(PathInfo(
 
     // Set name for test-level status entry after subtests discovered.
     // Parameter is number of subtests.
-    resultsTable[0].name = this.statusName(resultsTable.length - 1);
+    resultsTable[0].name = this.statusName(resultsTable.length - 2);
     return resultsTable;
   }
 


### PR DESCRIPTION
## Description
Fixes https://github.com/web-platform-tests/wpt.fyi/issues/2825 and partially fixes https://github.com/web-platform-tests/wpt.fyi/issues/1958.
[Staging Link](https://ui-scoring-change-dot-wptdashboard-staging.uk.r.appspot.com/results/?label=experimental&label=master&aligned)

This change adds a new display for how test results are shown on wpt.fyi's results view. Instead of displaying the flat number of tests that have passed over the test total, a percentage will display with this information. Any cell that represents a directory that contains tests will display the number of tests that exist in that directory along with the pass percentage.


This PR contains ONLY the UI changes to scoring, and does not change anything associated with the aggregation method.