### PR TITLE
Add Chromium to wpt.fyi browsers

### DIFF
--- a/shared/browsers.go
+++ b/shared/browsers.go
@@ -14,7 +14,7 @@ var defaultBrowsers = []string{
 
 // An extra list of known browsers.
 var extraBrowsers = []string{
-	"android_webview", "chrome_android", "chrome_ios", "deno", "epiphany", "flow", "node.js", "servo", "uc", "wktr", "webkitgtk",
+	"android_webview", "chrome_android", "chrome_ios", "chromium", "deno", "epiphany", "flow", "node.js", "servo", "uc", "wktr", "webkitgtk",
 }
 
 var allBrowsers mapset.Set

--- a/shared/browsers_test.go
+++ b/shared/browsers_test.go
@@ -1,4 +1,3 @@
-//go:build small
 // +build small
 
 // Copyright 2017 The WPT Dashboard Project. All rights reserved.

--- a/shared/browsers_test.go
+++ b/shared/browsers_test.go
@@ -1,3 +1,4 @@
+//go:build small
 // +build small
 
 // Copyright 2017 The WPT Dashboard Project. All rights reserved.
@@ -21,6 +22,7 @@ func TestGetDefaultBrowserNames(t *testing.T) {
 		assert.NotEqual(t, "android_webview", n)
 		assert.NotEqual(t, "chrome_android", n)
 		assert.NotEqual(t, "chrome_ios", n)
+		assert.NotEqual(t, "chromium", n)
 		assert.NotEqual(t, "deno", n)
 		assert.NotEqual(t, "epiphany", n)
 		assert.NotEqual(t, "flow", n)
@@ -34,6 +36,7 @@ func TestGetDefaultBrowserNames(t *testing.T) {
 
 func TestIsBrowserName(t *testing.T) {
 	assert.True(t, IsBrowserName("chrome"))
+	assert.True(t, IsBrowserName("chromium"))
 	assert.True(t, IsBrowserName("deno"))
 	assert.True(t, IsBrowserName("edge"))
 	assert.True(t, IsBrowserName("firefox"))

--- a/shared/product_spec.go
+++ b/shared/product_spec.go
@@ -72,6 +72,8 @@ func (p ProductSpec) DisplayName() string {
 	switch p.BrowserName {
 	case "chrome":
 		return "Chrome"
+	case "chromium":
+		return "Chromium"
 	case "chrome_android":
 		return "ChromeAndroid"
 	case "chrome_ios":

--- a/webapp/components/product-info.js
+++ b/webapp/components/product-info.js
@@ -12,6 +12,7 @@ const DisplayNames = (() => {
   m.set('android_webview', 'WebView');
   m.set('chrome_android', 'ChromeAndroid');
   m.set('chrome_ios', 'ChromeIOS');
+  m.set('chromium', 'Chromium');
   m.set('deno', 'Deno');
   m.set('flow', 'Flow');
   m.set('node.js', 'Node.js');
@@ -46,7 +47,7 @@ const versionPatterns = Object.freeze({
 
 // The set of all browsers known to the wpt.fyi UI.
 const AllBrowserNames = Object.freeze(['android_webview', 'chrome_android', 'chrome_ios', 'chrome',
-  'deno', 'edge', 'firefox', 'flow', 'node.js', 'safari', 'servo', 'webkitgtk', 'wktr']);
+  'chromium', 'deno', 'edge', 'firefox', 'flow', 'node.js', 'safari', 'servo', 'webkitgtk', 'wktr']);
 
 // The list of default browsers used in cases where the user has not otherwise
 // chosen a set of browsers (e.g. which browsers to show runs for). Stored as
@@ -176,7 +177,7 @@ const ProductInfo = (superClass) => class extends superClass {
       // chrome_android is mapped to chrome on wptrunner.
       return '/static/chrome_64x64.png';
 
-    } else if (name !== 'deno' && name !== 'flow' && name !== 'node.js' && name !== 'servo' && name !== 'wktr') {  // Products without per-channel logos.
+    } else if (name !== 'chromium' && name !== 'deno' && name !== 'flow' && name !== 'node.js' && name !== 'servo' && name !== 'wktr') {  // Products without per-channel logos.
       let channel;
       const candidates = ['beta', 'dev', 'canary', 'nightly', 'preview'];
       for (const label of candidates) {

--- a/webapp/components/wpt-amend-metadata.js
+++ b/webapp/components/wpt-amend-metadata.js
@@ -292,9 +292,18 @@ class AmendMetadata extends LoadingState(PathInfo(ProductInfo(PolymerElement))) 
   }
 
   hasSearchURL(product) {
-    return product === 'chrome' || product === 'deno' || product === 'edge' ||
-      product === 'firefox' || product === 'node.js' || product === 'safari' ||
-      product === 'servo' || product === 'wktr' || product === 'webkitgtk';
+    return [
+      'chrome',
+      'chromium',
+      'deno',
+      'edge',
+      'firefox',
+      'node.js',
+      'safari',
+      'servo',
+      'wktr',
+      'webkitgtk',
+    ].includes(product);
   }
 
   getSearchURL(testName, product) {
@@ -305,7 +314,7 @@ class AmendMetadata extends LoadingState(PathInfo(ProductInfo(PolymerElement))) 
       testName = testName.replace(/((\/\*)?$)/, '');
     }
 
-    if (product === 'chrome' || product === 'edge') {
+    if (product === 'chrome' || product === 'chromium' || product === 'edge') {
       return `https://bugs.chromium.org/p/chromium/issues/list?q="${testName}"`;
     }
 


### PR DESCRIPTION
This change adds support for Chromium runs, which have not been ingested by wpt.fyi since the renaming of "chrome nightly" to "chromium nightly" in the WPT repo.