### PR TITLE
Update staging deployment instructions

### DIFF
--- a/docs/app-engine.md
+++ b/docs/app-engine.md
@@ -77,8 +77,14 @@ gcloud app deploy --project=wptdashboard index.yaml queue.yaml dispatch.yaml
 `index.yaml`, `queue.yaml` or `dispatch.yaml`.)
 
 To deploy manually, follow the same instructions as production but replace
-`wptdashboard` with `wptdashboard-staging`, and use `make deploy_staging`
-instead of `make deploy_production`.
+`wptdashboard` with `wptdashboard-staging`, use `make deploy_staging`
+instead of `make deploy_production` and use `app.staging.yaml` instead of `app.yaml`:
+
+```sh
+wptd_exec_it make deploy_production PROJECT=wptdashboard APP_PATH=webapp/web/app.staging.yaml
+wptd_exec_it make deploy_production PROJECT=wptdashboard APP_PATH=results-processor/app.staging.yaml
+wptd_exec_it make deploy_production PROJECT=wptdashboard APP_PATH=api/query/cache/service/app.staging.yaml
+```
 
 ## Out-of-repo configurations
 

--- a/docs/app-engine.md
+++ b/docs/app-engine.md
@@ -81,9 +81,9 @@ To deploy manually, follow the same instructions as production but replace
 instead of `make deploy_production` and use `app.staging.yaml` instead of `app.yaml`:
 
 ```sh
-wptd_exec_it make deploy_production PROJECT=wptdashboard APP_PATH=webapp/web/app.staging.yaml
-wptd_exec_it make deploy_production PROJECT=wptdashboard APP_PATH=results-processor/app.staging.yaml
-wptd_exec_it make deploy_production PROJECT=wptdashboard APP_PATH=api/query/cache/service/app.staging.yaml
+wptd_exec_it make deploy_staging PROJECT=wptdashboard-staging APP_PATH=webapp/web/app.staging.yaml
+wptd_exec_it make deploy_staging PROJECT=wptdashboard-staging APP_PATH=results-processor/app.staging.yaml
+wptd_exec_it make deploy_staging PROJECT=wptdashboard-staging APP_PATH=api/query/cache/service/app.staging.yaml
 ```
 
 ## Out-of-repo configurations


### PR DESCRIPTION
For staging deployment, **app.staging.yaml** should be used instead of **app.yaml** for all three services. This instruction updates do not affect the existing CI deployment instructions, as CI uses the correct commands.

###  Test
[This deployment instruction is tested on a Mac environment](https://pantheon.corp.google.com/appengine/versions?project=wptdashboard-staging&serviceId=default)