### PR TITLE
Add subtotal rows to sections on Interop page

### DIFF
--- a/webapp/components/interop.js
+++ b/webapp/components/interop.js
@@ -724,7 +724,7 @@ class InteropDashboard extends PolymerElement {
     if (!scores) {
       return '0%';
     }
-    let totalScore = scores.reduce((sum, area) => {
+    const totalScore = scores.reduce((sum, area) => {
       if (area.scores_over_time.length > 0) {
         return sum + area.scores_over_time[area.scores_over_time.length - 1].score;
       }


### PR DESCRIPTION
See https://github.com/web-platform-tests/interop/issues/205

This change renders a subtotal row under each table section on the Interop page.
![Screen Shot 2022-10-19 at 10 24 56 AM](https://user-images.githubusercontent.com/56164590/196763952-d0c2ff68-e390-433f-9e12-d17856184766.png)

Interop years with only 1 table section will not render a subtotal row (2021 for example).
![Screen Shot 2022-10-19 at 10 35 14 AM](https://user-images.githubusercontent.com/56164590/196764229-d62e3df8-2277-41dc-8220-fbe7462c6a0a.png)
