### PR TITLE
Consistently use wptd_exec_it in our docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,8 @@ information on using pull requests.
 There is a `make` rule for linting. Requirements for it are included in the docker image.
 
 ```sh
-docker exec -t -u $(id -u $USER):$(id -g $USER) wptd-dev-instance make lint
+source util/commands.sh
+wptd_exec_it make lint
 ```
 
 To run outside docker, you'll need to install `golint` and `eslint`.
@@ -39,7 +40,8 @@ npm test
 There is a number of `make` rule for testing. To run tests in docker:
 
 ```sh
-docker exec -t -u $(id -u $USER):$(id -g $USER) wptd-dev-instance make test
+source util/commands.sh
+wptd_exec_it make test
 ```
 
 See [`Makefile`](/Makefile) for more fine grained targets which take less time to run.

--- a/docs/app-engine.md
+++ b/docs/app-engine.md
@@ -42,6 +42,7 @@ Once the instance is running, run:
 ```sh
 git checkout main
 git pull
+source util/commands.sh
 wptd_exec_it make deploy_production PROJECT=wptdashboard APP_PATH=webapp/web
 wptd_exec_it make deploy_production PROJECT=wptdashboard APP_PATH=results-processor
 wptd_exec_it make deploy_production PROJECT=wptdashboard APP_PATH=api/query/cache/service


### PR DESCRIPTION
As issue #2786 illustrates, our docs aren't very consistent when it comes to executing commands inside the container. This PR improves things in that direction.