### PR TITLE
Skip cloud test and staging deploy on fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     # This means this CI job will have access to the service account.
     # In that case, similar to deploy.yml, trust only pull requests that are
     # made within web-platform-tests and exclude forks.
-    if: ${{ github.repository == 'web-platform-tests/wpt.fyi' && github.actor != 'dependabot[bot]' }}
+    if: ${{ github.event.pull_request.head.repo.full_name == 'web-platform-tests/wpt.fyi' && github.repository == 'web-platform-tests/wpt.fyi' && github.actor != 'dependabot[bot]' }}
     needs: [go_test, go_chrome_test, go_firefox_test]
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 jobs:
   deploy-staging:
-    if: ${{ github.repository == 'web-platform-tests/wpt.fyi' && github.actor != 'dependabot[bot]' }}
+    if: ${{ github.event.pull_request.head.repo.full_name == 'web-platform-tests/wpt.fyi' && github.repository == 'web-platform-tests/wpt.fyi' && github.actor != 'dependabot[bot]' }}
     name: Deploy staging.wpt.fyi
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
This change excludes `go_cloud_test`and `Deploy staging.wpt.fyi` CI checks for PRs coming from forked versions of the repo.