### PR TITLE
Add support for view=test query parameter

### DIFF
--- a/shared/params.go
+++ b/shared/params.go
@@ -333,7 +333,7 @@ func ParseMaxCountParamWithDefault(v url.Values, defaultValue int) (count int, e
 // ParseViewParam parses the 'view' parameter and ensures it is a valid value.
 func ParseViewParam(v url.Values) (*string, error) {
 	viewParam := v.Get("view")
-	if viewParam == "subtest" || viewParam == "interop" {
+	if viewParam == "subtest" || viewParam == "interop" || viewParam == "test" {
 		return &viewParam, nil
 	}
 	return nil, nil

--- a/shared/params_test.go
+++ b/shared/params_test.go
@@ -1,3 +1,4 @@
+//go:build small
 // +build small
 
 // Copyright 2017 The WPT Dashboard Project. All rights reserved.
@@ -393,6 +394,55 @@ func TestParseLabelsParam_LabelsAndLabel_Duplicate(t *testing.T) {
 	r := httptest.NewRequest("GET", "http://wpt.fyi/api/runs?labels=experimental&label=experimental", nil)
 	labels := ParseLabelsParam(r.URL.Query())
 	assert.Len(t, labels, 1)
+}
+
+// Generic method that can return the pointer of anything.
+func valuePtr[T any](in T) *T {
+	return &in
+}
+
+func TestParseViewParam(t *testing.T) {
+	testCases := []struct {
+		name           string
+		input          url.Values
+		expectedOutput *string
+	}{
+		{
+			name: "subtest",
+			input: map[string][]string{
+				"view": {"subtest"},
+			},
+			expectedOutput: valuePtr("subtest"),
+		},
+		{
+			name: "interop",
+			input: map[string][]string{
+				"view": {"interop"},
+			},
+			expectedOutput: valuePtr("interop"),
+		},
+		{
+			name: "test",
+			input: map[string][]string{
+				"view": {"test"},
+			},
+			expectedOutput: valuePtr("test"),
+		},
+		{
+			name: "badinput",
+			input: map[string][]string{
+				"view": {"badinput"},
+			},
+			expectedOutput: nil,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			output, err := ParseViewParam(tc.input)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedOutput, output)
+		})
+	}
 }
 
 func TestParseVersion(t *testing.T) {

--- a/webapp/components/wpt-flags.js
+++ b/webapp/components/wpt-flags.js
@@ -47,6 +47,7 @@ Object.defineProperty(wpt, 'ClientSideFeatures', {
       'queryBuilder',
       'queryBuilderSHA',
       'showBSF',
+      'showViewEqTest',
       'structuredQueries',
       'triageMetadataUI',
       'webPlatformTestsLive',
@@ -256,6 +257,11 @@ class WPTFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ false) {
     <paper-item>
       <paper-checkbox checked="{{showBSF}}">
         Enable Browser Specific Failures graph
+      </paper-checkbox>
+    </paper-item>
+    <paper-item>
+      <paper-checkbox checked="{{showViewEqTest}}">
+        Enable view=test query parameter
       </paper-checkbox>
     </paper-item>
 `;

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -1079,10 +1079,7 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
 
   isTestView() {
     // If the `showViewEqTest` feature flag is not active, return false immediately.
-    if (!this.showViewEqTest) {
-      return false;
-    }
-    return this.view === 'test';
+    return this.showViewEqTest && this.view === 'test';
   }
 
   getTotalsClass(totalInfo) {

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -55,6 +55,13 @@ const STATUS_ABBREVIATIONS = {
 };
 const PASSING_STATUSES = ['O', 'P'];
 
+// ViewEnum contains the different values for the `view` query parameter.
+const ViewEnum = {
+  Subtest: 'subtest',
+  Interop: 'interop',
+  Test: 'test'
+}
+
 class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathInfo(LoadingState(TestRunsUIBase)))))) {
   static get template() {
     return html`
@@ -1004,22 +1011,22 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
   }
 
   testViewButtonClass(view) {
-    return (view === 'test') ? 'selected' : 'unselected';
+    return (view === ViewEnum.Test) ? 'selected' : 'unselected';
   }
 
   interopButtonClass(view) {
-    return (view === 'interop') ? 'selected' : 'unselected';
+    return (view === ViewEnum.Interop) ? 'selected' : 'unselected';
   }
 
   defaultButtonClass(view) {
-    return (view !== 'interop' && view !== 'test') ? 'selected' : 'unselected';
+    return (view !== ViewEnum.Interop && view !== ViewEnum.Test) ? 'selected' : 'unselected';
   }
 
   clickInterop() {
     if (this.isInteropView()) {
       return;
     }
-    this.view = 'interop';
+    this.view = ViewEnum.Interop;
   }
 
   clickTestView() {
@@ -1031,14 +1038,14 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
     if (this.isTestView()) {
       return;
     }
-    this.view = 'test';
+    this.view = ViewEnum.Test;
   }
 
   clickDefault() {
     if (this.isDefaultView()) {
       return;
     }
-    this.view = 'subtest';
+    this.view = ViewEnum.Subtest;
   }
 
   changeView(view) {
@@ -1074,12 +1081,12 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
   }
 
   isInteropView() {
-    return this.view === 'interop';
+    return this.view === ViewEnum.Interop;
   }
 
   isTestView() {
     // If the `showViewEqTest` feature flag is not active, return false immediately.
-    return this.showViewEqTest && this.view === 'test';
+    return this.showViewEqTest && this.view === ViewEnum.Test;
   }
 
   getTotalsClass(totalInfo) {

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -255,7 +255,9 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
     <template is="dom-if" if="[[shouldDisplayToggle(canViewInteropScores, pathIsATestFile)]]">
       <div class="channel-area">
         <paper-button id="toggleInterop" class\$="[[ interopButtonClass(view) ]]" on-click="clickInterop">Interop View</paper-button>
-        <paper-button id="toggleTestView" class\$="[[ testViewButtonClass(view) ]]" on-click="clickTestView">Test View</paper-button>
+        <template is="dom-if" if="[[showViewEqTest]]">
+          <paper-button id="toggleTestView" class\$="[[ testViewButtonClass(view) ]]" on-click="clickTestView">Test View</paper-button>
+        </template>
         <paper-button id="toggleDefault" class\$="[[ defaultButtonClass(view) ]]" on-click="clickDefault">Default View</paper-button>
       </div>
     </template>
@@ -1021,6 +1023,11 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
   }
 
   clickTestView() {
+    if (!this.showViewEqTest) {
+      // Do nothing if the `showViewEqTest` feature flag is not enabled.
+      return;
+    }
+
     if (this.isTestView()) {
       return;
     }
@@ -1071,6 +1078,10 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
   }
 
   isTestView() {
+    // If the `showViewEqTest` feature flag is not active, return false immediately.
+    if (!this.showViewEqTest) {
+      return false;
+    }
     return this.view === 'test';
   }
 

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -1226,24 +1226,6 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
       }
     }
 
-    const formatPercent = parseFloat((passes / total * 100).toFixed(0));
-    let cellDisplay = '';
-    // Show flat 0% or 100% only if none or all tests/subtests pass.
-    if (passes === 0) {
-      cellDisplay = '0';
-    } else if (passes === total) {
-      cellDisplay = '100';
-    } else if (formatPercent === 0.0) {
-      // If there are passing tests, but only enough to round to 0.00,
-      // show 0.01 rather than 0.00 to differentiate between possible error states.
-      cellDisplay = '0.1';
-    } else if (formatPercent === 100.0) {
-      // If almost every test is passing, but there are some failures,
-      // don't round up to 'total / total' so that it's clear some failure exists.
-      cellDisplay = '99.9';
-    } else {
-      cellDisplay = `${formatPercent}`;
-    }
     // Only display the the numbers without percentages.
     return `${this.getTestNumbersDisplay(passes, total, isDir)}`;
   }

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -779,7 +779,7 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
       nodes.totals[i].subtest_passes += passes;
       row.results[i].subtest_total += total;
       nodes.totals[i].subtest_total += total;
