### PR TITLE
Remove Universal Analytics tracking

### DIFF
--- a/webapp/templates/_ga.html
+++ b/webapp/templates/_ga.html
@@ -6,9 +6,6 @@
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
 
-  // TODO: Remove when ready to move away from Universal Analytics
-  gtag('config', 'UA-89387706-1');
-
   // Configure Google Analytics 4
   // TODO: Look into using Google Tag Manager
   // https://github.com/web-platform-tests/wpt.fyi/issues/2919

--- a/webapp/templates/_ga.html
+++ b/webapp/templates/_ga.html
@@ -1,6 +1,6 @@
 {{- /* no data */ -}}
 <!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-89387706-1"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-R9Z49K7QCN"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}


### PR DESCRIPTION
This commit should be merged in once we are ready to fully move away
from Universal Analytics. The Google Analytics 4 tracking codes are
already in place from the work on #2917. This commit just removes
Universal Analytics

Closes #2916