### PR TITLE
Update lint parser

### DIFF
--- a/webapp/.eslintrc.json
+++ b/webapp/.eslintrc.json
@@ -5,9 +5,15 @@
     "mocha": true
   },
   "extends": "eslint:recommended",
-  "parser": "babel-eslint",
+  "parser": "@babel/eslint-parser",
   "parserOptions": {
-    "sourceType": "module"
+    "sourceType": "module",
+    "requireConfigFile": false,
+    "babelOptions": {
+      "plugins": [
+        "@babel/plugin-syntax-import-assertions"
+      ]
+    }
   },
   "globals": {
     "assert": true,

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -43,6 +43,8 @@
     "wct": "wct"
   },
   "dependencies": {
+    "@babel/eslint-parser": "^7.19.1",
+    "@babel/plugin-syntax-import-assertions": "^7.18.6",
     "@google-web-components/google-chart": "3.1.1",
     "@polymer/app-route": "3.0.2",
     "@polymer/iron-collapse": "3.0.1",


### PR DESCRIPTION
Needed for linting modern `assert {type: "json"}` imports.