### PR TITLE
Add chrome_ios as a browser name

### DIFF
--- a/shared/browsers.go
+++ b/shared/browsers.go
@@ -14,7 +14,7 @@ var defaultBrowsers = []string{
 
 // An extra list of known browsers.
 var extraBrowsers = []string{
-	"android_webview", "chrome_android", "deno", "epiphany", "flow", "servo", "uc", "webkitgtk",
+	"android_webview", "chrome_android", "chrome_ios", "deno", "epiphany", "flow", "servo", "uc", "webkitgtk",
 }
 
 var allBrowsers mapset.Set

--- a/shared/browsers_test.go
+++ b/shared/browsers_test.go
@@ -20,6 +20,7 @@ func TestGetDefaultBrowserNames(t *testing.T) {
 	for _, n := range names {
 		assert.NotEqual(t, "android_webview", n)
 		assert.NotEqual(t, "chrome_android", n)
+		assert.NotEqual(t, "chrome_ios", n)
 		assert.NotEqual(t, "deno", n)
 		assert.NotEqual(t, "epiphany", n)
 		assert.NotEqual(t, "flow", n)
@@ -37,6 +38,7 @@ func TestIsBrowserName(t *testing.T) {
 	assert.True(t, IsBrowserName("flow"))
 	assert.True(t, IsBrowserName("safari"))
 	assert.True(t, IsBrowserName("chrome_android"))
+	assert.True(t, IsBrowserName("chrome_ios"))
 	assert.True(t, IsBrowserName("android_webview"))
 	assert.True(t, IsBrowserName("epiphany"))
 	assert.True(t, IsBrowserName("servo"))

--- a/shared/product_spec.go
+++ b/shared/product_spec.go
@@ -74,6 +74,8 @@ func (p ProductSpec) DisplayName() string {
 		return "Chrome"
 	case "chrome_android":
 		return "ChromeAndroid"
+	case "chrome_ios":
+		return "ChromeIOS"
 	case "android_webview":
 		return "WebView"
 	case "deno":

--- a/webapp/components/product-info.js
+++ b/webapp/components/product-info.js
@@ -11,6 +11,7 @@ const DisplayNames = (() => {
   ['safari', 'safari-experimental'].forEach(n => m.set(n, 'Safari'));
   m.set('android_webview', 'WebView');
   m.set('chrome_android', 'ChromeAndroid');
+  m.set('chrome_ios', 'ChromeIOS');
   m.set('deno', 'Deno');
   m.set('flow', 'Flow');
   m.set('servo', 'Servo');
@@ -41,7 +42,8 @@ const versionPatterns = Object.freeze({
 });
 
 // The set of all browsers known to the wpt.fyi UI.
-const AllBrowserNames = Object.freeze(['android_webview', 'chrome_android', 'chrome', 'deno', 'edge', 'firefox', 'flow', 'safari', 'servo', 'webkitgtk']);
+const AllBrowserNames = Object.freeze(['android_webview', 'chrome_android', 'chrome_ios', 'chrome',
+    'deno', 'edge', 'firefox', 'flow', 'safari', 'servo', 'webkitgtk']);
 
 // The list of default browsers used in cases where the user has not otherwise
 // chosen a set of browsers (e.g. which browsers to show runs for). Stored as

--- a/webapp/components/product-info.js
+++ b/webapp/components/product-info.js
@@ -43,7 +43,7 @@ const versionPatterns = Object.freeze({
 
 // The set of all browsers known to the wpt.fyi UI.
 const AllBrowserNames = Object.freeze(['android_webview', 'chrome_android', 'chrome_ios', 'chrome',
-    'deno', 'edge', 'firefox', 'flow', 'safari', 'servo', 'webkitgtk']);
+  'deno', 'edge', 'firefox', 'flow', 'safari', 'servo', 'webkitgtk']);
 
 // The list of default browsers used in cases where the user has not otherwise
 // chosen a set of browsers (e.g. which browsers to show runs for). Stored as


### PR DESCRIPTION
Add chrome_ios as a browser name in wpt.fyi.
We plan to publish wpt test results for chrome ios to wpt.fyi.
