### PR TITLE
Adjust table sort UX

### DIFF
--- a/webapp/components/interop-dashboard.js
+++ b/webapp/components/interop-dashboard.js
@@ -107,11 +107,16 @@ class InteropDashboard extends PolymerElement {
           cursor: pointer;
         }
 
+        .sort-icon-focus-areas {
+          position: absolute;
+          top: 4px;
+          width: 20px;
+        }
+
         .sort-icon {
           position: absolute;
           top: 4px;
           right: -4px;
-          float: right;
           width: 20px;
         }
 
@@ -316,9 +321,7 @@ class InteropDashboard extends PolymerElement {
                     <tr class="section-header">
                       <th class="sortable-header" on-click="sortByName">
                         {{section.name}}
-                        <template is="dom-if" if="[[shouldShowSortIcon(0, sortColumn)]]">
-                          <img class="sort-icon" src="[[getSortIcon(isSortedAsc)]]" />
-                        </template>
+                        <img class="sort-icon-focus-areas" src="[[getSortIcon(0, sortColumn, isSortedAsc)]]" />
                       </th>
                       <th class="sortable-header" on-click="sortByChrome">
                         <template is="dom-if" if="[[stable]]">
@@ -333,9 +336,7 @@ class InteropDashboard extends PolymerElement {
                             <img src="/static/edge-dev_64x64.png" width="32" alt="Edge Dev" title="Edge Dev" />
                           </div>
                         </template>
-                        <template is="dom-if" if="[[shouldShowSortIcon(1, sortColumn)]]">
-                          <img class="sort-icon" src="[[getSortIcon(isSortedAsc)]]" />
-                        </template>
+                        <img class="sort-icon" src="[[getSortIcon(1, sortColumn, isSortedAsc)]]" />
                       </th>
                       <th class="sortable-header" on-click="sortByFF">
                         <template is="dom-if" if="[[stable]]">
@@ -348,9 +349,7 @@ class InteropDashboard extends PolymerElement {
                             <img src="/static/firefox-nightly_64x64.png" width="32" alt="Firefox Nightly" title="Firefox Nightly" />
                           </div>
                         </template>
-                        <template is="dom-if" if="[[shouldShowSortIcon(2, sortColumn)]]">
-                          <img class="sort-icon" src="[[getSortIcon(isSortedAsc)]]" />
-                        </template>
+                        <img class="sort-icon" src="[[getSortIcon(2, sortColumn, isSortedAsc)]]" />
                       </th>
                       <th class="sortable-header" on-click="sortBySafari">
                         <template is="dom-if" if="[[stable]]">
@@ -363,15 +362,11 @@ class InteropDashboard extends PolymerElement {
                             <img src="/static/safari-preview_64x64.png" width="32" alt="Safari Technology Preview" title="Safari Technology Preview" />
                           </div>
                         </template>
-                        <template is="dom-if" if="[[shouldShowSortIcon(3, sortColumn)]]">
-                          <img class="sort-icon" src="[[getSortIcon(isSortedAsc)]]" />
-                        </template>
+                        <img class="sort-icon" src="[[getSortIcon(3, sortColumn, isSortedAsc)]]" />
                       </th>
                       <th class="sortable-header" on-click="sortByInterop">
                         <div class="interop-header">INTEROP</div>
-                        <template is="dom-if" if="[[shouldShowSortIcon(4, sortColumn)]]">
-                          <img class="sort-icon" src="[[getSortIcon(isSortedAsc)]]" />
-                        </template>
+                        <img class="sort-icon" src="[[getSortIcon(4, sortColumn, isSortedAsc)]]" />
                       </th>
                     </tr>
                   </template>
@@ -788,7 +783,10 @@ class InteropDashboard extends PolymerElement {
     return columnNumber === sortColumn;
   }
 
-  getSortIcon(isSortedAsc) {
+  getSortIcon(index, sortColumn, isSortedAsc) {
+    if (sortColumn !== index) {
+      return '/static/expand_inactive.svg';
+    }
     if (isSortedAsc) {
       return '/static/expand_less.svg';
     }

--- a/webapp/components/interop-dashboard.js
+++ b/webapp/components/interop-dashboard.js
@@ -101,6 +101,24 @@ class InteropDashboard extends PolymerElement {
           color: white;
         }
 
+        .sortable-header {
+          position: relative;
+          user-select: none;
+          cursor: pointer;
+        }
+
+        .sort-icon {
+          position: absolute;
+          top: 4px;
+          right: -4px;
+          float: right;
+          width: 24px;
+        }
+
+        .interop-header {
+          padding-left: 4px;
+        }
+
         .focus-area-section {
           padding: 15px;
         }
@@ -292,13 +310,17 @@ class InteropDashboard extends PolymerElement {
             <template is="dom-repeat" items="{{getYearProp('tableSections')}}" as="section">
               <table class="score-table">
                 <thead>
-                  <tr class="section-header">
-                    <th>{{section.name}}</th>
-                    <template is="dom-if" if="[[section.score_as_group]]">
-                      <th colspan=4>Group Progress</th>
-                    </template>
-                    <template is="dom-if" if="[[showBrowserIcons(itemsIndex, section.score_as_group)]]">
-                      <th>
+
+                  <!-- First score table -->
+                  <template is="dom-if" if="[[isFirstTable(itemsIndex)]]">
+                    <tr class="section-header">
+                      <th class="sortable-header" on-click="sortByName">
+                        {{section.name}}
+                        <template is="dom-if" if="[[shouldShowSortIcon(0, sortColumn)]]">
+                          <img class="sort-icon" src="[[getSortIcon(isSortedAsc)]]" />
+                        </template>
+                      </th>
+                      <th class="sortable-header" on-click="sortByChrome">
                         <template is="dom-if" if="[[stable]]">
                           <div class="browser-icons">
                             <img src="/static/chrome_64x64.png" width="32" alt="Chrome" title="Chrome" />
@@ -311,8 +333,11 @@ class InteropDashboard extends PolymerElement {
                             <img src="/static/edge-dev_64x64.png" width="32" alt="Edge Dev" title="Edge Dev" />
                           </div>
                         </template>
+                        <template is="dom-if" if="[[shouldShowSortIcon(1, sortColumn)]]">
+                          <img class="sort-icon" src="[[getSortIcon(isSortedAsc)]]" />
+                        </template>
                       </th>
-                      <th>
+                      <th class="sortable-header" on-click="sortByFF">
                         <template is="dom-if" if="[[stable]]">
                           <div class="browser-icons single-browser-icon">
                             <img src="/static/firefox_64x64.png" width="32" alt="Firefox" title="Firefox" />
@@ -323,8 +348,11 @@ class InteropDashboard extends PolymerElement {
                             <img src="/static/firefox-nightly_64x64.png" width="32" alt="Firefox Nightly" title="Firefox Nightly" />
                           </div>
                         </template>
+                        <template is="dom-if" if="[[shouldShowSortIcon(2, sortColumn)]]">
+                          <img class="sort-icon" src="[[getSortIcon(isSortedAsc)]]" />
+                        </template>
                       </th>
-                      <th>
+                      <th class="sortable-header" on-click="sortBySafari">
                         <template is="dom-if" if="[[stable]]">
                           <div class="browser-icons single-browser-icon">
                             <img src="/static/safari_64x64.png" width="32" alt="Safari" title="Safari" />
@@ -335,23 +363,73 @@ class InteropDashboard extends PolymerElement {
                             <img src="/static/safari-preview_64x64.png" width="32" alt="Safari Technology Preview" title="Safari Technology Preview" />
                           </div>
                         </template>
+                        <template is="dom-if" if="[[shouldShowSortIcon(3, sortColumn)]]">
+                          <img class="sort-icon" src="[[getSortIcon(isSortedAsc)]]" />
+                        </template>
                       </th>
-                      <th>INTEROP</th>
-                    </template>
-                    <template is="dom-if" if="[[showNoOtherColumns(section.score_as_group, itemsIndex)]]">
-                      <th></th>
-                      <th></th>
-                      <th></th>
-                      <th></th>
-                    </template>
-                  </tr>
-                  <template is="dom-if" if="[[showSortToggle(itemsIndex)]]">
-                  <tr>
-                    <td><paper-icon-button class="sort-button" id="col-0" on-click="handleSortClick" src="[[getSortIcon(0, sortColumn, isSortedAsc)]]"></paper-icon-button></td>
-                    <td><paper-icon-button class="sort-button" id="col-1" on-click="handleSortClick" src="[[getSortIcon(1, sortColumn, isSortedAsc)]]"></paper-icon-button></td>
-                    <td><paper-icon-button class="sort-button" id="col-2" on-click="handleSortClick" src="[[getSortIcon(2, sortColumn, isSortedAsc)]]"></paper-icon-button></td>
-                    <td><paper-icon-button class="sort-button" id="col-3" on-click="handleSortClick" src="[[getSortIcon(3, sortColumn, isSortedAsc)]]"></paper-icon-button></td>
-                    <td><paper-icon-button class="sort-button" id="col-4" on-click="handleSortClick" src="[[getSortIcon(4, sortColumn, isSortedAsc)]]"></paper-icon-button></td>
+                      <th class="sortable-header" on-click="sortByInterop">
+                        <div class="interop-header">INTEROP</div>
+                        <template is="dom-if" if="[[shouldShowSortIcon(4, sortColumn)]]">
+                          <img class="sort-icon" src="[[getSortIcon(isSortedAsc)]]" />
+                        </template>
+                      </th>
+                    </tr>
+                  </template>
+
+                  <!-- Any score table after the first -->
+                  <template is="dom-if" if="[[!isFirstTable(itemsIndex)]]">
+                    <tr class="section-header">
+                      <th>{{section.name}}</th>
+                      <template is="dom-if" if="[[section.score_as_group]]">
+                        <th colspan=4>Group Progress</th>
+                      </template>
+                      <template is="dom-if" if="[[showBrowserIcons(itemsIndex, section.score_as_group)]]">
+                        <th>
+                          <template is="dom-if" if="[[stable]]">
+                            <div class="browser-icons">
+                              <img src="/static/chrome_64x64.png" width="32" alt="Chrome" title="Chrome" />
+                              <img src="/static/edge_64x64.png" width="32" alt="Edge" title="Edge" />
+                            </div>
+                          </template>
+                          <template is="dom-if" if="[[!stable]]">
+                            <div class="browser-icons">
+                              <img src="/static/chrome-dev_64x64.png" width="32" alt="Chrome Dev" title="Chrome Dev" />
+                              <img src="/static/edge-dev_64x64.png" width="32" alt="Edge Dev" title="Edge Dev" />
+                            </div>
+                          </template>
+                        </th>
+                        <th>
+                          <template is="dom-if" if="[[stable]]">
+                            <div class="browser-icons single-browser-icon">
+                              <img src="/static/firefox_64x64.png" width="32" alt="Firefox" title="Firefox" />
+                            </div>
+                          </template>
+                          <template is="dom-if" if="[[!stable]]">
+                            <div class="browser-icons single-browser-icon">
+                              <img src="/static/firefox-nightly_64x64.png" width="32" alt="Firefox Nightly" title="Firefox Nightly" />
+                            </div>
+                          </template>
+                        </th>
+                        <th>
+                          <template is="dom-if" if="[[stable]]">
+                            <div class="browser-icons single-browser-icon">
+                              <img src="/static/safari_64x64.png" width="32" alt="Safari" title="Safari" />
+                            </div>
+                          </template>
+                          <template is="dom-if" if="[[!stable]]">
+                            <div class="browser-icons single-browser-icon">
+                              <img src="/static/safari-preview_64x64.png" width="32" alt="Safari Technology Preview" title="Safari Technology Preview" />
+                            </div>
+                          </template>
+                        </th>
+                        <th>INTEROP</th>
+                      </template>
+                      <template is="dom-if" if="[[showNoOtherColumns(section.score_as_group, itemsIndex)]]">
+                        <th></th>
+                        <th></th>
+                        <th></th>
+                        <th></th>
+                      </template>
                     </tr>
                   </template>
                 </thead>
@@ -468,7 +546,7 @@ class InteropDashboard extends PolymerElement {
       scores: Object,
       sortColumn: {
         type: Number,
-        value: -1
+        value: 0
       },
       isSortedAsc: {
         type: Boolean,
@@ -604,10 +682,6 @@ class InteropDashboard extends PolymerElement {
     return index === 0 || !scoreAsGroup;
   }
 
-  showSortToggle(index) {
-    return index === 0;
-  }
-
   showNoOtherColumns(scoreAsGroup, index) {
     return !scoreAsGroup && !this.showBrowserIcons(index);
   }
@@ -704,20 +778,23 @@ class InteropDashboard extends PolymerElement {
     this.$.toggleExperimental.setAttribute('aria-pressed', false);
   }
 
-  getSortIcon(index) {
-    index = index - 1;
-    if (this.sortColumn !== index && this.isSortedAsc) {
-      return '/static/expand_less.svg';
-    } else if (this.sortColumn === index && this.isSortedAsc) {
-      return '/static/expand_more.svg';
-    } else if (this.sortColumn === index && !this.isSortedAsc) {
-      return '/static/expand_less.svg';
-    }
-    return '/static/expand_less.svg';
-
+  // Check if the table being rendered is the first table.
+  isFirstTable(tableIndex) {
+    return tableIndex === 0;
   }
 
-  alphabeticalSort(rows, featureOrder) {
+  shouldShowSortIcon(columnNumber, sortColumn) {
+    return columnNumber === sortColumn;
+  }
+
+  getSortIcon(isSortedAsc) {
+    if (isSortedAsc) {
+      return '/static/expand_less.svg';
+    }
+    return '/static/expand_more.svg';
+  }
+
+  alphabeticalSort = (rows, featureOrder) => {
     const rowNames = [];
     for(let i = 0; i < rows.length; i++) {
       const feature = rows[i];
@@ -729,11 +806,12 @@ class InteropDashboard extends PolymerElement {
     }
   }
 
-  numericalSort(rows, featureOrder, sortColumn) {
+  numericalSort = (rows, featureOrder, sortColumn) => {
+    const browserIndex = sortColumn - 1;
     const individualScores = [];
     for (let i = 0; i < rows.length; i++) {
       const feature = rows[i];
-      individualScores[i] = [feature, this.getNumericalBrowserScoreByFeature(sortColumn, feature)];
+      individualScores[i] = [feature, this.getNumericalBrowserScoreByFeature(browserIndex, feature)];
     }
     individualScores.sort((a, b) => a[1] - b[1]);
     for (let i = 0; i < individualScores.length; i++) {
@@ -741,18 +819,19 @@ class InteropDashboard extends PolymerElement {
     }
   }
 
-  sortRows(rows, index, sortColumn, isSortedAsc) {
+  sortRows = (rows, index, sortColumn, isSortedAsc) => {
     if(index !== 0) {
       return rows;
     }
     const sortedFeatureOrder = [];
     // For the first column, sort alphabetically by name
-    if(sortColumn === -1) {
+    if(sortColumn === 0) {
       this.alphabeticalSort(rows, sortedFeatureOrder);
+    } else {
       // For the other columns, sort numerically by score
-    } else if (sortColumn >= 0) {
       this.numericalSort(rows, sortedFeatureOrder, sortColumn);
     }
+
     // Reverse current sort order
     if (!isSortedAsc) {
       sortedFeatureOrder.reverse();
@@ -760,9 +839,30 @@ class InteropDashboard extends PolymerElement {
     return sortedFeatureOrder;
   }
 
-  handleSortClick(e) {
-    const i = parseInt(e.target.id.split('-')[1]) - 1;
+  // TODO(danielrsmith): There are surely better ways to this pass this on-click.
+  // Polymer makes it hard to pass arguments through event handlers.
+  // Find a way to pass the column as an argument to avoid these calls.
+  sortByName = () => {
+    this.handleSortClick(0);
+  }
 
+  sortByChrome = () => {
+    this.handleSortClick(1);
+  }
+
+  sortByFF = () => {
+    this.handleSortClick(2);
+  }
+
+  sortBySafari = () => {
+    this.handleSortClick(3);
+  }
+
+  sortByInterop = () => {
+    this.handleSortClick(4);
+  }
+
+  handleSortClick = (i) => {
     if (this.sortColumn !== i) {
       this.sortColumn = i;
       this.isSortedAsc = true;

--- a/webapp/components/interop-dashboard.js
+++ b/webapp/components/interop-dashboard.js
@@ -112,7 +112,7 @@ class InteropDashboard extends PolymerElement {
           top: 4px;
           right: -4px;
           float: right;
-          width: 24px;
+          width: 20px;
         }
 
         .interop-header {
@@ -311,7 +311,7 @@ class InteropDashboard extends PolymerElement {
               <table class="score-table">
                 <thead>
 
-                  <!-- First score table -->
+                  <!-- First score table header with sort functionality -->
                   <template is="dom-if" if="[[isFirstTable(itemsIndex)]]">
                     <tr class="section-header">
                       <th class="sortable-header" on-click="sortByName">
@@ -376,7 +376,7 @@ class InteropDashboard extends PolymerElement {
                     </tr>
                   </template>
 
-                  <!-- Any score table after the first -->
+                  <!-- All other score table headers after the first -->
                   <template is="dom-if" if="[[!isFirstTable(itemsIndex)]]">
                     <tr class="section-header">
                       <th>{{section.name}}</th>
@@ -432,6 +432,7 @@ class InteropDashboard extends PolymerElement {
                       </template>
                     </tr>
                   </template>
+
                 </thead>
                 <template is="dom-if" if="[[!section.score_as_group]]">
                   <tbody>
@@ -839,9 +840,12 @@ class InteropDashboard extends PolymerElement {
     return sortedFeatureOrder;
   }
 
-  // TODO(danielrsmith): There are surely better ways to this pass this on-click.
-  // Polymer makes it hard to pass arguments through event handlers.
-  // Find a way to pass the column as an argument to avoid these calls.
+  /** 
+   * Column sort handlers.
+   * TODO(danielrsmith): There are surely better ways to this pass this on-click.
+   * Polymer makes it hard to pass arguments through event handlers.
+   * Find a way to pass the column as an argument to avoid these calls.
+   **/
   sortByName = () => {
     this.handleSortClick(0);
   }
@@ -862,13 +866,13 @@ class InteropDashboard extends PolymerElement {
     this.handleSortClick(4);
   }
 
+  // Handle the table header click to sort a column.
   handleSortClick = (i) => {
-    if (this.sortColumn !== i) {
-      this.sortColumn = i;
-      this.isSortedAsc = true;
-    } else if (this.sortColumn === i && this.isSortedAsc) {
-      this.isSortedAsc = false;
-    } else if (this.sortColumn === i && !this.isSortedAsc) {
+    // Reverse the sort order if the same column is clicked again.
+    if (this.sortColumn === i) {
+      this.isSortedAsc = !this.isSortedAsc;
+    } else  {
+      // Otherwise, sort in ascending order.
       this.isSortedAsc = true;
     }
     this.sortColumn = i;

--- a/webapp/components/interop-dashboard.js
+++ b/webapp/components/interop-dashboard.js
@@ -872,8 +872,8 @@ class InteropDashboard extends PolymerElement {
     if (this.sortColumn === i) {
       this.isSortedAsc = !this.isSortedAsc;
     } else  {
-      // Otherwise, sort in ascending order.
-      this.isSortedAsc = true;
+      // Otherwise, sort in descending order.
+      this.isSortedAsc = false;
     }
     this.sortColumn = i;
   }

--- a/webapp/components/interop-dashboard.js
+++ b/webapp/components/interop-dashboard.js
@@ -805,7 +805,7 @@ class InteropDashboard extends PolymerElement {
     for (let i = 0; i < rowNames.length; i++) {
       featureOrder[i] = rowNames[i][0];
     }
-  }
+  };
 
   numericalSort = (rows, featureOrder, sortColumn) => {
     const browserIndex = sortColumn - 1;
@@ -818,7 +818,7 @@ class InteropDashboard extends PolymerElement {
     for (let i = 0; i < individualScores.length; i++) {
       featureOrder[i] = individualScores[i][0];
     }
-  }
+  };
 
   sortRows = (rows, index, sortColumn, isSortedAsc) => {
     if(index !== 0) {
@@ -838,9 +838,9 @@ class InteropDashboard extends PolymerElement {
       sortedFeatureOrder.reverse();
     }
     return sortedFeatureOrder;
-  }
+  };
 
-  /** 
+  /**
    * Column sort handlers.
    * TODO(danielrsmith): There are surely better ways to this pass this on-click.
    * Polymer makes it hard to pass arguments through event handlers.
@@ -848,23 +848,23 @@ class InteropDashboard extends PolymerElement {
    **/
   sortByName = () => {
     this.handleSortClick(0);
-  }
+  };
 
   sortByChrome = () => {
     this.handleSortClick(1);
-  }
+  };
 
   sortByFF = () => {
     this.handleSortClick(2);
-  }
+  };
 
   sortBySafari = () => {
     this.handleSortClick(3);
-  }
+  };
 
   sortByInterop = () => {
     this.handleSortClick(4);
-  }
+  };
 
   // Handle the table header click to sort a column.
   handleSortClick = (i) => {
@@ -876,6 +876,6 @@ class InteropDashboard extends PolymerElement {
       this.isSortedAsc = false;
     }
     this.sortColumn = i;
-  }
+  };
 }
 export { InteropDashboard };

--- a/webapp/components/interop-dashboard.js
+++ b/webapp/components/interop-dashboard.js
@@ -422,7 +422,7 @@ class InteropDashboard extends PolymerElement {
                             </div>
                           </template>
                         </th>
-                        <th>INTEROP</th>
+                        <th><div class="interop-header">INTEROP</div></th>
                       </template>
                       <template is="dom-if" if="[[showNoOtherColumns(section.score_as_group, itemsIndex)]]">
                         <th></th>

--- a/webapp/static/expand_inactive.svg
+++ b/webapp/static/expand_inactive.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="lightgrey" width="48px" height="48px"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 8l-6 6 1.41 1.41L12 10.83l4.59 4.58L18 14z"/></svg>


### PR DESCRIPTION
This change takes the newly-added sorting functionality and makes some UX changes to make the table headers clickable rather than adding a new row of clickable arrows.

This PR:
- Moves the new click handler logic to the table headers rather than a new row of arrows.
- Displays an arrow at the top right of the column sorted by, indicating the direction of the sort.

---
The table is sorted alphabetically ascending by default.
![Screenshot 2023-03-28 at 1 04 29 PM](https://user-images.githubusercontent.com/56164590/228354306-d17f1b52-1d63-4188-b4e3-a378c253572a.png)

Clicking a new column header will sort it in descending order.
![Screenshot 2023-03-28 at 1 04 40 PM](https://user-images.githubusercontent.com/56164590/228354308-e1134517-dad4-41a3-98eb-f69631bea6e7.png)

Clicking a column header twice will sort the table in ascending order.
![Screenshot 2023-03-28 at 1 04 49 PM](https://user-images.githubusercontent.com/56164590/228354310-7e051660-4ae8-4163-8f2f-b989ef7bf65a.png)
