### PR TITLE
Remove beta notices for searchcache docs

### DIFF
--- a/api/query/README.md
+++ b/api/query/README.md
@@ -40,8 +40,6 @@ Combines the filters such that there exists some result in the row that satisfie
 
 #### All and None
 
-> BETA: This feature is under development and may change without warning.
-
     all([query1] [query2])
 
 Combines filters such that they must all apply to all runs.
@@ -61,8 +59,6 @@ useful when there are multiple runs with the same product, e.g. to find a regres
 
 #### Count
 
-> BETA: This feature is under development and may change without warning.
-
     count:[number]([query1] [query2])
 
 Requires that the number of results matching the given query/queries is precisely
@@ -78,8 +74,6 @@ Safari is the only one missing a result:
     three(status:!missing) safari:missing
 
 ##### Count inequality
-
-> BETA: This feature is under development and may change without warning.
 
     count[inequality][number]([query1])
 
@@ -150,8 +144,6 @@ or, negation,
 Where `[product]` is a product specification (e.g. `safari`, `chrome-69`).
 
 #### Meta qualities
-
-> BETA: This feature is under development and may change without warning.
 
 Filters the results to values which possess/exhibit a given quality.
 


### PR DESCRIPTION
These noticed have been there since 2019:

https://github.com/web-platform-tests/wpt.fyi/pull/1445
https://github.com/web-platform-tests/wpt.fyi/pull/1463
https://github.com/web-platform-tests/wpt.fyi/pull/1471
https://github.com/web-platform-tests/wpt.fyi/pull/1498

They've been stable since then, so not beta.

<!--
Thanks for the PR, you probably worked hard on it! Before you submit it for review, please make sure you read our guidelines for contributing to this repository. 

Try to make the job easy for your reviewer! Below is a template you can use as a guide for what context your reviewer might need.  
If you changed any dev procedures, consider also updating the README.
-->

## Description
TODO
<!-- A detailed description explaining what your code accomplishes, and why this work is taking place. If this affects an open issue, please make sure to properly reference it. -->

## Review Information
TODO
<!-- Provide detailed instructions for how to run the code. -->

## Changes
TODO
<!-- Highlight the files that have changed and group them into concepts, or issues being solved -->

## Requirements
TODO
<!-- Describe any special configurations, environment requirements, or dependencies. -->
