### PR TITLE
Exclude false positive gosec rule

### DIFF
--- a/api/screenshot/cache.go
+++ b/api/screenshot/cache.go
@@ -73,8 +73,10 @@ func uploadScreenshotHandler(w http.ResponseWriter, r *http.Request) {
 
 		return
 	}
+	/* #nosec G101 */
 	bucketName := "wptd-screenshots-staging"
 	if aeAPI.GetHostname() == "wpt.fyi" {
+		/* #nosec G101 */
 		bucketName = "wptd-screenshots"
 	}
 	bucket := gcs.Bucket(bucketName)

--- a/api/screenshot_redirect_handler.go
+++ b/api/screenshot_redirect_handler.go
@@ -25,8 +25,10 @@ func apiScreenshotRedirectHandler(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 	aeAPI := shared.NewAppEngineAPI(ctx)
+	/* #nosec G101 */
 	bucket := "wptd-screenshots-staging"
 	if aeAPI.GetHostname() == "wpt.fyi" {
+		/* #nosec G101 */
 		bucket = "wptd-screenshots"
 	}
 	url := fmt.Sprintf("https://storage.googleapis.com/%s/%s.png", bucket, shot)

--- a/webapp/analyzer_handler.go
+++ b/webapp/analyzer_handler.go
@@ -28,8 +28,10 @@ func analyzerHandler(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 	aeAPI := shared.NewAppEngineAPI(ctx)
+	/* #nosec G101 */
 	bucket := "wptd-screenshots-staging"
 	if aeAPI.GetHostname() == "wpt.fyi" {
+		/* #nosec G101 */
 		bucket = "wptd-screenshots"
 	}
 


### PR DESCRIPTION
Fix CI issues in pending PRs. [Annotate](https://github.com/securego/gosec#annotating-code) the false positive G101 rules

```
golangci/golangci-lint info checking GitHub for latest tag
golangci/golangci-lint info found version: 1.54.2 for v1.54.2/linux/amd64
golangci/golangci-lint info installed /go/bin/golangci-lint
golangci-lint run ./api/...
api/screenshot_redirect_handler.go:28:2: G101: Potential hardcoded credentials (gosec)
	bucket := "wptd-screenshots-staging"
	^
api/screenshot/cache.go:76:2: G101: Potential hardcoded credentials (gosec)
	bucketName := "wptd-screenshots-staging"
	^
make: *** [Makefile:77: golangci_lint] Error 1
```