### PR TITLE
Add experimental interop mobile results view

### DIFF
--- a/webapp/components/interop-dashboard.js
+++ b/webapp/components/interop-dashboard.js
@@ -81,6 +81,10 @@ class InteropDashboard extends PolymerElement {
           grid-area: bottom-desc;
         }
 
+        .text-center {
+          text-align: center;
+        }
+
         .channel-area {
           display: flex;
           max-width: fit-content;
@@ -224,10 +228,6 @@ class InteropDashboard extends PolymerElement {
           background: hsl(0 0% 0% / 5%);
         }
 
-        .interop-years {
-          text-align: center;
-        }
-
         .interop-year-text {
           display: inline-block;
           padding: 0 5px;
@@ -297,6 +297,9 @@ class InteropDashboard extends PolymerElement {
       <div class="grid-container">
         <div class="grid-item grid-item-header">
           <h1>[[dashboardTitle]]</h1>
+          <div class="text-center" hidden$="[[!isMobileScoresView]]">
+            <p><i>Mobile browser results and how they are obtained are a work in progress. Scores may not reflect the real level of support for a given feature.</i></p>
+          </div>
           <div class="channel-area" hidden$="[[isMobileScoresView]]">
             <paper-button id="toggleStable" class\$="[[stableButtonClass(stable)]]" on-click="clickStable">Stable</paper-button>
             <paper-button id="toggleExperimental" class\$="[[experimentalButtonClass(stable)]]" on-click="clickExperimental">Experimental</paper-button>
@@ -520,7 +523,7 @@ class InteropDashboard extends PolymerElement {
         </div>
       </div>
       <footer class="compat-footer">
-        <div class="interop-years">
+        <div class="text-center">
           <div class="interop-year-text">
             <p>View by year: </p>
           </div>

--- a/webapp/components/interop-dashboard.js
+++ b/webapp/components/interop-dashboard.js
@@ -616,7 +616,7 @@ class InteropDashboard extends WPTFlags(PolymerElement) {
     const params = (new URL(document.location)).searchParams;
 
     this.stable = params.get('stable') !== null;
-    this.isMobileScoresView = params.get('mobileView') !== null && this.showMobileScoresView;
+    this.isMobileScoresView = params.get('mobile-view') !== null && this.showMobileScoresView;
     this.dataManager = new InteropDataManager(this.year, this.isMobileScoresView);
 
     if (this.isMobileScoresView) {
@@ -867,7 +867,7 @@ class InteropDashboard extends WPTFlags(PolymerElement) {
       params.push('embedded');
     }
     if (isMobileScoresView) {
-      params.push('mobileView');
+      params.push('mobile-view');
     }
 
     let url = location.pathname;
@@ -927,7 +927,7 @@ class InteropDashboard extends WPTFlags(PolymerElement) {
   toggleMobileView(showMobileScores, stable) {
     let queryString = '';
     if (showMobileScores) {
-      queryString += 'mobileView';
+      queryString += 'mobile-view';
     }
     if (stable) {
       queryString += (queryString.length) ? '&stable' : 'stable';

--- a/webapp/components/interop-dashboard.js
+++ b/webapp/components/interop-dashboard.js
@@ -880,7 +880,7 @@ class InteropDashboard extends WPTFlags(PolymerElement) {
       return;
     }
     if (this.isMobileScoresView) {
-      this.toggleMobileView(false);
+      this.toggleMobileView(false, false);
     } else {
       this.stable = false;
       this.isMobileScoresView = false;
@@ -894,7 +894,7 @@ class InteropDashboard extends WPTFlags(PolymerElement) {
       return;
     }
     if (this.isMobileScoresView) {
-      this.toggleMobileView(false);
+      this.toggleMobileView(false, true);
     } else {
       this.stable = true;
       this.isMobileScoresView = false;
@@ -907,15 +907,15 @@ class InteropDashboard extends WPTFlags(PolymerElement) {
     if (this.isMobileScoresView) {
       return;
     }
-    this.toggleMobileView(true);
+    this.toggleMobileView(true, false);
   }
 
-  toggleMobileView(showMobileScores) {
+  toggleMobileView(showMobileScores, stable) {
     let queryString = ''
     if (showMobileScores) {
       queryString += 'mobileView';
     }
-    if (this.stable) {
+    if (stable) {
       queryString += (queryString.length) ? '&stable' : 'stable'; 
     }
     if (queryString.length) {

--- a/webapp/components/interop-dashboard.js
+++ b/webapp/components/interop-dashboard.js
@@ -392,6 +392,14 @@ class InteropDashboard extends WPTFlags(PolymerElement) {
                           </th>
                         </template>
                       </template>
+                      <template is="dom-if" if="{{isMobileScoresView}}">
+                        <th class="sortable-header">
+                          <div class="browser-icons single-browser-icon">
+                            <img src="/static/wktr_64x64.png" width="32" alt="Safari iOS" title="Safari iOS" />
+                          </div>
+                          <img class="sort-icon" src="[[getSortIcon(2, sortColumn, isSortedAsc)]]" />
+                        </th>
+                      </template>
                       <th class="sortable-header">
                         <div class="interop-header">INTEROP</div>
                         <img class="sort-icon" src="[[getInteropSortIcon(sortColumn, isSortedAsc)]]" />
@@ -452,6 +460,9 @@ class InteropDashboard extends WPTFlags(PolymerElement) {
                         <template is="dom-repeat" items="{{getYearProp('browserInfo')}}" as="browserInfo">
                           <td>[[getBrowserScoreForFeature(itemsIndex, rowName, stable)]]</td>
                         </template>
+                        <template is="dom-if" if="[[isMobileScoresView]]">
+                          <td>--%</td>
+                        </template>
                         <td>[[getInteropScoreForFeature(rowName, stable)]]</td>
                       </tr>
                     </template>
@@ -461,6 +472,9 @@ class InteropDashboard extends WPTFlags(PolymerElement) {
                       <td><strong>TOTAL</strong></td>
                       <template is="dom-repeat" items="{{getYearProp('browserInfo')}}" as="browserInfo">
                         <td>[[getSubtotalScore(itemsIndex, section, stable)]]</td>
+                      </template>
+                      <template is="dom-if" if="[[isMobileScoresView]]">
+                        <td>--%</td>
                       </template>
                       <td>[[getInteropSubtotalScore(section, stable)]]</td>
                     </tr>
@@ -956,7 +970,8 @@ class InteropDashboard extends WPTFlags(PolymerElement) {
 
   // Determine the icon that should be displayed on the interop column.
   getInteropSortIcon(sortColumn, isSortedAsc) {
-    const interopIndex = this.dataManager.getYearProp('numBrowsers') + 1;
+    const indexOffset = (this.isMobileScoresView) ? 2 : 1
+    const interopIndex = this.dataManager.getYearProp('numBrowsers') + indexOffset;
     if (interopIndex !== sortColumn) {
       return '/static/expand_inactive.svg';
     }
@@ -992,7 +1007,7 @@ class InteropDashboard extends WPTFlags(PolymerElement) {
   };
 
   numericalSort = (rows, featureOrder, sortColumn) => {
-    const browserIndex = sortColumn - 1;
+    const browserIndex = (this.isMobileScoresView && sortColumn === 4) ? 2 : sortColumn - 1;
     const individualScores = [];
     for (let i = 0; i < rows.length; i++) {
       const feature = rows[i];
@@ -1006,6 +1021,10 @@ class InteropDashboard extends WPTFlags(PolymerElement) {
 
   sortRows = (rows, index, sortColumn, isSortedAsc) => {
     if(index !== 0) {
+      return rows;
+    }
+    // Safari column will not have data for mobile and cannot be sorted.
+    if (this.isMobileScoresView && sortColumn === 3) {
       return rows;
     }
     const sortedFeatureOrder = [];

--- a/webapp/components/interop-dashboard.js
+++ b/webapp/components/interop-dashboard.js
@@ -925,12 +925,12 @@ class InteropDashboard extends WPTFlags(PolymerElement) {
   }
 
   toggleMobileView(showMobileScores, stable) {
-    let queryString = ''
+    let queryString = '';
     if (showMobileScores) {
       queryString += 'mobileView';
     }
     if (stable) {
-      queryString += (queryString.length) ? '&stable' : 'stable'; 
+      queryString += (queryString.length) ? '&stable' : 'stable';
     }
     if (queryString.length) {
       queryString = `?${queryString}`;
@@ -970,7 +970,7 @@ class InteropDashboard extends WPTFlags(PolymerElement) {
 
   // Determine the icon that should be displayed on the interop column.
   getInteropSortIcon(sortColumn, isSortedAsc) {
-    const indexOffset = (this.isMobileScoresView) ? 2 : 1
+    const indexOffset = (this.isMobileScoresView) ? 2 : 1;
     const interopIndex = this.dataManager.getYearProp('numBrowsers') + indexOffset;
     if (interopIndex !== sortColumn) {
       return '/static/expand_inactive.svg';

--- a/webapp/components/interop-data-manager.js
+++ b/webapp/components/interop-data-manager.js
@@ -70,6 +70,14 @@ const BROWSER_INFO = {
     tableName: 'Safari',
     tooltipName: 'Safari',
   },
+  safari_mobile: {
+    experimentalIcon: 'wktr',
+    experimentalName: 'iOS',
+    graphColor: '#148cda',
+    stableIcon: 'safari',
+    tableName: 'Safari',
+    tooltipName: 'Safari',
+  }
 };
 
 // InteropDataManager encapsulates the loading of the CSV data that backs

--- a/webapp/components/interop-data-manager.js
+++ b/webapp/components/interop-data-manager.js
@@ -291,7 +291,7 @@ class InteropDataManager {
 
         let testScore = 0.0;
         // Mobile csv does not have an Interop version column to account for.
-        let versionOffset = (this.isMobileScoresView && browserName === 'Interop') ? 0 : 1;
+        const versionOffset = (this.isMobileScoresView && browserName === 'Interop') ? 0 : 1;
 
         headers.forEach((feature, j) => {
           let score = 0;

--- a/webapp/components/interop-data-manager.js
+++ b/webapp/components/interop-data-manager.js
@@ -125,14 +125,14 @@ class InteropDataManager {
       this.tableSections = yearInfo.mobile_table_sections;
     } else {
       // Default to the Chrome/Edge bundled unless specified.
-      this.browsers = yearInfo.browsers || ['chrome_edge_dev', 'firefox', 'safari']; 
+      this.browsers = yearInfo.browsers || ['chrome_edge_dev', 'firefox', 'safari'];
       this.csvURL = yearInfo.csv_url;
       this.validYears = paramsByYear.valid_years;
       // Focus areas are iterated through often, so keep a list of all of them.
       this.focusAreasList = Object.keys(this.focusAreas);
       this.tableSections = yearInfo.table_sections;
     }
-  
+
     this.browserInfo = this.browsers.map(browser => BROWSER_INFO[browser]);
     this.numBrowsers = this.browserInfo.length;
     this.summaryFeatureName = yearInfo.summary_feature_name;

--- a/webapp/components/interop-data.js
+++ b/webapp/components/interop-data.js
@@ -2,6 +2,8 @@
 // The JSON file is used by some Mozilla infrastructure, so the file should
 // not be deleted and should match the data in this file.
 export const interopData = {
+  'valid_years': ['2021', '2022', '2023', '2024'],
+  'valid_mobile_years': ['2024'],
   '2021': {
     'table_sections': [
       {
@@ -582,6 +584,7 @@ export const interopData = {
   },
   '2024': {
     'browsers': ['chrome_canary', 'edge', 'firefox', 'safari'],
+    'mobile_browsers': ['chrome_android', 'firefox_android'],
     'table_sections': [
       {
         'name': 'Active Focus Areas',
@@ -673,11 +676,56 @@ export const interopData = {
       },
     ],
     'investigation_weight': 0.0,
+    'mobile_table_sections': [
+      {
+        'name': 'Active Focus Areas',
+        'rows': [
+          'interop-2024-accessibility',
+          'interop-2024-nesting',
+          'interop-2023-property',
+          'interop-2024-dsd',
+          'interop-2024-font-size-adjust',
+          'interop-2024-websockets',
+          'interop-2024-indexeddb',
+          'interop-2024-layout',
+          'interop-2023-events',
+          'interop-2024-popover',
+          'interop-2024-relative-color',
+          'interop-2024-video-rvfc',
+          'interop-2024-scrollbar',
+          'interop-2024-starting-style-transition-behavior',
+          'interop-2024-dir',
+          'interop-2024-text-wrap',
+          'interop-2023-url',
+        ],
+        'score_as_group': false
+      }
+    ],
+    'mobile_focus_areas': [
+      'interop-2024-accessibility',
+      'interop-2024-nesting',
+      'interop-2023-property',
+      'interop-2024-dsd',
+      'interop-2024-font-size-adjust',
+      'interop-2024-websockets',
+      'interop-2024-indexeddb',
+      'interop-2024-layout',
+      'interop-2023-events',
+      'interop-2024-popover',
+      'interop-2024-relative-color',
+      'interop-2024-video-rvfc',
+      'interop-2024-scrollbar',
+      'interop-2024-starting-style-transition-behavior',
+      'interop-2024-dir',
+      'interop-2024-text-wrap',
+      'interop-2023-url',
+    ],
     /**
      * More information on results generation at
      * https://github.com/web-platform-tests/results-analysis
     **/
     'csv_url': 'https://raw.githubusercontent.com/web-platform-tests/results-analysis/gh-pages/data/interop-2024/interop-2024-{stable|experimental}-v2.csv',
+    'mobile_csv_url': 'https://api.github.com/repos/jgraham/interop-results/contents/2024/latest/aligned/mobile-{stable|experimental}-current.csv?ref=main',
     'summary_feature_name': 'summary',
     'issue_url': 'https://github.com/web-platform-tests/interop/issues/new',
     'focus_areas_description': 'https://github.com/web-platform-tests/interop/blob/main/2024/README.md',

--- a/webapp/components/interop-summary.js
+++ b/webapp/components/interop-summary.js
@@ -157,6 +157,7 @@ class InteropSummary extends PolymerElement {
       year: String,
       dataManager: Object,
       scores: Object,
+      isMobileScoresView: Boolean,
       stable: {
         type: Boolean,
         observer: '_stableChanged',
@@ -177,13 +178,13 @@ class InteropSummary extends PolymerElement {
     }
 
     const summaryDiv = this.shadowRoot.querySelector('.summary-container');
-    // Don't display the interop score for Interop 2021.
-    if (this.year === '2021') {
+    // Don't display the interop score for Interop 2021 or mobile view.
+    if (this.year === '2021' || this.isMobileScoresView) {
       const interopDiv = this.shadowRoot.querySelector('#interopSummary');
       interopDiv.style.display = 'none';
       summaryDiv.style.minHeight = '275px';
     }
-    if (this.year === '2024') {
+    else if (this.year === '2024') {
       summaryDiv.style.minHeight = '350px';
     }
 
@@ -195,7 +196,7 @@ class InteropSummary extends PolymerElement {
 
   shouldDisplayInvestigationNumber() {
     const scores = this.dataManager.getYearProp('investigationScores');
-    return scores !== null && scores !== undefined;
+    return scores !== null && scores !== undefined && !this.isMobileScoresView;
   }
 
   // roundScore defines the rounding rules for the top-level scores.

--- a/webapp/components/interop-summary.js
+++ b/webapp/components/interop-summary.js
@@ -143,6 +143,24 @@ class InteropSummary extends PolymerElement {
               </template>
             </div>
           </template>
+          <template is="dom-if" if="{{isMobileScoresView}}">
+            <div class="summary-flex-item" tabindex="0">
+              <div class="summary-number score-number smaller-summary-number">--</div>
+              <div class="summary-browser-name">
+                <figure>
+                  <img src="/static/wktr_64x64.png" width="36" alt="Safari iOS" />
+                  <template is="dom-if" if="[[stable]]">
+                    <figcaption>Safari</figcaption>
+                  </template>
+                  <template is="dom-if" if="[[!stable]]">
+                    <figcaption>
+                      Safari<br>iOS<br>
+                    </figcaption>
+                  </template>
+                </figure>
+              </div>
+            </div>
+          </template>
         </div>
       </div>
 `;
@@ -230,13 +248,16 @@ class InteropSummary extends PolymerElement {
     const scores = this.stable ? this.scores.stable : this.scores.experimental;
     const summaryFeatureName = this.dataManager.getYearProp('summaryFeatureName');
     // If the elements have not rendered yet, don't update the scores.
-    if (scoreElements.length !== scores.length) {
+    if ((!this.isMobileScoresView && scoreElements.length !== scores.length) ||
+        (this.isMobileScoresView && scoreElements.length !== scores.length + 1)) {
       return;
     }
-    // Update interop summary number first.
-    this.updateSummaryScore(scoreElements[0], scores[scores.length - 1][summaryFeatureName]);
+    if (!this.isMobileScoresView) {
+      // Update interop summary number first.
+      this.updateSummaryScore(scoreElements[0], scores[scores.length - 1][summaryFeatureName]);
+    }
     // Update the rest of the browser scores.
-    for (let i = 1; i < scoreElements.length; i++) {
+    for (let i = 1; i < scores.length; i++) {
       this.updateSummaryScore(scoreElements[i], scores[i - 1][summaryFeatureName]);
     }
 

--- a/webapp/components/interop-summary.js
+++ b/webapp/components/interop-summary.js
@@ -183,8 +183,7 @@ class InteropSummary extends PolymerElement {
       const interopDiv = this.shadowRoot.querySelector('#interopSummary');
       interopDiv.style.display = 'none';
       summaryDiv.style.minHeight = '275px';
-    }
-    else if (this.year === '2024') {
+    } else if (this.year === '2024') {
       summaryDiv.style.minHeight = '350px';
     }
 

--- a/webapp/components/wpt-flags.js
+++ b/webapp/components/wpt-flags.js
@@ -261,7 +261,7 @@ class WPTFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ false) {
     </paper-item>
     <paper-item>
       <paper-checkbox checked="{{showMobileScoresView}}">
-        Allow mobile results view on Interop dashboard
+        Enable mobile results view on Interop dashboard
       </paper-checkbox>
     </paper-item>
 `;

--- a/webapp/components/wpt-flags.js
+++ b/webapp/components/wpt-flags.js
@@ -47,6 +47,7 @@ Object.defineProperty(wpt, 'ClientSideFeatures', {
       'queryBuilder',
       'queryBuilderSHA',
       'showBSF',
+      'showMobileScoresView',
       'structuredQueries',
       'triageMetadataUI',
       'webPlatformTestsLive',
@@ -256,6 +257,11 @@ class WPTFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ false) {
     <paper-item>
       <paper-checkbox checked="{{showBSF}}">
         Enable Browser Specific Failures graph
+      </paper-checkbox>
+    </paper-item>
+    <paper-item>
+      <paper-checkbox checked="{{showMobileScoresView}}">
+        Allow mobile results view on Interop dashboard
       </paper-checkbox>
     </paper-item>
 `;

--- a/webapp/interop_handler.go
+++ b/webapp/interop_handler.go
@@ -19,6 +19,7 @@ type interopData struct {
 
 // Set of years that are valid for Interop 20XX.
 var validYears = map[string]bool{"2021": true, "2022": true, "2023": true, "2024": true}
+var validMobileYears = map[string]bool{"2024": true}
 
 // Year that any invalid year will redirect to.
 // TODO(danielrsmith): Change this redirect for next year's interop page.
@@ -36,6 +37,18 @@ func interopHandler(w http.ResponseWriter, r *http.Request) {
 		needsRedirect = true
 	}
 
+	q := r.URL.Query()
+	isMobileView, err := shared.ParseBooleanParam(q, "mobileView")
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	_, isValidMobileYear := validMobileYears[year];
+	if isMobileView != nil && !isValidMobileYear {
+		year = defaultRedirectYear
+		needsRedirect = true
+	}
+
 	if needsRedirect {
 		destination := *(r.URL)
 
@@ -49,7 +62,6 @@ func interopHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	q := r.URL.Query()
 	embedded, err := shared.ParseBooleanParam(q, "embedded")
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)

--- a/webapp/interop_handler.go
+++ b/webapp/interop_handler.go
@@ -38,7 +38,7 @@ func interopHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	q := r.URL.Query()
-	isMobileView, err := shared.ParseBooleanParam(q, "mobileView")
+	isMobileView, err := shared.ParseBooleanParam(q, "mobile-view")
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return

--- a/webapp/interop_handler_test.go
+++ b/webapp/interop_handler_test.go
@@ -39,6 +39,28 @@ func TestInteropHandler_redirect(t *testing.T) {
 	assert.Equal(t, loc.RawQuery, "embedded")
 }
 
+func TestInteropHandler_redirectMobile(t *testing.T) {
+	// 2021 is an invalid interop mobile year and should be redirected.
+	req := httptest.NewRequest("GET", "/interop-2021?mobileView", strings.NewReader("{}"))
+	req = mux.SetURLVars(req, map[string]string{
+		"name":     "interop",
+		"year":     "2021",
+		"mobileView": "true",
+	})
+
+	w := httptest.NewRecorder()
+	interopHandler(w, req)
+	resp := w.Result()
+	assert.Equal(t, resp.StatusCode, http.StatusTemporaryRedirect)
+
+	loc, err := resp.Location()
+	assert.Nil(t, err)
+	// Check that the path has been properly updated to the current interop effort.
+	assert.Equal(t, loc.Path, "/interop-2024")
+	// Check if mobileView param is maintained after redirect.
+	assert.Equal(t, loc.RawQuery, "mobileView")
+}
+
 func TestInteropHandler_redirectdefault(t *testing.T) {
 	// /interop route should redirect to the current default interop year dashboard.
 	req := httptest.NewRequest("GET", "/interop?embedded", strings.NewReader("{}"))
@@ -80,6 +102,22 @@ func TestInteropHandler_success(t *testing.T) {
 	req = mux.SetURLVars(req, map[string]string{
 		"name": "interop",
 		"year": defaultRedirectYear,
+	})
+
+	w := httptest.NewRecorder()
+	interopHandler(w, req)
+	resp := w.Result()
+	assert.Equal(t, resp.StatusCode, http.StatusOK)
+}
+
+func TestInteropHandler_mobileSuccess(t *testing.T) {
+	// A typical "/interop-20XX" path with a valid mobile year should not redirect.
+	req := httptest.NewRequest(
+		"GET", "/interop-"+defaultRedirectYear+"?mobileView", strings.NewReader("{}"))
+	req = mux.SetURLVars(req, map[string]string{
+		"name": "interop",
+		"year": defaultRedirectYear,
+		"mobileView": "true",
 	})
 
 	w := httptest.NewRecorder()

--- a/webapp/interop_handler_test.go
+++ b/webapp/interop_handler_test.go
@@ -41,7 +41,7 @@ func TestInteropHandler_redirect(t *testing.T) {
 
 func TestInteropHandler_redirectMobile(t *testing.T) {
 	// 2021 is an invalid interop mobile year and should be redirected.
-	req := httptest.NewRequest("GET", "/interop-2021?mobileView", strings.NewReader("{}"))
+	req := httptest.NewRequest("GET", "/interop-2021?mobile-view", strings.NewReader("{}"))
 	req = mux.SetURLVars(req, map[string]string{
 		"name":     "interop",
 		"year":     "2021",
@@ -58,7 +58,7 @@ func TestInteropHandler_redirectMobile(t *testing.T) {
 	// Check that the path has been properly updated to the current interop effort.
 	assert.Equal(t, loc.Path, "/interop-2024")
 	// Check if mobileView param is maintained after redirect.
-	assert.Equal(t, loc.RawQuery, "mobileView")
+	assert.Equal(t, loc.RawQuery, "mobile-view")
 }
 
 func TestInteropHandler_redirectdefault(t *testing.T) {
@@ -113,7 +113,7 @@ func TestInteropHandler_success(t *testing.T) {
 func TestInteropHandler_mobileSuccess(t *testing.T) {
 	// A typical "/interop-20XX" path with a valid mobile year should not redirect.
 	req := httptest.NewRequest(
-		"GET", "/interop-"+defaultRedirectYear+"?mobileView", strings.NewReader("{}"))
+		"GET", "/interop-"+defaultRedirectYear+"?mobile-view", strings.NewReader("{}"))
 	req = mux.SetURLVars(req, map[string]string{
 		"name": "interop",
 		"year": defaultRedirectYear,

--- a/webapp/static/interop-data.json
+++ b/webapp/static/interop-data.json
@@ -561,6 +561,7 @@
   },
   "2024": {
     "browsers": ["chrome_canary", "edge", "firefox", "safari"],
+    "mobile_browsers": ["chrome_android", "firefox_android"],
     "table_sections": [
       {
         "name": "Active Focus Areas",

--- a/webapp/static/interop-data.json
+++ b/webapp/static/interop-data.json
@@ -1,4 +1,6 @@
 {
+  "valid_years": ["2021", "2022", "2023", "2024"],
+  "valid_mobile_years": ["2024"],
   "2021": {
     "table_sections": [
       {
@@ -650,7 +652,52 @@
       }
     ],
     "investigation_weight": 0.0,
+    "mobile_table_sections": [
+    {
+      "name": "Active Focus Areas",
+      "rows": [
+        "interop-2024-accessibility",
+        "interop-2024-nesting",
+        "interop-2023-property",
+        "interop-2024-dsd",
+        "interop-2024-font-size-adjust",
+        "interop-2024-websockets",
+        "interop-2024-indexeddb",
+        "interop-2024-layout",
+        "interop-2023-events",
+        "interop-2024-popover",
+        "interop-2024-relative-color",
+        "interop-2024-video-rvfc",
+        "interop-2024-scrollbar",
+        "interop-2024-starting-style-transition-behavior",
+        "interop-2024-dir",
+        "interop-2024-text-wrap",
+        "interop-2023-url"
+      ],
+      "score_as_group": false
+    }
+    ],
+    "mobile_focus_areas": [
+    "interop-2024-accessibility",
+    "interop-2024-nesting",
+    "interop-2023-property",
+    "interop-2024-dsd",
+    "interop-2024-font-size-adjust",
+    "interop-2024-websockets",
+    "interop-2024-indexeddb",
+    "interop-2024-layout",
+    "interop-2023-events",
+    "interop-2024-popover",
+    "interop-2024-relative-color",
+    "interop-2024-video-rvfc",
+    "interop-2024-scrollbar",
+    "interop-2024-starting-style-transition-behavior",
+    "interop-2024-dir",
+    "interop-2024-text-wrap",
+    "interop-2023-url"
+    ],
     "csv_url": "https://raw.githubusercontent.com/web-platform-tests/results-analysis/gh-pages/data/interop-2024/interop-2024-{stable|experimental}-v2.csv",
+    "mobile_csv_url": "https://api.github.com/repos/jgraham/interop-results/contents/2024/latest/aligned/mobile-{stable|experimental}-current.csv?ref=main",
     "summary_feature_name": "summary",
     "issue_url": "https://github.com/web-platform-tests/interop/issues/new",
     "focus_areas_description": "https://github.com/web-platform-tests/interop/blob/main/2024/README.md",


### PR DESCRIPTION
This change pulls mobile results data from the [interop-results repo](https://github.com/jgraham/interop-results) and uses it to display a new mobile results view on the Interop dashboard. The mobile results view can only be seen by toggling a flag in `/flags`.


https://github.com/user-attachments/assets/afeef440-e2f3-4727-8e13-4132cbd028dc

