### PR TITLE
Fixed Triage Mode Issue 2844

### DIFF
--- a/webapp/components/test-file-results-table.js
+++ b/webapp/components/test-file-results-table.js
@@ -29,7 +29,6 @@ class TestFileResultsTable extends WPTFlags(Pluralizer(AmendMetadataMixin(WPTCol
 <style include="wpt-colors">
   table {
     width: 100%;
-    border-collapse: collapse;
   }
   th {
     background: white;
@@ -40,6 +39,8 @@ class TestFileResultsTable extends WPTFlags(Pluralizer(AmendMetadataMixin(WPTCol
   td {
     padding: 0.25em;
     height: 1.5em;
+    border: 2px solid transparent;
+    box-sizing: border-box;
   }
   td.diff {
     border-left: 8px solid white;


### PR DESCRIPTION
## Description
Fixes [issue 2844](https://github.com/web-platform-tests/wpt.fyi/issues/2844)
- To improve the user experience
- After this merge, when a user will enter in triage mode, clicking a cell for triage won't lead to shift in table.

## Review Information
- Try to click any feature from active focus area from (https://wpt.fyi/interop-2023), you will be redirected to a page consisting of Triage mode.

## Changes
- Added a Transparent border of 2px in "webapp/components/test-file-results-table.js"


https://user-images.githubusercontent.com/95562947/229328827-fbd95f8e-08c8-47e5-8915-5700aad0d5d5.mov

