### PR TITLE
Correct subtest order

### DIFF
--- a/webapp/components/new-test-results-history-grid.js
+++ b/webapp/components/new-test-results-history-grid.js
@@ -7,8 +7,6 @@
 import { PolymerElement, html } from '../node_modules/@polymer/polymer/polymer-element.js';
 const pageStyle = getComputedStyle(document.body);
 import { PathInfo } from './path.js';
-import { TestRunsUIQuery } from './test-runs-query.js';
-import { TestRunsQueryLoader } from './test-runs.js';
 
 const PASS_COLOR = pageStyle.getPropertyValue('--paper-green-300');
 const FAIL_COLOR = pageStyle.getPropertyValue('--paper-red-300');
@@ -98,7 +96,6 @@ class TestResultsGrid extends PathInfo(PolymerElement) {
   }
 
   displayCharts(showTestHistory, path, rows) {
-    console.log("HERE THE ROWS", rows)
     if (!path || !showTestHistory || !this.computePathIsATestFile(path)) {
       return;
     }
@@ -265,12 +262,10 @@ class TestResultsGrid extends PathInfo(PolymerElement) {
     this.historicalData = await fetch('/api/history', options)
       .then(r => r.json()).then(data => data.results);
 
-    this.subtestNames = []
-    rows.forEach(row => {
-      this.subtestNames.push(row.name)
-    })
-    // this.subtestNames = Object.keys(this.historicalData[BROWSER_NAMES[0]]);
-    console.log(this.subtestNames)
+    this.subtestNames = [''];
+    for (let i = 1; i < rows.length; i++) {
+      this.subtestNames.push(rows[i].name);
+    }
   }
 }
 

--- a/webapp/components/new-test-results-history-grid.js
+++ b/webapp/components/new-test-results-history-grid.js
@@ -83,13 +83,13 @@ class TestResultsGrid extends PathInfo(PolymerElement) {
       runIDs: Array,
       path: String,
       showTestHistory: { type: Boolean, value: false },
-      // testRuns: Array
+      rows: Array,
     };
   }
 
   static get observers() {
     return [
-      'displayCharts(showTestHistory, path, testRuns)',
+      'displayCharts(showTestHistory, path, rows)',
     ];
   }
 
@@ -97,15 +97,15 @@ class TestResultsGrid extends PathInfo(PolymerElement) {
     return 'new-test-results-history-grid';
   }
 
