### PR TITLE
Write new summaries as "_v2"

### DIFF
--- a/results-processor/processor.py
+++ b/results-processor/processor.py
@@ -204,7 +204,8 @@ class Processor(object):
         """Uploads the individual results recursively to GCS."""
         self.report.populate_upload_directory(output_dir=self._upload_dir)
 
-        # 1. Copy [ID]-summary.json.gz to gs://wptd/[SHA]/[ID]-summary.json.gz.
+        # 1. Copy [ID]-summary_v2.json.gz
+        # to gs://wptd/[SHA]/[ID]-summary_v2.json.gz.
         gsutil.copy(
             os.path.join(self._upload_dir, self.report.sha_summary_path),
             self.results_gs_url,

--- a/results-processor/wptreport.py
+++ b/results-processor/wptreport.py
@@ -415,7 +415,7 @@ class WPTReport(object):
         The directory structure is as follows:
         [output_dir]:
             - [sha][:10]:
-                - [product]-summary.json.gz
+                - [product]-summary_v2.json.gz
                 - [product]:
                     - (per-test results produced by write_result_directory)
 
@@ -445,8 +445,8 @@ class WPTReport(object):
 
     @property
     def sha_summary_path(self) -> str:
-        """A relative path: sha/product_id-summary.json.gz"""
-        return self.sha_product_path + '-summary.json.gz'
+        """A relative path: sha/product_id-summary_v2.json.gz"""
+        return self.sha_product_path + '-summary_v2.json.gz'
 
     @property
     def test_run_metadata(self) -> Dict[str, str]:
@@ -635,7 +635,7 @@ def create_test_run(report, run_id, labels_str, uploader, auth,
         uploader: The name of the uploader.
         auth: A (username, password) tuple for HTTP basic auth.
         results_url: URL of the gzipped summary file. (e.g.
-            'https://.../wptd/0123456789/chrome-62.0-linux-summary.json.gz')
+            'https://.../wptd/0123456789/chrome-62.0-linux-summary_v2.json.gz')
         raw_results_url: URL of the raw full report. (e.g.
             'https://.../wptd-results/[FullSHA]/chrome-62.0-linux/report.json')
 

--- a/results-processor/wptreport_test.py
+++ b/results-processor/wptreport_test.py
@@ -392,7 +392,7 @@ class WPTReportTest(unittest.TestCase):
 
         self.assertTrue(os.path.isfile(os.path.join(
             self.tmp_dir, revision,
-            'firefox-59.0-linux-0123456789-summary.json.gz'
+            'firefox-59.0-linux-0123456789-summary_v2.json.gz'
         )))
         self.assertTrue(os.path.isfile(os.path.join(
             self.tmp_dir, revision,
@@ -530,7 +530,7 @@ class WPTReportTest(unittest.TestCase):
         r.hashsum = lambda: 'afa59408e1797c7091d7e89de5561612f7da440d'
         self.assertEqual(r.sha_summary_path,
                          '0bdaaf9c1622ca49eb140381af1ece6d8001c934/'
-                         'firefox-59.0-linux-afa59408e1-summary.json.gz')
+                         'firefox-59.0-linux-afa59408e1-summary_v2.json.gz')
 
     def test_normalize_version(self):
         r = WPTReport()

--- a/shared/util.go
+++ b/shared/util.go
@@ -144,7 +144,7 @@ func GetResultsURL(run TestRun, testFile string) (resultsURL string) {
 		// Assumes that result files are under a directory named SHA[0:10].
 		resultsBase := strings.SplitAfter(resultsURL, "/"+run.Revision)[0]
 		resultsPieces := strings.Split(resultsURL, "/")
-		re := regexp.MustCompile("(-summary)?\\.json\\.gz$")
+		re := regexp.MustCompile("(-summary(_v2)?)?\\.json\\.gz$")
 		product := re.ReplaceAllString(resultsPieces[len(resultsPieces)-1], "")
 		resultsURL = fmt.Sprintf("%s/%s/%s", resultsBase, product, testFile)
 	}

--- a/shared/util_test.go
+++ b/shared/util_test.go
@@ -16,6 +16,7 @@ const shortSHA = "abcdef0123"
 const resultsURLBase = "https://storage.googleapis.com/wptd/" + shortSHA + "/"
 const product = "chrome-63.0-linux"
 const resultsURL = resultsURLBase + "/" + product + "-summary.json.gz"
+const resultsURLNewFormat = resultsURLBase + "/" + product + "-summary_v2.json.gz"
 
 func TestMapStringKeys(t *testing.T) {
 	m := map[string]int{"foo": 1}
@@ -62,6 +63,12 @@ func TestGetResultsURL_EmptyFile(t *testing.T) {
 	run := TestRun{ResultsURL: resultsURL}
 	run.Revision = shortSHA
 	checkResult(t, run, "", resultsURL)
+}
+
+func TestGetResultsURL_NewSummaryFormat(t *testing.T) {
+	run := TestRun{ResultsURL: resultsURLNewFormat}
+	run.Revision = shortSHA
+	checkResult(t, run, "", resultsURLNewFormat)
 }
 
 func TestGetResultsURL_TestFile(t *testing.T) {

--- a/webapp/components/test-file-results.js
+++ b/webapp/components/test-file-results.js
@@ -270,7 +270,8 @@ class TestFileResults extends WPTFlags(LoadingState(PathInfo(
 
   resultsURL(testRun, path) {
     path = this.encodeTestPath(path);
-    // This is relying on the assumption that result files end with '-summary.json.gz'.
+    // This is relying on the assumption that result
+    // files end with '-summary.json.gz' or '-summary_v2.json.gz'.
     let resultsSuffix = '-summary.json.gz';
     if (!testRun.results_url.contains('-summary')) {
       resultsSuffix = '-summary_v2.json.gz';

--- a/webapp/components/test-file-results.js
+++ b/webapp/components/test-file-results.js
@@ -273,7 +273,7 @@ class TestFileResults extends WPTFlags(LoadingState(PathInfo(
     // This is relying on the assumption that result
     // files end with '-summary.json.gz' or '-summary_v2.json.gz'.
     let resultsSuffix = '-summary.json.gz';
-    if (!testRun.results_url.contains('-summary')) {
+    if (!testRun.results_url.includes(resultsSuffix)) {
       resultsSuffix = '-summary_v2.json.gz';
     }
     const resultsBase = testRun.results_url.slice(0, testRun.results_url.lastIndexOf(resultsSuffix));

--- a/webapp/components/test-file-results.js
+++ b/webapp/components/test-file-results.js
@@ -271,7 +271,11 @@ class TestFileResults extends WPTFlags(LoadingState(PathInfo(
   resultsURL(testRun, path) {
     path = this.encodeTestPath(path);
     // This is relying on the assumption that result files end with '-summary.json.gz'.
-    const resultsBase = testRun.results_url.slice(0, testRun.results_url.lastIndexOf('-summary.json.gz'));
+    let resultsSuffix = '-summary.json.gz';
+    if (!testRun.results_url.contains('-summary')) {
+      resultsSuffix = '-summary_v2.json.gz';
+    }
+    const resultsBase = testRun.results_url.slice(0, testRun.results_url.lastIndexOf(resultsSuffix));
     return `${resultsBase}${path}`;
   }
 

--- a/webapp/components/test/test-file-results.html
+++ b/webapp/components/test/test-file-results.html
@@ -48,8 +48,8 @@ suite('TestFileResults', () => {
         tfr.resultsURL(
           TEST_RUNS_DATA[1],
           '/example/test/path'
-        )).to.equal('https://storage.googleapis.com/wptd/03d67ae5d9/edge-15-windows-10/example/test/path');
-      });
+        )).to.equal('https://storage.googleapis.com/wptd/03d67ae5d9/edge-15-windows-10-sauce/example/test/path');
+    });
     test('v2 url', () => {
       expect(
         tfr.resultsURL(

--- a/webapp/components/test/test-file-results.html
+++ b/webapp/components/test/test-file-results.html
@@ -42,6 +42,23 @@ suite('TestFileResults', () => {
     });
   });
 
+  suite('resultsURL', () => {
+    test('v1 url', () => {
+      expect(
+        tfr.resultsURL(
+          TEST_RUNS_DATA[1],
+          "/example/test/path"
+          )).to.equal("https://storage.googleapis.com/wptd/03d67ae5d9/edge-15-windows-10/example/test/path")
+      });
+    test('v2 url', () => {
+      expect(
+        tfr.resultsURL(
+          TEST_RUNS_DATA[0],
+          "/example/test/path"
+          )).to.equal("https://storage.googleapis.com/wptd/53c5bf648c/chrome-63.0-linux/example/test/path")
+    });
+  });
+
   suite('TestFileResults.prototype.*', () => {
     suite('statusName', () => {
       test('no subtests', () => {

--- a/webapp/components/test/test-file-results.html
+++ b/webapp/components/test/test-file-results.html
@@ -47,15 +47,15 @@ suite('TestFileResults', () => {
       expect(
         tfr.resultsURL(
           TEST_RUNS_DATA[1],
-          "/example/test/path"
-          )).to.equal("https://storage.googleapis.com/wptd/03d67ae5d9/edge-15-windows-10/example/test/path")
+          '/example/test/path'
+        )).to.equal('https://storage.googleapis.com/wptd/03d67ae5d9/edge-15-windows-10/example/test/path');
       });
     test('v2 url', () => {
       expect(
         tfr.resultsURL(
           TEST_RUNS_DATA[0],
-          "/example/test/path"
-          )).to.equal("https://storage.googleapis.com/wptd/53c5bf648c/chrome-63.0-linux/example/test/path")
+          '/example/test/path'
+        )).to.equal('https://storage.googleapis.com/wptd/53c5bf648c/chrome-63.0-linux/example/test/path');
     });
   });
 

--- a/webapp/components/test/util/helpers.js
+++ b/webapp/components/test/util/helpers.js
@@ -23,7 +23,7 @@ const TEST_RUNS_DATA = [
     os_name: 'linux',
     os_version: '*',
     revision: '53c5bf648c',
-    results_url: 'https://storage.googleapis.com/wptd/53c5bf648c/chrome-63.0-linux-summary.json.gz',
+    results_url: 'https://storage.googleapis.com/wptd/53c5bf648c/chrome-63.0-linux-summary_v2.json.gz',
     created_at: '2018-01-09T15:47:03.949Z',
   },
   {
@@ -43,7 +43,7 @@ const TEST_RUNS_DATA = [
     os_name: 'linux',
     os_version: '*',
     revision: '1f9c924a4b',
-    results_url: 'https://storage.googleapis.com/wptd/1f9c924a4b/firefox-57.0-linux-summary.json.gz',
+    results_url: 'https://storage.googleapis.com/wptd/1f9c924a4b/firefox-57.0-linux-summary_v2.json.gz',
     created_at: '2018-01-09T15:54:04.296Z',
   },
   {


### PR DESCRIPTION
Part of deprecating old summary formats. This change will now write new summary files with the `_v2` suffix, but will use any summary file, old or new. Additional checks will later be added to verify this suffix exists before using the file.

The plan is to ship this change and allow the new summaries to be written with the new filename, which will limit the need to delegate the work to the searchcache, as summary files are rarely referenced at later dates.