### PR TITLE
Interop Dashboard Sort Functionality 

### DIFF
--- a/webapp/components/interop-dashboard.js
+++ b/webapp/components/interop-dashboard.js
@@ -622,6 +622,13 @@ class InteropDashboard extends PolymerElement {
     return `${(score / 10).toFixed(1)}%`;
   }
 
+  getNumericalBrowserScoreByFeature(browserIndex, feature) {
+    const scores = this.stable ? this.scores.stable : this.scores.experimental;
+    const score = scores[browserIndex][feature];
+    const roundedScore = Math.round(score * 100) / 100;
+    return roundedScore / 10;
+  }
+
   getBrowserScoreTotal(browserIndex) {
     return this.totals[browserIndex];
   }
@@ -696,7 +703,7 @@ class InteropDashboard extends PolymerElement {
   }
 
   getSortIcon(index) {
-    index = index - 1
+    index = index - 1;
     if (this.sortColumn !== index && this.isSortedAsc === true) {
       return '/static/expand_less.svg';
     } else if (this.sortColumn === index && this.isSortedAsc === true) {
@@ -704,7 +711,7 @@ class InteropDashboard extends PolymerElement {
     } else if (this.sortColumn === index && this.isSortedAsc === false) {
       return '/static/expand_less.svg';
     }
-      return '/static/expand_less.svg';
+    return '/static/expand_less.svg';
 
   }
 
@@ -724,7 +731,7 @@ class InteropDashboard extends PolymerElement {
     const individualScores = [];
     for (let i = 0; i < rows.length; i++) {
       const feature = rows[i];
-      individualScores[i] = [feature, parseFloat(this.getBrowserScoreForFeature(sortColumn, feature))];
+      individualScores[i] = [feature, this.getNumericalBrowserScoreByFeature(sortColumn, feature)];
     }
     individualScores.sort((a, b) => a[1] - b[1]);
     for (let i = 0; i < individualScores.length; i++) {
@@ -733,20 +740,22 @@ class InteropDashboard extends PolymerElement {
   }
 
   sortRows(rows, index, sortColumn, isSortedAsc) {
-    if(index !== 0) return rows;
-      const sortedFeatureOrder = [];
-      // For the first column, sort alphabetically by name
-      if(sortColumn === -1) {
-        this.alphabeticalSort(rows, sortedFeatureOrder)
+    if(index !== 0) {
+      return rows;
+    }
+    const sortedFeatureOrder = [];
+    // For the first column, sort alphabetically by name
+    if(sortColumn === -1) {
+      this.alphabeticalSort(rows, sortedFeatureOrder);
       // For the other columns, sort numerically by score
-      } else if (sortColumn >= 0) {
-       this.numericalSort(rows, sortedFeatureOrder, sortColumn)
-      }
-      // Reverse current sort order
-      if (isSortedAsc === false) {
-        sortedFeatureOrder.reverse();
-      }
-      return sortedFeatureOrder;
+    } else if (sortColumn >= 0) {
+      this.numericalSort(rows, sortedFeatureOrder, sortColumn);
+    }
+    // Reverse current sort order
+    if (isSortedAsc === false) {
+      sortedFeatureOrder.reverse();
+    }
+    return sortedFeatureOrder;
   }
 
   handleSortClick(e) {

--- a/webapp/components/interop-dashboard.js
+++ b/webapp/components/interop-dashboard.js
@@ -622,6 +622,8 @@ class InteropDashboard extends PolymerElement {
     return `${(score / 10).toFixed(1)}%`;
   }
 
+  // getNumericalBrowserScoreByFeature returns the same score as
+  // getBrowserScoreForFeature but as a number instead of a string
   getNumericalBrowserScoreByFeature(browserIndex, feature) {
     const scores = this.stable ? this.scores.stable : this.scores.experimental;
     const score = scores[browserIndex][feature];
@@ -708,7 +710,7 @@ class InteropDashboard extends PolymerElement {
       return '/static/expand_less.svg';
     } else if (this.sortColumn === index && this.isSortedAsc === true) {
       return '/static/expand_more.svg';
-    } else if (this.sortColumn === index && this.isSortedAsc === false) {
+    } else if (this.sortColumn === index && !this.isSortedAsc) {
       return '/static/expand_less.svg';
     }
     return '/static/expand_less.svg';
@@ -752,7 +754,7 @@ class InteropDashboard extends PolymerElement {
       this.numericalSort(rows, sortedFeatureOrder, sortColumn);
     }
     // Reverse current sort order
-    if (isSortedAsc === false) {
+    if (!isSortedAsc) {
       sortedFeatureOrder.reverse();
     }
     return sortedFeatureOrder;
@@ -766,7 +768,7 @@ class InteropDashboard extends PolymerElement {
       this.isSortedAsc = true;
     } else if (this.sortColumn === i && this.isSortedAsc === true) {
       this.isSortedAsc = false;
-    } else if (this.sortColumn === i && this.isSortedAsc === false) {
+    } else if (this.sortColumn === i && !this.isSortedAsc) {
       this.isSortedAsc = true;
     }
     this.sortColumn = i;

--- a/webapp/components/interop-dashboard.js
+++ b/webapp/components/interop-dashboard.js
@@ -706,9 +706,9 @@ class InteropDashboard extends PolymerElement {
 
   getSortIcon(index) {
     index = index - 1;
-    if (this.sortColumn !== index && this.isSortedAsc === true) {
+    if (this.sortColumn !== index && this.isSortedAsc) {
       return '/static/expand_less.svg';
-    } else if (this.sortColumn === index && this.isSortedAsc === true) {
+    } else if (this.sortColumn === index && this.isSortedAsc) {
       return '/static/expand_more.svg';
     } else if (this.sortColumn === index && !this.isSortedAsc) {
       return '/static/expand_less.svg';
@@ -766,7 +766,7 @@ class InteropDashboard extends PolymerElement {
     if (this.sortColumn !== i) {
       this.sortColumn = i;
       this.isSortedAsc = true;
-    } else if (this.sortColumn === i && this.isSortedAsc === true) {
+    } else if (this.sortColumn === i && this.isSortedAsc) {
       this.isSortedAsc = false;
     } else if (this.sortColumn === i && !this.isSortedAsc) {
       this.isSortedAsc = true;


### PR DESCRIPTION
<!--
Thanks for the PR, you probably worked hard on it! Before you submit it for review, please make sure you read our guidelines for contributing to this repository. 

Try to make the job easy for your reviewer! Below is a template you can use as a guide for what context your reviewer might need.  
If you changed any dev procedures, consider also updating the README.
-->

## Description
This PR adds sort functionality to the Interop 2023 dashboard in the Active Focus Areas table, a feature requested in #3117. By default the data will sort in ascending order by feature name. When you click the toggle above any data column, it will sort the features in ascending order. If you click a toggle on any column that is sorted in ascending order, it will re-sort into descending order.

## Changes
This PR adds a row of buttons in the Active Focus Areas table header, as well as a click handler (`handleSortClick`) and a sorting method (`sortRows`)

<img width="510" alt="interopsort" src="https://user-images.githubusercontent.com/52478074/227388765-1ee40f60-da10-4ad8-bb75-e9240f3b5e29.png">
