### PR TITLE
Add support to search for web features in searchcache [Part 3/4]

### DIFF
--- a/api/query/README.md
+++ b/api/query/README.md
@@ -372,7 +372,7 @@ feature label, regardless of browsers.
 
 Where web-feature-name is a string, case-insensitive and matches the filename base
 for any of the .yml files in the
-[feature-group-definitions](https://github.com/web-platform-dx/web-features/tree/main/feature-group-definitions) directory..
+[feature-group-definitions](https://github.com/web-platform-dx/web-features/tree/main/feature-group-definitions) directory.
 
  E.g.
 

--- a/api/query/README.md
+++ b/api/query/README.md
@@ -362,3 +362,20 @@ Search triaged tests with a label interop-2022:
 
 See [Meta qualities](#meta-qualities) above for more information on other
 meta qualities than `"different"`.
+
+#### feature
+
+`feature` query atoms perform a search for tests that have a matching
+feature label, regardless of browsers.
+
+    {"feature": [web-feature-name]}
+
+Where web-feature-name is a string, case-insensitive and matches the filename base
+for any of the .yml files in the
+[feature-group-definitions](https://github.com/web-platform-dx/web-features/tree/main/feature-group-definitions) directory..
+
+ E.g.
+
+Search the [nesting](https://github.com/web-platform-dx/web-features/blob/main/feature-group-definitions/nesting.yml) feature:
+
+    feature:nesting

--- a/api/query/atoms.go
+++ b/api/query/atoms.go
@@ -365,6 +365,26 @@ func (t AbstractTestLabel) BindToRuns(_ ...shared.TestRun) ConcreteQuery {
 	}
 }
 
+// AbstractTestWebFeature represents the root of a web_feature query, which matches test-level
+// metadata to a searched web feature.
+type AbstractTestWebFeature struct {
+	WebFeature      string
+	manifestFetcher searchcacheWebFeaturesManifestFetcher
+}
+
+// BindToRuns for AbstractTestWebFeature fetches test-level metadata; it is independent of test runs.
+// nolint:ireturn // TODO: Fix ireturn lint error
+func (t AbstractTestWebFeature) BindToRuns(_ ...shared.TestRun) ConcreteQuery {
+	t.manifestFetcher = searchcacheWebFeaturesManifestFetcher{}
+
+	data, _ := t.manifestFetcher.Fetch()
+
+	return TestWebFeature{
+		WebFeature:      t.WebFeature,
+		WebFeaturesData: data,
+	}
+}
+
 // MetadataQuality represents the root of an "is" query, which asserts known
 // metadata qualities to the results.
 type MetadataQuality int
@@ -1003,6 +1023,27 @@ func (t *AbstractTestLabel) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// UnmarshalJSON for AbstractTestWebFeature attempts to interpret a query atom as
+// {"feature":<web_feature_string>}.
+func (t *AbstractTestWebFeature) UnmarshalJSON(b []byte) error {
+	var data map[string]*json.RawMessage
+	if err := json.Unmarshal(b, &data); err != nil {
+		return err
+	}
+	webFeatureMsg, ok := data["feature"]
+	if !ok {
+		return errors.New(`Missing web feature pattern property: "feature"`)
+	}
+	var webFeature string
+	if err := json.Unmarshal(*webFeatureMsg, &webFeature); err != nil {
+		return errors.New(`Property "feature" is not a string`)
+	}
+
+	t.WebFeature = webFeature
+
+	return nil
+}
+
 // UnmarshalJSON for AbstractTriaged attempts to interpret a query atom as
 // {"triaged":<browser name>}.
 func (t *AbstractTriaged) UnmarshalJSON(b []byte) error {
@@ -1182,6 +1223,12 @@ func unmarshalQ(b []byte) (AbstractQuery, error) {
 	}
 	{
 		var t AbstractTestLabel
+		if err := json.Unmarshal(b, &t); err == nil {
+			return t, nil
+		}
+	}
+	{
+		var t AbstractTestWebFeature
 		if err := json.Unmarshal(b, &t); err == nil {
 			return t, nil
 		}

--- a/api/query/cache/index/filter.go
+++ b/api/query/cache/index/filter.go
@@ -355,11 +355,11 @@ func (twf TestWebFeature) Filter(t TestID) bool {
 	if err != nil {
 		return false
 	}
-	// Check if there's any data
+	// Check if there's any data.
 	if twf.webFeaturesData == nil {
 		return false
 	}
-	// Get the Web Features for that exact test path
+	// Get the Web Features for that exact test path.
 	return twf.webFeaturesData.TestMatchesWithWebFeature(name, twf.webFeature)
 }
 

--- a/api/query/cache/index/index_filter_test.go
+++ b/api/query/cache/index/index_filter_test.go
@@ -860,7 +860,7 @@ func TestBindExecute_LabelWithWildcards(t *testing.T) {
 	})
 	metadata := map[string][]string{
 		"/foo/bar/b.html": {"random"},
-		"/a/*":  {"interop1", "INTEROP2"},
+		"/a/*":            {"interop1", "INTEROP2"},
 		"/d/e/f":          {""},
 		matchingTestName:  {"foo"},
 	}
@@ -869,6 +869,62 @@ func TestBindExecute_LabelWithWildcards(t *testing.T) {
 	// this matches the wildcard "/a/*". When mapped to test runs, that
 	// means it should match "/a/b/c" due to wildcard expansion.
 	testlabel := query.And{[]query.ConcreteQuery{query.TestLabel{Label: "interop2", Metadata: metadata}, query.TestLabel{Label: "interop1", Metadata: metadata}}}
+	plan, err := idx.Bind(runs, testlabel)
+	assert.Nil(t, err)
+
+	res := plan.Execute(runs, query.AggregationOpts{})
+	srs, ok := res.([]shared.SearchResult)
+	assert.True(t, ok)
+
+	assert.Equal(t, 1, len(srs))
+	expectedResult := shared.SearchResult{
+		Test: matchingTestName,
+		LegacyStatus: []shared.LegacySearchRunResult{
+			{
+				// Only matching test passes.
+				Passes:        1,
+				Total:         1,
+				Status:        "",
+				NewAggProcess: true,
+			},
+		},
+	}
+
+	assert.Equal(t, expectedResult, srs[0])
+}
+
+func TestBindExecute_TestWebFeature(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	loader := NewMockReportLoader(ctrl)
+	idx, err := NewShardedWPTIndex(loader, testNumShards)
+	assert.Nil(t, err)
+
+	matchingTestName := "/a/b/c"
+	runs := mockTestRuns(loader, idx, []testRunData{
+		{
+			shared.TestRun{ID: 1},
+			&metrics.TestResultsReport{
+				Results: []*metrics.TestResults{
+					{
+						Test:   matchingTestName,
+						Status: "PASS",
+					},
+					{
+						Test:   "/d/e/f",
+						Status: "FAIL",
+					},
+				},
+			},
+		},
+	})
+	data := shared.WebFeaturesData{
+		"/foo/bar/b.html": {"random": nil},
+		matchingTestName:  {"avif": nil, "grid": nil},
+		"/d/e/f":          {"": nil},
+	}
+
+	testlabel := query.TestWebFeature{WebFeature: "grid", WebFeaturesData: data}
 	plan, err := idx.Bind(runs, testlabel)
 	assert.Nil(t, err)
 

--- a/api/query/cache/poll/poll.go
+++ b/api/query/cache/poll/poll.go
@@ -209,10 +209,13 @@ func StartWebFeaturesManifestPollingService(ctx context.Context, logger shared.L
 	}
 }
 
+// webFeaturesGetter provides a thin interface to get web features data.
 type webFeaturesGetter interface {
 	Get(context.Context) (shared.WebFeaturesData, error)
 }
 
+// keepWebFeaturesManifestUpdated fetches a new copy of the web features data
+// and updates the local cache.
 func keepWebFeaturesManifestUpdated(
 	ctx context.Context,
 	logger shared.Logger,

--- a/api/query/cache/poll/poll.go
+++ b/api/query/cache/poll/poll.go
@@ -217,7 +217,7 @@ func keepWebFeaturesManifestUpdated(
 	ghClient *github.Client,
 	logger shared.Logger) {
 	logger.Infof("Running keepWebFeaturesManifestUpdated...")
-	downloader := shared.NewGitHubWebFeaturesManifestDownloader(netClient, ghClient)
+	downloader := shared.NewGitHubWebFeaturesManifestDownloader(netClient, ghClient.Repositories)
 
 	data, err := shared.GetWPTWebFeaturesManifest(ctx, downloader, shared.WebFeaturesManifestJSONParser{})
 	if err != nil {

--- a/api/query/cache/poll/poll_test.go
+++ b/api/query/cache/poll/poll_test.go
@@ -1,0 +1,95 @@
+//go:build small
+// +build small
+
+// Copyright 2024 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package poll
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/web-platform-tests/wpt.fyi/api/query"
+	"github.com/web-platform-tests/wpt.fyi/shared"
+)
+
+type testWebFeaturesGetter struct {
+	data shared.WebFeaturesData
+	err  error
+}
+
+func (g testWebFeaturesGetter) Get(_ context.Context) (shared.WebFeaturesData, error) {
+	return g.data, g.err
+}
+
+func TestKeepWebFeaturesManifestUpdated(t *testing.T) {
+	testCases := []struct {
+		name         string
+		initialCache shared.WebFeaturesData
+		dataToReturn shared.WebFeaturesData
+		errToReturn  error
+		expectedData shared.WebFeaturesData
+	}{
+		{
+			name:         "initial successful update",
+			initialCache: nil,
+			dataToReturn: shared.WebFeaturesData{
+				"foo": {"/foo.js": nil},
+			},
+			errToReturn: nil,
+			expectedData: shared.WebFeaturesData{
+				"foo": {"/foo.js": nil},
+			},
+		},
+		{
+			name:         "initial failed update",
+			initialCache: nil,
+			dataToReturn: nil,
+			errToReturn:  errors.New("whoops"),
+			expectedData: nil,
+		},
+		{
+			name: "successful update to existing cache",
+			initialCache: shared.WebFeaturesData{
+				"foo": {"/foo.js": nil},
+			},
+			dataToReturn: shared.WebFeaturesData{
+				"bar": {"/bar.js": nil},
+			},
+			errToReturn: nil,
+			expectedData: shared.WebFeaturesData{
+				"bar": {"/bar.js": nil},
+			},
+		},
+		{
+			name: "unsuccessful update to existing cache. return existing",
+			initialCache: shared.WebFeaturesData{
+				"foo": {"/foo.js": nil},
+			},
+			dataToReturn: nil,
+			errToReturn:  errors.New("whoops"),
+			expectedData: shared.WebFeaturesData{
+				"foo": {"/foo.js": nil},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Reset the cache.
+			query.SetWebFeaturesDataCache(tc.initialCache)
+			require.Equal(t, tc.initialCache, query.GetWebFeaturesDataCache())
+
+			getter := testWebFeaturesGetter{tc.dataToReturn, tc.errToReturn}
+			ctx := context.Background()
+			logger := shared.GetLogger(ctx)
+			keepWebFeaturesManifestUpdated(ctx, logger, getter)
+
+			assert.Equal(t, tc.expectedData, query.GetWebFeaturesDataCache())
+		})
+	}
+}

--- a/api/query/cache/service/main.go
+++ b/api/query/cache/service/main.go
@@ -183,8 +183,8 @@ func main() {
 	// Polls Metadata update every 10 minutes.
 	go poll.StartMetadataPollingService(context.Background(), logger, time.Minute*10)
 
-	// Polls Web Feature Manifest update every 10 minutes.
-	go poll.StartWebFeaturesManifestPollingService(context.Background(), logger, time.Minute*10)
+	// Polls Web Feature Manifest update every 30 minutes.
+	go poll.StartWebFeaturesManifestPollingService(context.Background(), logger, time.Minute*30)
 
 	http.HandleFunc("/_ah/liveness_check", livenessCheckHandler)
 	http.HandleFunc("/_ah/readiness_check", readinessCheckHandler)

--- a/api/query/cache/service/main.go
+++ b/api/query/cache/service/main.go
@@ -183,6 +183,9 @@ func main() {
 	// Polls Metadata update every 10 minutes.
 	go poll.StartMetadataPollingService(context.Background(), logger, time.Minute*10)
 
+	// Polls Web Feature Manifest update every 10 minutes.
+	go poll.StartWebFeaturesManifestPollingService(context.Background(), logger, time.Minute*10)
+
 	http.HandleFunc("/_ah/liveness_check", livenessCheckHandler)
 	http.HandleFunc("/_ah/readiness_check", readinessCheckHandler)
 	http.HandleFunc("/api/search/cache", shared.HandleWithLogging(searchHandler))

--- a/api/query/concrete_query.go
+++ b/api/query/concrete_query.go
@@ -81,6 +81,12 @@ type TestLabel struct {
 	Metadata map[string][]string
 }
 
+// TestWebFeature is a ConcreteQuery of AbstractTestWebFeature.
+type TestWebFeature struct {
+	WebFeature      string
+	WebFeaturesData shared.WebFeaturesData
+}
+
 // RunTestStatusEq constrains search results to include only test results from a
 // particular run that have a particular test status value. Run IDs are those
 // values automatically assigned to shared.TestRun instances by Datastore.
@@ -145,6 +151,10 @@ func (Triaged) Size() int { return 1 }
 // Size of TestLabel has a size of 1: servicing such a query requires a
 // label match per Metadata Link Node.
 func (TestLabel) Size() int { return 1 }
+
+// Size of TestWebFeature has a size of 1: servicing such a query requires a
+// web feature match per Web Features Node.
+func (TestWebFeature) Size() int { return 1 }
 
 // Size of Count is the sum of the sizes of its constituent ConcretQuery instances.
 func (c Count) Size() int { return size(c.Args) }

--- a/api/query/web_features_manifest_cache.go
+++ b/api/query/web_features_manifest_cache.go
@@ -45,7 +45,7 @@ func (f searchcacheWebFeaturesManifestFetcher) Fetch() (shared.WebFeaturesData, 
 
 		return nil, err
 	}
-	downloader := shared.NewGitHubWebFeaturesManifestDownloader(netClient, gitHubClient)
+	downloader := shared.NewGitHubWebFeaturesManifestDownloader(netClient, gitHubClient.Repositories)
 
 	data, err := shared.GetWPTWebFeaturesManifest(ctx, downloader, shared.WebFeaturesManifestJSONParser{})
 	if err != nil {

--- a/api/query/web_features_manifest_cache.go
+++ b/api/query/web_features_manifest_cache.go
@@ -1,0 +1,58 @@
+// Copyright 2024 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package query
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/web-platform-tests/wpt.fyi/shared"
+)
+
+// SetWebFeaturesDataCache safely swaps the data cache.
+// Currently, the separate goroutine in the poll folder will use this.
+func SetWebFeaturesDataCache(newData shared.WebFeaturesData) {
+	shared.GetLogger(context.Background()).Infof("setting data cache for manifest")
+	webFeaturesDataCacheLock.Lock()
+	defer webFeaturesDataCacheLock.Unlock()
+	webFeaturesDataCache = newData
+}
+
+// webFeaturesDataCache is the local cache of Web Features data in searchcache. Zero value is nil.
+var webFeaturesDataCache shared.WebFeaturesData // nolint:gochecknoglobals // TODO: Fix gochecknoglobals lint error
+var webFeaturesDataCacheLock sync.RWMutex       // nolint:gochecknoglobals // TODO: Fix gochecknoglobals lint error
+
+type searchcacheWebFeaturesManifestFetcher struct{}
+
+func (f searchcacheWebFeaturesManifestFetcher) Fetch() (shared.WebFeaturesData, error) {
+	webFeaturesDataCacheLock.RLock()
+	defer webFeaturesDataCacheLock.RUnlock()
+	if webFeaturesDataCache != nil {
+		return webFeaturesDataCache, nil
+	}
+
+	netClient := &http.Client{
+		Timeout: time.Second * 5,
+	}
+	ctx := context.Background()
+	gitHubClient, err := shared.NewAppEngineAPI(ctx).GetGitHubClient()
+	if err != nil {
+		shared.GetLogger(ctx).Warningf("unable to get github client for searchcache")
+
+		return nil, err
+	}
+	downloader := shared.NewGitHubWebFeaturesManifestDownloader(netClient, gitHubClient)
+
+	data, err := shared.GetWPTWebFeaturesManifest(ctx, downloader, shared.WebFeaturesManifestJSONParser{})
+	if err != nil {
+		shared.GetLogger(ctx).Errorf("unable to fetch web features manifest during query. %s", err.Error())
+
+		return nil, err
+	}
+
+	return data, nil
+}

--- a/shared/web_features.go
+++ b/shared/web_features.go
@@ -58,11 +58,11 @@ type webFeaturesManifestFile struct {
 // The value is a list of tests that are part of that web feature.
 type webFeaturesManifestV1Data map[string][]string
 
-// WebFeaturesManifestJSONParser is parser that can interpret a Web Features Manifest in a JSON format.
-type WebFeaturesManifestJSONParser struct{}
+// webFeaturesManifestJSONParser is parser that can interpret a Web Features Manifest in a JSON format.
+type webFeaturesManifestJSONParser struct{}
 
 // Parse parses a JSON file into a WebFeaturesData instance.
-func (p WebFeaturesManifestJSONParser) Parse(_ context.Context, r io.ReadCloser) (WebFeaturesData, error) {
+func (p webFeaturesManifestJSONParser) Parse(_ context.Context, r io.ReadCloser) (WebFeaturesData, error) {
 	defer r.Close()
 	file := new(webFeaturesManifestFile)
 	err := json.NewDecoder(r).Decode(file)
@@ -84,7 +84,7 @@ func (p WebFeaturesManifestJSONParser) Parse(_ context.Context, r io.ReadCloser)
 	return nil, fmt.Errorf("bad version %d %w", file.Version, errUnknownWebFeaturesManifestVersion)
 }
 
-// PrepareTestWebFeatureFilter maps a MetadataResult test name to its web features.
+// prepareTestWebFeatureFilter maps a MetadataResult test name to its web features.
 func (d webFeaturesManifestV1Data) prepareTestWebFeatureFilter() WebFeaturesData {
 	// Create a map where the value is effectively a set (map[string]interface{})
 	testToWebFeaturesMap := make(map[string]map[string]interface{})

--- a/shared/web_features_manifest_github_download.go
+++ b/shared/web_features_manifest_github_download.go
@@ -87,8 +87,8 @@ func (d gitHubWebFeaturesManifestDownloader) Download(ctx context.Context) (io.R
 	// Find the asset URL for the manifest file.
 	assetURL := ""
 	for _, asset := range release.Assets {
-		if asset != nil && asset.Name != nil &&
-			strings.EqualFold(webFeaturesManifestFilename, *asset.Name) &&
+		if asset != nil && asset.Label != nil &&
+			strings.EqualFold(webFeaturesManifestFilename, *asset.Label) &&
 			asset.BrowserDownloadURL != nil {
 			assetURL = *asset.BrowserDownloadURL
 

--- a/shared/web_features_manifest_github_download.go
+++ b/shared/web_features_manifest_github_download.go
@@ -150,7 +150,7 @@ type GitHubWebFeaturesClient struct {
 }
 
 // gitHubWebFeaturesClientOptions contains all the non-required options that
-// can be used to configure an instance of GitHubWebFeaturesClient
+// can be used to configure an instance of GitHubWebFeaturesClient.
 type gitHubWebFeaturesClientOptions struct {
 	netClient *http.Client
 }

--- a/shared/web_features_manifest_github_download.go
+++ b/shared/web_features_manifest_github_download.go
@@ -149,6 +149,8 @@ type GitHubWebFeaturesClient struct {
 	parser     webFeatureManifestParser
 }
 
+// gitHubWebFeaturesClientOptions contains all the non-required options that
+// can be used to configure an instance of GitHubWebFeaturesClient
 type gitHubWebFeaturesClientOptions struct {
 	netClient *http.Client
 }

--- a/shared/web_features_manifest_github_download_test.go
+++ b/shared/web_features_manifest_github_download_test.go
@@ -253,7 +253,7 @@ func TestGitHubWebFeaturesManifestDownloader_Download(t *testing.T) {
 			httpClient := &http.Client{
 				Transport: tc.roundTrip,
 			}
-			downloader := NewGitHubWebFeaturesManifestDownloader(httpClient, getter)
+			downloader := newGitHubWebFeaturesManifestDownloader(httpClient, getter)
 			downloader.bodyTransformer = mockBodyTransformer{t, tc.transformer}
 			body, err := downloader.Download(context.Background())
 			if !errors.Is(err, tc.expectedError) {

--- a/shared/web_features_manifest_github_download_test.go
+++ b/shared/web_features_manifest_github_download_test.go
@@ -127,6 +127,30 @@ func (g mockRepositoryReleaseGetter) GetLatestRelease(
 	return g.repoRelease, g.resp, g.err
 }
 
+/*
+Truncated example output from GitHub API.
+Useful for building the returned responses in TestGitHubWebFeaturesManifestDownloader_Download.
+
+gh release view --repo web-platform-tests/wpt --json assets
+{
+  "assets": [
+    {
+      "apiUrl": "https://api.github.com/repos/web-platform-tests/wpt/releases/assets/147533430",
+      "contentType": "application/octet-stream",
+      "createdAt": "2024-01-24T14:40:18Z",
+      "downloadCount": 0,
+      "id": "RA_kwDOADc1Vc4Iyy52",
+      "label": "WEB_FEATURES_MANIFEST.json.gz",
+      "name": "WEB_FEATURES_MANIFEST-f8871bc568c2cf86b38cb70f28a9d5f707e19259.json.gz",
+      "size": 38815,
+      "state": "uploaded",
+      "updatedAt": "2024-01-24T14:40:18Z",
+      "url": "https://github.com/web-platform-tests/wpt/releases/download/merge_pr_41522/WEB_FEATURES_MANIFEST-f8871bc568c2cf86b38cb70f28a9d5f707e19259.json.gz"
+    }
+  ]
+}
+*/
+
 func TestGitHubWebFeaturesManifestDownloader_Download(t *testing.T) {
 	// Test cases for Download
 	tests := []struct {
@@ -145,7 +169,7 @@ func TestGitHubWebFeaturesManifestDownloader_Download(t *testing.T) {
 				repoRelease: &github.RepositoryRelease{
 					Assets: []*github.ReleaseAsset{
 						{
-							Name:               github.String("WEB_FEATURES_MANIFEST.json.gz"),
+							Label:              github.String("WEB_FEATURES_MANIFEST.json.gz"),
 							BrowserDownloadURL: github.String("https://example.com/WEB_FEATURES_MANIFEST.json.gz"),
 						},
 					},
@@ -203,7 +227,7 @@ func TestGitHubWebFeaturesManifestDownloader_Download(t *testing.T) {
 				repoRelease: &github.RepositoryRelease{
 					Assets: []*github.ReleaseAsset{
 						{
-							Name:               github.String("WEB_FEATURES_MANIFEST.json.gz"),
+							Label:              github.String("WEB_FEATURES_MANIFEST.json.gz"),
 							BrowserDownloadURL: github.String("https://example.com/WEB_FEATURES_MANIFEST.json.gz"),
 						},
 					},
@@ -228,7 +252,7 @@ func TestGitHubWebFeaturesManifestDownloader_Download(t *testing.T) {
 				repoRelease: &github.RepositoryRelease{
 					Assets: []*github.ReleaseAsset{
 						{
-							Name:               github.String("WEB_FEATURES_MANIFEST.json.gz"),
+							Label:              github.String("WEB_FEATURES_MANIFEST.json.gz"),
 							BrowserDownloadURL: github.String("https://example.com/WEB_FEATURES_MANIFEST.json.gz"),
 						},
 					},

--- a/shared/web_features_manifest_util.go
+++ b/shared/web_features_manifest_util.go
@@ -9,12 +9,13 @@ import (
 	"io"
 )
 
-// GetWPTWebFeaturesManifest is the entrypoint for handling web features manifest downloads.
+// getWPTWebFeaturesManifest contains the common logic to handle retrieving a
+// web features manifest.
 // It includes two generic steps: Downloading and Parsing.
-func GetWPTWebFeaturesManifest(
+func getWPTWebFeaturesManifest(
 	ctx context.Context,
-	downloader WebFeaturesManifestDownloader,
-	parser WebFeatureManifestParser) (WebFeaturesData, error) {
+	downloader webFeaturesManifestDownloader,
+	parser webFeatureManifestParser) (WebFeaturesData, error) {
 	manifest, err := downloader.Download(ctx)
 	if err != nil {
 		return nil, err
@@ -27,17 +28,17 @@ func GetWPTWebFeaturesManifest(
 	return data, nil
 }
 
-// WebFeaturesManifestDownloader provides an interface for downloading a manifest file.
+// webFeaturesManifestDownloader provides an interface for downloading a manifest file.
 // Typically implementers of the interface create a struct based on the location of the file.
 // For example: GitHub.
-type WebFeaturesManifestDownloader interface {
+type webFeaturesManifestDownloader interface {
 	Download(context.Context) (io.ReadCloser, error)
 }
 
-// WebFeatureManifestParser provides an interface on how to parse a given manifest.
+// webFeatureManifestParser provides an interface on how to parse a given manifest.
 // Typically implementers of the interface create a struct per type of file.
 // For example: JSON file or YAML file.
-type WebFeatureManifestParser interface {
+type webFeatureManifestParser interface {
 	// Parse reads the stream of data and returns a map.
 	// The map mirrors the structure of MetadataResults where the key is the
 	// test name and the value is the actual data. In this case the "data" is a

--- a/shared/web_features_manifest_util_test.go
+++ b/shared/web_features_manifest_util_test.go
@@ -74,7 +74,7 @@ func TestGetWPTWebFeaturesManifest(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := GetWPTWebFeaturesManifest(context.Background(), tc.mockDownloader, tc.mockParser)
+			result, err := getWPTWebFeaturesManifest(context.Background(), tc.mockDownloader, tc.mockParser)
 			assert.Equal(t, tc.expectedData, result)
 			assert.Equal(t, tc.expectedError, err)
 		})

--- a/shared/web_features_test.go
+++ b/shared/web_features_test.go
@@ -103,7 +103,7 @@ func TestWebFeaturesManifestJSONParser_Parse(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			parser := WebFeaturesManifestJSONParser{}
+			parser := webFeaturesManifestJSONParser{}
 			r := io.NopCloser(strings.NewReader(tc.inputJSON))
 			data, err := parser.Parse(context.Background(), r)
 			if !errors.Is(err, tc.expectedError) {


### PR DESCRIPTION
The service will now interpret a query that takes the form of feature:<web-feature-key>

Similarly to the searchcacheMetadataFetcher, there is now a searchcacheWebFeaturesManifestFetcher

