### PR TITLE
Aankirz: Fixes interop-invalidyear

### DIFF
--- a/webapp/components/interop-404.js
+++ b/webapp/components/interop-404.js
@@ -23,7 +23,7 @@ class Interop404 extends PolymerElement {
     </style>
     <div>
       <iron-icon icon="error"></iron-icon>
-      <h1>Sorry, data is not available for this year 🥲</h1>
+      <h1>Interop data is not available for this year</h1>
     </div>
     <a href="/">
       <paper-button>Go to the home page</paper-button>

--- a/webapp/components/interop-404.js
+++ b/webapp/components/interop-404.js
@@ -1,0 +1,37 @@
+import { PolymerElement, html } from '../node_modules/@polymer/polymer/polymer-element.js';
+import '../node_modules/@polymer/iron-icon/iron-icon.js';
+import '../node_modules/@polymer/paper-button/paper-button.js';
+
+class Interop404 extends PolymerElement {
+  static get template() {
+    return html`
+    <style>
+      :host {
+        display: block;
+        text-align: center;
+        color: var(--app-secondary-color);
+      }
+      iron-icon {
+        display: inline-block;
+        width: 60px;
+        height: 60px;
+      }
+      h1 {
+        margin: 50px 0 50px 0;
+        font-weight: 300;
+      }
+    </style>
+    <div>
+      <iron-icon icon="error"></iron-icon>
+      <h1>Sorry, data is not available for this year 🥲</h1>
+    </div>
+    <a href="/">
+      <paper-button>Go to the home page</paper-button>
+    </a>
+`;
+  }
+
+  static get is() { return 'interop-404'; }
+}
+
+customElements.define(Interop404.is, Interop404);

--- a/webapp/interop_handler.go
+++ b/webapp/interop_handler.go
@@ -62,8 +62,5 @@ func interopHandler(w http.ResponseWriter, r *http.Request) {
 		Embedded: embedded != nil && *embedded,
 		Year:     year,
 	}
-
-    
-
 	RenderTemplate(w, r, "interop.html", data)
 }

--- a/webapp/interop_handler.go
+++ b/webapp/interop_handler.go
@@ -29,12 +29,14 @@ func interopHandler(w http.ResponseWriter, r *http.Request) {
 	name := mux.Vars(r)["name"]
 	year := mux.Vars(r)["year"]
 
-	// /compat20XX redirects to /interop-20XX
+	// /compat20XX redirects to /interop-20XX 
+    // If the year is not valid, render the 404 page instead.
+
 	needsRedirect := name == "compat"
 	if _, ok := validYears[year]; !ok {
-		year = defaultRedirectYear
-		needsRedirect = true
-	}
+        http.ServeFile(w, r, "components/interop-404.js")
+        return
+    }
 
 	if needsRedirect {
 		destination := *(r.URL)
@@ -60,5 +62,8 @@ func interopHandler(w http.ResponseWriter, r *http.Request) {
 		Embedded: embedded != nil && *embedded,
 		Year:     year,
 	}
+
+    
+
 	RenderTemplate(w, r, "interop.html", data)
 }


### PR DESCRIPTION
## Description
Fixes [issue 2975](https://github.com/web-platform-tests/wpt.fyi/issues/2975)
- To improve the user experience
- Whenever user enters any invalid year (Interop) , redirects to a sorry page.



## Review Information
- Try entering any invalid year to https://wpt.fyi/interop-XXXX

## Changes
- Added a new file `interop-404.js` in `webapp/components`
- Modified `interop_handler.go`



