### PR TITLE
Ensure Chrome Canary logo is used

### DIFF
--- a/webapp/components/product-info.js
+++ b/webapp/components/product-info.js
@@ -166,7 +166,7 @@ const ProductInfo = (superClass) => class extends superClass {
     }
     labels = new Set(labels);
     // Special case for Chrome nightly, which is in fact Chromium ToT:
-    if (name === 'chrome' && labels.has('nightly')) {
+    if (name === 'chrome' && labels.has('nightly') && !labels.has('canary')) {
       name = 'chromium';
 
     } else if (name === 'android_webview') {


### PR DESCRIPTION
Chrome Canary runs can have both the "nightly" and "canary" labels. Some special logic will label old "nightly" Chrome runs with the Chromium logo. Now that we're expecting to have canary runs for Chrome, the logic needs to be adjusted to not give Chrome Canary the Chromium logo.