### PR TITLE
Update Interop color logic for summary scores

### DIFF
--- a/webapp/components/interop-summary.js
+++ b/webapp/components/interop-summary.js
@@ -287,29 +287,13 @@ class InteropSummary extends PolymerElement {
   calculateColor(score) {
     const gradient = [
       // Red.
-      {
-        scale: 0,
-        backgroundColor: [238, 43, 43],
-        textColor: [238, 43, 43],
-      },
+      { scale: 0, color: [250, 0, 0] },
       // Orange.
-      {
-        scale: 33.33,
-        backgroundColor: [250, 125, 0],
-        textColor: [209, 105, 0],
-      },
+      { scale: 33.33, color: [250, 125, 0] },
       // Yellow.
-      {
-        scale: 66.67,
-        backgroundColor: [220, 220, 0],
-        textColor: [184, 132, 0],
-      },
+      { scale: 66.67, color: [220, 220, 0] },
       // Green.
-      {
-        scale: 100,
-        backgroundColor: [0, 160, 0],
-        textColor: [0, 160, 0],
-      },
+      { scale: 100, color: [0, 160, 0] },
     ];
 
     let color1, color2;
@@ -321,20 +305,15 @@ class InteropSummary extends PolymerElement {
       }
     }
     const colorWeight = ((score - color1.scale) / (color2.scale - color1.scale));
-    const textColor = [
-      Math.round(color1.textColor[0] * (1 - colorWeight) + color2.textColor[0] * colorWeight),
-      Math.round(color1.textColor[1] * (1 - colorWeight) + color2.textColor[1] * colorWeight),
-      Math.round(color1.textColor[2] * (1 - colorWeight) + color2.textColor[2] * colorWeight),
+    const color = [
+      Math.round(color1.color[0] * (1 - colorWeight) + color2.color[0] * colorWeight),
+      Math.round(color1.color[1] * (1 - colorWeight) + color2.color[1] * colorWeight),
+      Math.round(color1.color[2] * (1 - colorWeight) + color2.color[2] * colorWeight),
     ];
 
-    const backgroundColor = [
-      Math.round(color1.backgroundColor[0] * (1 - colorWeight) + color2.backgroundColor[0] * colorWeight),
-      Math.round(color1.backgroundColor[1] * (1 - colorWeight) + color2.backgroundColor[1] * colorWeight),
-      Math.round(color1.backgroundColor[2] * (1 - colorWeight) + color2.backgroundColor[2] * colorWeight),
-    ]
     return [
-      `rgb(${textColor[0]}, ${textColor[1]}, ${textColor[2]})`,
-      `rgba(${backgroundColor[0]}, ${backgroundColor[1]}, ${backgroundColor[2]}, 0.15)`,
+      `rgb(${color[0]}, ${color[1]}, ${color[2]})`,
+      `rgba(${color[0]}, ${color[1]}, ${color[2]}, 0.15)`,
     ];
   }
 }

--- a/webapp/components/interop-summary.js
+++ b/webapp/components/interop-summary.js
@@ -309,7 +309,7 @@ class InteropSummary extends PolymerElement {
       Math.round(color1.color[0] * (1 - colorWeight) + color2.color[0] * colorWeight),
       Math.round(color1.color[1] * (1 - colorWeight) + color2.color[1] * colorWeight),
       Math.round(color1.color[2] * (1 - colorWeight) + color2.color[2] * colorWeight),
-    ]
+    ];
 
     return [
       `rgb(${color[0]}, ${color[1]}, ${color[2]})`,

--- a/webapp/components/interop-summary.js
+++ b/webapp/components/interop-summary.js
@@ -287,13 +287,29 @@ class InteropSummary extends PolymerElement {
   calculateColor(score) {
     const gradient = [
       // Red.
-      { scale: 0, color: [250, 0, 0] },
+      {
+        scale: 0,
+        backgroundColor: [238, 43, 43],
+        textColor: [238, 43, 43],
+      },
       // Orange.
-      { scale: 33.33, color: [250, 125, 0] },
+      {
+        scale: 33.33,
+        backgroundColor: [250, 125, 0],
+        textColor: [209, 105, 0],
+      },
       // Yellow.
-      { scale: 66.67, color: [220, 220, 0] },
+      {
+        scale: 66.67,
+        backgroundColor: [220, 220, 0],
+        textColor: [184, 132, 0],
+      },
       // Green.
-      { scale: 100, color: [0, 160, 0] },
+      {
+        scale: 100,
+        backgroundColor: [0, 160, 0],
+        textColor: [0, 160, 0],
+      },
     ];
 
     let color1, color2;
@@ -305,15 +321,20 @@ class InteropSummary extends PolymerElement {
       }
     }
     const colorWeight = ((score - color1.scale) / (color2.scale - color1.scale));
-    const color = [
-      Math.round(color1.color[0] * (1 - colorWeight) + color2.color[0] * colorWeight),
-      Math.round(color1.color[1] * (1 - colorWeight) + color2.color[1] * colorWeight),
-      Math.round(color1.color[2] * (1 - colorWeight) + color2.color[2] * colorWeight),
+    const textColor = [
+      Math.round(color1.textColor[0] * (1 - colorWeight) + color2.textColor[0] * colorWeight),
+      Math.round(color1.textColor[1] * (1 - colorWeight) + color2.textColor[1] * colorWeight),
+      Math.round(color1.textColor[2] * (1 - colorWeight) + color2.textColor[2] * colorWeight),
     ];
 
+    const backgroundColor = [
+      Math.round(color1.backgroundColor[0] * (1 - colorWeight) + color2.backgroundColor[0] * colorWeight),
+      Math.round(color1.backgroundColor[1] * (1 - colorWeight) + color2.backgroundColor[1] * colorWeight),
+      Math.round(color1.backgroundColor[2] * (1 - colorWeight) + color2.backgroundColor[2] * colorWeight),
+    ]
     return [
-      `rgb(${color[0]}, ${color[1]}, ${color[2]})`,
-      `rgba(${color[0]}, ${color[1]}, ${color[2]}, 0.15)`,
+      `rgb(${textColor[0]}, ${textColor[1]}, ${textColor[2]})`,
+      `rgba(${backgroundColor[0]}, ${backgroundColor[1]}, ${backgroundColor[2]}, 0.15)`,
     ];
   }
 }

--- a/webapp/components/interop-summary.js
+++ b/webapp/components/interop-summary.js
@@ -221,7 +221,7 @@ class InteropSummary extends PolymerElement {
       startVal: curScore === '--' ? 0 : curScore
     }).start();
     const colors = this.calculateColor(score);
