### PR TITLE
Ignore client-secret.json from being committed or uploaded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ debug.test
 packrd/
 *-packr.go
 /web
+
+# Google Cloud secret
+client-secret.json

--- a/api/query/cache/service/.gcloudignore
+++ b/api/query/cache/service/.gcloudignore
@@ -1,0 +1,6 @@
+# Files matching the following rules won't be uploaded to AppEngine (webapp).
+# The syntax is the same as `.gitignore`; we do not use `.gitignore` directly
+# because we need to update some generated files.
+
+# Google Cloud secret
+client-secret.json

--- a/results-processor/.gcloudignore
+++ b/results-processor/.gcloudignore
@@ -1,1 +1,4 @@
 #!include:.gitignore
+
+# Google Cloud secret
+client-secret.json

--- a/webapp/web/.gcloudignore
+++ b/webapp/web/.gcloudignore
@@ -30,6 +30,9 @@ ISSUE_TEMPLATE/
 PULL_REQUEST_TEMPLATE.md
 README.md
 
+# Google Cloud secret
+client-secret.json
+
 # Other services
 /api/query/cache/service/
 /results-processor/


### PR DESCRIPTION
client-secret.json is needed for deploying not for runtime.
Details in #2906 found that it was being uploaded

Fixes #2906

## Description
Check #2906 for more details of the problem.

## Changes
Added client-secret.json to .gitignore and .gcloudignore files for the various services

Before changes:
![image](https://user-images.githubusercontent.com/7788930/179251439-ccb2c1b1-73b1-41fb-a63a-276b860694e0.png)


After changes:
![image](https://user-images.githubusercontent.com/7788930/179251484-a00e5520-4025-4748-a4cd-eb9767a43704.png)

The client-secret.json is gone now