### PR TITLE
Refresh history data when page is changed

### DIFF
--- a/webapp/components/new-test-results-history-grid.js
+++ b/webapp/components/new-test-results-history-grid.js
@@ -97,7 +97,7 @@ class TestResultsGrid extends PolymerElement {
   }
 
   displayCharts(showTestHistory, path) {
-    if (!path || !showTestHistory) {
+    if (!path || !showTestHistory || path.split('?')[0].slice(-5) !== ".html") {
       return;
     }
 
@@ -234,7 +234,7 @@ class TestResultsGrid extends PolymerElement {
   // get test history and aligned run data
   async getTestHistory(path) {
     // If there is existing data, clear it to make sure nothing is cached
-    if(this.historicalData && path.split('?')[0].slice(-5) === ".html") {
+    if(this.historicalData) {
       this.historicalData = {};
     }
 

--- a/webapp/components/new-test-results-history-grid.js
+++ b/webapp/components/new-test-results-history-grid.js
@@ -89,7 +89,7 @@ class TestResultsGrid extends PolymerElement {
   static get observers() {
     return [
       'displayCharts(showTestHistory, path)',
-      'updateForPath(showTestHistory, path)'
+      'clearCharts(path, this.historicalData)',
     ];
   }
 
@@ -115,6 +115,15 @@ class TestResultsGrid extends PolymerElement {
     window.addEventListener('resize', () => {
       this.updateAllCharts(this.historicalData);
     });
+    console.log(this.historicalData)
+  }
+
+  // Clear all charts so that data does not persist between tests
+  clearCharts(path, history) {
+    console.log("data:", path, history)
+    // var chart = document.getElementsByClassName('chart');
+    // console.log(chart)
+    // chart.clearChart(); 
   }
 
   // Load Google charts for test history display
@@ -236,8 +245,13 @@ class TestResultsGrid extends PolymerElement {
 
   // get test history and aligned run data
   async getTestHistory(path) {
-    if (!this.path) {
+    if (!path) {
       throw new Error('Test path is undefined');
+    }
+
+    if(this.historicalData) {
+      console.log("existing history found", this.historicalData)
+      this.historicalData = {}
     }
 
     const options = {

--- a/webapp/components/new-test-results-history-grid.js
+++ b/webapp/components/new-test-results-history-grid.js
@@ -101,7 +101,7 @@ class TestResultsGrid extends PolymerElement {
     if (!path) {
       return
     }
-    if (!showTestHistory || this.historicalData !== undefined) {
+    if (!showTestHistory) {
       return;
     }
     // Get the test history data and then populate the chart

--- a/webapp/components/new-test-results-history-grid.js
+++ b/webapp/components/new-test-results-history-grid.js
@@ -234,7 +234,7 @@ class TestResultsGrid extends PolymerElement {
   // get test history and aligned run data
   async getTestHistory(path) {
     // If there is existing data, clear it to make sure nothing is cached
-    if(this.historicalData) {
+    if(this.historicalData && path.split('?')[0].slice(-5) === ".html") {
       this.historicalData = {};
     }
 

--- a/webapp/components/new-test-results-history-grid.js
+++ b/webapp/components/new-test-results-history-grid.js
@@ -85,10 +85,11 @@ class TestResultsGrid extends PolymerElement {
       showTestHistory: { type: Boolean, value: false }
     };
   }
-
+  
   static get observers() {
     return [
-      'displayCharts(showTestHistory, path)'
+      'displayCharts(showTestHistory, path)',
+      'updateForPath(showTestHistory, path)'
     ];
   }
 
@@ -105,7 +106,7 @@ class TestResultsGrid extends PolymerElement {
     }
     // Get the test history data and then populate the chart
     Promise.all([
-      this.getTestHistory(),
+      this.getTestHistory(path),
       this.loadCharts()
     ]).then(() => this.updateAllCharts(this.historicalData));
 
@@ -234,7 +235,7 @@ class TestResultsGrid extends PolymerElement {
   }
 
   // get test history and aligned run data
-  async getTestHistory() {
+  async getTestHistory(path) {
     if (!this.path) {
       throw new Error('Test path is undefined');
     }
@@ -244,7 +245,7 @@ class TestResultsGrid extends PolymerElement {
       headers: {
         'Content-Type': 'application/json'
       },
-      body: JSON.stringify({ testName: this.path})
+      body: JSON.stringify({ testName: path})
     };
 
     this.historicalData = await fetch('/api/history', options)

--- a/webapp/components/new-test-results-history-grid.js
+++ b/webapp/components/new-test-results-history-grid.js
@@ -97,12 +97,10 @@ class TestResultsGrid extends PolymerElement {
   }
 
   displayCharts(showTestHistory, path) {
-    if (!path) {
+    if (!path || !showTestHistory) {
       return;
     }
-    if (!showTestHistory) {
-      return;
-    }
+
     // Get the test history data and then populate the chart
     Promise.all([
       this.getTestHistory(path),
@@ -235,10 +233,6 @@ class TestResultsGrid extends PolymerElement {
 
   // get test history and aligned run data
   async getTestHistory(path) {
-    if (!path) {
-      throw new Error('Test path is undefined');
-    }
-
     // If there is existing data, clear it to make sure nothing is cached
     if(this.historicalData) {
       this.historicalData = {};

--- a/webapp/components/new-test-results-history-grid.js
+++ b/webapp/components/new-test-results-history-grid.js
@@ -6,6 +6,7 @@
 
 import { PolymerElement, html } from '../node_modules/@polymer/polymer/polymer-element.js';
 const pageStyle = getComputedStyle(document.body);
+import { PathInfo } from './path.js';
 
 const PASS_COLOR = pageStyle.getPropertyValue('--paper-green-300');
 const FAIL_COLOR = pageStyle.getPropertyValue('--paper-red-300');
@@ -36,7 +37,7 @@ const BROWSER_NAMES = [
   'safari'
 ];
 
-class TestResultsGrid extends PolymerElement {
+class TestResultsGrid extends PathInfo(PolymerElement) {
   static get template() {
     return html`
         <style>
@@ -97,7 +98,7 @@ class TestResultsGrid extends PolymerElement {
   }
 
   displayCharts(showTestHistory, path) {
-    if (!path || !showTestHistory || path.split('?')[0].slice(-5) !== '.html') {
+    if (!path || !showTestHistory || !this.computePathIsATestFile(path)) {
       return;
     }
 

--- a/webapp/components/new-test-results-history-grid.js
+++ b/webapp/components/new-test-results-history-grid.js
@@ -97,6 +97,9 @@ class TestResultsGrid extends PolymerElement {
   }
 
   displayCharts(showTestHistory, path) {
+    if (!path) {
+      return
+    }
     if (!showTestHistory || this.historicalData !== undefined) {
       return;
     }

--- a/webapp/components/new-test-results-history-grid.js
+++ b/webapp/components/new-test-results-history-grid.js
@@ -85,11 +85,10 @@ class TestResultsGrid extends PolymerElement {
       showTestHistory: { type: Boolean, value: false }
     };
   }
-  
+
   static get observers() {
     return [
       'displayCharts(showTestHistory, path)',
-      'clearCharts(path, this.historicalData)',
     ];
   }
 
@@ -99,7 +98,7 @@ class TestResultsGrid extends PolymerElement {
 
   displayCharts(showTestHistory, path) {
     if (!path) {
-      return
+      return;
     }
     if (!showTestHistory) {
       return;
@@ -115,15 +114,6 @@ class TestResultsGrid extends PolymerElement {
     window.addEventListener('resize', () => {
       this.updateAllCharts(this.historicalData);
     });
-    console.log(this.historicalData)
-  }
-
-  // Clear all charts so that data does not persist between tests
-  clearCharts(path, history) {
-    console.log("data:", path, history)
-    // var chart = document.getElementsByClassName('chart');
-    // console.log(chart)
-    // chart.clearChart(); 
   }
 
   // Load Google charts for test history display
@@ -249,9 +239,9 @@ class TestResultsGrid extends PolymerElement {
       throw new Error('Test path is undefined');
     }
 
+    // If there is existing data, clear it to make sure nothing is cached
     if(this.historicalData) {
-      console.log("existing history found", this.historicalData)
-      this.historicalData = {}
+      this.historicalData = {};
     }
 
     const options = {

--- a/webapp/components/new-test-results-history-grid.js
+++ b/webapp/components/new-test-results-history-grid.js
@@ -114,10 +114,6 @@ class TestResultsGrid extends PolymerElement {
     window.addEventListener('resize', () => {
       this.updateAllCharts(this.historicalData);
     });
-
-    window.addEventListener('load', () => {
-      this.updateAllCharts(this.historicalData);
-    })
   }
 
   // Load Google charts for test history display

--- a/webapp/components/new-test-results-history-grid.js
+++ b/webapp/components/new-test-results-history-grid.js
@@ -88,7 +88,7 @@ class TestResultsGrid extends PolymerElement {
 
   static get observers() {
     return [
-      'displayCharts(showTestHistory)'
+      'displayCharts(showTestHistory, path)'
     ];
   }
 
@@ -96,7 +96,7 @@ class TestResultsGrid extends PolymerElement {
     return 'new-test-results-history-grid';
   }
 
-  displayCharts(showTestHistory) {
+  displayCharts(showTestHistory, path) {
     if (!showTestHistory || this.historicalData !== undefined) {
       return;
     }
@@ -111,6 +111,10 @@ class TestResultsGrid extends PolymerElement {
     window.addEventListener('resize', () => {
       this.updateAllCharts(this.historicalData);
     });
+
+    window.addEventListener('load', () => {
+      this.updateAllCharts(this.historicalData);
+    })
   }
 
   // Load Google charts for test history display

--- a/webapp/components/new-test-results-history-grid.js
+++ b/webapp/components/new-test-results-history-grid.js
@@ -97,7 +97,7 @@ class TestResultsGrid extends PolymerElement {
   }
 
   displayCharts(showTestHistory, path) {
-    if (!path || !showTestHistory || path.split('?')[0].slice(-5) !== ".html") {
+    if (!path || !showTestHistory || path.split('?')[0].slice(-5) !== '.html') {
       return;
     }
 

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -715,6 +715,7 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
       this.sortCol = new Array(this.testRuns.length).fill(false);
       this.isPathSorted = false;
     }
+    this.showNewHistory = false
   }
 
   aggregateTestTotals(nodes, row, rs, diffRun) {


### PR DESCRIPTION
This PR solves issue #3446 where the same data was persisting for different tests. I solved this by checking for and clearing any existing data before running the query for new data. I also added logic to hide the history timelines when a new test page is visited after viewing a previous one.
