### PR TITLE
Update the links for 2024 investigation areas

### DIFF
--- a/webapp/components/interop-data.js
+++ b/webapp/components/interop-data.js
@@ -651,17 +651,17 @@ export const interopData = {
     'investigation_scores': [
       {
         'name': 'Accessibility Testing',
-        'url': 'https://github.com/web-platform-tests/interop-2023-accessibility-testing',
+        'url': 'https://github.com/web-platform-tests/interop-accessibility-testing',
         'scores_over_time': []
       },
       {
         'name': 'Mobile Testing',
-        'url': 'https://github.com/web-platform-tests/interop-2023-mobile-testing',
+        'url': 'https://github.com/web-platform-tests/interop-mobile-testing',
         'scores_over_time': []
       },
       {
         'name': 'WebAssembly Testing',
-        'url': '',
+        'url': 'https://github.com/web-platform-tests/interop-2024-wasm',
         'scores_over_time': []
       },
     ],

--- a/webapp/static/interop-data.json
+++ b/webapp/static/interop-data.json
@@ -628,17 +628,17 @@
     "investigation_scores": [
       {
         "name": "Accessibility Testing",
-        "url": "https://github.com/web-platform-tests/interop-2023-accessibility-testing",
+        "url": "https://github.com/web-platform-tests/interop-accessibility-testing",
         "scores_over_time": []
       },
       {
         "name": "Mobile Testing",
-        "url": "https://github.com/web-platform-tests/interop-2023-mobile-testing",
+        "url": "https://github.com/web-platform-tests/interop-mobile-testing",
         "scores_over_time": []
       },
       {
         "name": "WebAssembly Testing",
-        "url": "",
+        "url": "https://github.com/web-platform-tests/interop-2024-wasm",
         "scores_over_time": []
       }
     ],


### PR DESCRIPTION
Closes https://github.com/web-platform-tests/interop/issues/630

This adds the missing URL for the accessibility area as the repo has now been created.
I also updated links for the other 2 investigation areas as the repositories have been renamed (the old name redirects to the new one, so the links were not broken)