### PR TITLE
Fix AND conjunction in query

### DIFF
--- a/api/query/atoms.go
+++ b/api/query/atoms.go
@@ -118,6 +118,11 @@ type AbstractExists struct {
 // each specific/individual run.
 func (e AbstractExists) BindToRuns(runs ...shared.TestRun) ConcreteQuery {
 	queries := make([]ConcreteQuery, len(e.Args))
+	// When the nested query is a single query, e.g. And/Or, bind that query directly.
+	if len(e.Args) == 1 {
+		return e.Args[0].BindToRuns(runs...)
+	}
+
 	for i, arg := range e.Args {
 		var query ConcreteQuery
 		// Exists queries are split; one run must satisfy the whole tree.

--- a/api/query/atoms_test.go
+++ b/api/query/atoms_test.go
@@ -624,6 +624,38 @@ func TestStructuredQuery_combinednotlink(t *testing.T) {
 		AbstractQuery: AbstractExists{Args: []AbstractQuery{AbstractAnd{Args: []AbstractQuery{TestNamePattern{Pattern: "cssom"}, AbstractNot{Arg: AbstractLink{Pattern: "chromium.bug"}}}}}}}, rq)
 }
 
+func TestStructuredQuery_existsSimple(t *testing.T) {
+	var rq RunQuery
+	err := json.Unmarshal([]byte(`{
+		"run_ids": [0, 1, 2],
+		"query": {
+			"exists": [
+				{"and": [
+					{"pattern": "cssom"}
+				  ]
+				}
+			]
+		}
+	}`), &rq)
+	assert.Nil(t, err)
+	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2},
+		AbstractQuery: AbstractExists{Args: []AbstractQuery{AbstractAnd{Args: []AbstractQuery{TestNamePattern{Pattern: "cssom"}}}}}}, rq)
+}
+
+func TestStructuredQuery_existsWithAnd(t *testing.T) {
+	var rq RunQuery
+	err := json.Unmarshal([]byte(`{
+		"run_ids": [0, 1, 2],
+		"query": {
+			"exists": [
+				{"pattern": "cssom"}
+			]
+		}
+	}`), &rq)
+	assert.Nil(t, err)
+	assert.Equal(t, RunQuery{RunIDs: []int64{0, 1, 2}, AbstractQuery: AbstractExists{[]AbstractQuery{TestNamePattern{"cssom"}}}}, rq)
+}
+
 func TestStructuredQuery_nested(t *testing.T) {
 	var rq RunQuery
 	err := json.Unmarshal([]byte(`{
@@ -841,6 +873,59 @@ func TestStructuredQuery_bindExists(t *testing.T) {
 		} else { // Odds are firefox
 			or2.Args = append(or2.Args,
 				RunTestStatusNeq{
+					Run:    int64(i),
+					Status: 1,
+				},
+			)
+		}
+	}
+	expected := And{
+		Args: []ConcreteQuery{or1, or2},
+	}
+	assert.Equal(t, expected, q.BindToRuns(runs...))
+}
+
+func TestStructuredQuery_bindExistsWithTwoProducts(t *testing.T) {
+	e := shared.ParseProductSpecUnsafe("edge")
+	f := shared.ParseProductSpecUnsafe("firefox")
+	q := AbstractExists{
+		Args: []AbstractQuery{
+			AbstractAnd{
+				Args: []AbstractQuery{
+					TestStatusEq{
+						Product: &e,
+						Status:  1,
+					},
+					TestStatusEq{
+						Product: &f,
+						Status:  1,
+					},
+				},
+			},
+		},
+	}
+
+	runs := shared.TestRuns{}
+	or1 := Or{}
+	or2 := Or{}
+	products := []shared.ProductSpec{e, f}
+	for i := 1; i <= 10; i++ {
+		runs = append(
+			runs,
+			shared.TestRun{
+				ID:                int64(i),
+				ProductAtRevision: products[i%2].ProductAtRevision,
+			})
+		if i%2 == 0 { // Evens are edge
+			or1.Args = append(or1.Args,
+						RunTestStatusEq{
+							Run:    int64(i),
+							Status: 1,
+						},
+				)
+		} else { // Odds are firefox
+			or2.Args = append(or2.Args,
+				RunTestStatusEq{
 					Run:    int64(i),
 					Status: 1,
 				},

--- a/webapp/components/test/test-search.html
+++ b/webapp/components/test/test-search.html
@@ -114,6 +114,24 @@ suite('<test-search>', () => {
           {product: 'firefox', status: 'TIMEOUT'},
         ],
       });
+
+      assertQueryParse('cssom AND firefox:timeout', {
+        exists: [{
+          and: [
+            {pattern: 'cssom'},
+            {product: 'firefox', status: 'TIMEOUT'},
+          ]
+        }],
+      });
+
+      assertQueryParse('cssom & firefox:timeout', {
+        exists: [{
+          and: [
+            {pattern: 'cssom'},
+            {product: 'firefox', status: 'TIMEOUT'},
+          ]
+        }],
+      });
     });
 
     test('pattern | test status', () => {


### PR DESCRIPTION
Fix #3171. The and-conjunction likely stopped working since https://github.com/web-platform-tests/wpt.fyi/pull/1057. The issue never surfaced because `AND` is implied between query terms, and the top-level queries work properly without it.

### Issues
and-conjunction does not work when it queries two or more distinct products. For example,  a simple query like `edge:pass and triaged:edge` works, but `edge:pass and triaged:chrome` does not work.

### Cause
https://github.com/web-platform-tests/wpt.fyi/pull/1057 introduces the notion of `exists` root node, and `exists` is implied [unless another root node is specified](https://github.com/web-platform-tests/wpt.fyi/tree/main/api/query#root-queries), e.g. all, none. A query is parsed differently when `and` is explicit vs implicit:

```
      assertQueryParse('chrome:pass firefox:timeout', {
        exists: [
          {product: 'chrome', status: 'PASS'},
          {product: 'firefox', status: 'TIMEOUT'},
        ],
      });
      assertQueryParse('chrome:pass AND firefox:timeout', {
        exists: [{
          and: [
            {product: 'chrome', status: 'PASS'},
            {product: 'firefox', status: 'TIMEOUT'},
          ]
        }],
      });
```

By definition & implementation of `exists`, each of query objects of `exists` must be true for a single run. Without the explicit `and`, the query objects of `exists` root are `{product: 'chrome', status: 'PASS'}`, `{product: 'firefox', status: 'TIMEOUT'}`.  With `and`,  it is a single query object  `and: [{product: 'chrome', status: 'PASS'},{product: 'firefox', status: 'TIMEOUT'},]`. In `BindToRuns` method, there does not exists `ONE` run where it can be both chrome and firefox. Thus it fails to bind to any runs.

###  Solutions
For top-level queries (means without nested queries) with a single query object, e.g. Or/And, bind them directly without the `exists` logic.

### Future Issues
When there are nested `AND` with two or more distinct products, the query still will not work as expected, because they are bound to one run at `BindToRuns` , e.g. `edge:pass or (chrome:pass firefox:fail)`. However, they never worked to begin with. I believe `exists` root node is still correct by its definiton, but should not be attached to all queries by default. 

Alternatively,  either user somehow rewrites this query with a different root node, e.g. all, none, etc. or we should remove  `exists` node by default.

### Follow-up
I will file a bug against the future issues mentioned above