### PR TITLE
add mdn and spec links to interop focus areas

### DIFF
--- a/webapp/components/interop.js
+++ b/webapp/components/interop.js
@@ -414,7 +414,7 @@ class InteropDashboard extends PolymerElement {
         }
 
         .score-table tbody td {
-          padding: .25em .5em;
+          padding: 0 .5em;
         }
         .score-table tbody th:not(:last-of-type) {
           padding-right: .5em;
@@ -430,7 +430,7 @@ class InteropDashboard extends PolymerElement {
         }
 
         .score-table tr > th:first-of-type {
-          width: 20ch;
+          width: 30ch;
         }
 
         .score-table tr > :is(td,th):not(:first-of-type) {
@@ -438,7 +438,7 @@ class InteropDashboard extends PolymerElement {
         }
 
         .score-table td {
-          min-width: 7ch;
+          min-width: 6ch;
           font-variant-numeric: tabular-nums;
         }
 
@@ -496,7 +496,9 @@ class InteropDashboard extends PolymerElement {
           place-items: center;
         }
 
-
+        .grid-container {
+          margin: 0 2em;
+        }
 
         @media only screen and (max-width: 1400px) {
           .grid-container {
@@ -526,16 +528,6 @@ class InteropDashboard extends PolymerElement {
         Look more like the desktop version. This should be removed with new mobile compatibility. */
         p {
           text-size-adjust: none;
-        }
-        @media only screen and (max-width: 1000px) {
-          .grid-item-description, .grid-item-scores, .grid-item-graph {
-            font-size: 20px;
-          }
-        }
-        @media only screen and (max-width: 600px) {
-          .grid-item-description, .grid-item-scores, .grid-item-graph {
-            font-size: 24px;
-          }
         }
 
       </style>

--- a/webapp/static/interop-data.json
+++ b/webapp/static/interop-data.json
@@ -241,12 +241,17 @@
                     "interop-2023-has",
                     "interop-2023-inert",
                     "interop-2023-mathfunctions",
+                    "interop-2023-cssmasking",
                     "interop-2023-mediaqueries",
                     "interop-2023-modules",
                     "interop-2023-motion",
                     "interop-2023-offscreencanvas",
                     "interop-2023-events",
+                    "interop-2022-scrolling",
+                    "interop-2022-subgrid",
+                    "interop-2021-transforms",
                     "interop-2023-url",
+                    "interop-2023-webcodecs",
                     "interop-2023-webcompat",
                     "interop-2023-webcomponents"
                 ],
@@ -255,7 +260,7 @@
             {
                 "name": "Active Investigations",
                 "rows": [
-                    "Accessibility Tree",
+                    "Accessibility Testing",
                     "Mobile Testing"
                 ],
                 "score_as_group": true
@@ -432,6 +437,13 @@
                 "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-inert", 
                 "countsTowardScore": true
             },
+            "interop-2023-cssmasking": {
+                "description": "Masking",
+                "mdn": "",
+                "spec": "",
+                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-cssmasking",
+                "countsTowardScore": true
+            },
             "interop-2023-mathfunctions": {
                 "description": "Math Functions",
                 "mdn": "",
@@ -474,18 +486,46 @@
                 "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-events", 
                 "countsTowardScore": true
             },
+            "interop-2022-scrolling": {
+                "description": "Scrolling",
+                "mdn": "https://developer.mozilla.org/docs/Web/CSS/overflow",
+                "spec": "https://drafts.csswg.org/css-overflow/#propdef-overflow",
+                "tests": "/results/css?label=master&label=experimental&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2022-scrolling",
+                "countsTowardScore": true
+            },
+            "interop-2022-subgrid": {
+                "description": "Subgrid",
+                "mdn": "https://developer.mozilla.org/docs/Web/CSS/CSS_Grid_Layout/Subgrid",
+                "spec": "https://drafts.csswg.org/css-grid-2/#subgrids",
+                "tests": "/results/css/css-grid/subgrid?label=master&label=experimental&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2022-subgrid",
+                "countsTowardScore": true
+            },
+            "interop-2021-transforms": {
+                "description": "Transforms",
+                "mdn": "https://developer.mozilla.org/docs/Web/CSS/transform",
+                "spec": "https://drafts.csswg.org/css-transforms/",
+                "tests": "/results/css/css-transforms?label=master&label=experimental&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2021-transforms",
+                "countsTowardScore": true
+            },
             "interop-2023-url": {
                 "description": "URL",
                 "mdn": "",
                 "spec": "",
-                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-url", 
+                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-url",
                 "countsTowardScore": true
             },
             "interop-2023-webcompat": {
                 "description": "Web Compat 2023",
                 "mdn": "",
                 "spec": "",
-                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-webcompat", 
+                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-webcompat",
+                "countsTowardScore": true
+            },
+            "interop-2023-webcodecs": {
+                "description": "Web Codecs (video)",
+                "mdn": "",
+                "spec": "",
+                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-webcodecs",
                 "countsTowardScore": true
             },
             "interop-2023-webcomponents": {

--- a/webapp/static/interop-data.json
+++ b/webapp/static/interop-data.json
@@ -322,119 +322,118 @@
                 "description": "Cascade Layers",
                 "mdn": "https://developer.mozilla.org/docs/Web/CSS/@layer",
                 "spec": "https://drafts.csswg.org/css-cascade/#layering",
-                "tests": "/results/css/css-cascade?label=master&label=experimental&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2022-cascade", 
+                "tests": "/results/css/css-cascade?label=master&label=experimental&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2022-cascade",
                 "countsTowardScore": false
             },
             "interop-2022-dialog": {
                 "description": "Dialog Element",
                 "mdn": "https://developer.mozilla.org/docs/Web/HTML/Element/dialog",
                 "spec": "https://html.spec.whatwg.org/multipage/interactive-elements.html#the-dialog-element",
-                "tests": "/results/?label=master&label=experimental&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2022-dialog", 
+                "tests": "/results/?label=master&label=experimental&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2022-dialog",
                 "countsTowardScore": false
             },
             "interop-2022-text": {
                 "description": "Typography and Encodings",
                 "mdn": "",
                 "spec": "",
-                "tests": "/results/?label=master&label=experimental&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2022-text", 
+                "tests": "/results/?label=master&label=experimental&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2022-text",
                 "countsTowardScore": false
             },
             "interop-2022-viewport": {
                 "description": "Viewport Units",
                 "mdn": "",
                 "spec": "https://drafts.csswg.org/css-values/#viewport-relative-units",
-                "tests": "/results/css/css-values?label=master&label=experimental&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2022-viewport", 
+                "tests": "/results/css/css-values?label=master&label=experimental&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2022-viewport",
                 "countsTowardScore": false
             },
             "interop-2022-webcompat": {
                 "description": "Web Compat",
                 "mdn": "",
                 "spec": "",
-                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2022-webcompat", 
+                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2022-webcompat",
                 "countsTowardScore": false
             },
             "interop-2023-cssborderimage": {
                 "description": "Border Image",
-                "mdn": "",
-                "spec": "",
-                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-cssborderimage", 
+                "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-image",
+                "spec": "https://w3c.github.io/csswg-drafts/css-backgrounds/#the-border-image",
+                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-cssborderimage",
                 "countsTowardScore": true
             },
             "interop-2023-color": {
                 "description": "Color Spaces and Functions",
-                "mdn": "",
-                "spec": "",
-                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-color", 
+                "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/color_value",
+                "spec": "https://w3c.github.io/csswg-drafts/css-color/#color-syntax",
+                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-color",
                 "countsTowardScore": true
             },
             "interop-2023-container": {
                 "description": "Container Queries",
-                "mdn": "",
-                "spec": "",
-                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-container", 
+                "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Container_Queries",
+                "spec": "https://www.w3.org/TR/css-contain-3/#container-queries",
+                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-container",
                 "countsTowardScore": true
             },
             "interop-2023-contain": {
                 "description": "Containment",
-                "mdn": "",
-                "spec": "",
-                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-contain", 
+                "mdn": "https://developer.mozilla.org/docs/Web/CSS/contain",
+                "spec": "https://drafts.csswg.org/css-contain/#contain-property",
+                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-contain",
                 "countsTowardScore": true
             },
             "interop-2023-pseudos": {
                 "description": "CSS Pseudo-classes",
-                "mdn": "",
-                "spec": "",
-                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-pseudos", 
+                "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes",
+                "spec": "https://html.spec.whatwg.org/multipage/semantics-other.html#pseudo-classes",
+                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-pseudos",
                 "countsTowardScore": true
             },
             "interop-2023-property": {
                 "description": "Custom Properties",
-                "mdn": "",
-                "spec": "",
-                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-property", 
+                "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/@property",
+                "spec": "https://drafts.css-houdini.org/css-properties-values-api/",
+                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-property",
                 "countsTowardScore": true
             },
             "interop-2023-flexbox": {
                 "description": "Flexbox",
-                "mdn": "",
-                "spec": "",
-                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-flexbox", 
+                "mdn": "https://developer.mozilla.org/docs/Learn/CSS/CSS_layout/Flexbox",
+                "spec": "https://drafts.csswg.org/css-flexbox/",
+                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-flexbox",
                 "countsTowardScore": true
             },
             "interop-2023-fonts": {
                 "description": "Font Feature Detection and Palettes",
-                "mdn": "",
-                "spec": "",
-                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-fonts", 
+                "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/font-palette",
+                "spec": "https://w3c.github.io/csswg-drafts/css-fonts/#font-palette-prop",
+                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-fonts",
                 "countsTowardScore": true
             },
             "interop-2023-forms": {
                 "description": "Forms",
-                "mdn": "",
-                "spec": "",
-                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-forms", 
+                "mdn": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form",
+                "spec": "https://html.spec.whatwg.org/multipage/forms.html#the-form-element",
                 "countsTowardScore": true
             },
             "interop-2023-grid": {
                 "description": "Grid",
-                "mdn": "",
-                "spec": "",
-                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-grid", 
+                "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout",
+                "spec": "https://drafts.csswg.org/css-grid/",
+                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-grid",
                 "countsTowardScore": true
             },
             "interop-2023-has": {
                 "description": ":has()",
-                "mdn": "",
-                "spec": "",
-                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-has", 
+                "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/:has",
+                "spec": "https://drafts.csswg.org/selectors-4/#relational",
+                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-has",
                 "countsTowardScore": true
             },
             "interop-2023-inert": {
                 "description": "Inert",
-                "mdn": "",
-                "spec": "",
-                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-inert", 
+                "mdn": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert",
+                "spec": "https://html.spec.whatwg.org/multipage/interaction.html#the-inert-attribute",
+                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-inert",
                 "countsTowardScore": true
             },
             "interop-2023-cssmasking": {
@@ -446,44 +445,44 @@
             },
             "interop-2023-mathfunctions": {
                 "description": "Math Functions",
-                "mdn": "",
-                "spec": "",
-                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-mathfunctions", 
+                "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Functions#math_functions",
+                "spec": "https://w3c.github.io/csswg-drafts/css-values-4/#math",
+                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-mathfunctions",
                 "countsTowardScore": true
             },
             "interop-2023-mediaqueries": {
                 "description": "Media Queries 4",
-                "mdn": "",
-                "spec": "",
-                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-mediaqueries", 
+                "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Using_media_queries",
+                "spec": "https://www.w3.org/TR/mediaqueries-4/",
+                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-mediaqueries",
                 "countsTowardScore": true
             },
             "interop-2023-modules": {
                 "description": "Modules",
-                "mdn": "",
-                "spec": "",
-                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-modules", 
+                "mdn": "https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers",
+                "spec": "https://html.spec.whatwg.org/multipage/workers.html#module-worker-example",
+                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-modules",
                 "countsTowardScore": true
             },
             "interop-2023-motion": {
                 "description": "Motion Path",
-                "mdn": "",
-                "spec": "",
-                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-motion", 
+                "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Motion_Path",
+                "spec": "https://drafts.fxtf.org/motion-1/",
+                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-motion",
                 "countsTowardScore": true
             },
             "interop-2023-offscreencanvas": {
                 "description": "Offscreen Canvas",
-                "mdn": "",
-                "spec": "",
-                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-offscreencanvas", 
+                "mdn": "https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas",
+                "spec": "https://html.spec.whatwg.org/multipage/canvas.html#the-offscreencanvas-interface",
+                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-offscreencanvas",
                 "countsTowardScore": true
             },
             "interop-2023-events": {
                 "description": "Pointer & Mouse Events",
-                "mdn": "",
-                "spec": "",
-                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-events", 
+                "mdn": "https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events",
+                "spec": "https://w3c.github.io/pointerevents/",
+                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-events",
                 "countsTowardScore": true
             },
             "interop-2022-scrolling": {
@@ -509,8 +508,13 @@
             },
             "interop-2023-url": {
                 "description": "URL",
+<<<<<<< HEAD
                 "mdn": "",
                 "spec": "",
+=======
+                "mdn": "https://developer.mozilla.org/en-US/docs/Web/API/URL",
+                "spec": "https://url.spec.whatwg.org",
+>>>>>>> 1cb97f3 (add mdn and spec links to interop focus areas)
                 "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-url",
                 "countsTowardScore": true
             },
@@ -519,6 +523,7 @@
                 "mdn": "",
                 "spec": "",
                 "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-webcompat",
+<<<<<<< HEAD
                 "countsTowardScore": true
             },
             "interop-2023-webcodecs": {
@@ -526,13 +531,15 @@
                 "mdn": "",
                 "spec": "",
                 "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-webcodecs",
+=======
+>>>>>>> 1cb97f3 (add mdn and spec links to interop focus areas)
                 "countsTowardScore": true
             },
             "interop-2023-webcomponents": {
                 "description": "Web Components",
-                "mdn": "",
-                "spec": "",
-                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-webcomponents", 
+                "mdn": "https://developer.mozilla.org/en-US/docs/Web/Web_Components",
+                "spec": "https://www.w3.org/wiki/WebComponents/",
+                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-webcomponents",
                 "countsTowardScore": true
             }
         }

--- a/webapp/static/interop-data.json
+++ b/webapp/static/interop-data.json
@@ -334,7 +334,7 @@
             },
             "interop-2022-text": {
                 "description": "Typography and Encodings",
-                "mdn": "",
+                "mdn": "https://developer.mozilla.org/docs/Web/CSS/length#relative_length_units_based_on_viewport",
                 "spec": "",
                 "tests": "/results/?label=master&label=experimental&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2022-text",
                 "countsTowardScore": false
@@ -355,22 +355,22 @@
             },
             "interop-2023-cssborderimage": {
                 "description": "Border Image",
-                "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/border-image",
-                "spec": "https://w3c.github.io/csswg-drafts/css-backgrounds/#the-border-image",
+                "mdn": "https://developer.mozilla.org/docs/Web/CSS/border-image",
+                "spec": "https://www.w3.org/TR/css-backgrounds-3/#the-border-image",
                 "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-cssborderimage",
                 "countsTowardScore": true
             },
             "interop-2023-color": {
                 "description": "Color Spaces and Functions",
-                "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/color_value",
+                "mdn": "https://developer.mozilla.org/docs/Web/CSS/color_value",
                 "spec": "https://w3c.github.io/csswg-drafts/css-color/#color-syntax",
                 "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-color",
                 "countsTowardScore": true
             },
             "interop-2023-container": {
                 "description": "Container Queries",
-                "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Container_Queries",
-                "spec": "https://www.w3.org/TR/css-contain-3/#container-queries",
+                "mdn": "https://developer.mozilla.org/docs/Web/CSS/CSS_Container_Queries",
+                "spec": "https://drafts.csswg.org/css-contain-3/#container-queries",
                 "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-container",
                 "countsTowardScore": true
             },
@@ -383,14 +383,14 @@
             },
             "interop-2023-pseudos": {
                 "description": "CSS Pseudo-classes",
-                "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes",
-                "spec": "https://html.spec.whatwg.org/multipage/semantics-other.html#pseudo-classes",
+                "mdn": "https://developer.mozilla.org/docs/Web/CSS/Pseudo-classes",
+                "spec": "https://drafts.csswg.org/selectors/",
                 "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-pseudos",
                 "countsTowardScore": true
             },
             "interop-2023-property": {
                 "description": "Custom Properties",
-                "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/@property",
+                "mdn": "https://developer.mozilla.org/docs/Web/CSS/@property",
                 "spec": "https://drafts.css-houdini.org/css-properties-values-api/",
                 "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-property",
                 "countsTowardScore": true
@@ -404,34 +404,34 @@
             },
             "interop-2023-fonts": {
                 "description": "Font Feature Detection and Palettes",
-                "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/font-palette",
-                "spec": "https://w3c.github.io/csswg-drafts/css-fonts/#font-palette-prop",
+                "mdn": "https://developer.mozilla.org/docs/Web/CSS/font-palette",
+                "spec": "https://drafts.csswg.org/css-fonts-4/#font-palette-prop",
                 "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-fonts",
                 "countsTowardScore": true
             },
             "interop-2023-forms": {
                 "description": "Forms",
-                "mdn": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form",
+                "mdn": "https://developer.mozilla.org/docs/Web/HTML/Element/form",
                 "spec": "https://html.spec.whatwg.org/multipage/forms.html#the-form-element",
                 "countsTowardScore": true
             },
             "interop-2023-grid": {
                 "description": "Grid",
-                "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout",
+                "mdn": "https://developer.mozilla.org/docs/Web/CSS/CSS_Grid_Layout",
                 "spec": "https://drafts.csswg.org/css-grid/",
                 "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-grid",
                 "countsTowardScore": true
             },
             "interop-2023-has": {
                 "description": ":has()",
-                "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/:has",
+                "mdn": "https://developer.mozilla.org/docs/Web/CSS/:has",
                 "spec": "https://drafts.csswg.org/selectors-4/#relational",
                 "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-has",
                 "countsTowardScore": true
             },
             "interop-2023-inert": {
                 "description": "Inert",
-                "mdn": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/inert",
+                "mdn": "https://developer.mozilla.org/docs/Web/API/HTMLElement/inert",
                 "spec": "https://html.spec.whatwg.org/multipage/interaction.html#the-inert-attribute",
                 "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-inert",
                 "countsTowardScore": true
@@ -445,42 +445,42 @@
             },
             "interop-2023-mathfunctions": {
                 "description": "Math Functions",
-                "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Functions#math_functions",
-                "spec": "https://w3c.github.io/csswg-drafts/css-values-4/#math",
+                "mdn": "https://developer.mozilla.org/docs/Web/CSS/CSS_Functions#math_functions",
+                "spec": "https://drafts.csswg.org/css-values-4/#math",
                 "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-mathfunctions",
                 "countsTowardScore": true
             },
             "interop-2023-mediaqueries": {
                 "description": "Media Queries 4",
-                "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Using_media_queries",
+                "mdn": "https://developer.mozilla.org/docs/Web/CSS/Media_Queries/Using_media_queries",
                 "spec": "https://www.w3.org/TR/mediaqueries-4/",
                 "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-mediaqueries",
                 "countsTowardScore": true
             },
             "interop-2023-modules": {
                 "description": "Modules",
-                "mdn": "https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers",
-                "spec": "https://html.spec.whatwg.org/multipage/workers.html#module-worker-example",
+                "mdn": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules",
+                "spec": "https://tc39.es/proposal-import-assertions/",
                 "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-modules",
                 "countsTowardScore": true
             },
             "interop-2023-motion": {
                 "description": "Motion Path",
-                "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Motion_Path",
+                "mdn": "https://developer.mozilla.org/docs/Web/CSS/CSS_Motion_Path",
                 "spec": "https://drafts.fxtf.org/motion-1/",
                 "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-motion",
                 "countsTowardScore": true
             },
             "interop-2023-offscreencanvas": {
                 "description": "Offscreen Canvas",
-                "mdn": "https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas",
+                "mdn": "https://developer.mozilla.org/docs/Web/API/OffscreenCanvas",
                 "spec": "https://html.spec.whatwg.org/multipage/canvas.html#the-offscreencanvas-interface",
                 "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-offscreencanvas",
                 "countsTowardScore": true
             },
             "interop-2023-events": {
                 "description": "Pointer & Mouse Events",
-                "mdn": "https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events",
+                "mdn": "https://developer.mozilla.org/docs/Web/API/Pointer_events",
                 "spec": "https://w3c.github.io/pointerevents/",
                 "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-events",
                 "countsTowardScore": true
@@ -508,7 +508,7 @@
             },
             "interop-2023-url": {
                 "description": "URL",
-                "mdn": "https://developer.mozilla.org/en-US/docs/Web/API/URL",
+                "mdn": "https://developer.mozilla.org/docs/Web/API/URL",
                 "spec": "https://url.spec.whatwg.org",
                 "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-url",
                 "countsTowardScore": true
@@ -529,7 +529,7 @@
             },
             "interop-2023-webcomponents": {
                 "description": "Web Components",
-                "mdn": "https://developer.mozilla.org/en-US/docs/Web/Web_Components",
+                "mdn": "https://developer.mozilla.org/docs/Web/Web_Components",
                 "spec": "https://www.w3.org/wiki/WebComponents/",
                 "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-webcomponents",
                 "countsTowardScore": true

--- a/webapp/static/interop-data.json
+++ b/webapp/static/interop-data.json
@@ -362,15 +362,9 @@
             },
             "interop-2023-color": {
                 "description": "Color Spaces and Functions",
-<<<<<<< HEAD
                 "mdn": "https://developer.mozilla.org/docs/Web/CSS/color_value",
                 "spec": "https://w3c.github.io/csswg-drafts/css-color/#color-syntax",
                 "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-color",
-=======
-                "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/color_value",
-                "spec": "https://w3c.github.io/csswg-drafts/css-color/#color-syntax",
-                "tests": "/results/?label=master&label=experimental&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2022-color%20or%20label%3Ainterop-2023-color", 
->>>>>>> 7ed554680989d53b65ee6b225450f71f61b62ba5
                 "countsTowardScore": true
             },
             "interop-2023-container": {
@@ -384,11 +378,7 @@
                 "description": "Containment",
                 "mdn": "https://developer.mozilla.org/docs/Web/CSS/contain",
                 "spec": "https://drafts.csswg.org/css-contain/#contain-property",
-<<<<<<< HEAD
                 "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-contain",
-=======
-                "tests": "/results/css?label=master&label=experimental&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2022-contain%20or%20label%3Ainterop-2023-contain", 
->>>>>>> 7ed554680989d53b65ee6b225450f71f61b62ba5
                 "countsTowardScore": true
             },
             "interop-2023-pseudos": {
@@ -409,11 +399,7 @@
                 "description": "Flexbox",
                 "mdn": "https://developer.mozilla.org/docs/Learn/CSS/CSS_layout/Flexbox",
                 "spec": "https://drafts.csswg.org/css-flexbox/",
-<<<<<<< HEAD
                 "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-flexbox",
-=======
-                "tests": "/results/css/css-flexbox?label=master&label=experimental&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2021-flexbox%20or%20label%3Ainterop-2023-flexbox", 
->>>>>>> 7ed554680989d53b65ee6b225450f71f61b62ba5
                 "countsTowardScore": true
             },
             "interop-2023-fonts": {
@@ -431,15 +417,9 @@
             },
             "interop-2023-grid": {
                 "description": "Grid",
-<<<<<<< HEAD
                 "mdn": "https://developer.mozilla.org/docs/Web/CSS/CSS_Grid_Layout",
                 "spec": "https://drafts.csswg.org/css-grid/",
                 "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-grid",
-=======
-                "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout",
-                "spec": "https://drafts.csswg.org/css-grid/",
-                "tests": "/results/css/css-grid?label=master&label=experimental&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2021-grid%20or%20label%3Ainterop-2023-grid", 
->>>>>>> 7ed554680989d53b65ee6b225450f71f61b62ba5
                 "countsTowardScore": true
             },
             "interop-2023-has": {
@@ -467,14 +447,14 @@
                 "description": "Math Functions",
                 "mdn": "https://developer.mozilla.org/docs/Web/CSS/CSS_Functions#math_functions",
                 "spec": "https://drafts.csswg.org/css-values-4/#math",
-                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-mathfunctions",
+                "tests": "/results/css/css-values?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-mathfunctions",
                 "countsTowardScore": true
             },
             "interop-2023-mediaqueries": {
                 "description": "Media Queries 4",
                 "mdn": "https://developer.mozilla.org/docs/Web/CSS/Media_Queries/Using_media_queries",
                 "spec": "https://www.w3.org/TR/mediaqueries-4/",
-                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-mediaqueries",
+                "tests": "/results/css/mediaqueries?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-mediaqueries",
                 "countsTowardScore": true
             },
             "interop-2023-modules": {
@@ -488,7 +468,7 @@
                 "description": "Motion Path",
                 "mdn": "https://developer.mozilla.org/docs/Web/CSS/CSS_Motion_Path",
                 "spec": "https://drafts.fxtf.org/motion-1/",
-                "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-motion",
+                "tests": "/results/css/motion?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-motion",
                 "countsTowardScore": true
             },
             "interop-2023-offscreencanvas": {

--- a/webapp/static/interop-data.json
+++ b/webapp/static/interop-data.json
@@ -508,13 +508,8 @@
             },
             "interop-2023-url": {
                 "description": "URL",
-<<<<<<< HEAD
-                "mdn": "",
-                "spec": "",
-=======
                 "mdn": "https://developer.mozilla.org/en-US/docs/Web/API/URL",
                 "spec": "https://url.spec.whatwg.org",
->>>>>>> 1cb97f3 (add mdn and spec links to interop focus areas)
                 "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-url",
                 "countsTowardScore": true
             },
@@ -523,7 +518,6 @@
                 "mdn": "",
                 "spec": "",
                 "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-webcompat",
-<<<<<<< HEAD
                 "countsTowardScore": true
             },
             "interop-2023-webcodecs": {
@@ -531,8 +525,6 @@
                 "mdn": "",
                 "spec": "",
                 "tests": "/results/?label=experimental&label=master&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2023-webcodecs",
-=======
->>>>>>> 1cb97f3 (add mdn and spec links to interop focus areas)
                 "countsTowardScore": true
             },
             "interop-2023-webcomponents": {


### PR DESCRIPTION
This PR adds MDN and spec links to the interop-data.json file for interop 2023. I picked the links by following the issue originally proposed. When I couldn't find a specific issue I used my working knowledge of the platform. Not sure if I got everything right. When there was more than one spec I did my best to pick the best entry point. Review appreciated.