### PR TITLE
Fix missing dependencies when Chrome install fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,7 @@ chrome: wget
 	if [[ -z "$$(which google-chrome)" ]]; then \
 		ARCHIVE=google-chrome-stable_current_amd64.deb; \
 		wget -q https://dl.google.com/linux/direct/$${ARCHIVE}; \
+		sudo apt-get update; \
 		sudo dpkg --install $${ARCHIVE} 2>/dev/null || true; \
 		sudo apt-get install --fix-broken --fix-missing -qqy; \
 		sudo dpkg --install $${ARCHIVE} 2>/dev/null; \

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ chrome: wget
 		ARCHIVE=google-chrome-stable_current_amd64.deb; \
 		wget -q https://dl.google.com/linux/direct/$${ARCHIVE}; \
 		sudo dpkg --install $${ARCHIVE} 2>/dev/null || true; \
-		sudo apt-get install --fix-broken -qqy; \
+		sudo apt-get install --fix-broken --fix-missing -qqy; \
 		sudo dpkg --install $${ARCHIVE} 2>/dev/null; \
 	fi
 


### PR DESCRIPTION
The error message in #2985 suggests to try passing --fix-missing, which although I am not certain it will help, I confirmed that it doesn't hurt. Code spelunking indicates that this bit was added in #1165 without a lot of rigor anyway.