### PR TITLE
Fix case-sensitive path matching for the search box

### DIFF
--- a/webapp/components/test-search.js
+++ b/webapp/components/test-search.js
@@ -525,7 +525,7 @@ class TestSearch extends WPTFlags(PolymerElement) {
   }
 
   handleKeyDown(e) {
-    // Prevent tab key from working
+    // Prevent tab key navigation on search bar.
     if (e.keyCode === 9) {
       e.preventDefault();
       return false;

--- a/webapp/components/test-search.js
+++ b/webapp/components/test-search.js
@@ -514,7 +514,7 @@ class TestSearch extends WPTFlags(PolymerElement) {
   }
 
   commitQuery() {
-    this.query = this.queryInput;    
+    this.query = this.queryInput;
     this.dispatchEvent(new CustomEvent('commit', {
       detail: {
         query: this.query,

--- a/webapp/components/test-search.js
+++ b/webapp/components/test-search.js
@@ -487,8 +487,7 @@ class TestSearch extends WPTFlags(PolymerElement) {
       let matches = Array.from(paths);
       if (query) {
         matches = matches
-          .filter(p => p.toLowerCase())
-          .filter(p => p.includes(query))
+          .filter(p => p.toLowerCase().includes(query))
           .sort((p1, p2) => p1.indexOf(query) - p2.indexOf(query));
       }
       for (const match of matches.slice(0, 10 - datalist.children.length)) {
@@ -515,7 +514,7 @@ class TestSearch extends WPTFlags(PolymerElement) {
   }
 
   commitQuery() {
-    this.query = this.queryInput;
+    this.query = this.queryInput;    
     this.dispatchEvent(new CustomEvent('commit', {
       detail: {
         query: this.query,
@@ -526,6 +525,7 @@ class TestSearch extends WPTFlags(PolymerElement) {
   }
 
   handleKeyDown(e) {
+    // Prevent tab key from working
     if (e.keyCode === 9) {
       e.preventDefault();
       return false;
@@ -533,6 +533,7 @@ class TestSearch extends WPTFlags(PolymerElement) {
   }
 
   handleKeyUp(e) {
+    // Commit when enter key was pressed
     if (e.keyCode === 13) {
       this.commitQuery();
     }
@@ -551,9 +552,9 @@ class TestSearch extends WPTFlags(PolymerElement) {
       if (autocompleteSelection.getAttribute('atom')) {
         return;
       }
-      if (autocompleteSelection.value === path) {
+      if (autocompleteSelection.value.toLowerCase() === path) {
         this.dispatchEvent(new CustomEvent('autocomplete', {
-          detail: {path: path},
+          detail: {path: autocompleteSelection.value},
         }));
         this.shadowRoot.querySelector('.query').blur();
       }

--- a/webapp/components/test-search.js
+++ b/webapp/components/test-search.js
@@ -552,7 +552,7 @@ class TestSearch extends WPTFlags(PolymerElement) {
       if (autocompleteSelection.getAttribute('atom')) {
         return;
       }
-      if (autocompleteSelection.value.toLowerCase() === path) {
+      if (autocompleteSelection.value.toLowerCase() === path.toLowerCase()) {
         this.dispatchEvent(new CustomEvent('autocomplete', {
           detail: {path: autocompleteSelection.value},
         }));


### PR DESCRIPTION
## Description
<!-- A detailed description explaining what your code accomplishes, and why this work is taking place. If this affects an open issue, please make sure to properly reference it. -->
Currently, navigating to a file-path with uppercase characters like `/encoding/encodeInto.any.html` does not work.  
Somewhat related issue: #3009 

## Review Information
<!-- Provide detailed instructions for how to run the code. -->
Enter any file-path which contains upper-case characters into the search-box.

Local build vs production:

https://user-images.githubusercontent.com/11293086/230372141-ed486db7-25b1-483f-adec-f58e5a7f8a77.mp4

## Changes
```javascript
matches = matches
          .filter(p => p.toLowerCase())
          .filter(p => p.includes(query))
``` 
Auto-complete options are generated from `matches`. I believe the intention here was to map all paths to a lower-case string and perform query matching. However, converting all paths to lowercase would cause further issues later (since the file-path is case-sensitive). Thus, the change was to perform case-insensitive query matching while keeping case-sensitive paths.

```javascript
if (autocompleteSelection.value === path) {
  this.dispatchEvent(new CustomEvent('autocomplete', {
    detail: {path: path},
  }));
```
`path` refers to `queryInput` which is the text within the search-box. Currently, `queryInput` is being converted to lowercase and hence the equality-check fails for any path which contains uppercase characters. The path passed into detail should also be changed to use the case-sensitive value in autocompleteSelection.

## Notes
I am unable to test whether these changes affects complex queries due to #2941. This would also mean that fixes on #2980 and other bugs would be unable to proceed.

An alternative solution to this would be to ensure `queryInput` does not get lowercased, however due to the above issue, keeping it lowercase for now would be the safer option.
