### PR TITLE
Update history endpoint

### DIFF
--- a/api/test_history.go
+++ b/api/test_history.go
@@ -1,16 +1,45 @@
 package api
 
 import (
+	"encoding/json"
+	"io"
 	"net/http"
 	"os"
 
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
+type RequestBody struct {
+	TestName string `json:"testName"`
+}
+
 // Handler for fetching historical data of a specific test for each of the four major browsers.
 func testHistoryHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Invalid HTTP method", http.StatusBadRequest)
+		return
+	}
+
 	ctx := r.Context()
 	logger := shared.GetLogger(ctx)
+
+	data, err := io.ReadAll(r.Body)
+	if len(data) == 0 {
+		http.Error(w, "Data array is empty", http.StatusInternalServerError)
+		return
+	}
+
+	if err != nil {
+		http.Error(w, "Failed to read request body", http.StatusInternalServerError)
+		return
+	}
+
+	var reqBody RequestBody
+	err = json.Unmarshal(data, &reqBody)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 
 	jsonData, jsonErr := os.ReadFile("./api/test-data/mock_history_data.json")
 
@@ -18,7 +47,7 @@ func testHistoryHandler(w http.ResponseWriter, r *http.Request) {
 		logger.Errorf("Unable to get json %s", jsonErr.Error())
 	}
 
-	_, err := w.Write(jsonData)
+	_, err = w.Write(jsonData)
 
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/api/test_history.go
+++ b/api/test_history.go
@@ -9,6 +9,7 @@ import (
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
+// RequestBody is the expected format of requests for specific test run data.
 type RequestBody struct {
 	TestName string `json:"testName"`
 }
@@ -17,6 +18,7 @@ type RequestBody struct {
 func testHistoryHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Invalid HTTP method", http.StatusBadRequest)
+
 		return
 	}
 
@@ -26,11 +28,13 @@ func testHistoryHandler(w http.ResponseWriter, r *http.Request) {
 	data, err := io.ReadAll(r.Body)
 	if len(data) == 0 {
 		http.Error(w, "Data array is empty", http.StatusInternalServerError)
+
 		return
 	}
 
 	if err != nil {
 		http.Error(w, "Failed to read request body", http.StatusInternalServerError)
+
 		return
 	}
 
@@ -38,6 +42,7 @@ func testHistoryHandler(w http.ResponseWriter, r *http.Request) {
 	err = json.Unmarshal(data, &reqBody)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
+
 		return
 	}
 

--- a/webapp/components/new-test-results-history-grid.js
+++ b/webapp/components/new-test-results-history-grid.js
@@ -74,16 +74,25 @@ class TestResultsGrid extends PolymerElement {
     return {
       dataTable: Object,
       runIDs: Array,
+      path: String,
+      showTestHistory: { type: Boolean, value: false }
     };
+  }
+
+  static get observers() {
+    return [
+      'displayCharts(showTestHistory)'
+    ];
   }
 
   static get is() {
     return 'new-test-results-history-grid';
   }
 
-  constructor() {
-    super();
-
+  displayCharts(showTestHistory) {
+    if (!showTestHistory || this.historicalData !== undefined) {
+      return;
+    }
     // Get the test history data and then populate the chart
     Promise.all([
       this.getTestHistory(),
@@ -216,7 +225,19 @@ class TestResultsGrid extends PolymerElement {
 
   // get test history and aligned run data
   async getTestHistory() {
-    this.historicalData = await fetch('/api/history')
+    if (!this.path) {
+      throw new Error('Test path is undefined');
+    }
+
+    const options = {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ testName: this.path})
+    };
+
+    this.historicalData = await fetch('/api/history', options)
       .then(r => r.json()).then(data => data.results);
     this.subtestNames = Object.keys(this.historicalData[0]);
   }

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -384,7 +384,9 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
           History <span>(Experimental)</span>
         </h3>
         <template is="dom-if" if="[[pathIsATestFile]]">
-          <new-test-results-history-grid>
+          <new-test-results-history-grid
+            path="[[path]]"
+            show-test-history="[[showNewHistory]]">
           </new-test-results-history-grid>
         </template>
       </template>


### PR DESCRIPTION
This PR alters the existing `/api/history` endpoint to accept POST requests rather than GET requests. This is due to GET requests supporting a finite URL length. The POST request body will give us more flexibility with what information can be sent along with the request.