### PR TITLE
Add WebFeaturesData container [Part 1/4]

### DIFF
--- a/shared/web_features.go
+++ b/shared/web_features.go
@@ -1,0 +1,109 @@
+// Copyright 2024 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package shared
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// WebFeaturesData is the public data type that represents the data parsed from
+// a given manifest file
+type WebFeaturesData map[string]map[string]interface{}
+
+// ErrUnknownWebFeaturesManifestVersion indicates that the parser does not know how to parse
+// this version of the web features file.
+var ErrUnknownWebFeaturesManifestVersion = errors.New("unknown web features manifest version")
+
+// ErrBadWebFeaturesManifestJSON indicates that there was an error parsing the given
+// v1 manifest file.
+var ErrBadWebFeaturesManifestJSON = errors.New("invalid json when reading web features manifest")
+
+// ErrUnexpectedWebFeaturesManifestV1Format indicates that there was an error parsing the given
+// v1 manifest file.
+var ErrUnexpectedWebFeaturesManifestV1Format = errors.New("unexpected web features manifest v1 format")
+
+// TestMatchesWithWebFeature performs two checks.
+// If the given test path is present in the data. If not, return false
+// If it is present, check if the given web feature applies to that test.
+func (d WebFeaturesData) TestMatchesWithWebFeature(test, webFeature string) bool {
+	if len(d) == 0 {
+		return false
+	}
+	if webFeatures, ok := d[test]; ok {
+		_, found := webFeatures[strings.ToLower(webFeature)]
+
+		return found
+	}
+
+	return false
+}
+
+// webFeaturesManifestFile is the base format for any manifest file.
+type webFeaturesManifestFile struct {
+	Version int             `json:"version,omitempty"`
+	Data    json.RawMessage `json:"data,omitempty"`
+}
+
+// webFeaturesManifestV1Data represents the data section in the manifest file
+// given manifest version 1.
+// The data is a simple map.
+// The key is the web feature key
+// The value is a list of tests that are part of that web feature.
+type webFeaturesManifestV1Data map[string][]webFeaturesManifestV1DataTest
+
+type webFeaturesManifestV1DataTest struct {
+	URL string `json:"url"`
+}
+
+// WebFeaturesManifestJSONParser is parser that can interpret a Web Features Manifest in a JSON format
+type WebFeaturesManifestJSONParser struct{}
+
+// Parse parses a JSON file into a WebFeaturesData instance.
+func (p WebFeaturesManifestJSONParser) Parse(ctx context.Context, r io.ReadCloser) (WebFeaturesData, error) {
+	defer r.Close()
+	file := webFeaturesManifestFile{}
+	err := json.NewDecoder(r).Decode(&file)
+	if err != nil {
+		return nil, errors.Join(ErrBadWebFeaturesManifestJSON, err)
+	}
+
+	switch file.Version {
+	case 1:
+		data := new(webFeaturesManifestV1Data)
+		err = json.Unmarshal(file.Data, data)
+		if err != nil {
+			return nil, errors.Join(ErrUnexpectedWebFeaturesManifestV1Format, err)
+		}
+
+		return data.prepareTestWebFeatureFilter(), nil
+	}
+
+	return nil, fmt.Errorf("bad version %d %w", file.Version, ErrUnknownWebFeaturesManifestVersion)
+}
+
+// PrepareTestWebFeatureFilter maps a MetadataResult test name to its web features.
+func (d webFeaturesManifestV1Data) prepareTestWebFeatureFilter() WebFeaturesData {
+	// Create a map where the value is effectively a set (map[string]interface{})
+	testToWebFeaturesMap := make(map[string]map[string]interface{})
+	for webFeature, tests := range d {
+		for _, test := range tests {
+			key := strings.ToLower(test.URL)
+			value := strings.ToLower(webFeature)
+			if set, found := testToWebFeaturesMap[key]; found {
+				set[value] = nil
+				testToWebFeaturesMap[key] = set
+			} else {
+				testToWebFeaturesMap[key] = map[string]interface{}{value: nil}
+			}
+		}
+	}
+
+	return testToWebFeaturesMap
+}

