### PR TITLE
Revert "README: Correct syntax for and-conjuction"

### DIFF
--- a/api/query/README.md
+++ b/api/query/README.md
@@ -14,17 +14,21 @@ By default, a search query will be implicitly treated as an `exists` query (a di
 across each of the runs separately). However, there are several other root query types that
 can be invoked by wrapping the query(s), including explicitly wrapping with `exists`.
 
-If multiple root queries are used, then each query must separately be true. e.g.
+If multiple root queries are used, they are implicitly combined with `AND`, i.e. each query
+must separately be true. e.g.
 
     count>1(status:!pass) none(status:missing)
 
 Requires that more than one non-pass result is present, and none of the results are missing.
+You can also explicitly combine the root queries with `and`, e.g.
+
+    count<3(status:pass) and none(status:missing)
 
 Alternatively, root queries can be combined using `or`, e.g.
 
     none(status:pass) or all(status:pass)
 
-Note that the and-conjunction (no keyword) takes precedence over the `or` conjunction.
+Note that the `and` conjunction takes precedence over the `or` conjunction.
 
 #### Exists
 
@@ -174,11 +178,11 @@ are not supported.
 
 #### And-conjuction
 
-    [query1] [query2] [...]
+    [query1] and [query2] [and ...]
 
 Combines filters, such that they must all apply, e.g.
 
-    chrome:pass firefox:!pass
+    chrome:pass and firefox:!pass
 
 #### Or-conjuction
 
@@ -188,8 +192,8 @@ Combines filters, such that any must apply, e.g.
 
     chrome:pass or chrome:ok
 
-> NOTE: Or-conjuction takes less precedence than and-conjuction. Precedence can be modified
-> using parens, e.g. `chrome:pass (firefox:!pass or safari:!pass)`
+> NOTE: Or-conjuction takes less precedence than `and`. Precedence can be modified
+> using parens, e.g. `chrome:pass and (firefox:!pass or safari:!pass)`
 
 ## /api/search
 
@@ -309,11 +313,11 @@ Same as satuts, but with a specific product-spec.
 
 Search untriaged issues -
 
-    chrome:fail !link:bugs.chromium.org
+    chrome:fail and !link:bugs.chromium.org
 
 Search triaged issues -
 
-    chrome:pass link:bugs.chromium.org
+    chrome:pass and link:bugs.chromium.org
 
 #### triaged
 
@@ -327,11 +331,11 @@ Where [browsername] is a browser specification (e.g. safari, chrome).
 
 Search untriaged Chrome failures -
 
-    chrome:fail none(triaged:chrome)
+    chrome:fail and none(triaged:chrome)
 
 Search triaged Chrome tests -
 
-    chrome:pass triaged:chrome
+    chrome:pass and triaged:chrome
 
 #### label
 


### PR DESCRIPTION
Reverts web-platform-tests/wpt.fyi#3170. https://github.com/web-platform-tests/wpt.fyi/pull/3313 fixed the `and` issue