### PR TITLE
Remove edge_webdriver, and add support for edge as well as edgechromium in results-processor.

### DIFF
--- a/results-processor/wptreport.py
+++ b/results-processor/wptreport.py
@@ -552,7 +552,8 @@ def _channel_to_labels(browser: str, channel: str) -> Set[str]:
     if channel == 'release':
         # e.g. Edge release
         labels.add('stable')
-    if channel == 'canary' and (browser == 'edgechromium' or browser == 'edge'):
+    if (channel == 'canary' and
+            (browser == 'edgechromium' or browser == 'edge')):
         # Edge Canary is almost nightly.
         labels.add('nightly')
 

--- a/results-processor/wptreport.py
+++ b/results-processor/wptreport.py
@@ -552,7 +552,7 @@ def _channel_to_labels(browser: str, channel: str) -> Set[str]:
     if channel == 'release':
         # e.g. Edge release
         labels.add('stable')
-    if channel == 'canary' and browser == 'edgechromium':
+    if channel == 'canary' and (browser == 'edgechromium' or browser == 'edge'):
         # Edge Canary is almost nightly.
         labels.add('nightly')
 
@@ -618,10 +618,7 @@ def normalize_product(report: WPTReport) -> Set[str]:
        A set of strings.
     """
     product = report.run_info['product']
-    if product == 'edge_webdriver':
-        report.run_info['product'] = 'edge'
-        return {'edge', 'webdriver', 'edge_webdriver'}
-    elif product == 'edgechromium':
+    if product == 'edgechromium' or product == 'edge':
         report.run_info['product'] = 'edge'
         return {'edge', 'edgechromium'}
     elif product == 'webkitgtk_minibrowser':

--- a/results-processor/wptreport_test.py
+++ b/results-processor/wptreport_test.py
@@ -637,16 +637,16 @@ class HelpersTest(unittest.TestCase):
             {'blade-runner', 'beta', 'firefox'}
         )
 
-    def test_normalize_product_edge_webdriver(self):
+    def test_normalize_product_edge(self):
         r = WPTReport()
         r._report = {
             'run_info': {
-                'product': 'edge_webdriver',
+                'product': 'edge',
             }
         }
         self.assertSetEqual(
             normalize_product(r),
-            {'edge', 'webdriver', 'edge_webdriver'}
+            {'edge', 'edgechromium'}
         )
         self.assertEqual(
             r.run_info['product'],


### PR DESCRIPTION
## Description
Removes references to deprecated edge_webdriver, which was removed from WPT Tests via https://github.com/web-platform-tests/wpt/pull/44233 back in Feb 2024. 

Also supports both edge and edgechromium as valid product names, as edgechromium is being renamed edge via https://github.com/web-platform-tests/wpt/pull/45959

## Changes
Only files changed are in results processor, and only related to removing edge_webdriver and supporting both edge, and edgechromium.

## Requirements
No special requirements/configuration needed. 
