### PR TITLE
Fix small rounding error for Interop Dashboard

### DIFF
--- a/webapp/components/interop.js
+++ b/webapp/components/interop.js
@@ -854,7 +854,7 @@ class InteropDashboard extends PolymerElement {
     const totalScore = section.rows.reduce((sum, rowName) => {
       return sum + scores[browserIndex][rowName];
     }, 0);
-    const avg = Math.floor(totalScore / 10) / section.rows.length;
+    const avg = Math.floor(totalScore / section.rows.length) / 10;
     // Don't display decimal places for a 100% score.
     if (avg >= 100) {
       return '100%';


### PR DESCRIPTION
This change fixes a small rounding error that caused the numbers in the table totals to sometimes differ from the summary number bubbles.

---
Before with rounding error:
![Screenshot 2023-01-31 at 8 15 39 AM](https://user-images.githubusercontent.com/56164590/215818800-b18126cb-7ab8-4f3a-951f-de0c7eddd2b6.png)

After:
![Screenshot 2023-01-31 at 8 15 56 AM](https://user-images.githubusercontent.com/56164590/215818909-0cd6ba08-37fc-450b-a859-47dfa9b92cbe.png)
