### PR TITLE
Support wildcards in label search

### DIFF
--- a/api/query/cache/index/filter.go
+++ b/api/query/cache/index/filter.go
@@ -324,6 +324,18 @@ func (tl TestLabel) Filter(t TestID) bool {
 	}
 
 	labels, ok := tl.metadata[name]
+	dir := filepath.Dir(name)
+	// Dir terminates with either '.' (when the top-level is a file) or '/'
+	// (when the top-level is a directory).
+	for !ok && len(dir) > 1 {
+		labels, ok = tl.metadata[dir+"/*"]
+		if ok {
+			break
+		}
+
+		dir = filepath.Dir(dir)
+	}
+
 	if !ok {
 		return false
 	}

--- a/api/query/cache/index/index_filter_test.go
+++ b/api/query/cache/index/index_filter_test.go
@@ -833,6 +833,65 @@ func TestBindExecute_TestLabel(t *testing.T) {
 	assert.Equal(t, expectedResult, srs[0])
 }
 
+func TestBindExecute_LabelWithWildcards(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	loader := NewMockReportLoader(ctrl)
+	idx, err := NewShardedWPTIndex(loader, testNumShards)
+	assert.Nil(t, err)
+
+	matchingTestName := "/a/b/c"
+	runs := mockTestRuns(loader, idx, []testRunData{
+		{
+			shared.TestRun{ID: 1},
+			&metrics.TestResultsReport{
+				Results: []*metrics.TestResults{
+					{
+						Test:   matchingTestName,
+						Status: "PASS",
+					},
+					{
+						Test:   "/d/e/f",
+						Status: "FAIL",
+					},
+				},
+			},
+		},
+	})
+	metadata := map[string][]string{
+		"/foo/bar/b.html": {"random"},
+		"/a/*":  {"interop1", "INTEROP2"},
+		"/d/e/f":          {""},
+	}
+
+	// Create an execute a plan for `label:interop1 & label:interop2`. Inside the metadata
+	// this matches the wildcard "/a/*". When mapped to test runs, that
+	// means it should match "/a/b/c" due to wildcard expansion.
+	testlabel := query.And{[]query.ConcreteQuery{query.TestLabel{Label: "interop2", Metadata: metadata}, query.TestLabel{Label: "interop1", Metadata: metadata}}}
+	plan, err := idx.Bind(runs, testlabel)
+	assert.Nil(t, err)
+
+	res := plan.Execute(runs, query.AggregationOpts{})
+	srs, ok := res.([]shared.SearchResult)
+	assert.True(t, ok)
+
+	assert.Equal(t, 1, len(srs))
+	expectedResult := shared.SearchResult{
+		Test: matchingTestName,
+		LegacyStatus: []shared.LegacySearchRunResult{
+			{
+				// Only matching test passes.
+				Passes:        1,
+				Total:         1,
+				Status:        "",
+				NewAggProcess: true,
+			},
+		},
+	}
+
+	assert.Equal(t, expectedResult, srs[0])
+}
+
 func TestBindExecute_IsDifferent(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
Fix https://github.com/web-platform-tests/wpt.fyi/issues/3351. Support searching wildcards in label.  

This is intended for use case https://github.com/web-platform-tests/wpt-metadata/pull/4297, and https://github.com/web-platform-tests/wpt-metadata/pull/4303