### PR TITLE
Update Chrome logo in test history timeline

### DIFF
--- a/webapp/components/test-results-history-timeline.js
+++ b/webapp/components/test-results-history-timeline.js
@@ -50,7 +50,7 @@ class TestResultsTimeline extends PathInfo(PolymerElement) {
           }
         </style>
         <h2>
-          <img class="browser" alt="chrome chrome,dev,experimental,master,taskcluster,user:chromium-wpt-export-bot,prod logo" src="/static/chrome-dev_64x64.png">
+          <img class="browser" alt="chrome chrome,canary,experimental,master,taskcluster,user:chromium-wpt-export-bot,prod logo" src="/static/chrome-canary.png">
           Chrome
         </h2>
         <div class="chart" id="chromeHistoryChart"></div>

--- a/webapp/components/test-results-history-timeline.js
+++ b/webapp/components/test-results-history-timeline.js
@@ -50,7 +50,7 @@ class TestResultsTimeline extends PathInfo(PolymerElement) {
           }
         </style>
         <h2>
-          <img class="browser" alt="chrome chrome,canary,experimental,master,taskcluster,user:chromium-wpt-export-bot,prod logo" src="/static/chrome-canary.png">
+          <img class="browser" alt="chrome chrome,canary,experimental,master,taskcluster,user:chromium-wpt-export-bot,prod logo" src="/static/chrome-canary_64x64.png">
           Chrome
         </h2>
         <div class="chart" id="chromeHistoryChart"></div>


### PR DESCRIPTION
The timeline is now populated using Canary runs rather than Dev runs.

![Screenshot 2024-04-29 at 2 33 44 PM](https://github.com/web-platform-tests/wpt.fyi/assets/56164590/298d195c-b857-496e-8249-af899f011d96)
