### PR TITLE
Clean up unused interop-data properties

### DIFF
--- a/webapp/components/interop-dashboard.js
+++ b/webapp/components/interop-dashboard.js
@@ -304,7 +304,7 @@ class InteropDashboard extends PolymerElement {
           to contribute improvements to
           <a href="https://github.com/web-platform-tests/wpt" target="_blank">WPT</a>
           and then
-          <a href="[[getYearProp('issueURL')]]" target="_blank">file an issue</a>
+          <a href="https://github.com/web-platform-tests/interop/issues/new" target="_blank">file an issue</a>
           to request updating the set of tests used for scoring. You're also
           welcome to
           <a href="https://matrix.to/#/#interop20xx:matrix.org?web-instance%5Belement.io%5D=app.element.io" target="_blank">join

--- a/webapp/components/interop-data.js
+++ b/webapp/components/interop-data.js
@@ -18,7 +18,6 @@ export const interopData = {
     ],
     'csv_url': 'https://raw.githubusercontent.com/web-platform-tests/results-analysis/gh-pages/data/interop-2021/interop-2021-{stable|experimental}-v2.csv',
     'summary_feature_name': 'summary',
-    'matrix_url': 'https://matrix.to/#/#interop20xx:matrix.org?web-instance%5Belement.io%5D=app.element.io',
     'focus_areas': {
       'interop-2021-aspect-ratio': {
         'description': 'Aspect Ratio',
@@ -117,10 +116,8 @@ export const interopData = {
         ]
       }
     ],
-    'investigation_weight': 0.0,
     'csv_url': 'https://raw.githubusercontent.com/web-platform-tests/results-analysis/gh-pages/data/interop-2022/interop-2022-{stable|experimental}-v2.csv',
     'summary_feature_name': 'summary',
-    'issue_url': 'https://github.com/web-platform-tests/interop/issues/new',
     'focus_areas': {
       'interop-2021-aspect-ratio': {
         'description': 'Aspect Ratio',
@@ -309,10 +306,8 @@ export const interopData = {
         'scores_over_time': []
       }
     ],
-    'investigation_weight': 0.0,
     'csv_url': 'https://raw.githubusercontent.com/web-platform-tests/results-analysis/gh-pages/data/interop-2023/interop-2023-{stable|experimental}-v2.csv',
     'summary_feature_name': 'summary',
-    'issue_url': 'https://github.com/web-platform-tests/interop/issues/new',
     'focus_areas': {
       'interop-2021-aspect-ratio': {
         'description': 'Aspect Ratio',

--- a/webapp/static/interop-data.json
+++ b/webapp/static/interop-data.json
@@ -15,7 +15,6 @@
     ],
     "csv_url": "https://raw.githubusercontent.com/web-platform-tests/results-analysis/gh-pages/data/interop-2021/interop-2021-{stable|experimental}-v2.csv",
     "summary_feature_name": "summary",
-    "matrix_url": "https://matrix.to/#/#interop20xx:matrix.org?web-instance%5Belement.io%5D=app.element.io",
     "focus_areas": {
       "interop-2021-aspect-ratio": {
         "description": "Aspect Ratio",
@@ -114,10 +113,8 @@
         ]
       }
     ],
-    "investigation_weight": 0.0,
     "csv_url": "https://raw.githubusercontent.com/web-platform-tests/results-analysis/gh-pages/data/interop-2022/interop-2022-{stable|experimental}-v2.csv",
     "summary_feature_name": "summary",
-    "issue_url": "https://github.com/web-platform-tests/interop/issues/new",
     "focus_areas": {
       "interop-2021-aspect-ratio": {
         "description": "Aspect Ratio",
@@ -306,10 +303,8 @@
         "scores_over_time": []
       }
     ],
-    "investigation_weight": 0.0,
     "csv_url": "https://raw.githubusercontent.com/web-platform-tests/results-analysis/gh-pages/data/interop-2023/interop-2023-{stable|experimental}-v2.csv",
     "summary_feature_name": "summary",
-    "issue_url": "https://github.com/web-platform-tests/interop/issues/new",
     "focus_areas": {
       "interop-2021-aspect-ratio": {
         "description": "Aspect Ratio",


### PR DESCRIPTION
Some properties have become less useful as the Interop Dashboard has evolved and can be removed.

- `matrix_url`: Previously, there were separate Matrix chats for each interop year. Now, there is a single chat for the interop effort, and that URL can be added directly to the dashboard page.
- `issue_url`: Like the Matrix chats, there were previously repositories to create issues for each interop year. Now, it is recommended to create an issue at https://github.com/web-platform-tests/interop
- `investigation_weight`: For Interop 2022, investigation scores were weighted to account for 10% of each overall browser score. This has now changed to displaying an investigation score separately and not factoring it directly into browser scores. This property has been removed since it is unlikely the former approach will return, as well as the logic to add the investigation score to each browser score based on the weight.
**Note**: Interop 2022 will still display with this 10% investigation weight when the scores are frozen.