### PR TITLE
Do not zero out tests with harness errors in Interop view

### DIFF
--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -726,13 +726,14 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
           return [0, 0];
         }
         // Take the passes / total subtests to get a percentage passing.
-        const percentPassed = rs[i].passes / rs[i].total;
-        passes += percentPassed;
-      // If this is a new summary, aggregate using the new process.
-      } else if (passingStatus || (rs[i].total > 0 && rs[i].total === rs[i].passes)) {
-        // If we have a total of 0 subtests but the status is passing,
-        // mark as 100% passing.
-        passes += (rs[i].total === 0) ? 1 : rs[i].passes / rs[i].total;
+        passes = rs[i].passes / rs[i].total;
+      // If we have a total of 0 subtests but the status is passing,
+      // mark as 100% passing.
+      } else if (passingStatus && rs[i].total === 0) {
+        passes = 1;
+      // Otherwise, the passing percentage is the number of passes divided by the total.
+      } else if (rs[i].total > 0) {
+        passes = rs[i].passes / rs[i].total;
       }
 
       return [passes, 1];


### PR DESCRIPTION
In the results analysis script, we currently do not zero out test scores that contained harness errors. This change updates wpt.fyi's aggregations to match the analysis script. This should remove anamolies that exist today on the "Test Totals" section of the page.