### PR TITLE
Make some Dockerfile maintenance improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # vim: set expandtab sw=4
-FROM golang:1.19-buster
+FROM golang:1.20.1-bullseye
 
 # Create a non-priviledged user to run browsers as (Firefox and Chrome do not
 # like to run as root).
@@ -14,8 +14,7 @@ RUN apt-get update -qqy && apt-get install -qqy --no-install-suggests \
         firefox-esr \
         lsb-release \
         openjdk-11-jdk \
-        python-crcmod \
-        python3.7 \
+        python3.9 \
         sudo \
         tox \
         wget \

--- a/Makefile
+++ b/Makefile
@@ -205,8 +205,7 @@ curl: apt-get-curl
 gcc: apt-get-gcc
 git: apt-get-git
 psmisc: apt-get-psmisc
-python3: apt-get-python3.7
-python: apt-get-python
+python3: apt-get-python3.9
 tox: apt-get-tox
 unzip: apt-get-unzip
 wget: apt-get-wget
@@ -235,7 +234,7 @@ node: curl gpg
 		sudo apt-get install -qqy nodejs; \
 	fi
 
-gcloud: python curl gpg
+gcloud: python3 curl gpg
 	if [[ "$$(which gcloud)" == "" ]]; then \
 		curl -s https://sdk.cloud.google.com > ./install-gcloud.sh; \
 		bash ./install-gcloud.sh --disable-prompts --install-dir=$(HOME) > /dev/null; \

--- a/api/query/cache/service/Dockerfile
+++ b/api/query/cache/service/Dockerfile
@@ -1,7 +1,7 @@
 # Production deployment spec for query cache service.
 
-# Base golang 1.19 image.
-FROM golang:1.19-buster as builder
+# Base golang 1.20.1 image.
+FROM golang:1.20.1-bullseye as builder
 
 RUN apt-get update
 RUN apt-get install -qy --no-install-suggests git

--- a/docs/upgrading-go.md
+++ b/docs/upgrading-go.md
@@ -1,6 +1,6 @@
 # Maintenance: Upgrading Golang
 
-This document details the files to change and the necessary steps when upgrading Golang. At the time of the writing, we only upgrade on minor version changes to Golang, not patch changes. If that changes, please update this document.
+This document details the files to change and the necessary steps when upgrading Golang.
 
 ## Step 1 - Change the Runtime Version in webapp's app.staging.yaml and app.yaml files
 
@@ -15,7 +15,7 @@ Once you have confirmed that the desired version is available:
 - tooling [Dockerfile](../Dockerfile) at the root of the repo
 - searchcache [Dockerfile](../api/query/cache/service/Dockerfile)
 
-The tooling image and the first stage of searchcache use the same Golang image. Check out the Golang [page](https://hub.docker.com/_/golang?tab=tags) on Docker Hub for the latest tags. Currently, we are using the `buster` [release](https://wiki.debian.org/DebianReleases) of Debian. As a result pick the `golang:<latest stable version>-buster` tag. If buster is superseded by a new version, you should change that as well.
+The tooling image and the first stage of searchcache use the same Golang image. Check out the Golang [page](https://hub.docker.com/_/golang?tab=tags) on Docker Hub for the latest tags. Currently, we are using the `bullseye` [release](https://wiki.debian.org/DebianReleases) of Debian. As a result pick the `golang:<latest stable version>-bullseye` tag. If bullseye is superseded by a new version, you should change that as well.
 
 ## Step 3 - Change the version in go.mod
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/web-platform-tests/wpt.fyi
 
-go 1.19
+go 1.20
 
 require (
 	cloud.google.com/go/cloudtasks v1.9.0

--- a/results-processor/Dockerfile
+++ b/results-processor/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/google-appengine/python
+FROM python:3.9.16-bullseye
 
 # Default WORKDIR: /home/vmagent/app (/app symlinks to this)
 
@@ -18,7 +18,7 @@ RUN gcloud config set disable_usage_reporting false
 RUN rm -f $HOME/.config/gcloud/gce
 
 # Setup and activate virtualenv.
-RUN virtualenv -p python3.7 /env
+RUN virtualenv -p python3.9 /env
 ENV VIRTUAL_ENV /env
 ENV PATH /env/bin:$PATH
 

--- a/results-processor/README.md
+++ b/results-processor/README.md
@@ -1,6 +1,6 @@
 ## Basics
 
-The results processor runs on Python 3.7. The entry point is a Flask web server
+The results processor runs on Python 3.9. The entry point is a Flask web server
 (`main.py`). In production, gunicorn is used as the WSGI (see `Dockerfile`) and
 the container runs as a custom AppEngine Flex instance (see `app.yaml`).
 
@@ -10,7 +10,7 @@ We can create a virtualenv to recreate a setup close to production for daily
 development.
 
 ```bash
-virtualenv env -p python3.7
+virtualenv env -p python3.9
 . env/bin/activate
 pip install -r requirements.txt
 ```
@@ -38,6 +38,6 @@ Dependabot is used to automatically update `requirements.txt`. To manually
 update dependencies, run the following commands:
 
 ```bash
-pip3.7 install --user pip-tools
-python3.7 -m piptools compile requirements.in
+pip3.9 install --user pip-tools
+python3.9 -m piptools compile requirements.in
 ```

--- a/results-processor/tox.ini
+++ b/results-processor/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37
+envlist = py39
 # We don't have or need setup.py for now.
 skipsdist=True
 

--- a/webapp/web/app.staging.yaml
+++ b/webapp/web/app.staging.yaml
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-runtime: go119
+runtime: go120
 instance_class: F4_1G
 
 inbound_services:

--- a/webapp/web/app.yaml
+++ b/webapp/web/app.yaml
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-runtime: go119
+runtime: go120
 instance_class: F4_1G
 
 inbound_services:


### PR DESCRIPTION
- Upgrade to Go 1.20.1 and pin the patch version
- Upgrade to Python 3.9 and use the official Python image
- Get rid of the obsolete dependency on Python 2
- Upgrade to Debian 11 for local development

Further upgrades to Python 3.10+ would need an updated official Go image that doesn't exist yet. This should resolve most of issue #3033, modulo the dependabot change that will come in a future PR.