### PR TITLE
Detect interop-* triage metadata

### DIFF
--- a/shared/triage_metadata.go
+++ b/shared/triage_metadata.go
@@ -190,7 +190,7 @@ func (tm triageMetadata) createWPTMetadataPR(sha *string, triagedMetadataMap map
 		return "", err
 	}
 
-	err := tm.addPRLabels(pr)
+	err = tm.addPRLabels(pr)
 	if err != nil {
 		log.Errorf("Error while adding labels: %s", err)
 		return "", err

--- a/shared/triage_metadata_test.go
+++ b/shared/triage_metadata_test.go
@@ -406,3 +406,38 @@ func TestNewTriageMetadata_email_fallback(t *testing.T) {
 	assert.Equal(t, m.authorName, "testuser")
 	assert.Equal(t, m.authorEmail, "testuser@users.noreply.github.com")
 }
+
+func TestContainsInterop_True(t *testing.T) {
+	var amendment MetadataResults
+	json.Unmarshal([]byte(`{
+		"/foo/foo1/abc.html": [
+			{
+				"label": "interop"
+			}
+		]
+	}`), &amendment)
+
+	actual := containsInterop(amendment)
+
+	assert.True(t, actual)
+}
+
+func TestContainsInterop_False(t *testing.T) {
+	var amendment MetadataResults
+	json.Unmarshal([]byte(`{
+		"/foo/foo1/*": [
+			{
+				"url": "foo1",
+				"product": "chrome",
+				"results": [
+					{"status": 6 }
+				]
+			}
+		]
+	}`), &amendment)
+
+	actual := containsInterop(amendment)
+
+	assert.False(t, actual)
+}
+


### PR DESCRIPTION
A part of https://github.com/web-platform-tests/wpt-metadata/issues/3954.  Add an "interop" PR label to metadata that is labelled "interop-*".


### Staging Test
https://github.com/web-platform-tests/wpt-metadata/pull/4104