### PR TITLE
Fix flaky tests that use datastore emulator

### DIFF
--- a/shared/sharedtest/util.go
+++ b/shared/sharedtest/util.go
@@ -136,8 +136,7 @@ func (i aeInstance) stop() error {
 		fmt.Printf("removing data dir: %s\n", i.dataDir)
 		err := os.RemoveAll(i.dataDir)
 		if err != nil {
-			// Do not need to return error.
-			// In case the emulator failed to
+			// Do not need to return error. Just warn.
 			fmt.Printf("warning: unable to delete temporary data directory. %s\n",
 				err.Error())
 		}

--- a/shared/sharedtest/util.go
+++ b/shared/sharedtest/util.go
@@ -85,6 +85,11 @@ func (i *aeInstance) start(stronglyConsistentDatastore bool) error {
 		break
 	case <-time.After(time.Second * 30):
 		i.stop()
+		stdoutStderr, err := i.gcd.CombinedOutput()
+		if err != nil {
+			fmt.Printf("unable to get output for the datastore emulator. it may be empty. %s\n", err)
+		}
+		fmt.Printf("output for datastore emulator command unable to start in time:\n%s\n", stdoutStderr)
 		return errors.New("timed out starting Datastore emulator")
 	}
 

--- a/shared/sharedtest/util.go
+++ b/shared/sharedtest/util.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -59,7 +58,7 @@ func (i *aeInstance) start(stronglyConsistentDatastore bool) error {
 	if err != nil {
 		return err
 	}
-	dir, err := ioutil.TempDir("wpt_fyi", "datastore")
+	dir, err := os.MkdirTemp("", "wpt_fyi_datastore")
 	if err != nil {
 		fmt.Println("unable to create temporary datastore data directory")
 		return err

--- a/shared/sharedtest/util.go
+++ b/shared/sharedtest/util.go
@@ -133,11 +133,11 @@ func (i aeInstance) stop() error {
 	stopped <- i.gcd.Wait()
 
 	if i.dataDir != "" {
-		fmt.Printf("removing data dir: %s\n", i.dataDir)
 		err := os.RemoveAll(i.dataDir)
 		if err != nil {
 			// Do not need to return error. Just warn.
-			fmt.Printf("warning: unable to delete temporary data directory. %s\n",
+			fmt.Printf("warning: unable to delete temporary data directory %s. %s\n",
+				i.dataDir,
 				err.Error())
 		}
 		i.dataDir = ""

--- a/shared/sharedtest/util.go
+++ b/shared/sharedtest/util.go
@@ -95,7 +95,7 @@ func (i *aeInstance) start(stronglyConsistentDatastore bool) error {
 	select {
 	case <-started:
 		break
-	case <-time.After(time.Second * 30):
+	case <-time.After(time.Second * 10):
 		i.stop()
 		fmt.Printf("datastore emulator unable to start in time:\nstdout:\n%s\nstderr:\n%s\n",
 			stdoutBuffer.String(),

--- a/shared/sharedtest/util.go
+++ b/shared/sharedtest/util.go
@@ -90,7 +90,7 @@ func (i *aeInstance) start(stronglyConsistentDatastore bool) error {
 		break
 	case <-time.After(time.Second * 30):
 		i.stop()
-		fmt.Printf("datastore emulator unable to start in time:\nstdout:\n%s\nstderr:\n%s",
+		fmt.Printf("datastore emulator unable to start in time:\nstdout:\n%s\nstderr:\n%s\n",
 			stdoutBuffer.String(),
 			stderrBuffer.String())
 		return errors.New("timed out starting Datastore emulator")


### PR DESCRIPTION
More details in #3093

Turns out that even though we have "--no-store-on-disk" added to the datastore command, it still uses some default directory. 

Changes:
- In order to debug why the datastore is intermittently failing, print out the stdout and stderr of the command.
- Temporarily create a directory per time the datastore is created.
  - I temporarily added a log to see when the datastore emulator started up / and torn down. If you check the logs for `removing data dir` now in this particular `go_test` [run](https://github.com/web-platform-tests/wpt.fyi/actions/runs/3795116942/jobs/6453905629), you will see that the datastore was being created multiple times.
  - **HYPOTHESIS**: There is some clean up that did not happen properly whenever the emulator shut down with "--no-store-on-disk" every time. This default directory is expected to be empty when starting up. And the flag does not mean it keeps in memory. Rather, it temporarily keeps it on disk and cleans up after it shuts down.
- Revert the timeout back to 10 seconds.

