### PR TITLE
Increase timeout waiting for test datastore

### DIFF
--- a/shared/sharedtest/util.go
+++ b/shared/sharedtest/util.go
@@ -83,7 +83,7 @@ func (i *aeInstance) start(stronglyConsistentDatastore bool) error {
 	select {
 	case <-started:
 		break
-	case <-time.After(time.Second * 10):
+	case <-time.After(time.Second * 20):
 		i.stop()
 		return errors.New("timed out starting Datastore emulator")
 	}


### PR DESCRIPTION
There has been an increased frequency of the go tests failing because the timeout is exceeded. As a result, the CI run has to be re-ran multiple times. This commit adjusts the timeout from 10 seconds to 20 seconds. Not sure it will fix it but worth a try.

