### PR TITLE
Fix the int conversion warning in linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ GO_FILES := $(shell find $(WPTD_PATH) -type f -name '*.go')
 GO_TEST_FILES := $(shell find $(WPTD_PATH) -type f -name '*_test.go')
 # Golangci version should be updated periodically.
 # See: https://golangci-lint.run/usage/install/#other-ci
-GOLANGCI_LINT_VERSION := v1.52.2
+GOLANGCI_LINT_VERSION := v1.60.3
 
 build: go_build
 

--- a/api/query/cache/backfill/backfill.go
+++ b/api/query/cache/backfill/backfill.go
@@ -117,7 +117,6 @@ func FillIndex(
 
 func startBackfillMonitor(store shared.Datastore, logger shared.Logger, maxBytes uint64, m *backfillMonitor) error {
 	// FetchRuns will return at most N runs for each product, so divide the upper bound by the number of products.
-	//nolint:gosec
 	limit := int(maxBytes/bytesPerRun) / len(shared.GetDefaultProducts())
 	runsByProduct, err := store.TestRunQuery().LoadTestRuns(shared.GetDefaultProducts(), nil, nil, nil, nil, &limit, nil)
 	if err != nil {

--- a/api/query/cache/backfill/backfill.go
+++ b/api/query/cache/backfill/backfill.go
@@ -117,6 +117,7 @@ func FillIndex(
 
 func startBackfillMonitor(store shared.Datastore, logger shared.Logger, maxBytes uint64, m *backfillMonitor) error {
 	// FetchRuns will return at most N runs for each product, so divide the upper bound by the number of products.
+	//nolint:gosec
 	limit := int(maxBytes/bytesPerRun) / len(shared.GetDefaultProducts())
 	runsByProduct, err := store.TestRunQuery().LoadTestRuns(shared.GetDefaultProducts(), nil, nil, nil, nil, &limit, nil)
 	if err != nil {

--- a/api/query/cache/index/index.go
+++ b/api/query/cache/index/index.go
@@ -207,7 +207,6 @@ func (i *shardedWPTIndex) IngestRun(r shared.TestRun) error {
 			return err
 		}
 
-		//nolint:gosec
 		shardIdx := int(t.testID % numShardsU64)
 		dataForShard := shardData[shardIdx]
 		re := ResultID(shared.TestStatusValueFromString(res.Status))

--- a/api/query/cache/index/index.go
+++ b/api/query/cache/index/index.go
@@ -207,6 +207,7 @@ func (i *shardedWPTIndex) IngestRun(r shared.TestRun) error {
 			return err
 		}
 
+		//nolint:gosec
 		shardIdx := int(t.testID % numShardsU64)
 		dataForShard := shardData[shardIdx]
 		re := ResultID(shared.TestStatusValueFromString(res.Status))


### PR DESCRIPTION
Fix the int conversion warning in Linter, suggested in https://github.com/securego/gosec/issues/1185#issuecomment-2304307264. Nolint the intended use of int64 to int conversion