### PR TITLE
Ignore gcloud tests for dependabot & ignore certain npm packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,11 @@ updates:
   directory: "/webapp"
   schedule:
     interval: "weekly"
+  ignore:
+  # https://github.com/web-platform-tests/wpt.fyi/commit/9b99cfd70568dc8d991d2b13ad9c5aec53c390a6
+  - dependency-name: "@vaadin/vaadin-grid"
+  - dependency-name: "@vaadin/vaadin-date-picker"
+  - dependency-name: "@vaadin/vaadin-context-menu"
 - package-ecosystem: "npm"
   directory: "/webdriver"
   schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     # This means this CI job will have access to the service account.
     # In that case, similar to deploy.yml, trust only pull requests that are
     # made within web-platform-tests and exclude forks.
-    if: ${{ github.repository == 'web-platform-tests/wpt.fyi' }}
+    if: ${{ github.repository == 'web-platform-tests/wpt.fyi' && github.actor != 'dependabot[bot]' }}
     needs: [go_test, go_chrome_test, go_firefox_test]
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
For security reasons, dependabot builds do not have access to the same secrets as a regular CI build. As a result, it cannot run gcloud tests properly. This patch ignores gcloud tests for dependabot builds.

Also, configure dependabot to ignore certain packages for /webapp. They were ignored in renovate previously. During the migration, they were only ignored for webdriver/ but not webapp/. This fixes that.

