### PR TITLE
Add default Interop dashboard URL route

### DIFF
--- a/webapp/components/wpt-header.js
+++ b/webapp/components/wpt-header.js
@@ -63,7 +63,7 @@ class WPTHeader extends WPTFlags(PolymerElement) {
         <!-- TODO: handle onclick with wpt-results.navigate if available -->
         <a href="/">Latest Run</a>
         <a href="/runs">Recent Runs</a>
-        <a href="/interop-2023">&#10024;Interop 2023&#10024;</a>
+        <a href="/interop">&#10024;Interop 2023&#10024;</a>
         <a href="/insights">Insights</a>
         <template is="dom-if" if="[[processorTab]]">
           <a href="/status">Processor</a>

--- a/webapp/interop_handler.go
+++ b/webapp/interop_handler.go
@@ -29,8 +29,8 @@ func interopHandler(w http.ResponseWriter, r *http.Request) {
 	name := mux.Vars(r)["name"]
 	year := mux.Vars(r)["year"]
 
-	// /compat20XX redirects to /interop-20XX
-	needsRedirect := name == "compat"
+	// /compat20XX and /interop20XX redirect to /interop-20XX
+	needsRedirect := name == "compat" || name == "interop"
 	if _, ok := validYears[year]; !ok {
 		year = defaultRedirectYear
 		needsRedirect = true

--- a/webapp/interop_handler.go
+++ b/webapp/interop_handler.go
@@ -29,8 +29,8 @@ func interopHandler(w http.ResponseWriter, r *http.Request) {
 	name := mux.Vars(r)["name"]
 	year := mux.Vars(r)["year"]
 
-	// /compat20XX and /interop20XX redirect to /interop-20XX
-	needsRedirect := name == "compat" || name == "interop"
+	// /compat20XX redirects to /interop-20XX
+	needsRedirect := name == "compat"
 	if _, ok := validYears[year]; !ok {
 		year = defaultRedirectYear
 		needsRedirect = true

--- a/webapp/interop_handler_test.go
+++ b/webapp/interop_handler_test.go
@@ -1,3 +1,4 @@
+//go:build small
 // +build small
 
 package webapp
@@ -32,7 +33,7 @@ func TestInteropHandler_redirect(t *testing.T) {
 
 	loc, err := resp.Location()
 	assert.Nil(t, err)
-	// Check if embedded param is maintained after redirect.
+	// Check that the path has been properly updated to the current interop effort.
 	assert.Equal(t, loc.Path, "/interop-2023")
 	// Check if embedded param is maintained after redirect.
 	assert.Equal(t, loc.RawQuery, "embedded")
@@ -53,7 +54,7 @@ func TestInteropHandler_redirectdefault(t *testing.T) {
 
 	loc, err := resp.Location()
 	assert.Nil(t, err)
-	// Check if embedded param is maintained after redirect.
+	// Check that the path has been properly updated to the current interop effort.
 	assert.Equal(t, loc.Path, "/interop-2023")
 	// Check if embedded param is maintained after redirect.
 	assert.Equal(t, loc.RawQuery, "embedded")

--- a/webapp/interop_handler_test.go
+++ b/webapp/interop_handler_test.go
@@ -1,4 +1,3 @@
-//go:build small
 // +build small
 
 package webapp

--- a/webapp/interop_handler_test.go
+++ b/webapp/interop_handler_test.go
@@ -33,10 +33,12 @@ func TestInteropHandler_redirect(t *testing.T) {
 	loc, err := resp.Location()
 	assert.Nil(t, err)
 	// Check if embedded param is maintained after redirect.
-	assert.NotEqual(t, loc.Path, "interop-2022?embedded")
+	assert.Equal(t, loc.Path, "/interop-2023")
+	// Check if embedded param is maintained after redirect.
+	assert.Equal(t, loc.RawQuery, "embedded")
 }
 
-func TestInteropHandler_redirect(t *testing.T) {
+func TestInteropHandler_redirectdefault(t *testing.T) {
 	// /interop route should redirect to the current default interop year dashboard.
 	req := httptest.NewRequest("GET", "/interop?embedded", strings.NewReader("{}"))
 	req = mux.SetURLVars(req, map[string]string{
@@ -52,7 +54,9 @@ func TestInteropHandler_redirect(t *testing.T) {
 	loc, err := resp.Location()
 	assert.Nil(t, err)
 	// Check if embedded param is maintained after redirect.
-	assert.NotEqual(t, loc.Path, "interop-2023?embedded")
+	assert.Equal(t, loc.Path, "/interop-2023")
+	// Check if embedded param is maintained after redirect.
+	assert.Equal(t, loc.RawQuery, "embedded")
 }
 
 func TestInteropHandler_compatRedirect(t *testing.T) {

--- a/webapp/interop_handler_test.go
+++ b/webapp/interop_handler_test.go
@@ -36,6 +36,25 @@ func TestInteropHandler_redirect(t *testing.T) {
 	assert.NotEqual(t, loc.Path, "interop-2022?embedded")
 }
 
+func TestInteropHandler_redirect(t *testing.T) {
+	// /interop route should redirect to the current default interop year dashboard.
+	req := httptest.NewRequest("GET", "/interop?embedded", strings.NewReader("{}"))
+	req = mux.SetURLVars(req, map[string]string{
+		"name":     "interop",
+		"embedded": "true",
+	})
+
+	w := httptest.NewRecorder()
+	interopHandler(w, req)
+	resp := w.Result()
+	assert.Equal(t, resp.StatusCode, http.StatusTemporaryRedirect)
+
+	loc, err := resp.Location()
+	assert.Nil(t, err)
+	// Check if embedded param is maintained after redirect.
+	assert.NotEqual(t, loc.Path, "interop-2023?embedded")
+}
+
 func TestInteropHandler_compatRedirect(t *testing.T) {
 	// "/compat20XX" paths should redirect to the interop version of the given year.
 	req := httptest.NewRequest("GET", "/compat2021", strings.NewReader("{}"))

--- a/webapp/routes.go
+++ b/webapp/routes.go
@@ -37,8 +37,11 @@ func RegisterRoutes() {
 	shared.AddRoute("/runs", "test-runs", testRunsHandler)
 	shared.AddRoute("/test-runs", "test-runs", testRunsHandler) // Legacy name
 
-	// Dashboard for the interop effort, by year. Defaults to current year.
-	shared.AddRoute("/{name:(?:compat|interop-?)}{year:[0-9]*}", "interop-dashboard", interopHandler)
+	// Dashboard for the interop effort, by year.
+	shared.AddRoute("/{name:(?:compat|interop-)}{year:[0-9]+}", "interop-dashboard", interopHandler)
+
+	// Redirect to current year's interop effort.
+	shared.AddRoute("/interop", "interop-dashboard", interopHandler)
 
 	// Admin-only manual results upload.
 	shared.AddRoute("/admin/results/upload", "admin-results-upload", adminUploadHandler)

--- a/webapp/routes.go
+++ b/webapp/routes.go
@@ -37,11 +37,8 @@ func RegisterRoutes() {
 	shared.AddRoute("/runs", "test-runs", testRunsHandler)
 	shared.AddRoute("/test-runs", "test-runs", testRunsHandler) // Legacy name
 
-	// Dashboard for the interop effort, by year.
-	shared.AddRoute("/{name:(?:compat|interop-)}{year:[0-9]+}", "interop-dashboard", interopHandler)
-
-	// Default interop dashboard route that defaults to current year.
-	shared.AddRoute("/interop", "interop-dashboard", interopHandler)
+	// Dashboard for the interop effort, by year. Defaults to current year.
+	shared.AddRoute("/{name:(?:compat|interop-?)}{year:[0-9]*}", "interop-dashboard", interopHandler)
 
 	// Admin-only manual results upload.
 	shared.AddRoute("/admin/results/upload", "admin-results-upload", adminUploadHandler)

--- a/webapp/routes.go
+++ b/webapp/routes.go
@@ -40,6 +40,9 @@ func RegisterRoutes() {
 	// Dashboard for the interop effort, by year.
 	shared.AddRoute("/{name:(?:compat|interop-)}{year:[0-9]+}", "interop-dashboard", interopHandler)
 
+	// Default interop dashboard route that defaults to current year.
+	shared.AddRoute("/interop", "interop-dashboard", interopHandler)
+
 	// Admin-only manual results upload.
 	shared.AddRoute("/admin/results/upload", "admin-results-upload", adminUploadHandler)
 


### PR DESCRIPTION
Fixes #3641

This change makes the `/interop` route redirect to the interop dashboard of the current active interop effort.