### PR TITLE
Move from analytics.js to gtag.js

### DIFF
--- a/webapp/components/self-navigator.js
+++ b/webapp/components/self-navigator.js
@@ -130,9 +130,11 @@ const SelfNavigation = (superClass) => class SelfNavigation extends PathInfo(sup
       .replace(/%3A00.000Z/g, '');
     window.history.pushState(params, '', url);
 
-    // Send Google Analytics pageview event
-    if ('ga' in window) {
-      window.ga('send', 'pageview', path);
+    // Send Google Analytics page_view event
+    if ('gtag' in window) {
+      window.gtag('event', 'page_view', {
+        page_path: path
+      });
     }
   }
 

--- a/webapp/templates/_ga.html
+++ b/webapp/templates/_ga.html
@@ -1,23 +1,21 @@
 {{- /* no data */ -}}
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-89387706-1"></script>
 <script>
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
 
-ga('create', 'UA-89387706-1', 'auto');
-// self-navigator.js sends more pageview events for in-page navigations.
-ga('send', 'pageview');
-
-window.onerror = function(message, source, lineno, colno) {
-  let description;
-  // https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onerror
-  if (message.toLowerCase().indexOf('script error') > -1) {
-    description = `External error: ${message}`;
-  } else {
-    description = `${message} at ${source}:${lineno}:${colno}`;
-  }
-  // https://developers.google.com/analytics/devguides/collection/analyticsjs/exceptions
-  ga('send', 'exception', {'exDescription': description});
-};
+  gtag('config', 'UA-89387706-1');
+  window.onerror = function(message, source, lineno, colno) {
+    let description;
+    // https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onerror
+    if (message.toLowerCase().indexOf('script error') > -1) {
+      description = `External error: ${message}`;
+    } else {
+      description = `${message} at ${source}:${lineno}:${colno}`;
+    }
+    // https://developers.google.com/analytics/devguides/collection/analyticsjs/exceptions
+    gtag('send', 'exception', {'description': description});
+  };
 </script>

--- a/webapp/templates/_ga.html
+++ b/webapp/templates/_ga.html
@@ -28,7 +28,7 @@
     } else {
       description = `${message} at ${source}:${lineno}:${colno}`;
     }
-    // https://developers.google.com/analytics/devguides/collection/analyticsjs/exceptions
-    gtag('send', 'exception', {'description': description});
+    // https://developers.google.com/analytics/devguides/collection/gtagjs/exceptions
+    gtag('event', 'exception', {'description': description});
   };
 </script>

--- a/webapp/templates/_ga.html
+++ b/webapp/templates/_ga.html
@@ -6,7 +6,20 @@
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
 
+  // TODO: Remove when ready to move away from Universal Analytics
   gtag('config', 'UA-89387706-1');
+
+  // Configure Google Analytics 4
+  // TODO: Look into using Google Tag Manager
+  // https://github.com/web-platform-tests/wpt.fyi/issues/2919
+  // Until then, determine which Google Analytics to use by examining the host
+  const host = window.location.hostname;
+  if (host == "wpt.fyi"){
+    gtag('config', 'G-Q5FRYPBBYC');
+  } else {
+    // Default to using the staging one
+    gtag('config', 'G-R9Z49K7QCN');
+  }
   window.onerror = function(message, source, lineno, colno) {
     let description;
     // https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onerror

--- a/webapp/views/wpt-app.js
+++ b/webapp/views/wpt-app.js
@@ -237,13 +237,11 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
       this.isBSFCollapsed = !this.isBSFCollapsed;
       // Record hide/open actions on the BSF graph. Currently, we only
       // show it on the homepage.
-      if ('ga' in window) {
-        window.ga('send', {
-          hitType: 'event',
-          eventCategory: 'bsf',
-          eventAction: 'visibility change',
-          eventLabel: this.path,
-          eventValue: this.isBSFCollapsed ? 1 : 0
+      if ('gtag' in window) {
+        window.gtag('event', 'visibility change', {
+          'event_category': 'bsf',
+          'event_label': this.path,
+          'value': this.isBSFCollapsed ? 1 : 0
         });
       }
       this.setLocalStorageFlag(this.isBSFCollapsed, 'isBSFCollapsed');
@@ -270,13 +268,11 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
         return;
       }
 
-      if ('ga' in window) {
-        window.ga('send', {
-          hitType: 'event',
-          eventCategory: 'bsf',
-          eventAction: 'hover',
-          eventLabel: this.path,
-          eventValue: duration
+      if ('gtag' in window) {
+        window.gtag('event', 'hover', {
+          'event_category': 'bsf',
+          'event_label': this.path,
+          'value': duration
         });
       }
       this.bsfStartTime = null;


### PR DESCRIPTION
<!--
Thanks for the PR, you probably worked hard on it! Before you submit it for review, please make sure you read our guidelines for contributing to this repository. 

Try to make the job easy for your reviewer! Below is a template you can use as a guide for what context your reviewer might need.  
If you changed any dev procedures, consider also updating the README.
-->

## Description
Part of #2916. Need to move to gtag.js. Instead of jumping straight to
gtag.js for Google Analytics 4, this work moves Universal Analytics to
use gtag.js. That we can test out the same functionality before point
the data to Google Analytics 4 without having to change the syntax.

A future PR will remove the Universal Analytics code.


## Changes
- Add Google Analytics 4 tracking codes for prod and non-prod while also keeping the Universal Analytics code.
- Remove the analytics.js script and place the gtag script from the Universal Analytics dashboard
- Move the exception event handling to the gtag.js. Syntax is a little different. [Docs](https://developers.google.com/analytics/devguides/collection/gtagjs/exceptions)
- Changed Page View events [syntax](https://developers.google.com/analytics/devguides/collection/gtagjs/pages#page_view_event) to work for gtag.js
- Changed other custom events [syntax](https://developers.google.com/tag-platform/gtagjs/reference#event) to work for gtag.js

