### PR TITLE
Upgrade actions/checkout to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,42 +8,42 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/make-in-docker
         with:
           target: lint
   python_test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/make-in-docker
         with:
           target: python_test
   go_test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/make-in-docker
         with:
           target: go_test
   web_components_test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/make-in-docker
         with:
           target: web_components_test
   go_chrome_test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/make-in-docker
         with:
           target: go_chrome_test
   go_firefox_test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/make-in-docker
         with:
           target: go_firefox_test
@@ -62,7 +62,7 @@ jobs:
       DOCKER_IMAGE: webplatformtests/wpt.fyi:latest
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
       DOCKER_IMAGE: webplatformtests/wpt.fyi:latest
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
 

--- a/.github/workflows/docker-update.yml
+++ b/.github/workflows/docker-update.yml
@@ -20,7 +20,7 @@ jobs:
       (github.event_name != 'pull_request'))
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: elgohr/Publish-Docker-Github-Action@v5
         # https://github.com/elgohr/Publish-Docker-Github-Action
         with:


### PR DESCRIPTION
I missed one more warning in our Actions page. Turns out that checkout v4 has been released.