### PR TITLE
Address final feedback in RFC 190 for view=test

### DIFF
--- a/webapp/components/wpt-flags.js
+++ b/webapp/components/wpt-flags.js
@@ -47,7 +47,6 @@ Object.defineProperty(wpt, 'ClientSideFeatures', {
       'queryBuilder',
       'queryBuilderSHA',
       'showBSF',
-      'showViewEqTest',
       'structuredQueries',
       'triageMetadataUI',
       'webPlatformTestsLive',
@@ -257,11 +256,6 @@ class WPTFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ false) {
     <paper-item>
       <paper-checkbox checked="{{showBSF}}">
         Enable Browser Specific Failures graph
-      </paper-checkbox>
-    </paper-item>
-    <paper-item>
-      <paper-checkbox checked="{{showViewEqTest}}">
-        Enable view=test query parameter
       </paper-checkbox>
     </paper-item>
 `;

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -262,9 +262,6 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
     <template is="dom-if" if="[[shouldDisplayToggle(canViewInteropScores, pathIsATestFile)]]">
       <div class="channel-area">
         <paper-button id="toggleInterop" class\$="[[ interopButtonClass(view) ]]" on-click="clickInterop">Interop View</paper-button>
-        <template is="dom-if" if="[[showViewEqTest]]">
-          <paper-button id="toggleTestView" class\$="[[ testViewButtonClass(view) ]]" on-click="clickTestView">Test View</paper-button>
-        </template>
         <paper-button id="toggleDefault" class\$="[[ defaultButtonClass(view) ]]" on-click="clickDefault">Default View</paper-button>
       </div>
     </template>
@@ -1010,10 +1007,6 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
     return canViewInteropScores && !pathIsATestFile;
   }
 
-  testViewButtonClass(view) {
-    return (view === VIEW_ENUM.Test) ? 'selected' : 'unselected';
-  }
-
   interopButtonClass(view) {
     return (view === VIEW_ENUM.Interop) ? 'selected' : 'unselected';
   }
@@ -1027,18 +1020,6 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
       return;
     }
     this.view = VIEW_ENUM.Interop;
-  }
-
-  clickTestView() {
-    if (!this.showViewEqTest) {
-      // Do nothing if the `showViewEqTest` feature flag is not enabled.
-      return;
-    }
-
-    if (this.isTestView()) {
-      return;
-    }
-    this.view = VIEW_ENUM.Test;
   }
 
   clickDefault() {
@@ -1085,8 +1066,7 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
   }
 
   isTestView() {
-    // If the `showViewEqTest` feature flag is not active, return false immediately.
-    return this.showViewEqTest && this.view === VIEW_ENUM.Test;
+    return this.view === VIEW_ENUM.Test;
   }
 
   getTotalsClass(totalInfo) {


### PR DESCRIPTION
During the review of [RFC 190](https://github.com/web-platform-tests/rfcs/pull/190), we agreed that we should:
- Remove the button when in interop and allow this to be reachable by query parameter only.

This change does that by removing the button added in https://github.com/web-platform-tests/wpt.fyi/pull/3753

The idea is to allow users to accomplish their
workflows with view=test without confusing others. Another RFC would be needed to add a button.

Additionally, since this RFC has been accepted, we can remove the feature flag gating it.
