### PR TITLE
change testHistoryEntry format

### DIFF
--- a/api/test_history.go
+++ b/api/test_history.go
@@ -10,6 +10,12 @@ import (
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
+// Subtest represents the final format for subtest data.
+type Subtest map[string]string
+
+// Browser represents the final format for browser data.
+type Browser map[string][]Subtest
+
 // RequestBody is the expected format of requests for specific test run data.
 type RequestBody struct {
 	TestName string `json:"testName"`
@@ -75,9 +81,6 @@ func testHistoryHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Convert datastore data to correct JSON format
-	type Subtest map[string]string
-	type Browser map[string][]Subtest
-
 	resultsSlice := []Browser{}
 	testsByBrowser := map[string]Browser{}
 

--- a/api/test_history.go
+++ b/api/test_history.go
@@ -83,10 +83,10 @@ func testHistoryHandler(w http.ResponseWriter, r *http.Request) {
 
 	for _, run := range runs {
 
-		_, ok := testsByBrowser[run.Browser]
+		_, ok := testsByBrowser[run.BrowserName]
 
 		if !ok {
-			testsByBrowser[run.Browser] = Browser{}
+			testsByBrowser[run.BrowserName] = Browser{}
 		}
 
 		subdata := Subtest{
@@ -95,8 +95,8 @@ func testHistoryHandler(w http.ResponseWriter, r *http.Request) {
 			"run_id": run.RunID,
 		}
 
-		testsByBrowser[run.Browser][run.SubtestName] =
-			append(testsByBrowser[run.Browser][run.SubtestName], subdata)
+		testsByBrowser[run.BrowserName][run.SubtestName] =
+			append(testsByBrowser[run.BrowserName][run.SubtestName], subdata)
 	}
 
 	for _, browser := range testsByBrowser {

--- a/api/test_history.go
+++ b/api/test_history.go
@@ -48,7 +48,7 @@ func testHistoryHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	store := shared.NewAppEngineDatastore(ctx, false)
-	q := store.NewQuery("TestHistory").Filter("TestName =", reqBody.TestName)
+	q := store.NewQuery("TestHistoryEntry").Filter("TestName =", reqBody.TestName)
 
 	var runs []shared.TestHistoryEntry
 	_, err = store.GetAll(q, &runs)

--- a/shared/models.go
+++ b/shared/models.go
@@ -301,13 +301,12 @@ func (a PendingTestRunByUpdated) Less(i, j int) bool { return a[i].Updated.Befor
 
 // TestHistoryEntry formats Test History data for the datastore.
 type TestHistoryEntry struct {
-	Browser        string
-	BrowserVersion string
-	RunID          string
-	Date           string
-	TestName       string
-	SubtestName    string
-	Status         string
+	BrowserName string
+	RunID       string
+	Date        string
+	TestName    string
+	SubtestName string
+	Status      string
 }
 
 // CheckSuite entities represent a GitHub check request that has been noted by

--- a/util/populate_dev_data.go
+++ b/util/populate_dev_data.go
@@ -464,5 +464,5 @@ func addFakeHistoryData(store shared.Datastore) {
 			browserEntries = append(browserEntries, &testHistoryEntry)
 		}
 	}
-	addData(store, "TestHistory", browserEntries)
+	addData(store, "TestHistoryEntry", browserEntries)
 }

--- a/util/populate_dev_data.go
+++ b/util/populate_dev_data.go
@@ -435,22 +435,18 @@ func addFakeHistoryData(store shared.Datastore) {
 
 	browserMetadata := []map[string]string{
 		{
-			"browser":         "chrome",
-			"browser_version": "100",
+			"browser": "chrome",
 		},
 		{
-			"browser":         "edge",
-			"browser_version": "101e",
+			"browser": "edge",
 		},
 
 		{
-			"browser":         "firefox",
-			"browser_version": "103.5962",
+			"browser": "firefox",
 		},
 
 		{
-			"browser":         "safari",
-			"browser_version": "1203 example",
+			"browser": "safari",
 		},
 	}
 
@@ -458,13 +454,12 @@ func addFakeHistoryData(store shared.Datastore) {
 	for _, metadata := range browserMetadata {
 		for _, entry := range devData {
 			testHistoryEntry := shared.TestHistoryEntry{
-				Browser:        metadata["browser"],
-				BrowserVersion: metadata["browser_version"],
-				RunID:          entry["run_id"],
-				Date:           entry["date"],
-				TestName:       entry["test_name"],
-				SubtestName:    entry["subtest_name"],
-				Status:         entry["status"],
+				BrowserName: metadata["browser"],
+				RunID:       entry["run_id"],
+				Date:        entry["date"],
+				TestName:    entry["test_name"],
+				SubtestName: entry["subtest_name"],
+				Status:      entry["status"],
 			}
 			browserEntries = append(browserEntries, &testHistoryEntry)
 		}

--- a/webapp/components/new-test-results-history-grid.js
+++ b/webapp/components/new-test-results-history-grid.js
@@ -163,14 +163,14 @@ class TestResultsGrid extends PolymerElement {
     this.subtestNames.forEach(subtestName => {
       for (let i = 0; i < browserTestData[subtestName].length; i++) {
         const dataPoint = browserTestData[subtestName][i];
-        const startDate = new Date(Number(dataPoint.date));
+        const startDate = new Date(dataPoint.date);
 
         // Use the next entry as the end date, or use present time if this
         // is the last entry
         let endDate = now;
         if (i + 1 !== browserTestData[subtestName].length) {
           const nextDataPoint = browserTestData[subtestName][i + 1];
-          endDate = new Date(Number(nextDataPoint.date));
+          endDate = new Date(nextDataPoint.date);
         }
 
         // If this is the main test status, name it based on the amount of subtests


### PR DESCRIPTION
This PR removes the `BrowserVersion` item in the `TestHistoryEntry` struct because it is not being used. It also renames the item `Browser` to `BrowserName` to better match naming conventions elsewhere in the project.
