### PR TITLE
Update app-engine.md deployment instructions

### DIFF
--- a/docs/app-engine.md
+++ b/docs/app-engine.md
@@ -24,8 +24,15 @@ at least Editor privileges. Then from the project root directory:
 If you are running on Linux:
 
 ```sh
+# Ensure you have the latest code
 git checkout main
 git pull
+
+# Login to gcloud if not already logged in.
+# To check if you are already logged in, run `make gcloud_login`. It will fail if it cannot find a logged in profile.
+gcloud auth login
+
+# Deploy the services
 make deploy_production PROJECT=wptdashboard APP_PATH=webapp/web
 make deploy_production PROJECT=wptdashboard APP_PATH=results-processor
 make deploy_production PROJECT=wptdashboard APP_PATH=api/query/cache/service
@@ -40,8 +47,15 @@ If you are running on non-Linux, first start a Docker instance:
 Once the instance is running, run:
 
 ```sh
+# Ensure you have the latest code
 git checkout main
 git pull
+
+# Login to gcloud if not already logged in.
+# To check if you are already logged in, run `wptd_exec_it make gcloud_login`. It will fail if it cannot find a logged in profile.
+wptd_exec_it gcloud auth login
+
+# Deploy the services
 wptd_exec_it make deploy_production PROJECT=wptdashboard APP_PATH=webapp/web
 wptd_exec_it make deploy_production PROJECT=wptdashboard APP_PATH=results-processor
 wptd_exec_it make deploy_production PROJECT=wptdashboard APP_PATH=api/query/cache/service


### PR DESCRIPTION
The deployment steps currently assume you are either:
1.  logged in, or
  - (works if deploying from local but not docker since the docker instance has a separate GCP profile),
2.  have a client-secret.json from the IAM GCP panel
  - (works if for local or docker given the user has downloaded a client-secret beforehand)

This update ensures case number 1 works when running the docker instance by making users to log in using gcloud auth login

