### PR TITLE
Remove whitespace from bug links

### DIFF
--- a/webapp/components/test-file-results-table.js
+++ b/webapp/components/test-file-results-table.js
@@ -148,9 +148,7 @@ class TestFileResultsTable extends WPTFlags(Pluralizer(AmendMetadataMixin(WPTCol
             <code>[[ subtestMessage(result, verbose) ]]</code>
 
             <template is="dom-if" if="[[shouldDisplayMetadata(index, row.name, metadataMap, result.status, isTriageMode)]]">
-              <a href="[[ getMetadataUrlForSubtest(index, row.name, metadataMap) ]]" target="_blank">
-                <iron-icon class="bug" icon="bug-report"></iron-icon>
-              </a>
+              <a href="[[ getMetadataUrlForSubtest(index, row.name, metadataMap) ]]" target="_blank"><iron-icon class="bug" icon="bug-report"></iron-icon></a>
             </template>
 
             <template is="dom-if" if="[[result.screenshots]]">

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -302,9 +302,7 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
                       is-triage-mode=[[isTriageMode]]>
                   </path-part>
                   <template is="dom-if" if="[[shouldDisplayMetadata(null, node.path, metadataMap)]]">
-                    <a href="[[ getMetadataUrl(null, node.path, metadataMap) ]]" target="_blank">
-                      <iron-icon class="bug" icon="bug-report"></iron-icon>
-                    </a>
+                    <a href="[[ getMetadataUrl(null, node.path, metadataMap) ]]" target="_blank"><iron-icon class="bug" icon="bug-report"></iron-icon></a>
                   </template>
                   <template is="dom-if" if="[[shouldDisplayTestLabel(node.path, labelMap)]]">
                     <iron-icon class="bug" icon="label" title="[[getTestLabelTitle(node.path, labelMap)]]"></iron-icon>
@@ -325,9 +323,7 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
                       </template>
                     </template>
                     <template is="dom-if" if="[[shouldDisplayMetadata(index, node.path, metadataMap)]]">
-                      <a href="[[ getMetadataUrl(index, node.path, metadataMap) ]]" target="_blank">
-                        <iron-icon class="bug" icon="bug-report"></iron-icon>
-                      </a>
+                      <a href="[[ getMetadataUrl(index, node.path, metadataMap) ]]" target="_blank"><iron-icon class="bug" icon="bug-report"></iron-icon></a>
                     </template>
                   </td>
                 </template>


### PR DESCRIPTION
Fixes #3224 

Quick fix for an issue I found while doing some unrelated work. Avoids whitespace being underlined as part of the bug links.

Before:
![Screenshot 2023-03-23 at 4 27 58 PM](https://user-images.githubusercontent.com/56164590/227386923-39135627-db20-4ae2-9143-e7c37800d5d6.png)

After:
![Screenshot 2023-03-23 at 4 28 20 PM](https://user-images.githubusercontent.com/56164590/227386938-da7cacd3-e6b4-4a81-a265-6a84c3e21975.png)
