### PR TITLE
No historical test data quick bug fix

### DIFF
--- a/webapp/components/new-test-results-history-grid.js
+++ b/webapp/components/new-test-results-history-grid.js
@@ -244,7 +244,11 @@ class TestResultsGrid extends PathInfo(PolymerElement) {
     window.google.visualization.events.addListener(
       this.charts[chartIndex], 'select', () => statusSelectHandler(chartIndex));
 
-    this.charts[chartIndex].draw(this.dataTable, options);
+    if (dataTableRows > 0) {
+      this.charts[chartIndex].draw(this.dataTable, options);
+    } else {
+      div.innerHTML = 'No browser historical data found for this test.';
+    }
   }
 
   // get test history and aligned run data

--- a/webapp/components/new-test-results-history-grid.js
+++ b/webapp/components/new-test-results-history-grid.js
@@ -244,7 +244,7 @@ class TestResultsGrid extends PathInfo(PolymerElement) {
     window.google.visualization.events.addListener(
       this.charts[chartIndex], 'select', () => statusSelectHandler(chartIndex));
 
-    if (dataTableRows > 0) {
+    if (dataTableRows.length > 0) {
       this.charts[chartIndex].draw(this.dataTable, options);
     } else {
       div.innerHTML = 'No browser historical data found for this test.';

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -630,10 +630,11 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
 
   handleGetSubtestRows(event) {
     this.subtestNames = event.detail.rows.map(subtestRow => {
-      if(subtestRow.name === 'Harness status') {
+      // The overall test status is given as an empty string.
+      if(subtestRow.name === 'Harness status' || subtestRow.name === 'Test status') {
         return '';
       }
-      return subtestRow.name;
+      return subtestRow.name.replace(/\s/g, ' ');
     }).filter(subtestName => subtestName !== 'Duration')
   }
 


### PR DESCRIPTION
Found a quick fix for a bug caused from a test having no historical data available. Also, an update to clean the subtest name the same new way that the processing script does.