### PR TITLE
removed view param runs route

### DIFF
--- a/webapp/components/test-runs-query.js
+++ b/webapp/components/test-runs-query.js
@@ -182,7 +182,6 @@ const TestRunsQuery = (superClass, opt_queryCompute) => class extends QueryBuild
     // results. Removing this allows special views (interop) to be
     // viewed on any results page.
     if (this.showDefaultView(parsed.view, parsed.q)) {
-      parsed.view = 'subtest';
       parsed.canViewInteropScores = false;
     } else {
       parsed.canViewInteropScores = true;
@@ -285,8 +284,6 @@ const TestRunsQuery = (superClass, opt_queryCompute) => class extends QueryBuild
     }
     if ('view' in params) {
       batchUpdate.view = params.view;
-    } else {
-      batchUpdate.view = 'subtest';
     }
     if ('canViewInteropScores' in params) {
       batchUpdate.canViewInteropScores = params.canViewInteropScores;

--- a/webapp/components/test/test-runs-query.html
+++ b/webapp/components/test/test-runs-query.html
@@ -60,7 +60,7 @@ suite('TestRunsQuery', () => {
       test(channel, () => {
         testRunsQuery.products = DefaultProducts
           .map(p => Object.assign({}, p, { labels: [channel] }));
-        expect(testRunsQuery.query).to.equal(`label=${channel}&view=subtest`);
+        expect(testRunsQuery.query).to.equal(`label=${channel}`);
       });
     }
   });


### PR DESCRIPTION
<!--
Thanks for the PR, you probably worked hard on it! Before you submit it for review, please make sure you read our guidelines for contributing to this repository. 

Try to make the job easy for your reviewer! Below is a template you can use as a guide for what context your reviewer might need.  
If you changed any dev procedures, consider also updating the README.
-->

## Description
This PR removes `view=subtest` param from `/runs` query as mentioned in #3011 

## Preview

https://user-images.githubusercontent.com/65391345/226902761-1513656b-0858-4bf4-8e1d-cba803e81d90.mp4


<!-- Describe any special configurations, environment requirements, or dependencies. -->
