### PR TITLE
Upgrade to go 1.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # vim: set expandtab sw=4
-FROM golang:1.16-buster
+FROM golang:1.19-buster
 
 # Create a non-priviledged user to run browsers as (Firefox and Chrome do not
 # like to run as root).

--- a/api/query/cache/service/Dockerfile
+++ b/api/query/cache/service/Dockerfile
@@ -1,7 +1,7 @@
 # Production deployment spec for query cache service.
 
-# Base golang 1.16 image.
-FROM golang:1.16-buster as builder
+# Base golang 1.19 image.
+FROM golang:1.19-buster as builder
 
 RUN apt-get update
 RUN apt-get install -qy --no-install-suggests git

--- a/webapp/web/app.staging.yaml
+++ b/webapp/web/app.staging.yaml
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-runtime: go116
+runtime: go119
 instance_class: F4_1G
 
 inbound_services:

--- a/webapp/web/app.yaml
+++ b/webapp/web/app.yaml
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-runtime: go116
+runtime: go119
 instance_class: F4_1G
 
 inbound_services:


### PR DESCRIPTION
go1.19 went to Public Preview on app engine

https://cloud.google.com/appengine/docs/standard/go/runtime
    
This commit updates it.
    
The steps that were followed are at https://github.com/web-platform-tests/wpt.fyi/blob/main/docs/upgrading-go.md
Steps 3 & 4 were skipped because webplatformtests/wpt.fyi:latest is still go 1.16

Why is it safe to use go 1.19 on a bunch of go 1.16 packages? Go guarantees [backwards compatibility](https://go.dev/doc/go1compat) for all 1.x versions

This PR is part 1 of 2.