### PR TITLE
Ignore version and os_build conflicts

### DIFF
--- a/results-processor/wptreport.py
+++ b/results-processor/wptreport.py
@@ -37,7 +37,8 @@ DEFAULT_PROJECT = 'wptdashboard'
 RELEASE_CHANNEL_LABELS = frozenset({'stable', 'beta', 'experimental'})
 # Ignore inconsistent browser minor versions for now.
 # TODO(Hexcles): Remove this when the TC decision task is implemented.
-IGNORED_CONFLICTS = frozenset({'browser_build_id', 'browser_changeset'})
+IGNORED_CONFLICTS = frozenset({'browser_build_id', 'browser_changeset',
+                               'version', 'os_build'})
 
 # A map of abbreviations for test statuses. This will be used
 # to convert test statuses to smaller formats to store in summary files.

--- a/results-processor/wptreport_test.py
+++ b/results-processor/wptreport_test.py
@@ -188,6 +188,8 @@ class WPTReportTest(unittest.TestCase):
                 'run_info': {
                     'browser_build_id': '1',
                     'browser_changeset': 'r1',
+                    'version': 'v1',
+                    'os_build': 'b1',
                 },
             }, f)
         with open(tmp_path, 'rb') as f:
@@ -199,12 +201,16 @@ class WPTReportTest(unittest.TestCase):
                 'run_info': {
                     'browser_build_id': '2',
                     'browser_changeset': 'r2',
+                    'version': 'v2',
+                    'os_build': 'b2',
                 },
             }, f)
         with open(tmp_path, 'rb') as f:
             r.load_json(f)
         self.assertIsNone(r.run_info['browser_build_id'])
         self.assertIsNone(r.run_info['browser_changeset'])
+        self.assertIsNone(r.run_info['version'])
+        self.assertIsNone(r.run_info['os_build'])
 
     def test_load_gzip_json(self):
         # This case also covers the Unicode testing of load_json().


### PR DESCRIPTION
Since we don't control the OS versions we get from Azure, we can't guarantee there will be no conflicting versions. 