### PR TITLE
Probe directory tree for wildcard matching

### DIFF
--- a/api/query/cache/index/filter.go
+++ b/api/query/cache/index/filter.go
@@ -323,21 +323,14 @@ func (tl TestLabel) Filter(t TestID) bool {
 		return false
 	}
 
-	labels, ok := tl.metadata[name]
+	labels := tl.metadata[name]
 	dir := filepath.Dir(name)
 	// Dir terminates with either '.' (when the top-level is a file) or '/'
 	// (when the top-level is a directory).
-	for !ok && len(dir) > 1 {
-		labels, ok = tl.metadata[dir+"/*"]
-		if ok {
-			break
-		}
-
+	for len(dir) > 1 {
+		lbs := tl.metadata[dir+"/*"]
+		labels = append(labels, lbs...)
 		dir = filepath.Dir(dir)
-	}
-
-	if !ok {
-		return false
 	}
 
 	for _, label := range labels {

--- a/api/query/cache/index/index_filter_test.go
+++ b/api/query/cache/index/index_filter_test.go
@@ -862,6 +862,7 @@ func TestBindExecute_LabelWithWildcards(t *testing.T) {
 		"/foo/bar/b.html": {"random"},
 		"/a/*":  {"interop1", "INTEROP2"},
 		"/d/e/f":          {""},
+		matchingTestName:  {"foo"},
 	}
 
 	// Create an execute a plan for `label:interop1 & label:interop2`. Inside the metadata


### PR DESCRIPTION
Fix https://github.com/web-platform-tests/wpt-metadata/issues/4665 and a part of https://github.com/web-platform-tests/wpt.fyi/issues/3448.  Probe directory tree for wildcard matching, regardless if a match has found. 

It should not have much performance impact before and after the change.