### PR TITLE
Fix the link to file an issue in the interop dashboard

### DIFF
--- a/webapp/components/interop-data-manager.js
+++ b/webapp/components/interop-data-manager.js
@@ -52,7 +52,7 @@ class InteropDataManager {
     this.focusAreasList = Object.keys(this.focusAreas);
     this.summaryFeatureName = yearInfo.summary_feature_name;
     this.csvURL = yearInfo.csv_url;
-    this.issueURL = yearInfo.issue_url
+    this.issueURL = yearInfo.issue_url;
     this.tableSections = yearInfo.table_sections;
     // Keep a list of years we have interop data prepared for.
     this.validYears = Object.keys(paramsByYear);

--- a/webapp/components/interop-data-manager.js
+++ b/webapp/components/interop-data-manager.js
@@ -52,6 +52,7 @@ class InteropDataManager {
     this.focusAreasList = Object.keys(this.focusAreas);
     this.summaryFeatureName = yearInfo.summary_feature_name;
     this.csvURL = yearInfo.csv_url;
+    this.issueURL = yearInfo.issue_url
     this.tableSections = yearInfo.table_sections;
     // Keep a list of years we have interop data prepared for.
     this.validYears = Object.keys(paramsByYear);


### PR DESCRIPTION
## Description
The `file an issue` `<a>` in the interop dashboard does not have its `href` attribute: 
![image](https://user-images.githubusercontent.com/439401/234709931-6b87f6b7-129d-451a-9007-09017782b975.png)

## Changes

The component reads `issueURL` from the year info. But the data manager was not creating this property by reading it from the data.

## Requirements
