### PR TITLE
Use python3-crcmod apt-get package for results-processor and developer Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update -qqy && apt-get install -qqy --no-install-suggests \
         lsb-release \
         openjdk-11-jdk \
         python3.9 \
+        python3-crcmod \
         sudo \
         tox \
         wget \

--- a/results-processor/Dockerfile
+++ b/results-processor/Dockerfile
@@ -5,7 +5,7 @@ FROM python:3.9.16-bullseye
 # Install runtime dependencies.
 # python-crcmod for faster gsutil checksum
 # https://cloud.google.com/storage/docs/gsutil/commands/rsync#slow-checksums
-RUN apt-get update -q && apt-get install -qy python-crcmod && apt-get clean
+RUN apt-get update -q && apt-get install -qy python3-crcmod && apt-get clean
 # gcloud SDK
 RUN curl -s https://sdk.cloud.google.com > install-gcloud.sh
 RUN bash install-gcloud.sh --disable-prompts --install-dir=/opt > /dev/null

--- a/results-processor/Dockerfile
+++ b/results-processor/Dockerfile
@@ -1,11 +1,10 @@
 FROM python:3.9.16-bullseye
 
-# Default WORKDIR: /home/vmagent/app (/app symlinks to this)
-
 # Install runtime dependencies.
-# python-crcmod for faster gsutil checksum
+# python3-crcmod for faster gsutil checksum
+# python3-virtualenv for virtualenv
 # https://cloud.google.com/storage/docs/gsutil/commands/rsync#slow-checksums
-RUN apt-get update -q && apt-get install -qy python3-crcmod && apt-get clean
+RUN apt-get update -q && apt-get install -qy python3-crcmod python3-virtualenv  && apt-get clean
 # gcloud SDK
 RUN curl -s https://sdk.cloud.google.com > install-gcloud.sh
 RUN bash install-gcloud.sh --disable-prompts --install-dir=/opt > /dev/null
@@ -21,6 +20,9 @@ RUN rm -f $HOME/.config/gcloud/gce
 RUN virtualenv -p python3.9 /env
 ENV VIRTUAL_ENV /env
 ENV PATH /env/bin:$PATH
+
+# WORKDIR needs to be set explicitly to /app
+WORKDIR /app
 
 # Install Python dependencies.
 ADD requirements.txt /app/


### PR DESCRIPTION
Use python3-crcmod apt-get package for results-processor and developer Dockerfiles

In the results-processor, `virtualenv` is not there by default. added `python3-virtualenv` to install it.