### PR TITLE
Move interop and investigation label

### DIFF
--- a/webapp/components/interop.js
+++ b/webapp/components/interop.js
@@ -974,6 +974,7 @@ class InteropSummary extends PolymerElement {
           display: flex;
           justify-content: center;
           gap: 30px;
+          margin-bottom: 20px;
         }
 
         .summary-container {
@@ -1028,13 +1029,13 @@ class InteropSummary extends PolymerElement {
         <div id="summaryNumberRow">
           <!-- Interop -->
           <div id="interopSummary" class="summary-flex-item" tabindex="0">
-            <h3 class="summary-title">INTEROP</h3>
             <div class="summary-number score-number">--</div>
+            <h3 class="summary-title">INTEROP</h3>
           </div>
           <!-- Investigations -->
           <div id="investigationSummary" class="summary-flex-item" tabindex="0">
-            <h3 class="summary-title">INVESTIGATIONS</h3>
             <div id="investigationNumber" class="summary-number">--</div>
+            <h3 class="summary-title">INVESTIGATIONS</h3>
           </div>
         </div>
         <div id="summaryNumberRow">


### PR DESCRIPTION
Fixes #3114 

Small change that moves the "INTEROP" and "INVESTIGATIONS" labels below their summary numbers and adds a small amount of spacing between the summary number rows.

---
Before:
![Screenshot 2023-01-31 at 8 22 43 AM](https://user-images.githubusercontent.com/56164590/215819531-d11c5d18-b041-448d-b142-bb84c98f9ba3.png)


After:
![Screenshot 2023-01-31 at 8 22 35 AM](https://user-images.githubusercontent.com/56164590/215819582-898fb9ca-80d8-4f18-a8c2-cca201bf9ffb.png)
