### PR TITLE
[Interop 2024] Add mdn/spec links and focus area descriptions

### DIFF
--- a/webapp/components/interop-dashboard.js
+++ b/webapp/components/interop-dashboard.js
@@ -114,6 +114,10 @@ class InteropDashboard extends PolymerElement {
           color: white;
         }
 
+        .focus-area-description-link {
+          margin-top: 12px;
+        }
+
         .sortable-header {
           position: relative;
           user-select: none;
@@ -463,7 +467,7 @@ class InteropDashboard extends PolymerElement {
                   </tfoot>
                 </template>
               </table>
-              <div hidden$=[[!shouldShowFocusAreasDescriptionLink(itemsIndex)]]>
+              <div class="focus-area-description-link" hidden$=[[!shouldShowFocusAreasDescriptionLink(itemsIndex)]]>
                 <a target="_blank" href$="[[focusAreasDescriptionLink]]">Descriptions of all focus areas</a>
               </div>
             </template>

--- a/webapp/components/interop-dashboard.js
+++ b/webapp/components/interop-dashboard.js
@@ -443,9 +443,6 @@ class InteropDashboard extends PolymerElement {
                     </tr>
                   </tfoot>
                 </template>
-                <div hidden$=[[!hasFocusAreasDescriptionLink]]>
-                  <a target="_blank" href$="[[focusAreasDescriptionLink]]">Descriptions of all focus areas</a>
-                </div>
                 <template is="dom-if" if="[[section.score_as_group]]">
                   <tbody>
                     <template is="dom-repeat" items="{{section.rows}}" as="rowName">
@@ -466,6 +463,9 @@ class InteropDashboard extends PolymerElement {
                   </tfoot>
                 </template>
               </table>
+              <div hidden$=[[!shouldShowFocusAreasDescriptionLink(itemsIndex)]]>
+                <a target="_blank" href$="[[focusAreasDescriptionLink]]">Descriptions of all focus areas</a>
+              </div>
             </template>
           </div>
         </div>
@@ -590,7 +590,6 @@ class InteropDashboard extends PolymerElement {
     this.currentInteropYear = allYears[allYears.length - 1];
     this.isCurrentYear = this.year === this.currentInteropYear;
     this.focusAreasDescriptionLink = this.dataManager.getYearProp('focusAreasDescriptionLink');
-    this.hasFocusAreasDescriptionLink = !!this.focusAreasDescriptionLink;
 
     super.ready();
 
@@ -854,6 +853,10 @@ class InteropDashboard extends PolymerElement {
   // Check if the table being rendered is the first table.
   isFirstTable(tableIndex) {
     return tableIndex === 0;
+  }
+
+  shouldShowFocusAreasDescriptionLink(tableIndex) {
+    return this.isFirstTable(tableIndex) && !!this.focusAreasDescriptionLink
   }
 
   shouldShowSortIcon(columnNumber, sortColumn) {

--- a/webapp/components/interop-dashboard.js
+++ b/webapp/components/interop-dashboard.js
@@ -443,6 +443,9 @@ class InteropDashboard extends PolymerElement {
                     </tr>
                   </tfoot>
                 </template>
+                <div hidden$=[[!hasFocusAreasDescriptionLink]]>
+                  <a target="_blank" href$="[[focusAreasDescriptionLink]]">Descriptions of all focus areas</a>
+                </div>
                 <template is="dom-if" if="[[section.score_as_group]]">
                   <tbody>
                     <template is="dom-repeat" items="{{section.rows}}" as="rowName">
@@ -586,6 +589,8 @@ class InteropDashboard extends PolymerElement {
     const allYears = this.getAllYears();
     this.currentInteropYear = allYears[allYears.length - 1];
     this.isCurrentYear = this.year === this.currentInteropYear;
+    this.focusAreasDescriptionLink = this.dataManager.getYearProp('focusAreasDescriptionLink');
+    this.hasFocusAreasDescriptionLink = !!this.focusAreasDescriptionLink;
 
     super.ready();
 

--- a/webapp/components/interop-dashboard.js
+++ b/webapp/components/interop-dashboard.js
@@ -856,7 +856,7 @@ class InteropDashboard extends PolymerElement {
   }
 
   shouldShowFocusAreasDescriptionLink(tableIndex) {
-    return this.isFirstTable(tableIndex) && !!this.focusAreasDescriptionLink
+    return this.isFirstTable(tableIndex) && !!this.focusAreasDescriptionLink;
   }
 
   shouldShowSortIcon(columnNumber, sortColumn) {

--- a/webapp/components/interop-data-manager.js
+++ b/webapp/components/interop-data-manager.js
@@ -107,6 +107,7 @@ class InteropDataManager {
     this.csvURL = yearInfo.csv_url;
     this.issueURL = yearInfo.issue_url;
     this.tableSections = yearInfo.table_sections;
+    this.focusAreasDescriptionLink = yearInfo.focus_areas_description;
     // Keep a list of years we have interop data prepared for.
     // TODO(DanielRyanSmith): Revert this back to using the keys in interop-data
     // with the change to set Interop 2024 as the default dashboard.

--- a/webapp/components/interop-data.js
+++ b/webapp/components/interop-data.js
@@ -673,6 +673,7 @@ export const interopData = {
     'csv_url': 'https://raw.githubusercontent.com/web-platform-tests/results-analysis/gh-pages/data/interop-2024/interop-2024-{stable|experimental}-v2.csv',
     'summary_feature_name': 'summary',
     'issue_url': 'https://github.com/web-platform-tests/interop/issues/new',
+    'focus_areas_description': 'https://github.com/web-platform-tests/interop/blob/main/2024/README.md',
     'focus_areas': {
       'interop-2021-aspect-ratio': {
         'description': 'Aspect Ratio',
@@ -725,14 +726,14 @@ export const interopData = {
       },
       'interop-2024-accessibility': {
         'description': 'Accessibility',
-        'mdn': '',
+        'mdn': 'https://developer.mozilla.org/en-US/docs/Glossary/Accessible_name',
         'spec': '',
         'tests': '/results/?label=master&label=experimental&product=chrome&product=edge&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2024-accessibility',
         'countsTowardScore': true
       },
       'interop-2024-starting-style-transition-behavior': {
         'description': '@starting-style & transition-behavior',
-        'mdn': '',
+        'mdn': 'https://developer.mozilla.org/en-US/docs/Web/CSS/@starting-style',
         'spec': '',
         'tests': '/results/css?label=experimental&label=master&product=chrome&product=edge&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2024-starting-style%20or%20label%3Ainterop-2024-transition-behavior',
         'countsTowardScore': true
@@ -746,14 +747,14 @@ export const interopData = {
       },
       'interop-2024-dir': {
         'description': 'Text Directionality',
-        'mdn': '',
+        'mdn': 'https://developer.mozilla.org/en-US/docs/Web/CSS/:dir',
         'spec': '',
         'tests': '/results/html/dom/elements/global-attributes?label=master&label=experimental&product=chrome&product=edge&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2024-dir',
         'countsTowardScore': true
       },
       'interop-2024-font-size-adjust': {
         'description': 'font-size-adjust',
-        'mdn': '',
+        'mdn': 'https://developer.mozilla.org/en-US/docs/Web/CSS/font-size-adjust',
         'spec': '',
         'tests': '/results/css/css-fonts?label=experimental&label=master&product=chrome&product=edge&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2024-font-size-adjust',
         'countsTowardScore': true
@@ -761,13 +762,13 @@ export const interopData = {
       'interop-2024-websockets': {
         'description': 'HTTPS URLs for WebSocket',
         'mdn': '',
-        'spec': '',
+        'spec': 'https://websockets.spec.whatwg.org/ ',
         'tests': '/results/websockets?label=experimental&label=master&product=chrome&product=edge&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2024-websockets',
         'countsTowardScore': true
       },
       'interop-2024-indexeddb': {
         'description': 'IndexedDB',
-        'mdn': '',
+        'mdn': 'https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB',
         'spec': '',
         'tests': '/results/IndexedDB?label=master&label=experimental&product=chrome&product=edge&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2024-indexeddb',
         'countsTowardScore': true
@@ -781,14 +782,14 @@ export const interopData = {
       },
       'interop-2024-nesting': {
         'description': 'CSS Nesting',
-        'mdn': '',
+        'mdn': 'https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_nesting',
         'spec': '',
         'tests': '/results/css?label=experimental&label=master&product=chrome&product=edge&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2024-nesting',
         'countsTowardScore': true
       },
       'interop-2024-popover': {
         'description': 'Popover',
-        'mdn': '',
+        'mdn': 'https://developer.mozilla.org/en-US/docs/Web/API/Popover_API',
         'spec': '',
         'tests': '/results/html/semantics/popovers?label=master&label=experimental&product=chrome&product=edge&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2024-popover',
         'countsTowardScore': true
@@ -802,21 +803,21 @@ export const interopData = {
       },
       'interop-2024-video-rvfc': {
         'description': 'requestVideoFrameCallback',
-        'mdn': '',
+        'mdn': 'https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement/requestVideoFrameCallback',
         'spec': '',
         'tests': '/results/video-rvfc?label=experimental&label=master&product=chrome&product=edge&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2024-video-rvfc',
         'countsTowardScore': true
       },
       'interop-2024-scrollbar': {
         'description': 'Scrollbar Styling',
-        'mdn': '',
+        'mdn': 'https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-width',
         'spec': '',
         'tests': '/results/css?label=master&label=experimental&product=chrome&product=edge&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2024-scrollbar',
         'countsTowardScore': true
       },
       'interop-2024-text-wrap': {
         'description': 'text-wrap: balance',
-        'mdn': '',
+        'mdn': 'https://developer.mozilla.org/en-US/docs/Web/CSS/text-wrap',
         'spec': '',
         'tests': '/results/css/css-text?label=master&label=experimental&product=chrome&product=edge&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2024-text-wrap',
         'countsTowardScore': true

--- a/webapp/static/interop-data.json
+++ b/webapp/static/interop-data.json
@@ -646,6 +646,7 @@
     "csv_url": "https://raw.githubusercontent.com/web-platform-tests/results-analysis/gh-pages/data/interop-2024/interop-2024-{stable|experimental}-v2.csv",
     "summary_feature_name": "summary",
     "issue_url": "https://github.com/web-platform-tests/interop/issues/new",
+    "focus_areas_description": "https://github.com/web-platform-tests/interop/blob/main/2024/README.md",
     "focus_areas": {
       "interop-2021-aspect-ratio": {
         "description": "Aspect Ratio",
@@ -698,14 +699,14 @@
       },
       "interop-2024-accessibility": {
         "description": "Accessibility",
-        "mdn": "",
+        "mdn": "https://developer.mozilla.org/en-US/docs/Glossary/Accessible_name",
         "spec": "",
         "tests": "/results/?label=master&label=experimental&product=chrome&product=edge&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2024-accessibility",
         "countsTowardScore": true
       },
       "interop-2024-starting-style-transition-behavior": {
         "description": "@starting-style & transition-behavior",
-        "mdn": "",
+        "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/@starting-style",
         "spec": "",
         "tests": "/results/css?label=experimental&label=master&product=chrome&product=edge&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2024-starting-style%20or%20label%3Ainterop-2024-transition-behavior",
         "countsTowardScore": true
@@ -719,14 +720,14 @@
       },
       "interop-2024-dir": {
         "description": "Text Directionality",
-        "mdn": "",
+        "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/:dir",
         "spec": "",
         "tests": "/results/html/dom/elements/global-attributes?label=master&label=experimental&product=chrome&product=edge&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2024-dir",
         "countsTowardScore": true
       },
       "interop-2024-font-size-adjust": {
         "description": "font-size-adjust",
-        "mdn": "",
+        "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/font-size-adjust",
         "spec": "",
         "tests": "/results/css/css-fonts?label=experimental&label=master&product=chrome&product=edge&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2024-font-size-adjust",
         "countsTowardScore": true
@@ -734,13 +735,13 @@
       "interop-2024-websockets": {
         "description": "HTTPS URLs for WebSocket",
         "mdn": "",
-        "spec": "",
+        "spec": "https://websockets.spec.whatwg.org/ ",
         "tests": "/results/websockets?label=experimental&label=master&product=chrome&product=edge&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2024-websockets",
         "countsTowardScore": true
       },
       "interop-2024-indexeddb": {
         "description": "IndexedDB",
-        "mdn": "",
+        "mdn": "https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB",
         "spec": "",
         "tests": "/results/IndexedDB?label=master&label=experimental&product=chrome&product=edge&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2024-indexeddb",
         "countsTowardScore": true
@@ -754,14 +755,14 @@
       },
       "interop-2024-nesting": {
         "description": "CSS Nesting",
-        "mdn": "",
+        "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_nesting",
         "spec": "",
         "tests": "/results/css?label=experimental&label=master&product=chrome&product=edge&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2024-nesting",
         "countsTowardScore": true
       },
       "interop-2024-popover": {
         "description": "Popover",
-        "mdn": "",
+        "mdn": "https://developer.mozilla.org/en-US/docs/Web/API/Popover_API",
         "spec": "",
         "tests": "/results/html/semantics/popovers?label=master&label=experimental&product=chrome&product=edge&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2024-popover",
         "countsTowardScore": true
@@ -775,21 +776,21 @@
       },
       "interop-2024-video-rvfc": {
         "description": "requestVideoFrameCallback",
-        "mdn": "",
+        "mdn": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement/requestVideoFrameCallback",
         "spec": "",
         "tests": "/results/video-rvfc?label=experimental&label=master&product=chrome&product=edge&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2024-video-rvfc",
         "countsTowardScore": true
       },
       "interop-2024-scrollbar": {
         "description": "Scrollbar Styling",
-        "mdn": "",
+        "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-width",
         "spec": "",
         "tests": "/results/css?label=master&label=experimental&product=chrome&product=edge&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2024-scrollbar",
         "countsTowardScore": true
       },
       "interop-2024-text-wrap": {
         "description": "text-wrap: balance",
-        "mdn": "",
+        "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/text-wrap",
         "spec": "",
         "tests": "/results/css/css-text?label=master&label=experimental&product=chrome&product=edge&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2024-text-wrap",
         "countsTowardScore": true


### PR DESCRIPTION
This change updates a number of focus area info links, as well as adding an additional link overall to the Interop 2024 focus areas README

![Screenshot 2024-01-30 at 10 57 28 AM](https://github.com/web-platform-tests/wpt.fyi/assets/56164590/3df8fcf4-8de2-4460-a286-96337780010a)
