### PR TITLE
Upgrade to actions/checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,42 +8,42 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/make-in-docker
         with:
           target: lint
   python_test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/make-in-docker
         with:
           target: python_test
   go_test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/make-in-docker
         with:
           target: go_test
   web_components_test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/make-in-docker
         with:
           target: web_components_test
   go_chrome_test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/make-in-docker
         with:
           target: go_chrome_test
   go_firefox_test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./.github/actions/make-in-docker
         with:
           target: go_firefox_test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
       DOCKER_IMAGE: webplatformtests/wpt.fyi:latest
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 2
 

--- a/.github/workflows/docker-update.yml
+++ b/.github/workflows/docker-update.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: elgohr/Publish-Docker-Github-Action@master
+      - uses: elgohr/Publish-Docker-Github-Action@v4
         # https://github.com/elgohr/Publish-Docker-Github-Action
         with:
           name: webplatformtests/wpt.fyi

--- a/.github/workflows/docker-update.yml
+++ b/.github/workflows/docker-update.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.repository == 'web-platform-tests/wpt.fyi'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: elgohr/Publish-Docker-Github-Action@master
         # https://github.com/elgohr/Publish-Docker-Github-Action
         with:

--- a/.github/workflows/docker-update.yml
+++ b/.github/workflows/docker-update.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: elgohr/Publish-Docker-Github-Action@v4
+      - uses: elgohr/Publish-Docker-Github-Action@master
         # https://github.com/elgohr/Publish-Docker-Github-Action
         with:
           name: webplatformtests/wpt.fyi


### PR DESCRIPTION
Upgrade to actions/checkout@v3, which runs node16 by default. Resolve following [warnings](https://github.com/web-platform-tests/wpt.fyi/actions/runs/3228727256):

```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-
09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please 
update the following actions to use Node.js 16: actions/checkout, actions/checkout
```