### PR TITLE
Add a flag allowing interop view to be viewed everywhere

### DIFF
--- a/webapp/components/test-runs-query.js
+++ b/webapp/components/test-runs-query.js
@@ -6,13 +6,14 @@
 import { pluralize } from './pluralize.js';
 import { Channels, DefaultProductSpecs, ProductInfo } from './product-info.js';
 import { QueryBuilder } from './results-navigation.js';
+import { WPTFlags } from './wpt-flags.js';
 
 const testRunsQueryComputer =
   'computeTestRunQueryParams(shas, aligned, master, labels, productSpecs, to, from, maxCount, offset, view)';
 
-const TestRunsQuery = (superClass, opt_queryCompute) => class extends QueryBuilder(
+const TestRunsQuery = (superClass, opt_queryCompute) => class extends WPTFlags(QueryBuilder(
   ProductInfo(superClass),
-  opt_queryCompute || testRunsQueryComputer) {
+  opt_queryCompute || testRunsQueryComputer)) {
 
   static get properties() {
     return {
@@ -172,7 +173,7 @@ const TestRunsQuery = (superClass, opt_queryCompute) => class extends QueryBuild
   }
 
   showDefaultView(view, q) {
-    return !view || !q || !q.includes('interop-202');
+    return !this.anyInteropView && (!view || !q || !q.includes('interop-202'));
   }
 
   parseQuery(query) {

--- a/webapp/components/wpt-flags.js
+++ b/webapp/components/wpt-flags.js
@@ -50,6 +50,7 @@ Object.defineProperty(wpt, 'ClientSideFeatures', {
       'structuredQueries',
       'triageMetadataUI',
       'webPlatformTestsLive',
+      'anyInteropView',
     ];
   }
 });
@@ -256,6 +257,11 @@ class WPTFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ false) {
     <paper-item>
       <paper-checkbox checked="{{showBSF}}">
         Enable Browser Specific Failures graph
+      </paper-checkbox>
+    </paper-item>
+    <paper-item>
+      <paper-checkbox checked="{{anyInteropView}}">
+        Allow Interop View to be selected for any result set.
       </paper-checkbox>
     </paper-item>
 `;


### PR DESCRIPTION
<!--
Thanks for the PR, you probably worked hard on it! Before you submit it for review, please make sure you read our guidelines for contributing to this repository. 

Try to make the job easy for your reviewer! Below is a template you can use as a guide for what context your reviewer might need.  
If you changed any dev procedures, consider also updating the README.
-->

## Description

This adds a flag which overrides the default logic for allowing the interop scores.

<!-- A detailed description explaining what your code accomplishes, and why this work is taking place. If this affects an open issue, please make sure to properly reference it. -->

## Review Information

As I understand it, we pull defaults from somewhere server-side; it's not clear to me where actually controls this. As I understand, it sounds like 
people with admin accounts on wpt.fyi can change these defaults, but given they default to false this shouldn't need anything to be done there.

Note I haven't actually tested this (I don't have a working local setup), so someone who does should probably test this as part of the review.

<!-- Provide detailed instructions for how to run the code. -->

