### PR TITLE
Fix the URL for the accessibility investigation area

### DIFF
--- a/webapp/components/interop-data.js
+++ b/webapp/components/interop-data.js
@@ -651,7 +651,7 @@ export const interopData = {
     'investigation_scores': [
       {
         'name': 'Accessibility Testing',
-        'url': 'https://github.com/web-platform-tests/interop-accessibility-testing',
+        'url': 'https://github.com/web-platform-tests/interop-accessibility',
         'scores_over_time': []
       },
       {

--- a/webapp/static/interop-data.json
+++ b/webapp/static/interop-data.json
@@ -628,7 +628,7 @@
     "investigation_scores": [
       {
         "name": "Accessibility Testing",
-        "url": "https://github.com/web-platform-tests/interop-accessibility-testing",
+        "url": "https://github.com/web-platform-tests/interop-accessibility",
         "scores_over_time": []
       },
       {


### PR DESCRIPTION
## Changes

This fixes the URL to use the actual repo name (the section for the 2023 data had the right URL)
