### PR TITLE
Disable local debug mode by default

### DIFF
--- a/results-processor/README.md
+++ b/results-processor/README.md
@@ -41,3 +41,10 @@ update dependencies, run the following commands:
 pip3.9 install --user pip-tools
 python3.9 -m piptools compile requirements.in
 ```
+
+## Local debugging
+
+Debugging is disabled both in production and when running locally by default.
+To enable debugging when running locally pass `debug=True` to the `app.run()`
+call in the last line of
+[`main.py`](https://github.com/web-platform-tests/wpt.fyi/blob/main/results-processor/main.py).

--- a/results-processor/main.py
+++ b/results-processor/main.py
@@ -122,4 +122,4 @@ def task_handler():
 # Run the script directly locally to start Flask dev server.
 if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)
-    app.run(debug=True)
+    app.run(debug=False)


### PR DESCRIPTION
This should fix the related code scanning [alert](https://github.com/web-platform-tests/wpt.fyi/security/code-scanning/3).

I bet nobody is using the debugger at the moment, but at least leaving the parameter in the source will remind anyone who wants to do so in the future.