### PR TITLE
Exclude dependabot from all events for docker-update GH action

### DIFF
--- a/.github/workflows/docker-update.yml
+++ b/.github/workflows/docker-update.yml
@@ -15,8 +15,8 @@ jobs:
     # Forks and dependabot cannot access secrets so the job would fail.
     # Run for non dependabot PRs or regular pushes to web-platform-tests/wpt.fyi
     if: |
-      (github.repository == 'web-platform-tests/wpt.fyi') &&
-      ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'web-platform-tests/wpt.fyi' && github.actor != 'dependabot[bot]') ||
+      (github.repository == 'web-platform-tests/wpt.fyi' && github.actor != 'dependabot[bot]') &&
+      ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'web-platform-tests/wpt.fyi') ||
       (github.event_name != 'pull_request'))
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Currently docker-update GH action triggers on pushes to all branches [1] (The other GH workflows trigger on pushes only to the main branch [2][3])

As a result, the docker-update runs with the push event to dependabot's branch and it fails because it cannot access the credentials to push a docker image.

This change moves the conditional against dependabot to apply for all events against this repository instead of just for the pull_request event.

[1] https://github.com/web-platform-tests/wpt.fyi/blob/1824e41a7d02d33b90cc60c574a58551ee756391/.github/workflows/docker-update.yml#L3-L9
[2] https://github.com/web-platform-tests/wpt.fyi/blob/1824e41a7d02d33b90cc60c574a58551ee756391/.github/workflows/ci.yml#L4-L5
[3] https://github.com/web-platform-tests/wpt.fyi/blob/1824e41a7d02d33b90cc60c574a58551ee756391/.github/workflows/deploy.yml#L4-L5


It leads to a bad developer experience
![image](https://github.com/web-platform-tests/wpt.fyi/assets/7788930/4417323c-40c3-4ec9-aaf6-54f218a7677f)
