### PR TITLE
Change Declarative Shadow DOM interop link

### DIFF
--- a/webapp/components/interop-data.js
+++ b/webapp/components/interop-data.js
@@ -742,7 +742,7 @@ export const interopData = {
         'description': 'Declarative Shadow DOM',
         'mdn': '',
         'spec': '',
-        'tests': '/shadow-dom/declarative?label=master&label=experimental&product=chrome&product=edge&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2024-dsd',
+        'tests': '/shadow-dom?label=master&label=experimental&product=chrome&product=edge&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2024-dsd',
         'countsTowardScore': true
       },
       'interop-2024-dir': {

--- a/webapp/static/interop-data.json
+++ b/webapp/static/interop-data.json
@@ -715,7 +715,7 @@
         "description": "Declarative Shadow DOM",
         "mdn": "",
         "spec": "",
-        "tests": "/shadow-dom/declarative?label=master&label=experimental&product=chrome&product=edge&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2024-dsd",
+        "tests": "/shadow-dom?label=master&label=experimental&product=chrome&product=edge&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2024-dsd",
         "countsTowardScore": true
       },
       "interop-2024-dir": {


### PR DESCRIPTION
The DSD focus area contains a test outside of the `/shadow-dom/declarative` directory, which caused some confusion about which tests are part of the focus area. This change updates the link to navigate outside of the subdirectory to make all relevant tests visible.