### PR TITLE
Use FilterEntity instead of Filter

### DIFF
--- a/api/checks/api.go
+++ b/api/checks/api.go
@@ -76,7 +76,8 @@ func (s checksAPIImpl) ScheduleResultsProcessing(sha string, product shared.Prod
 func (s checksAPIImpl) GetSuitesForSHA(sha string) ([]shared.CheckSuite, error) {
 	var suites []shared.CheckSuite
 	store := shared.NewAppEngineDatastore(s.Context(), false)
-	_, err := store.GetAll(store.NewQuery("CheckSuite").Filter("SHA =", sha), &suites)
+	q := store.NewQuery("CheckSuite")
+	_, err := store.GetAll(q.FilterEntity(q.FilterBuilder().PropertyFilter("SHA", "=", sha)), &suites)
 
 	return suites, err
 }

--- a/api/checks/suites.go
+++ b/api/checks/suites.go
@@ -20,12 +20,14 @@ func getOrCreateCheckSuite(
 	prNumbers ...int,
 ) (*shared.CheckSuite, error) {
 	ds := shared.NewAppEngineDatastore(ctx, false)
-	query := ds.NewQuery("CheckSuite").
-		Filter("SHA =", sha).
-		Filter("AppID =", appID).
-		Filter("InstallationID =", installationID).
-		Filter("Owner =", owner).
-		Filter("Repo =", repo).
+	query := ds.NewQuery("CheckSuite")
+	filterBuilder := query.FilterBuilder()
+	query = query.
+		FilterEntity(filterBuilder.PropertyFilter("SHA", "=", sha)).
+		FilterEntity(filterBuilder.PropertyFilter("AppID", "=", appID)).
+		FilterEntity(filterBuilder.PropertyFilter("InstallationID", "=", installationID)).
+		FilterEntity(filterBuilder.PropertyFilter("Owner", "=", owner)).
+		FilterEntity(filterBuilder.PropertyFilter("Repo", "=", repo)).
 		KeysOnly()
 	var suite shared.CheckSuite
 	if keys, err := ds.GetAll(query, nil); err != nil {

--- a/api/pending_test_runs.go
+++ b/api/pending_test_runs.go
@@ -23,15 +23,16 @@ func apiPendingTestRunsHandler(w http.ResponseWriter, r *http.Request) {
 
 	filter := strings.ToLower(mux.Vars(r)["filter"])
 	q := store.NewQuery("PendingTestRun")
+	filterBuilder := q.FilterBuilder()
 	switch filter {
 	case "pending":
-		q = q.Order("-Stage").Filter("Stage < ", int(shared.StageValid))
+		q = q.Order("-Stage").FilterEntity(filterBuilder.PropertyFilter("Stage", "<", int(shared.StageValid)))
 	case "invalid":
-		q = q.Filter("Stage = ", int(shared.StageInvalid))
+		q = q.FilterEntity(filterBuilder.PropertyFilter("Stage", "=", int(shared.StageInvalid)))
 	case "empty":
-		q = q.Filter("Stage = ", int(shared.StageEmpty))
+		q = q.FilterEntity(filterBuilder.PropertyFilter("Stage", "=", int(shared.StageEmpty)))
 	case "duplicate":
-		q = q.Filter("Stage = ", int(shared.StageDuplicate))
+		q = q.FilterEntity(filterBuilder.PropertyFilter("Stage", "= ", int(shared.StageDuplicate)))
 	case "":
 		// No-op
 	default:

--- a/api/screenshot/model.go
+++ b/api/screenshot/model.go
@@ -140,7 +140,7 @@ func RecentScreenshotHashes(
 	for all.Cardinality() < totalLimit {
 		query := ds.NewQuery("Screenshot")
 		for _, l := range labels {
-			query = query.Filter("Labels =", l)
+			query = query.FilterEntity(query.FilterBuilder().PropertyFilter("Labels", "=", l))
 		}
 		query = query.Order("-LastUsed").Limit(totalLimit)
 

--- a/api/test_history.go
+++ b/api/test_history.go
@@ -54,7 +54,8 @@ func testHistoryHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	store := shared.NewAppEngineDatastore(ctx, false)
-	q := store.NewQuery("TestHistoryEntry").Filter("TestName =", reqBody.TestName)
+	q := store.NewQuery("TestHistoryEntry")
+	q = q.FilterEntity(q.FilterBuilder().PropertyFilter("TestName", "=", reqBody.TestName))
 
 	var runs []shared.TestHistoryEntry
 	_, err = store.GetAll(q, &runs)

--- a/shared/datastore.go
+++ b/shared/datastore.go
@@ -36,7 +36,7 @@ type Iterator interface {
 
 // Query abstracts a datastore.Query
 type Query interface {
-	Filter(filterStr string, value interface{}) Query
+	FilterEntity(EntityFilter) Query
 	Project(fields ...string) Query
 	Limit(limit int) Query
 	Offset(offset int) Query
@@ -44,6 +44,18 @@ type Query interface {
 	KeysOnly() Query
 	Distinct() Query
 	Run(Datastore) Iterator
+
+	FilterBuilder() FilterBuilder
+}
+
+// PropertyFilter is a particular filter that filters based on property value.
+type PropertyFilter interface {
+	EntityFilter
+}
+
+// FilterBuilder contains the logic to create different types of filters
+type FilterBuilder interface {
+	PropertyFilter(FieldName string, Operator string, Value interface{}) EntityFilter
 }
 
 // Datastore abstracts a datastore, hiding the distinctions between cloud and

--- a/shared/datastore_cloud.go
+++ b/shared/datastore_cloud.go
@@ -197,6 +197,14 @@ type cloudQuery struct {
 	query *datastore.Query
 }
 
+func (q cloudQuery) FilterBuilder() FilterBuilder {
+	return cloudFilterBuilder{}
+}
+
+func (q cloudQuery) FilterEntity(entityFilter EntityFilter) Query {
+	return cloudQuery{q.query.FilterEntity(entityFilter)}
+}
+
 func (q cloudQuery) Filter(filterStr string, value interface{}) Query {
 	return cloudQuery{q.query.Filter(filterStr, value)}
 }
@@ -239,4 +247,17 @@ type cloudIterator struct {
 func (i cloudIterator) Next(dst interface{}) (Key, error) {
 	key, err := i.iter.Next(dst)
 	return cloudKey{key}, err
+}
+
+// EntityFilter wraps datastore.EntityFilter.
+// datastore.EntityFilter does not expose any methods. But using this type
+// allows us to be strict on the filters returned by the FilterBuilder.
+type EntityFilter interface {
+	datastore.EntityFilter
+}
+
+type cloudFilterBuilder struct{}
+
+func (b cloudFilterBuilder) PropertyFilter(FieldName string, Operator string, Value interface{}) EntityFilter {
+	return datastore.PropertyFilter{FieldName: FieldName, Operator: Operator, Value: Value}
 }


### PR DESCRIPTION
The datastore library has marked Filter as deprecated. By moving to FilterEntity, we can use more advanced queries as well.

This commit introduces a new EntityFilter type. That type just wraps datastore.EntityFilter because there are no exposed methods on datastore.EntityFilter for us to manually declare.

In order to create an EntityFilter, another type called FilterBuilder is created which will allow consumers to make a particular Filter that reteurns an EntityFilter.

More about the deprecation here: https://pkg.go.dev/cloud.google.com/go/datastore#Query.Filter