--- a/shared/web_features.go
+++ b/shared/web_features.go
@@ -56,11 +56,7 @@ type webFeaturesManifestFile struct {
 // The data is a simple map.
 // The key is the web feature key
 // The value is a list of tests that are part of that web feature.
-type webFeaturesManifestV1Data map[string][]webFeaturesManifestV1DataTest
-
-type webFeaturesManifestV1DataTest struct {
-	URL string `json:"url"`
-}
+type webFeaturesManifestV1Data map[string][]string
 
 // WebFeaturesManifestJSONParser is parser that can interpret a Web Features Manifest in a JSON format.
 type WebFeaturesManifestJSONParser struct{}
@@ -94,7 +90,7 @@ func (d webFeaturesManifestV1Data) prepareTestWebFeatureFilter() WebFeaturesData
 	testToWebFeaturesMap := make(map[string]map[string]interface{})
 	for webFeature, tests := range d {
 		for _, test := range tests {
-			key := strings.ToLower(test.URL)
+			key := strings.ToLower(test)
 			value := strings.ToLower(webFeature)
 			if set, found := testToWebFeaturesMap[key]; found {
 				set[value] = nil

--- a/shared/web_features.go
+++ b/shared/web_features.go
@@ -17,17 +17,17 @@ import (
 // a given manifest file
 type WebFeaturesData map[string]map[string]interface{}
 
-// ErrUnknownWebFeaturesManifestVersion indicates that the parser does not know how to parse
+// errUnknownWebFeaturesManifestVersion indicates that the parser does not know how to parse
 // this version of the web features file.
-var ErrUnknownWebFeaturesManifestVersion = errors.New("unknown web features manifest version")
+var errUnknownWebFeaturesManifestVersion = errors.New("unknown web features manifest version")
 
-// ErrBadWebFeaturesManifestJSON indicates that there was an error parsing the given
+// errBadWebFeaturesManifestJSON indicates that there was an error parsing the given
 // v1 manifest file.
-var ErrBadWebFeaturesManifestJSON = errors.New("invalid json when reading web features manifest")
+var errBadWebFeaturesManifestJSON = errors.New("invalid json when reading web features manifest")
 
-// ErrUnexpectedWebFeaturesManifestV1Format indicates that there was an error parsing the given
+// errUnexpectedWebFeaturesManifestV1Format indicates that there was an error parsing the given
 // v1 manifest file.
-var ErrUnexpectedWebFeaturesManifestV1Format = errors.New("unexpected web features manifest v1 format")
+var errUnexpectedWebFeaturesManifestV1Format = errors.New("unexpected web features manifest v1 format")
 
 // TestMatchesWithWebFeature performs two checks.
 // If the given test path is present in the data. If not, return false
@@ -71,7 +71,7 @@ func (p WebFeaturesManifestJSONParser) Parse(ctx context.Context, r io.ReadClose
 	file := webFeaturesManifestFile{}
 	err := json.NewDecoder(r).Decode(&file)
 	if err != nil {
-		return nil, errors.Join(ErrBadWebFeaturesManifestJSON, err)
+		return nil, errors.Join(errBadWebFeaturesManifestJSON, err)
 	}
 
 	switch file.Version {
@@ -79,13 +79,13 @@ func (p WebFeaturesManifestJSONParser) Parse(ctx context.Context, r io.ReadClose
 		data := new(webFeaturesManifestV1Data)
 		err = json.Unmarshal(file.Data, data)
 		if err != nil {
-			return nil, errors.Join(ErrUnexpectedWebFeaturesManifestV1Format, err)
+			return nil, errors.Join(errUnexpectedWebFeaturesManifestV1Format, err)
 		}
 
 		return data.prepareTestWebFeatureFilter(), nil
 	}
 
-	return nil, fmt.Errorf("bad version %d %w", file.Version, ErrUnknownWebFeaturesManifestVersion)
+	return nil, fmt.Errorf("bad version %d %w", file.Version, errUnknownWebFeaturesManifestVersion)
 }
 
 // PrepareTestWebFeatureFilter maps a MetadataResult test name to its web features.

--- a/shared/web_features.go
+++ b/shared/web_features.go
@@ -14,7 +14,7 @@ import (
 )
 
 // WebFeaturesData is the public data type that represents the data parsed from
-// a given manifest file
+// a given manifest file.
 type WebFeaturesData map[string]map[string]interface{}
 
 // errUnknownWebFeaturesManifestVersion indicates that the parser does not know how to parse
@@ -62,14 +62,14 @@ type webFeaturesManifestV1DataTest struct {
 	URL string `json:"url"`
 }
 
-// WebFeaturesManifestJSONParser is parser that can interpret a Web Features Manifest in a JSON format
+// WebFeaturesManifestJSONParser is parser that can interpret a Web Features Manifest in a JSON format.
 type WebFeaturesManifestJSONParser struct{}
 
 // Parse parses a JSON file into a WebFeaturesData instance.
-func (p WebFeaturesManifestJSONParser) Parse(ctx context.Context, r io.ReadCloser) (WebFeaturesData, error) {
+func (p WebFeaturesManifestJSONParser) Parse(_ context.Context, r io.ReadCloser) (WebFeaturesData, error) {
 	defer r.Close()
-	file := webFeaturesManifestFile{}
-	err := json.NewDecoder(r).Decode(&file)
+	file := new(webFeaturesManifestFile)
+	err := json.NewDecoder(r).Decode(file)
 	if err != nil {
 		return nil, errors.Join(errBadWebFeaturesManifestJSON, err)
 	}

--- a/shared/web_features_manifest_util.go
+++ b/shared/web_features_manifest_util.go
@@ -1,0 +1,43 @@
+// Copyright 2024 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package shared
+
+import (
+	"context"
+	"io"
+)
+
+// GetWPTWebFeaturesManifest is the entrypoint for handling web features manifest downloads.
+// It includes two generic steps: Downloading and Parsing.
+func GetWPTWebFeaturesManifest(ctx context.Context, downloader WebFeaturesManifestDownloader, parser WebFeatureManifestParser) (WebFeaturesData, error) {
+	manifest, err := downloader.Download(ctx)
+	if err != nil {
+		return nil, nil
+	}
+	data, err := parser.Parse(ctx, manifest)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+// WebFeaturesManifestDownloader provides an interface for downloading a manifest file.
+// Typically implementers of the interface create a struct based on the location of the file.
+// For example: GitHub.
+type WebFeaturesManifestDownloader interface {
+	Download(context.Context) (io.ReadCloser, error)
+}
+
+// WebFeatureManifestParser provides an interface on how to parse a given manifest.
+// Typically implementers of the interface create a struct per type of file.
+// For example: JSON file or YAML file
+type WebFeatureManifestParser interface {
+	// Parse reads the stream of data and returns a map.
+	// The map mirrors the structure of MetadataResults where the key is the
+	// test name and the value is the actual data. In this case the "data" is a
+	// collection of applicable web features
+	Parse(context.Context, io.ReadCloser) (WebFeaturesData, error)
+}

--- a/shared/web_features_manifest_util.go
+++ b/shared/web_features_manifest_util.go
@@ -14,7 +14,7 @@ import (
 func GetWPTWebFeaturesManifest(ctx context.Context, downloader WebFeaturesManifestDownloader, parser WebFeatureManifestParser) (WebFeaturesData, error) {
 	manifest, err := downloader.Download(ctx)
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 	data, err := parser.Parse(ctx, manifest)
 	if err != nil {

--- a/shared/web_features_manifest_util.go
+++ b/shared/web_features_manifest_util.go
@@ -11,7 +11,10 @@ import (
 
 // GetWPTWebFeaturesManifest is the entrypoint for handling web features manifest downloads.
 // It includes two generic steps: Downloading and Parsing.
-func GetWPTWebFeaturesManifest(ctx context.Context, downloader WebFeaturesManifestDownloader, parser WebFeatureManifestParser) (WebFeaturesData, error) {
+func GetWPTWebFeaturesManifest(
+	ctx context.Context,
+	downloader WebFeaturesManifestDownloader,
+	parser WebFeatureManifestParser) (WebFeaturesData, error) {
 	manifest, err := downloader.Download(ctx)
 	if err != nil {
 		return nil, err
@@ -33,7 +36,7 @@ type WebFeaturesManifestDownloader interface {
 
 // WebFeatureManifestParser provides an interface on how to parse a given manifest.
 // Typically implementers of the interface create a struct per type of file.
-// For example: JSON file or YAML file
+// For example: JSON file or YAML file.
 type WebFeatureManifestParser interface {
 	// Parse reads the stream of data and returns a map.
 	// The map mirrors the structure of MetadataResults where the key is the

--- a/shared/web_features_manifest_util_test.go
+++ b/shared/web_features_manifest_util_test.go
@@ -1,0 +1,82 @@
+// Copyright 2024 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+//go:build small
+
+package shared
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// --- Test Data ---
+
+// Sample (valid) WebFeaturesData
+var sampleWebFeaturesData = WebFeaturesData{
+	"test1": {"featureA": nil, "featureB": nil},
+}
+
+type mockDownloader struct {
+	returnData io.ReadCloser
+	returnErr  error
+}
+
+func (m *mockDownloader) Download(ctx context.Context) (io.ReadCloser, error) {
+	return m.returnData, m.returnErr
+}
+
+// --- Mocked Parser ---
+
+type mockParser struct {
+	returnData WebFeaturesData
+	returnErr  error
+}
+
+func (m *mockParser) Parse(ctx context.Context, manifest io.ReadCloser) (WebFeaturesData, error) {
+	return m.returnData, m.returnErr
+}
+
+func TestGetWPTWebFeaturesManifest(t *testing.T) {
+	testCases := []struct {
+		name           string
+		mockDownloader *mockDownloader
+		mockParser     *mockParser
+		expectedData   WebFeaturesData
+		expectedError  error
+	}{
+		{
+			name:           "Success",
+			mockDownloader: &mockDownloader{returnData: io.NopCloser(strings.NewReader(`{}`))},
+			mockParser:     &mockParser{returnData: sampleWebFeaturesData},
+			expectedData:   sampleWebFeaturesData,
+			expectedError:  nil,
+		},
+		{
+			name:           "Downloader Error",
+			mockDownloader: &mockDownloader{returnErr: errors.New("Download failed")},
+			// ... (mockParser doesn't matter in this case)
+			expectedError: errors.New("Download failed"),
+		},
+		{
+			name:           "Parser Error",
+			mockDownloader: &mockDownloader{returnData: io.NopCloser(strings.NewReader(`{}`))},
+			mockParser:     &mockParser{returnErr: errors.New("Parsing failed")},
+			expectedError:  errors.New("Parsing failed"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := GetWPTWebFeaturesManifest(context.Background(), tc.mockDownloader, tc.mockParser)
+			assert.Equal(t, tc.expectedData, result)
+			assert.Equal(t, tc.expectedError, err)
+		})
+	}
+}

--- a/shared/web_features_test.go
+++ b/shared/web_features_test.go
@@ -85,19 +85,19 @@ func TestWebFeaturesManifestJSONParser_Parse(t *testing.T) {
 			name:          "invalid manifest JSON",
 			inputJSON:     `{"version": 1, "data": invalid}`,
 			expectedData:  nil,
-			expectedError: ErrBadWebFeaturesManifestJSON,
+			expectedError: errBadWebFeaturesManifestJSON,
 		},
 		{
 			name:          "invalid manifest v1 JSON",
 			inputJSON:     `{"version": 1, "data": "invalid"}`,
 			expectedData:  nil,
-			expectedError: ErrUnexpectedWebFeaturesManifestV1Format,
+			expectedError: errUnexpectedWebFeaturesManifestV1Format,
 		},
 		{
 			name:          "unknown manifest version",
 			inputJSON:     `{"version": 2}`,
 			expectedData:  nil,
-			expectedError: ErrUnknownWebFeaturesManifestVersion,
+			expectedError: errUnknownWebFeaturesManifestVersion,
 		},
 	}
 

--- a/shared/web_features_test.go
+++ b/shared/web_features_test.go
@@ -1,0 +1,133 @@
+// Copyright 2024 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+//go:build small
+
+package shared
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWebFeaturesData_TestMatchesWithWebFeature(t *testing.T) {
+	// Test cases for TestMatchesWithWebFeature
+	tests := []struct {
+		name       string
+		data       WebFeaturesData
+		test       string
+		webFeature string
+		expected   bool
+	}{
+		{
+			name:       "test matches with web feature",
+			data:       WebFeaturesData{"test1": map[string]interface{}{"feature1": nil, "feature2": nil}},
+			test:       "test1",
+			webFeature: "feature1",
+			expected:   true,
+		},
+		{
+			name:       "test doesn't match with web feature",
+			data:       WebFeaturesData{"test1": map[string]interface{}{"feature1": nil, "feature2": nil}},
+			test:       "test1",
+			webFeature: "feature3",
+			expected:   false,
+		},
+		{
+			name:       "test not present in data",
+			data:       WebFeaturesData{},
+			test:       "test1",
+			webFeature: "feature1",
+			expected:   false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.data.TestMatchesWithWebFeature(tc.test, tc.webFeature)
+			assert.Equal(t, result, tc.expected)
+		})
+	}
+}
+
+func TestWebFeaturesManifestJSONParser_Parse(t *testing.T) {
+	// Test cases for Parse
+	tests := []struct {
+		name          string
+		inputJSON     string
+		expectedData  WebFeaturesData
+		expectedError error
+	}{
+		{
+			name:      "valid manifest version 1",
+			inputJSON: `{"version": 1, "data": {"feature1": [{"path": "test1", "url": "/test1"}, {"path": "test2", "url": "/test2"}], "feature2": [{"path": "test1", "url": "/test1"}, {"path": "test3", "url": "/test3"}]}}`,
+			expectedData: WebFeaturesData{
+				"/test1": map[string]interface{}{
+					"feature1": nil,
+					"feature2": nil,
+				},
+				"/test2": map[string]interface{}{
+					"feature1": nil,
+				},
+				"/test3": map[string]interface{}{
+					"feature2": nil,
+				},
+			},
+			expectedError: nil,
+		},
+		{
+			name:          "invalid manifest JSON",
+			inputJSON:     `{"version": 1, "data": invalid}`,
+			expectedData:  nil,
+			expectedError: ErrBadWebFeaturesManifestJSON,
+		},
+		{
+			name:          "invalid manifest v1 JSON",
+			inputJSON:     `{"version": 1, "data": "invalid"}`,
+			expectedData:  nil,
+			expectedError: ErrUnexpectedWebFeaturesManifestV1Format,
+		},
+		{
+			name:          "unknown manifest version",
+			inputJSON:     `{"version": 2}`,
+			expectedData:  nil,
+			expectedError: ErrUnknownWebFeaturesManifestVersion,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			parser := WebFeaturesManifestJSONParser{}
+			r := io.NopCloser(strings.NewReader(tc.inputJSON))
+			data, err := parser.Parse(context.Background(), r)
+			if !errors.Is(err, tc.expectedError) {
+				t.Errorf("Parse() returned unexpected error: (%v). expected error: (%v).", err, tc.expectedError)
+			}
+			assert.Equal(t, tc.expectedData, data)
+		})
+	}
+}
+
+func TestWebFeaturesManifestV1Data_prepareTestWebFeatureFilter(t *testing.T) {
+	// Test cases for prepareTestWebFeatureFilter
+	data := webFeaturesManifestV1Data{
+		"feature1": []webFeaturesManifestV1DataTest{
+			{URL: "/test1"},
+			{URL: "/test2"},
+		},
+		"feature2": []webFeaturesManifestV1DataTest{
+			{URL: "/test2"},
+		}}
+	expectedResult := WebFeaturesData{
+		"/test1": {"feature1": nil},
+		"/test2": {"feature1": nil, "feature2": nil},
+	}
+	result := data.prepareTestWebFeatureFilter()
+	assert.Equal(t, expectedResult, result)
+}

--- a/shared/web_features_test.go
+++ b/shared/web_features_test.go
@@ -66,7 +66,7 @@ func TestWebFeaturesManifestJSONParser_Parse(t *testing.T) {
 	}{
 		{
 			name:      "valid manifest version 1",
-			inputJSON: `{"version": 1, "data": {"feature1": [{"path": "test1", "url": "/test1"}, {"path": "test2", "url": "/test2"}], "feature2": [{"path": "test1", "url": "/test1"}, {"path": "test3", "url": "/test3"}]}}`,
+			inputJSON: `{"version": 1, "data": {"feature1": ["/test1", "/test2"], "feature2": ["/test1", "/test3"]}}`,
 			expectedData: WebFeaturesData{
 				"/test1": map[string]interface{}{
 					"feature1": nil,
@@ -117,12 +117,12 @@ func TestWebFeaturesManifestJSONParser_Parse(t *testing.T) {
 func TestWebFeaturesManifestV1Data_prepareTestWebFeatureFilter(t *testing.T) {
 	// Test cases for prepareTestWebFeatureFilter
 	data := webFeaturesManifestV1Data{
-		"feature1": []webFeaturesManifestV1DataTest{
-			{URL: "/test1"},
-			{URL: "/test2"},
+		"feature1": []string{
+			"/test1",
+			"/test2",
 		},
-		"feature2": []webFeaturesManifestV1DataTest{
-			{URL: "/test2"},
+		"feature2": []string{
+			"/test2",
 		}}
 	expectedResult := WebFeaturesData{
 		"/test1": {"feature1": nil},


### PR DESCRIPTION
This commit introduces WebFeaturesData which is a struct that consumers of the web features data can use to check if a feature matches with a web feature.

This commit supports the initial v1 of the manifest file which will be generated during each WPT release

This commit excludes the GitHubDownloader to actually download from GitHub in order to make the PRs easier to review

