### PR TITLE
Tighten the interop label criteria

### DIFF
--- a/shared/triage_metadata.go
+++ b/shared/triage_metadata.go
@@ -267,7 +267,8 @@ func appendTestName(test string, metadata MetadataResults) {
 func containsInterop(metadata MetadataResults) bool {
 	for _, links := range metadata {
 		for _, link := range links {
-			if strings.Contains(link.Label, "interop") {
+			// Assume that all interop labels start with interop-.
+			if strings.HasPrefix(link.Label, "interop-") {
 				return true
 			}
 		}

--- a/shared/triage_metadata_test.go
+++ b/shared/triage_metadata_test.go
@@ -412,7 +412,7 @@ func TestContainsInterop_True(t *testing.T) {
 	json.Unmarshal([]byte(`{
 		"/foo/foo1/abc.html": [
 			{
-				"label": "interop"
+				"label": "interop-x"
 			}
 		]
 	}`), &amendment)
@@ -420,6 +420,21 @@ func TestContainsInterop_True(t *testing.T) {
 	actual := containsInterop(amendment)
 
 	assert.True(t, actual)
+}
+
+func TestContainsInterop_NotInteropLabel(t *testing.T) {
+	var amendment MetadataResults
+	json.Unmarshal([]byte(`{
+		"/foo/foo1/abc.html": [
+			{
+				"label": "lets-go-interoperability"
+			}
+		]
+	}`), &amendment)
+
+	actual := containsInterop(amendment)
+
+	assert.False(t, actual)
 }
 
 func TestContainsInterop_False(t *testing.T) {


### PR DESCRIPTION
Follow-up for #3275. Only label it when it prefixes with **interop-**