### PR TITLE
Tweak the color limits for Interop 2022 (and Compat 2021)

### DIFF
--- a/webapp/components/interop-2022.js
+++ b/webapp/components/interop-2022.js
@@ -944,13 +944,13 @@ class Interop2022Summary extends PolymerElement {
     if (score >= 95) {
       return ['#388E3C', '#00c70a1a'];  // Green 700
     }
-    if (score > 75) {
+    if (score >= 75) {
       return ['#568f24', '#64d60026'];  // Light Green 700
     }
-    if (score > 50) {
+    if (score >= 50) {
       return ['#b88400', '#ffc22926'];  // Yellow 700
     }
-    if (score > 25) {
+    if (score >= 25) {
       return ['#d16900', '#f57a0026'];  // Orange 700
     }
     return ['#ee2b2b', '#ff050526']; // Red 700


### PR DESCRIPTION
This was somewhat inconsistent, with >=95 being one limit,
but >75 and >25 being others.

Since the score is rounded down to an integer, changing the color on
the transition between 49.9 to 50.1 seems more sensible than between
50.9 and 51.1.