### PR TITLE
Upgrade node.js to version 18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update -qqy && apt-get install -qqy --no-install-suggests \
 RUN echo "root ALL=(ALL:ALL) ALL" > /etc/sudoers
 
 # Node LTS
-RUN curl -sL https://deb.nodesource.com/setup_16.x | bash - && \
+RUN curl -sL https://deb.nodesource.com/setup_18.x | bash - && \
     apt-get install -qqy nodejs
 
 # Google Cloud SDK

--- a/Makefile
+++ b/Makefile
@@ -257,7 +257,7 @@ inotifywait:
 
 node: curl gpg
 	if [[ "$$(which node)" == "" ]]; then \
-		curl -sL https://deb.nodesource.com/setup_16.x | sudo -E bash -; \
+		curl -sL https://deb.nodesource.com/setup_18.x | sudo -E bash -; \
 		sudo apt-get install -qqy nodejs; \
 	fi
 


### PR DESCRIPTION
Node.js 16 [reached the end of life](https://github.com/nodejs/Release) last November.