### PR TITLE
Changed HTTP Status Codes and Methods with constants defined in http lib

### DIFF
--- a/api/query/search.go
+++ b/api/query/search.go
@@ -47,7 +47,7 @@ func apiSearchHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (sh searchHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if r.Method != "GET" && r.Method != "POST" {
+	if r.Method != http.MethodGet && r.Method != http.MethodPost {
 		http.Error(w, "Invalid HTTP method", http.StatusBadRequest)
 
 		return

--- a/webapp/admin_handler.go
+++ b/webapp/admin_handler.go
@@ -80,7 +80,7 @@ func handleAdminFlags(a shared.AppEngineAPI, ds shared.Datastore, acl shared.Git
 		return
 	}
 
-	if r.Method == "GET" {
+	if r.Method == http.MethodGet {
 		data := struct {
 			Host string
 		}{
@@ -88,7 +88,7 @@ func handleAdminFlags(a shared.AppEngineAPI, ds shared.Datastore, acl shared.Git
 		}
 		// We don't need user info in this template.
 		RenderTemplate(w, nil, "admin_flags.html", data)
-	} else if r.Method == "POST" {
+	} else if r.Method == http.MethodPost {
 		var flag shared.Flag
 		if bytes, err := ioutil.ReadAll(r.Body); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/webapp/interop_handler.go
+++ b/webapp/interop_handler.go
@@ -44,7 +44,7 @@ func interopHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if r.Method != "GET" {
+	if r.Method != http.MethodGet {
 		http.Error(w, "Only GET is supported.", http.StatusMethodNotAllowed)
 		return
 	}

--- a/webapp/processor.go
+++ b/webapp/processor.go
@@ -10,7 +10,7 @@ import (
 
 // processorStatusHandler handles GET requests to /processor
 func processorStatusHandler(w http.ResponseWriter, r *http.Request) {
-	if r.Method http.MethodGet {
+	if r.Method != http.MethodGet {
 		http.Error(w, "Only GET is supported.", http.StatusMethodNotAllowed)
 		return
 	}

--- a/webapp/processor.go
+++ b/webapp/processor.go
@@ -10,7 +10,7 @@ import (
 
 // processorStatusHandler handles GET requests to /processor
 func processorStatusHandler(w http.ResponseWriter, r *http.Request) {
-	if r.Method != "GET" {
+	if r.Method http.MethodGet {
 		http.Error(w, "Only GET is supported.", http.StatusMethodNotAllowed)
 		return
 	}

--- a/webapp/test_runs_handler.go
+++ b/webapp/test_runs_handler.go
@@ -13,7 +13,7 @@ import (
 
 // testRunsHandler handles GET/POST requests to /test-runs
 func testRunsHandler(w http.ResponseWriter, r *http.Request) {
-	if r.Method != "GET" {
+	if r.Method != http.MethodGet {
 		http.Error(w, "Only GET is supported.", http.StatusMethodNotAllowed)
 		return
 	}


### PR DESCRIPTION
## Description
As I am approaching the codebase to take care of the golint related issues that are currently open, I took care of some linter errors that came out through a dry run of golangci-lint.
 
## Changes
Replaced string literals for HTTP methods and integers for status codes as required from the linter errors.

## Requirements
No requirements should be needed as this just replaces some parts of the code with an equivalent that is compliant with what I have read in the majority of the codebase.
