### PR TITLE
Fix logo install errors

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -38,7 +38,7 @@
     "test": "wct --local chrome && wct --local firefox",
     "lint": "eslint 'components/*.js' && eslint --plugin html 'components/test/*.html'",
     "lint-fix": "eslint --fix 'components/**/*.js' && eslint --fix --plugin html 'components/test/*.html' ",
-    "postinstall": "cpy node_modules/@browser-logos/{chrome,chrome-beta,chrome-canary,chrome-dev,chromium,deno,edge,edge-beta,edge-canary,edge-dev,firefox,firefox-beta,firefox-nightly,safari,servo,uc}/*_64x64.png static && cpy node_modules/@browser-logos/firefox-developer-edition/*_64x64.png static --rename=firefox-dev_64x64.png && cpy node_modules/@browser-logos/safari/*_64x64.png static --rename=safari-beta_64x64.png && cpy node_modules/@browser-logos/safari-technology-preview/*_64x64.png  static --rename=safari-dev_64x64.png && cpy node_modules/@browser-logos/safari-technology-preview/*_64x64.png static --rename=safari-preview_64x64.png",
+    "postinstall": "cpy 'node_modules/@browser-logos/{chrome,chrome-beta,chrome-canary,chrome-dev,chromium,deno,edge,edge-beta,edge-canary,edge-dev,firefox,firefox-beta,firefox-nightly,safari,servo,uc}/*_64x64.png' static && cpy 'node_modules/@browser-logos/firefox-developer-edition/*_64x64.png' static --rename=firefox-dev_64x64.png && cpy 'node_modules/@browser-logos/safari/*_64x64.png' static --rename=safari-beta_64x64.png && cpy 'node_modules/@browser-logos/safari-technology-preview/*_64x64.png'  static --rename=safari-dev_64x64.png && cpy 'node_modules/@browser-logos/safari-technology-preview/*_64x64.png' static --rename=safari-preview_64x64.png",
     "wctp": "wct -p",
     "wct": "wct"
   },


### PR DESCRIPTION
#2955

The recent update of `cpy-cli` requires the path to be supplied with quotes.

Staging link: https://logo-fix-dot-wptdashboard-staging.uk.r.appspot.com/