### PR TITLE
Add Interop 2025 proposal submission banner

### DIFF
--- a/webapp/components/interop-dashboard.js
+++ b/webapp/components/interop-dashboard.js
@@ -36,15 +36,18 @@ class InteropDashboard extends PolymerElement {
           text-align: center;
         }
 
-        .previous-year-banner {
+        .interop-2025-banner {
           height: 40px;
           background-color: #DEF;
           text-align: center;
           padding-top: 16px;
+          border: 2px solid #1D79F2;
+          border-radius: 8px;
         }
 
-        .previous-year-banner p {
+        .interop-2025-banner p {
           margin: 0;
+          font-size: 18px;
         }
 
         .grid-container {
@@ -284,12 +287,14 @@ class InteropDashboard extends PolymerElement {
         }
 
       </style>
-      <div class="previous-year-banner" hidden$=[[isCurrentYear]]>
-        <p>
-          You are viewing Interop data from a previous year.
-          <a href="/interop-[[currentInteropYear]]">View the current Interop Dashboard</a>.
-        </p>
-      </div>
+      <a href="https://example.com" target="_blank">
+        <div class="interop-2025-banner">
+          <p>
+            🚀 Submit a proposal for Interop 2025! 🚀
+          </p>
+        </div>
+      </a>
+
       <div class="grid-container">
         <div class="grid-item grid-item-header">
           <h1>Interop [[year]] Dashboard</h1>

--- a/webapp/components/interop-dashboard.js
+++ b/webapp/components/interop-dashboard.js
@@ -287,7 +287,7 @@ class InteropDashboard extends PolymerElement {
         }
 
       </style>
-      <a href="https://example.com" target="_blank">
+      <a href="https://github.com/web-platform-tests/interop/blob/main/2025/README.md" target="_blank">
         <div class="interop-2025-banner">
           <p>
             🚀 Submit a proposal for Interop 2025! 🚀

--- a/webapp/views/wpt-app.js
+++ b/webapp/views/wpt-app.js
@@ -68,12 +68,38 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
           padding: 0px;
           height: 28px;
         }
+
+        /* TODO(danielrsmith): Remove these when interop 2025 proposals are closed. */
+        .interop-2025-banner {
+          height: 40px;
+          background-color: #DEF;
+          text-align: center;
+          padding-top: 16px;
+          border: 2px solid #1D79F2;
+          border-radius: 8px;
+        }
+        .interop-2025-banner p {
+          margin: 0;
+          font-size: 18px;
+        }
+        .interop-2025-banner a {
+          color: #0d5de6;
+          text-decoration: none;
+        }
       </style>
 
       <app-location route="{{route}}" url-space-regex="^/(results)/"></app-location>
       <app-route route="{{route}}" pattern="/:page" data="{{routeData}}" tail="{{subroute}}"></app-route>
 
       <wpt-header path="[[encodedPath]]" query="[[query]]" user="[[user]]" is-triage-mode="[[isTriageMode]]"></wpt-header>
+
+      <a href="https://example.com" target="_blank">
+        <div class="interop-2025-banner">
+          <p>
+            🚀 Submit a proposal for Interop 2025! 🚀
+          </p>
+        </div>
+      </a>
 
       <section class="search">
         <div class="path">
@@ -390,6 +416,7 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
   }
 
   handleTestRunsLoad(e) {
+    console.log('testRuns', e.detail);
     this.testRuns = e.detail.testRuns;
   }
 

--- a/webapp/views/wpt-app.js
+++ b/webapp/views/wpt-app.js
@@ -416,7 +416,6 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
   }
 
   handleTestRunsLoad(e) {
-    console.log('testRuns', e.detail);
     this.testRuns = e.detail.testRuns;
   }
 

--- a/webapp/views/wpt-app.js
+++ b/webapp/views/wpt-app.js
@@ -69,7 +69,7 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
           height: 28px;
         }
 
-        /* TODO(danielrsmith): Remove these when interop 2025 proposals are closed. */
+        /* TODO(DanielRyanSmith): Remove these when interop 2025 proposals are closed. */
         .interop-2025-banner {
           height: 40px;
           background-color: #DEF;

--- a/webapp/views/wpt-app.js
+++ b/webapp/views/wpt-app.js
@@ -93,7 +93,8 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
 
       <wpt-header path="[[encodedPath]]" query="[[query]]" user="[[user]]" is-triage-mode="[[isTriageMode]]"></wpt-header>
 
-      <a href="https://example.com" target="_blank">
+      <!-- TODO(DanielRyanSmith): Remove this banner after the Interop 2025 submission period -->
+      <a href="https://github.com/web-platform-tests/interop/blob/main/2025/README.md" target="_blank">
         <div class="interop-2025-banner">
           <p>
             🚀 Submit a proposal for Interop 2025! 🚀


### PR DESCRIPTION
This change adds a banner across the front page and interop dashboard page of wpt.fyi to direct users to more information about proposal submission for Interop 2025. 

This is a simple update, and any design or wording choices can be changed as needed or directed.
![Screenshot 2024-08-13 at 4 11 47 PM](https://github.com/user-attachments/assets/e7069db6-d77e-4c92-9d4c-f1775b4552cb)

Note that this change should be cleanly reverted once the proposal period has ended.