-    number.style.color = colors[0];
+    number.style.color = `color-mix(in lch, ${colors[0]} 70%, black)`;
     number.style.backgroundColor = colors[1];
   }
 

--- a/webapp/components/interop-summary.js
+++ b/webapp/components/interop-summary.js
@@ -285,19 +285,36 @@ class InteropSummary extends PolymerElement {
   }
 
   calculateColor(score) {
-    if (score >= 95) {
-      return ['#388E3C', '#00c70a1a'];
+    const gradient = [
+      // Red.
+      { scale: 0, color: [250, 0, 0] },
+      // Orange.
+      { scale: 33.33, color: [250, 125, 0] },
+      // Yellow.
+      { scale: 66.67, color: [220, 220, 0] },
+      // Green.
+      { scale: 100, color: [0, 160, 0] },
+    ];
+
+    let color1, color2;
+    for (let i = 1; i < gradient.length; i++) {
+      if (score <= gradient[i].scale) {
+        color1 = gradient[i - 1];
+        color2 = gradient[i];
+        break;
+      }
     }
-    if (score >= 75) {
-      return ['#568f24', '#64d60026'];
-    }
-    if (score >= 50) {
-      return ['#b88400', '#ffc22926'];
-    }
-    if (score >= 25) {
-      return ['#d16900', '#f57a0026'];
-    }
-    return ['#ee2b2b', '#ff050526'];
+    const colorWeight = ((score - color1.scale) / (color2.scale - color1.scale));
+    const color = [
+      Math.round(color1.color[0] * (1 - colorWeight) + color2.color[0] * colorWeight),
+      Math.round(color1.color[1] * (1 - colorWeight) + color2.color[1] * colorWeight),
+      Math.round(color1.color[2] * (1 - colorWeight) + color2.color[2] * colorWeight),
+    ]
+
+    return [
+      `rgb(${color[0]}, ${color[1]}, ${color[2]})`,
+      `rgba(${color[0]}, ${color[1]}, ${color[2]}, 0.15)`,
+    ];
   }
 }
 export { InteropSummary };


### PR DESCRIPTION
Updates the Interop dashboard to use a color based on a gradient when displaying the summary scores.

---

Example with 2024 Stable dashboard
![Screenshot 2024-02-05 at 1 53 12 PM](https://github.com/web-platform-tests/wpt.fyi/assets/56164590/e2d21c9b-10dc-44be-aef7-f00e843084c9)
![Screenshot 2024-02-05 at 1 53 18 PM](https://github.com/web-platform-tests/wpt.fyi/assets/56164590/43a4d84b-0b84-4678-9b11-7f31c39cf0dd)


---
Interop 2023 dashboard
![Screenshot 2024-02-05 at 1 54 50 PM](https://github.com/web-platform-tests/wpt.fyi/assets/56164590/8bf5a3d8-fb64-41fb-aeca-1be2f9c0bb20)
![Screenshot 2024-02-05 at 1 54 55 PM](https://github.com/web-platform-tests/wpt.fyi/assets/56164590/430ba4b4-9b9b-4e8a-8d9c-b493e1f3ac78)

