### PR TITLE
Label Chrome Canary runs with "experimental" label

### DIFF
--- a/results-processor/wptreport.py
+++ b/results-processor/wptreport.py
@@ -531,32 +531,32 @@ def _channel_to_labels(browser: str, channel: str) -> Set[str]:
     convenience.
     """
     labels = {channel}
-    if channel == 'release':
-        # e.g. Edge release
-        labels.add('stable')
     if channel == 'preview':
-        # e.g. Safari Technology Preview
+        # e.g. Safari Technology Preview.
         labels.add('experimental')
-    if channel == 'dev' and browser != 'chrome':
+    elif channel == 'dev' and browser != 'chrome':
         # e.g. Edge Dev.
         labels.add('experimental')
-    if channel == 'canary' and browser == 'chrome':
-        # e.g. Chrome Canary.
+    elif channel == 'canary' and browser == 'chrome':
         # We only label Chrome Canary as experimental to avoid confusion
         # with Chrome Dev.
         labels.add('experimental')
-    if channel == 'nightly' and browser != 'chrome':
+    elif channel == 'canary' and browser == 'deno':
+        # Deno Canary is the experimental channel.
+        labels.add('experimental')
+    elif channel == 'nightly' and browser != 'chrome':
         # Notably, we don't want to treat Chrome Nightly (Chromium trunk) as
         # experimental, as it would cause confusion with Chrome Canary and Dev.
         labels.add('experimental')
+
+    if channel == 'release':
+        # e.g. Edge release
+        labels.add('stable')
     if channel == 'canary' and browser == 'edgechromium':
         # Edge Canary is almost nightly.
         labels.add('nightly')
-    if channel == 'canary' and browser == 'deno':
-        # Deno Canary is the experimental channel.
-        labels.add('experimental')
 
-    # TODO(Hexcles): Figure out how we'd like to handle Chrome/Edge Canary.
+    # TODO(DanielRyanSmith): Figure out how we'd like to handle Edge Canary.
     # https://github.com/web-platform-tests/wpt.fyi/issues/1635
     return labels
 

--- a/results-processor/wptreport.py
+++ b/results-processor/wptreport.py
@@ -534,15 +534,23 @@ def _channel_to_labels(browser: str, channel: str) -> Set[str]:
     if channel == 'release':
         # e.g. Edge release
         labels.add('stable')
-    if channel == 'dev' or channel == 'preview':
-        # e.g. Chrome Dev and Safari Technology Preview
+    if channel == 'preview':
+        # e.g. Safari Technology Preview
+        labels.add('experimental')
+    if channel == 'dev' and browser != 'chrome':
+        # e.g. Edge Dev.
+        labels.add('experimental')
+    if channel == 'canary' and browser == 'chrome':
+        # e.g. Chrome Canary.
+        # We only label Chrome Canary as experimental to avoid confusion
+        # with Chrome Dev.
         labels.add('experimental')
     if channel == 'nightly' and browser != 'chrome':
         # Notably, we don't want to treat Chrome Nightly (Chromium trunk) as
-        # experimental, as it would cause confusion with Chrome Dev.
+        # experimental, as it would cause confusion with Chrome Canary and Dev.
         labels.add('experimental')
-    if channel == 'canary' and browser in ('chrome', 'edgechromium'):
-        # Chrome/Edge Canary is almost nightly.
+    if channel == 'canary' and browser == 'edgechromium':
+        # Edge Canary is almost nightly.
         labels.add('nightly')
     if channel == 'canary' and browser == 'deno':
         # Deno Canary is the experimental channel.

--- a/results-processor/wptreport_test.py
+++ b/results-processor/wptreport_test.py
@@ -598,14 +598,14 @@ class HelpersTest(unittest.TestCase):
         }
         self.assertSetEqual(
             prepare_labels(r, '', 'blade-runner'),
-            {'blade-runner', 'dev', 'experimental', 'chrome'}
+            {'blade-runner', 'dev', 'chrome'}
         )
 
         # Chrome Canary
         r._report['run_info']['browser_channel'] = 'canary'
         self.assertSetEqual(
             prepare_labels(r, '', 'blade-runner'),
-            {'blade-runner', 'canary', 'nightly', 'chrome'}
+            {'blade-runner', 'canary', 'experimental', 'chrome'}
         )
 
         # Chrome Nightly


### PR DESCRIPTION
Adjust labeling logic so that:

- Chrome Canary runs are labeled as "experimental"
- New runs of Chrome Dev are no longer labeled with "experimental".
- Chrome Canary no longer has the "nightly" label.