### PR TITLE
Display a banner on dashboards for previous Interop years

### DIFF
--- a/webapp/components/interop-dashboard.js
+++ b/webapp/components/interop-dashboard.js
@@ -35,6 +35,17 @@ class InteropDashboard extends PolymerElement {
           text-align: center;
         }
 
+        .previous-year-banner {
+          height: 40px;
+          background-color: #DEF;
+          text-align: center;
+          padding-top: 16px;
+        }
+
+        .previous-year-banner p {
+          margin: 0;
+        }
+
         .grid-container {
           margin: 0 2em;
           display: grid;
@@ -267,6 +278,12 @@ class InteropDashboard extends PolymerElement {
         }
 
       </style>
+      <div class="previous-year-banner" hidden$=[[isCurrentYear]]>
+        <p>
+          You are viewing Interop data from a previous year.
+          <a href="/interop-[[currentInteropYear]]">View the current Interop Dashboard</a>.
+        </p>
+      </div>
       <div class="grid-container">
         <div class="grid-item grid-item-header">
           <h1>Interop [[year]] Dashboard</h1>
@@ -544,6 +561,8 @@ class InteropDashboard extends PolymerElement {
         type: Number,
         value: 0
       },
+      currentInteropYear: Number,
+      isCurrentYear: Boolean,
       isSortedAsc: {
         type: Boolean,
         value: true
@@ -582,6 +601,14 @@ class InteropDashboard extends PolymerElement {
 
     this.features = Object.entries(this.getYearProp('focusAreas'))
       .map(([id, info]) => Object.assign({ id }, info));
+
+    // Determine the current Interop year. It is assumed that
+    // the current year is the latest year defined in interop-data.
+    const currentInteropYear = Math.max(
+        ...this.getYearProp('validYears')
+        .map(yearString => parseInt(yearString)));
+    this.isCurrentYear = parseInt(this.year) === currentInteropYear;
+    this.currentInteropYear = currentInteropYear;
 
     super.ready();
 

--- a/webapp/components/interop-dashboard.js
+++ b/webapp/components/interop-dashboard.js
@@ -562,7 +562,10 @@ class InteropDashboard extends PolymerElement {
         value: 0
       },
       currentInteropYear: Number,
-      isCurrentYear: Boolean,
+      isCurrentYear: {
+        type: Boolean,
+        value: true,
+      },
       isSortedAsc: {
         type: Boolean,
         value: true
@@ -604,11 +607,10 @@ class InteropDashboard extends PolymerElement {
 
     // Determine the current Interop year. It is assumed that
     // the current year is the latest year defined in interop-data.
-    const currentInteropYear = Math.max(
-      ...this.getYearProp('validYears')
-        .map(yearString => parseInt(yearString)));
-    this.isCurrentYear = parseInt(this.year) === currentInteropYear;
-    this.currentInteropYear = currentInteropYear;
+    // allYears is returned sorted. The last index is the current Interop year.
+    const allYears = this.getAllYears();
+    this.currentInteropYear = allYears[allYears.length - 1];
+    this.isCurrentYear = this.year === this.currentInteropYear;
 
     super.ready();
 

--- a/webapp/components/interop-dashboard.js
+++ b/webapp/components/interop-dashboard.js
@@ -605,7 +605,7 @@ class InteropDashboard extends PolymerElement {
     // Determine the current Interop year. It is assumed that
     // the current year is the latest year defined in interop-data.
     const currentInteropYear = Math.max(
-        ...this.getYearProp('validYears')
+      ...this.getYearProp('validYears')
         .map(yearString => parseInt(yearString)));
     this.isCurrentYear = parseInt(this.year) === currentInteropYear;
     this.currentInteropYear = currentInteropYear;


### PR DESCRIPTION
This PR adds a banner that displays on Interop dashboards for previous years noting that the user is viewing interop scores from a previous year, and contains a link to view the current interop year's dashboard.

The banner is displayed for Interop 2021 and 2022.
![Screenshot 2023-04-06 at 3 53 46 PM](https://user-images.githubusercontent.com/56164590/230508632-c7f22217-e7d8-42ac-88fa-8eaa050cf824.png)

The banner does not display for Interop 2023.
![Screenshot 2023-04-06 at 3 53 54 PM](https://user-images.githubusercontent.com/56164590/230508698-c4c14ded-1439-4794-aa92-4dee0843ee89.png)