-  displayCharts(showTestHistory, path, testRuns) {
-    console.log(testRuns)
+  displayCharts(showTestHistory, path, rows) {
+    console.log("HERE THE ROWS", rows)
     if (!path || !showTestHistory || !this.computePathIsATestFile(path)) {
       return;
     }
 
     // Get the test history data and then populate the chart
     Promise.all([
-      this.getTestHistory(path),
+      this.getTestHistory(path, rows),
       this.loadCharts()
     ]).then(() => this.updateAllCharts(this.historicalData));
 
@@ -248,7 +248,7 @@ class TestResultsGrid extends PathInfo(PolymerElement) {
   }
 
   // get test history and aligned run data
-  async getTestHistory(path) {
+  async getTestHistory(path, rows) {
     // If there is existing data, clear it to make sure nothing is cached
     if(this.historicalData) {
       this.historicalData = {};

--- a/webapp/components/new-test-results-history-grid.js
+++ b/webapp/components/new-test-results-history-grid.js
@@ -265,6 +265,7 @@ class TestResultsGrid extends PathInfo(PolymerElement) {
     this.historicalData = await fetch('/api/history', options)
       .then(r => r.json()).then(data => data.results);
     this.subtestNames = Object.keys(this.historicalData[BROWSER_NAMES[0]]);
+    console.log(this.subtestNames)
   }
 }
 

--- a/webapp/components/new-test-results-history-grid.js
+++ b/webapp/components/new-test-results-history-grid.js
@@ -80,14 +80,17 @@ class TestResultsGrid extends PathInfo(PolymerElement) {
       dataTable: Object,
       runIDs: Array,
       path: String,
-      showTestHistory: { type: Boolean, value: false },
+      showTestHistory: { 
+        type: Boolean, 
+        value: false 
+      },
       subtestNames: Array,
     };
   }
 
   static get observers() {
     return [
-      'displayCharts(showTestHistory, path)',
+      'displayCharts(showTestHistory, path, subtestNames)',
     ];
   }
 
@@ -95,7 +98,7 @@ class TestResultsGrid extends PathInfo(PolymerElement) {
     return 'new-test-results-history-grid';
   }
 
-  displayCharts(showTestHistory, path) {
+  displayCharts(showTestHistory, path, subtestNames) {
     if (!path || !showTestHistory || !this.computePathIsATestFile(path)) {
       return;
     }
@@ -109,7 +112,7 @@ class TestResultsGrid extends PathInfo(PolymerElement) {
     // Google Charts is not responsive, even if one sets a percentage-width, so
     // we add a resize observer to redraw the chart if the size changes.
     window.addEventListener('resize', () => {
-      this.updateAllCharts(this.historicalData);
+      this.updateAllCharts(subtestNames);
     });
   }
 
@@ -118,7 +121,7 @@ class TestResultsGrid extends PathInfo(PolymerElement) {
     await window.google.charts.load('current', { packages: ['timeline'] });
   }
 
-  updateAllCharts(historicalData) {
+  updateAllCharts(subtestNames) {
     const divNames = [
       'chromeHistoryChart',
       'edgeHistoryChart',
@@ -132,14 +135,14 @@ class TestResultsGrid extends PathInfo(PolymerElement) {
     this.chartRunIDs = [[],[],[],[]];
 
     divNames.forEach((name, i) => {
-      this.updateChart(historicalData[BROWSER_NAMES[i]], name, i);
+      this.updateChart(subtestNames, name, i);
     });
   }
 
-  updateChart(browserTestData, divID, chartIndex) {
+  updateChart(browserTestData, divID, chartIndex, subtestNames) {
     // Our observer may be called before the historical data has been fetched,
     // so debounce that.
-    if (!browserTestData) {
+    if (!browserTestData || !subtestNames) {
       return;
     }
 
@@ -167,8 +170,6 @@ class TestResultsGrid extends PathInfo(PolymerElement) {
     this.chartRunIDs[chartIndex] = [];
 
     // Create a row for each subtest
-    if (this.subtestNames) {
-
       this.subtestNames.forEach(subtestName => {
         if (!browserTestData[subtestName]) {
           return;
@@ -208,8 +209,7 @@ class TestResultsGrid extends PathInfo(PolymerElement) {
           ]);
         }
       });
-    }
-
+    
     const getChartHeight = numOfSubTests => {
       const testHeight = 41;
       const xAxisHeight = 50;

--- a/webapp/components/new-test-results-history-grid.js
+++ b/webapp/components/new-test-results-history-grid.js
@@ -82,7 +82,7 @@ class TestResultsGrid extends PathInfo(PolymerElement) {
       path: String,
       showTestHistory: {
         type: Boolean,
-        value: false
+        value: false,
       },
       subtestNames: Array,
     };

--- a/webapp/components/new-test-results-history-grid.js
+++ b/webapp/components/new-test-results-history-grid.js
@@ -264,7 +264,12 @@ class TestResultsGrid extends PathInfo(PolymerElement) {
 
     this.historicalData = await fetch('/api/history', options)
       .then(r => r.json()).then(data => data.results);
-    this.subtestNames = Object.keys(this.historicalData[BROWSER_NAMES[0]]);
+
+    this.subtestNames = []
+    rows.forEach(row => {
+      this.subtestNames.push(row.name)
+    })
+    // this.subtestNames = Object.keys(this.historicalData[BROWSER_NAMES[0]]);
     console.log(this.subtestNames)
   }
 }

--- a/webapp/components/new-test-results-history-grid.js
+++ b/webapp/components/new-test-results-history-grid.js
@@ -7,6 +7,8 @@
 import { PolymerElement, html } from '../node_modules/@polymer/polymer/polymer-element.js';
 const pageStyle = getComputedStyle(document.body);
 import { PathInfo } from './path.js';
+import { TestRunsUIQuery } from './test-runs-query.js';
+import { TestRunsQueryLoader } from './test-runs.js';
 
 const PASS_COLOR = pageStyle.getPropertyValue('--paper-green-300');
 const FAIL_COLOR = pageStyle.getPropertyValue('--paper-red-300');
@@ -80,13 +82,14 @@ class TestResultsGrid extends PathInfo(PolymerElement) {
       dataTable: Object,
       runIDs: Array,
       path: String,
-      showTestHistory: { type: Boolean, value: false }
+      showTestHistory: { type: Boolean, value: false },
+      // testRuns: Array
     };
   }
 
   static get observers() {
     return [
-      'displayCharts(showTestHistory, path)',
+      'displayCharts(showTestHistory, path, testRuns)',
     ];
   }
 
@@ -94,7 +97,8 @@ class TestResultsGrid extends PathInfo(PolymerElement) {
     return 'new-test-results-history-grid';
   }
 
-  displayCharts(showTestHistory, path) {
+  displayCharts(showTestHistory, path, testRuns) {
+    console.log(testRuns)
     if (!path || !showTestHistory || !this.computePathIsATestFile(path)) {
       return;
     }

--- a/webapp/components/new-test-results-history-grid.js
+++ b/webapp/components/new-test-results-history-grid.js
@@ -80,9 +80,9 @@ class TestResultsGrid extends PathInfo(PolymerElement) {
       dataTable: Object,
       runIDs: Array,
       path: String,
-      showTestHistory: { 
-        type: Boolean, 
-        value: false 
+      showTestHistory: {
+        type: Boolean,
+        value: false
       },
       subtestNames: Array,
     };

--- a/webapp/components/new-test-results-history-grid.js
+++ b/webapp/components/new-test-results-history-grid.js
@@ -95,10 +95,20 @@ class TestResultsGrid extends PathInfo(PolymerElement) {
     return 'new-test-results-history-grid';
   }
 
+  handleGetRows(e) {
+    console.log("event???",e)
+    this.rows = e.detail.val;
+  }
+
   displayCharts(showTestHistory, path, rows) {
     if (!path || !showTestHistory || !this.computePathIsATestFile(path)) {
       return;
     }
+
+    // this.addEventListener('getRows', this.handleGetRows.bind(this));
+    this.addEventListener('getRows', () => {console.log("ya boi")} );
+
+    console.log("HELLO", this.rows)
 
     // Get the test history data and then populate the chart
     Promise.all([

--- a/webapp/components/test-file-results.js
+++ b/webapp/components/test-file-results.js
@@ -315,7 +315,7 @@ class TestFileResults extends WPTFlags(LoadingState(PathInfo(
     } else {
       this.subtestRowCount = 0;
     }
-    this._fireEvent('getSubtestRows', { rows })
+    this._fireEvent('getSubtestRows', { rows });
     return rows;
   }
 

--- a/webapp/components/test-file-results.js
+++ b/webapp/components/test-file-results.js
@@ -55,8 +55,7 @@ class TestFileResults extends WPTFlags(LoadingState(PathInfo(
                              rows="{{rows}}"
                              verbose="[[isVerbose]]"
                              is-triage-mode="[[isTriageMode]]"
-                             metadata-map="[[metadataMap]]"
-                             on-dom-change="getRows">
+                             metadata-map="[[metadataMap]]">
     </test-file-results-table>
 `;
   }
@@ -319,10 +318,6 @@ class TestFileResults extends WPTFlags(LoadingState(PathInfo(
     }
 
     return rows;
-  }
-
-  getRows() {
-    // console.log(this.rows)
   }
 }
 

--- a/webapp/components/test-file-results.js
+++ b/webapp/components/test-file-results.js
@@ -52,7 +52,7 @@ class TestFileResults extends WPTFlags(LoadingState(PathInfo(
                              diff-run="[[diffRun]]"
                              only-show-differences="{{onlyShowDifferences}}"
                              path="[[path]]"
-                             rows="{{rows}}"
+                             rows="[[rows]]"
                              verbose="[[isVerbose]]"
                              is-triage-mode="[[isTriageMode]]"
                              metadata-map="[[metadataMap]]">
@@ -83,7 +83,6 @@ class TestFileResults extends WPTFlags(LoadingState(PathInfo(
       rows: {
         type: Array,
         computed: 'computeRows(resultsTable, onlyShowDifferences)',
-        notify: true,
       },
       subtestRowCount: {
         type: Number,
@@ -316,7 +315,7 @@ class TestFileResults extends WPTFlags(LoadingState(PathInfo(
     } else {
       this.subtestRowCount = 0;
     }
-
+    window.Rows = rows
     return rows;
   }
 }

--- a/webapp/components/test-file-results.js
+++ b/webapp/components/test-file-results.js
@@ -315,7 +315,8 @@ class TestFileResults extends WPTFlags(LoadingState(PathInfo(
     } else {
       this.subtestRowCount = 0;
     }
-    this._fireEvent('getSubtestRows', { rows });
+
+    this._fireEvent('subtestrows', { rows });
     return rows;
   }
 

--- a/webapp/components/test-file-results.js
+++ b/webapp/components/test-file-results.js
@@ -52,10 +52,11 @@ class TestFileResults extends WPTFlags(LoadingState(PathInfo(
                              diff-run="[[diffRun]]"
                              only-show-differences="{{onlyShowDifferences}}"
                              path="[[path]]"
-                             rows="[[rows]]"
+                             rows="{{rows}}"
                              verbose="[[isVerbose]]"
                              is-triage-mode="[[isTriageMode]]"
-                             metadata-map="[[metadataMap]]">
+                             metadata-map="[[metadataMap]]"
+                             on-dom-change="getRows">
     </test-file-results-table>
 `;
   }
@@ -82,7 +83,8 @@ class TestFileResults extends WPTFlags(LoadingState(PathInfo(
       },
       rows: {
         type: Array,
-        computed: 'computeRows(resultsTable, onlyShowDifferences)'
+        computed: 'computeRows(resultsTable, onlyShowDifferences)',
+        notify: true,
       },
       subtestRowCount: {
         type: Number,
@@ -317,6 +319,10 @@ class TestFileResults extends WPTFlags(LoadingState(PathInfo(
     }
 
     return rows;
+  }
+
+  getRows() {
+    // console.log(this.rows)
   }
 }
 

--- a/webapp/components/test-file-results.js
+++ b/webapp/components/test-file-results.js
@@ -315,8 +315,17 @@ class TestFileResults extends WPTFlags(LoadingState(PathInfo(
     } else {
       this.subtestRowCount = 0;
     }
-    window.Rows = rows
+    this._fireEvent('getSubtestRows', { rows })
     return rows;
+  }
+
+  _fireEvent(eventName, detail) {
+    const event = new CustomEvent(eventName, {
+      bubbles: true,
+      composed: true,
+      detail,
+    });
+    this.dispatchEvent(event);
   }
 }
 

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -1275,18 +1275,8 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
 
   showNewHistoryClicked() {
     return () => {
-      this._fireEvent('getRows', { val: window.Rows })
       this.showNewHistory = true
     }
-  }
-
-  _fireEvent(eventName, detail) {
-    const event = new CustomEvent(eventName, {
-      bubbles: true,
-      composed: true,
-      detail,
-    });
-    this.dispatchEvent(event);
   }
 
   queryChanged(query, queryBefore) {

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -388,8 +388,7 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
           <new-test-results-history-grid
             path="[[path]]"
             show-test-history="[[showNewHistory]]"
-            test-runs="[[testRuns]]"
-            rows="[[rows]]">
+            subtest-names="[[subtestNames]]">
           </new-test-results-history-grid>
         </template>
       </template>
@@ -491,6 +490,10 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
         type: Boolean,
         value: false,
       },
+      subtestNames: {
+        type: Array,
+        value:[]
+      },
       resultsLoadFailed: Boolean,
       noResults: Boolean,
       editingQuery: {
@@ -584,6 +587,7 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
   connectedCallback() {
     super.connectedCallback();
     this.addEventListener('triagemetadata', this.reloadPendingMetadata);
+    window.addEventListener('getSubtestRows', this.handleGetSubtestRows.bind(this));
   }
 
   disconnectedCallback() {
@@ -624,6 +628,15 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
     this.displayedTotals = [];
     this.refreshDisplayedNodes();
     this.loadData();
+  }
+
+  handleGetSubtestRows(event) {
+    this.subtestNames = event.detail.rows.map(subtestRow => {
+      if(subtestRow.name === 'Harness status') {
+        return '';
+      }
+      return subtestRow.name;
+    }).filter(subtestName => subtestName !== 'Duration')
   }
 
   fetchResults(q) {

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -585,7 +585,7 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
   connectedCallback() {
     super.connectedCallback();
     this.addEventListener('triagemetadata', this.reloadPendingMetadata);
-    window.addEventListener('getSubtestRows', this.handleGetSubtestRows.bind(this));
+    this.addEventListener('subtestrows', this.handleGetSubtestRows);
   }
 
   disconnectedCallback() {
@@ -1286,7 +1286,7 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
 
   showNewHistoryClicked() {
     return () => {
-      this.showNewHistory = true
+      this.showNewHistory = true;
     }
   }
 

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -250,7 +250,8 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
                            products="[[products]]"
                            diff-run="[[diffRun]]"
                            is-triage-mode="[[isTriageMode]]"
-                           metadata-map="[[metadataMap]]">
+                           metadata-map="[[metadataMap]]"
+                           rows="{{rows}}">
         </test-file-results>
       </template>
     <template is="dom-if" if="[[shouldDisplayToggle(canViewInteropScores, pathIsATestFile)]]">
@@ -387,7 +388,8 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
           <new-test-results-history-grid
             path="[[path]]"
             show-test-history="[[showNewHistory]]"
-            test-runs="[[testRuns]]">
+            test-runs="[[testRuns]]"
+            rows="[[rows]]">
           </new-test-results-history-grid>
         </template>
       </template>
@@ -511,6 +513,7 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
       // path => {type, file[, refPath]} simplification.
       screenshots: Array,
       triageNotifier: Boolean,
+      rows: Array,
     };
   }
 

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -250,8 +250,7 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
                            products="[[products]]"
                            diff-run="[[diffRun]]"
                            is-triage-mode="[[isTriageMode]]"
-                           metadata-map="[[metadataMap]]"
-                           rows="[[rows]]">
+                           metadata-map="[[metadataMap]]">
         </test-file-results>
       </template>
     <template is="dom-if" if="[[shouldDisplayToggle(canViewInteropScores, pathIsATestFile)]]">
@@ -516,7 +515,6 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
       // path => {type, file[, refPath]} simplification.
       screenshots: Array,
       triageNotifier: Boolean,
-      rows: Array,
     };
   }
 

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -386,7 +386,8 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
         <template is="dom-if" if="[[pathIsATestFile]]">
           <new-test-results-history-grid
             path="[[path]]"
-            show-test-history="[[showNewHistory]]">
+            show-test-history="[[showNewHistory]]"
+            test-runs="[[testRuns]]">
           </new-test-results-history-grid>
         </template>
       </template>

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -371,7 +371,7 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
       <div class="history">
         <template is="dom-if" if="[[!showHistory]]">
           <template is="dom-if" if="[[historyTimeline]]">
-            <paper-button id="show-history" onclick="[[showNewHistoryClicked]]" raised>
+            <paper-button id="show-history" onclick="[[showNewHistoryClicked()]]" raised>
               Show New history
             </paper-button>
           </template>
@@ -1274,10 +1274,19 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
   }
 
   showNewHistoryClicked() {
-    console.log("WHERE THEY GO", window.Rows)
-    // return () => {
-      this.showNewHistory = true;
-    // };
+    return () => {
+      this._fireEvent('getRows', { val: window.Rows })
+      this.showNewHistory = true
+    }
+  }
+
+  _fireEvent(eventName, detail) {
+    const event = new CustomEvent(eventName, {
+      bubbles: true,
+      composed: true,
+      detail,
+    });
+    this.dispatchEvent(event);
   }
 
   queryChanged(query, queryBefore) {

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -251,7 +251,7 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
                            diff-run="[[diffRun]]"
                            is-triage-mode="[[isTriageMode]]"
                            metadata-map="[[metadataMap]]"
-                           rows="{{rows}}">
+                           rows="[[rows]]">
         </test-file-results>
       </template>
     <template is="dom-if" if="[[shouldDisplayToggle(canViewInteropScores, pathIsATestFile)]]">
@@ -371,7 +371,7 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
       <div class="history">
         <template is="dom-if" if="[[!showHistory]]">
           <template is="dom-if" if="[[historyTimeline]]">
-            <paper-button id="show-history" onclick="[[showNewHistoryClicked()]]" raised>
+            <paper-button id="show-history" onclick="[[showNewHistoryClicked]]" raised>
               Show New history
             </paper-button>
           </template>
@@ -1274,9 +1274,10 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
   }
 
   showNewHistoryClicked() {
-    return () => {
+    console.log("WHERE THEY GO", window.Rows)
+    // return () => {
       this.showNewHistory = true;
-    };
+    // };
   }
 
   queryChanged(query, queryBefore) {


### PR DESCRIPTION
This PR fixes issue #3473 by correcting the order in which subtests appear. Previously they were appearing in alphabetical order. Now the subtest names are being imported from the row info on the table above, so they should appear in the same order.

Edit: Logic refactored to use event listeners instead of two-way data binding.