-      const test_view_pass = (passes === total) ? 1: 0;
+      const test_view_pass = (passes === total && PASSING_STATUSES.includes(status)) ? 1: 0;
       row.results[i].test_view_passes += test_view_pass;
       nodes.totals[i].test_view_passes += test_view_pass;
       row.results[i].test_view_total++;
@@ -1211,11 +1211,11 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
   formatCellDisplayTestView(passes, total, status, isDir) {
 
     // At the test level:
-    // 1. Show PASS is passes == total for subtests.
-    // 2. Show FAIL if status is undefined (legacy summaries) or 'O' (because showing OKAY would be misleading).
+    // 1. Show PASS is passes == total for subtests AND (status is undefined (legacy) OR isPassingStatus (v2)).
+    // 2. Show FAIL if status is undefined (legacy summaries) or 'O' (because showing OK would be misleading).
     // 3. Show FAIL otherwise.
     if (!isDir) {
-      if (passes === total) {
+      if (passes === total && ((status === undefined) || (PASSING_STATUSES.includes(status)))) {
         return "PASS"
       } else if ((status === undefined) || (status === 'O')) {
         return "FAIL";


### PR DESCRIPTION
Backend changes:
- Add "test" to the allowlist values for the view url parameter
- Add TestParseViewParam to assert behavior for existing view params and the new "test" parameter

Frontend changes:
- Add new Test View button
- Add test_view_ prefix. This prefix is used to keep track of the new view=test mode.
- Add new helper method isTestView() to support this new view
- Add helper method isInteropView to retroactively support the already supported interop view.
- Create getNodeTotalProp and getNodePassProp to encapsulate the logic of which property from the aggregation node to use.

About view=test mode
- Test pass is only counted if the number of subtest passes == the total subtests
- This should **not** display percentages. Only the counts from the first bullet point when at  directory level.
- When on the individual test level, it should only show `PASS` when subtest passes == the total subtests
  - Other cases:
  - When the status == OKAY and subtest passes != the total subtests, still show FAIL
  - Show the status for other cases that come from the existing STATUS_ABBREVIATIONS mapping
  - Fallback to showing FAIL for anything else

For reviewers:
- Double check to make sure I accounted for the legacy v1 summary case? Or am I overthinking and the v1 case does not matter?

High level view:
![image](https://github.com/web-platform-tests/wpt.fyi/assets/7788930/5a1c4841-8b64-44d8-b46a-4cb261db7d1e)


Test View:
![image](https://github.com/web-platform-tests/wpt.fyi/assets/7788930/ef641603-f334-4ab4-9865-bad1ec764221)


Mixed View:
![image](https://github.com/web-platform-tests/wpt.fyi/assets/7788930/45e6ae50-83ae-4076-8694-ef837bedbf36)

Feature Flag (default is off and the feature does not work then):
![image](https://github.com/web-platform-tests/wpt.fyi/assets/7788930/4b500a86-bf2d-461a-9576-62da8a8f6c2a)

