### PR TITLE
Fix dependabot docker update & docker update conditional

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,11 +33,38 @@ updates:
   directory: "/results-processor"
   schedule:
     interval: "weekly"
+  # Results Processor Docker image should ignore major and minor updates to Docker Python Image
+  # There may be deprecations moving between minor vesrions that we need to
+  # test.
+  ignore:
+    - dependency-name: "*"
+      update-types:
+        - "version-update:semver-major"
+        - "version-update:semver-minor"
 - package-ecosystem: "docker"
   directory: "/"
   schedule:
     interval: "weekly"
+  # Webapp/Developer Docker image should ignore major and minor updates to Docker Go Image.
+  # Go versions are backwards compatible but we want to stay with the
+  # major.minor version supported by App Engine Standard. That should be
+  # updated manually.
+  ignore:
+    - dependency-name: "*"
+      update-types:
+        - "version-update:semver-major"
+        - "version-update:semver-minor"
 - package-ecosystem: "docker"
   directory: "/api/query/cache/service"
   schedule:
     interval: "weekly"
+  # Searchcache Docker image should ignore major and minor updates to Docker Go Image
+  # Searchcache follows the bring-your-own-container paradigm because it uses
+  # App Engine Flex. While we could use the latest version, we want this Go
+  # version to follow the same version used in the webapp above (which uses
+  # App Engine Standard).
+  ignore:
+    - dependency-name: "*"
+      update-types:
+        - "version-update:semver-major"
+        - "version-update:semver-minor"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
 jobs:
   deploy-staging:
+    # Forks and dependabot cannot access secrets so the job would fail.
+    # Run for non dependabot PRs or regular pushes to web-platform-tests/wpt.fyi
     if: |
       (github.repository == 'web-platform-tests/wpt.fyi') &&
       ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'web-platform-tests/wpt.fyi' && github.actor != 'dependabot[bot]') ||

--- a/.github/workflows/docker-update.yml
+++ b/.github/workflows/docker-update.yml
@@ -12,8 +12,12 @@ on:
     - cron: '0 0 * * 0'
 jobs:
   build-and-push:
-    # Forks cannot access secrets so the job would fail.
-    if: github.repository == 'web-platform-tests/wpt.fyi'
+    # Forks and dependabot cannot access secrets so the job would fail.
+    # Run for non dependabot PRs or regular pushes to web-platform-tests/wpt.fyi
+    if: |
+      (github.repository == 'web-platform-tests/wpt.fyi') &&
+      ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'web-platform-tests/wpt.fyi' && github.actor != 'dependabot[bot]') ||
+      (github.event_name != 'pull_request'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Dependabot has been modified to ignore major and minor updates to docker images. Comments are in YAML as to why.

More details:
- https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file?learn=dependency_version_updates&learnProduct=code-security#specifying-dependencies-and-versions-to-ignore


Also, change the docker update conditional to prevent pushing a docker image for the patch docker updates since dependabot does not have access to repo secrets


