### PR TITLE
Remove notify for testruns.

### DIFF
--- a/webapp/components/test-runs.js
+++ b/webapp/components/test-runs.js
@@ -19,7 +19,6 @@ const TestRunsQueryLoader = (superClass) =>
         // Fetched + parsed JSON blobs for the runs
         testRuns: {
           type: Array,
-          notify: true,
         },
         nextPageToken: String,
         displayedProducts: Array,

--- a/webapp/views/wpt-app.js
+++ b/webapp/views/wpt-app.js
@@ -154,7 +154,7 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
                      is-loading="{{resultsLoading}}"
                      structured-search="[[structuredSearch]]"
                      path="{{subroute.path}}"
-                     test-runs="{{testRuns}}"
+                     test-runs="[[testRuns]]"
                      test-paths="{{testPaths}}"
                      search-results="{{searchResults}}"
                      subtest-row-count={{subtestRowCount}}

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -264,7 +264,7 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
           <thead>
             <tr>
               <th>Path</th>
-              <template is="dom-repeat" items="{{testRuns}}" as="testRun">
+              <template is="dom-repeat" items="[[testRuns]]" as="testRun">
                 <!-- Repeats for as many different browser test runs are available -->
                 <th><test-run test-run="[[testRun]]" show-source show-platform></test-run></th>
               </template>
@@ -309,7 +309,7 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
                   </template>
                 </td>
 
-                <template is="dom-repeat" items="{{testRuns}}" as="testRun">
+                <template is="dom-repeat" items="[[testRuns]]" as="testRun">
                   <td class\$="numbers [[ testResultClass(node, index, testRun, 'passes') ]]" onclick="[[handleTriageSelect(index, node, testRun)]]" onmouseover="[[handleTriageHover(index, node, testRun)]]">
                     <template is="dom-if" if="[[diffRun]]">
                       <span class\$="passes [[ testResultClass(node, index, testRun, 'passes') ]]">{{ getNodeResultDataByPropertyName(node, index, testRun, 'subtest_passes') }}</span>


### PR DESCRIPTION
TestRunsQueryLoader is actually extended and used everywhere. So no parent objects actually need to be notified with an event listener.

---

Removed the notify from TestRunsQueryLoader
TestRunsQueryLoader is a base class that is extended by:
- TestRunsBase ('wpt-results-base') which is the parent class for
  - TestFileResultsTable ('test-file-results-table'). Not wrapped or extended by anything else.. CONCLUSION SAFE.
- TestRunsUIBase, which is the parent class for:
  - WPTRuns ('wpt-runs') - Has no parents. Not extended anymore. Only used by webapp/template/test-runs.html. notify does not go up.
  - WPTApp ('wpt-app'). Conclusion: SAFE
  - WPTResults ('wpt-results'). Used in wpt-app. Conclusion: NEED TO INVESTIGATE. Turns out that wpt-app has the testRuns already.

