### PR TITLE
Only display interop year links that are valid

### DIFF
--- a/webapp/components/interop.js
+++ b/webapp/components/interop.js
@@ -43,6 +43,7 @@ class InteropDataManager {
     this.issueURL = yearInfo.issue_url;
     this.investigationScores = yearInfo.investigation_scores;
     this.investigationWeight = yearInfo.investigation_weight;
+    this.validYears = Object.keys(paramsByYear);
   }
 
   // Fetches the datatable for the given feature and stable/experimental state.
@@ -766,13 +767,7 @@ class InteropDashboard extends PolymerElement {
   }
 
   getAllYears() {
-    const firstYear = 2021;
-    const currentYear = new Date().getFullYear();
-    const years = [];
-    for (let i = firstYear; i <= currentYear; i++) {
-      years.push(i.toString());
-    }
-    return years;
+    return this.dataManager.getYearProp('validYears').sort();
   }
 
   getYearProp(prop) {


### PR DESCRIPTION
The interop-2022 page is displaying a link at the bottom for 2023 now that it is 2023, which is not available. This change makes it so that only links to years that we have defined in `interop-data.json` will be displayed.