### PR TITLE
Fix #3009: unable to search for mixed case filenames

### DIFF
--- a/webapp/components/test-search.js
+++ b/webapp/components/test-search.js
@@ -510,7 +510,7 @@ class TestSearch extends WPTFlags(PolymerElement) {
   }
 
   latchQuery() {
-    this.query = (this.queryInput || '').toLowerCase();
+    this.query = (this.queryInput || '');
   }
 
   commitQuery() {

--- a/webapp/components/test/test-search.html
+++ b/webapp/components/test/test-search.html
@@ -17,6 +17,7 @@
   <script type="module">
 import { AllBrowserNames } from '../product-info.js';
 import { TestSearch } from '../test-search.js';
+import { waitingOn } from './util/helpers.js';
 
 suite('<test-search>', () => {
   suite('Parser/interpreter', () => {
@@ -453,6 +454,25 @@ suite('<test-search>', () => {
           { exists: [{ pattern: '2dcontext' }] },
           { all: [{ status: 'FAIL' }] },
         ]
+      });
+    });
+  });
+  suite('TestSearch.prototype.*', () => {
+    suite('async latchQuery()', () => {
+      let search_fixture;
+
+      setup(() => {
+        search_fixture = fixture('test-search-fixture');
+      });
+
+      test('does not lowerCase', () => {
+        search_fixture.queryInput = "shadow-dom/DocumentOrShadowRoot-prototype-elementFromPoint.html";
+        return waitingOn(() => search_fixture.structuredQuery)
+          .then(() => {
+            assert.equal(search_fixture.structuredQuery, {
+              exists: [{ pattern: 'shadow-dom/DocumentOrShadowRoot-prototype-elementFromPoint.html' }]
+            });
+          });
       });
     });
   });


### PR DESCRIPTION
Fixes #3009.

I'm not sure why the test fails, as far as I can tell from https://polymer-library.polymer-project.org/3.0/docs/devguide/data-system setting `queryInput` should be running the `queryInputChanged` observer, which should call `latchQuery` after half a second, which sets `query`, which should call the `queryUpdated` observer, which should set `structuredQuery`?