### PR TITLE
Attempt to fix the deploy to staging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,10 @@ jobs:
     # This means this CI job will have access to the service account.
     # In that case, similar to deploy.yml, trust only pull requests that are
     # made within web-platform-tests and exclude forks.
-    if: ${{ github.event.pull_request.head.repo.full_name == 'web-platform-tests/wpt.fyi' && github.repository == 'web-platform-tests/wpt.fyi' && github.actor != 'dependabot[bot]' }}
+    if: |
+      (github.repository == 'web-platform-tests/wpt.fyi') &&
+      ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'web-platform-tests/wpt.fyi' && github.actor != 'dependabot[bot]') ||
+      (github.event_name != 'pull_request'))
     needs: [go_test, go_chrome_test, go_firefox_test]
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,10 @@ on:
   pull_request:
 jobs:
   deploy-staging:
-    if: ${{ github.event.pull_request.head.repo.full_name == 'web-platform-tests/wpt.fyi' && github.repository == 'web-platform-tests/wpt.fyi' && github.actor != 'dependabot[bot]' }}
+    if: |
+      (github.repository == 'web-platform-tests/wpt.fyi') &&
+      ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'web-platform-tests/wpt.fyi' && github.actor != 'dependabot[bot]') ||
+      (github.event_name != 'pull_request'))
     name: Deploy staging.wpt.fyi
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
The main conditional makes sure that the github.repository is always 'web-platform-tests/wpt.fyi'

Then we can check if the event comes from a PR event or non PR event.
- For the PR event, check if a fork and not dependabot
- For non PR event, we can let the event happen (which is only the push event to main according to the events in the `on` section above). Even for the push event, we can let dependabot be the actor since the PR has already been verified by a human and it will have access to the credentials when we merge it.

Inspiration:
- https://github.com/orgs/community/discussions/26409#discussioncomment-3251818

Fixes: #3237

