### PR TITLE
Upgrade Docker GitHub CI

### DIFF
--- a/.github/workflows/docker-update.yml
+++ b/.github/workflows/docker-update.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: elgohr/Publish-Docker-Github-Action@master
+      - uses: elgohr/Publish-Docker-Github-Action@v4
         # https://github.com/elgohr/Publish-Docker-Github-Action
         with:
           name: webplatformtests/wpt.fyi

--- a/.github/workflows/docker-update.yml
+++ b/.github/workflows/docker-update.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: elgohr/Publish-Docker-Github-Action@v4
+      - uses: elgohr/Publish-Docker-Github-Action@v5
         # https://github.com/elgohr/Publish-Docker-Github-Action
         with:
           name: webplatformtests/wpt.fyi


### PR DESCRIPTION
Fix CI issues in #3259. The error messages:
```
>> elgohr/Publish-Docker-Github-Action@master has been deprecated.
>> Please use elgohr/Publish-Docker-Github-Action@v4 for a blast in speed and security.
```