### PR TITLE
Fix #3906: Implement a /api/checks/ endpoint for GitHub Actions

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -395,6 +395,11 @@ for its format). This field can be repeated to include multiple links (for chunk
 __`screenshot_url`__: A URL to a **gzipped** screenshot database produced by `wpt run --log-screenshot`.
 This field can be repeated to include multiple links (for chunked reports).
 
+__`archive_url`__: A URL to a ZIP archive containing files like `wpt_report*.json` and
+`wpt_screenshot*.json`, similar to `result_url` and `screenshot_url` respectively. This field can
+be repeated to include multiple links (for chunked reports). This field cannot co-exist with
+`result_url` or `screenshot_url`.
+
 __`callback_url`__: (Optional) A URL that the processor should `POST` when successful, which will
 create the TestRun. Defaults to /api/results/create in the current project's environment (e.g. wpt.fyi for
 wptdashboard, staging.wpt.fyi for wptdashboard-staging).

--- a/api/azure/webhook.go
+++ b/api/azure/webhook.go
@@ -105,9 +105,9 @@ func processBuild(
 			sha,
 			uploader.Username,
 			uploader.Password,
-			// Azure has a single zip artifact, special-cased by the receiver.
-			[]string{artifact.Resource.DownloadURL},
 			nil,
+			nil,
+			[]string{artifact.Resource.DownloadURL},
 			shared.ToStringSlice(labels))
 		if err != nil {
 			errors <- fmt.Errorf("failed to create run: %w", err)

--- a/api/ghactions/notify.go
+++ b/api/ghactions/notify.go
@@ -1,0 +1,195 @@
+// Copyright 2024 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package ghactions
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strconv"
+
+	mapset "github.com/deckarep/golang-set"
+	"github.com/gobwas/glob"
+	"github.com/google/go-github/v47/github"
+	uc "github.com/web-platform-tests/wpt.fyi/api/receiver/client"
+
+	"github.com/web-platform-tests/wpt.fyi/shared"
+)
+
+const uploaderName = "github-actions"
+
+var (
+	prHeadRegex        = regexp.MustCompile(`\baffected-tests$`)
+	prBaseRegex        = regexp.MustCompile(`\baffected-tests-without-changes$`)
+	epochBranchesRegex = regexp.MustCompile("^epochs/.*")
+)
+
+func notifyHandler(w http.ResponseWriter, r *http.Request) {
+	rawRunID := r.FormValue("run_id")
+	var runID int64
+	var err error
+	if runID, err = strconv.ParseInt(rawRunID, 0, 0); err != nil {
+		http.Error(w, fmt.Sprintf("Invalid run id: %s", rawRunID), http.StatusBadRequest)
+
+		return
+	}
+
+	owner := r.FormValue("owner")
+	repo := r.FormValue("repo")
+
+	if owner != shared.WPTRepoOwner || repo != shared.WPTRepoName {
+		http.Error(w, fmt.Sprintf("Invalid repo: %s/%s", owner, repo), http.StatusBadRequest)
+
+		return
+	}
+
+	artifactName := r.FormValue("artifact_name")
+	artifactNameGlob, err := glob.Compile(artifactName)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Invalid artifact name: %s", artifactName), http.StatusBadRequest)
+
+		return
+	}
+
+	ctx := r.Context()
+	aeAPI := shared.NewAppEngineAPI(ctx)
+	log := shared.GetLogger(ctx)
+
+	ghClient, err := aeAPI.GetGitHubClient()
+	if err != nil {
+		log.Errorf("Failed to get GitHub client: %s", err.Error())
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+
+		return
+	}
+
+	processed, err := processBuild(
+		ctx,
+		aeAPI,
+		ghClient,
+		owner,
+		repo,
+		runID,
+		artifactNameGlob,
+	)
+
+	if err != nil {
+		log.Errorf("%v", err.Error())
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+
+		return
+	}
+
+	if processed {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, "GitHub Actions workflow run artifacts retrieved successfully")
+	} else {
+		w.WriteHeader(http.StatusNoContent)
+		fmt.Fprintln(w, "Notification of workflow run artifacts was ignored")
+	}
+}
+
+func processBuild(
+	ctx context.Context,
+	aeAPI shared.AppEngineAPI,
+	ghClient *github.Client,
+	owner string,
+	repo string,
+	runID int64,
+	artifactNameGlob glob.Glob,
+) (bool, error) {
+	log := shared.GetLogger(ctx)
+
+	workflowRun, _, err := ghClient.Actions.GetWorkflowRunByID(ctx, owner, repo, runID)
+	if err != nil {
+		return false, err
+	}
+
+	opts := &github.ListOptions{PerPage: 100}
+
+	archiveURLs := []string{}
+
+	var labels mapset.Set
+
+	for {
+		artifacts, resp, err := ghClient.Actions.ListWorkflowRunArtifacts(ctx, owner, repo, runID, opts)
+
+		if err != nil {
+			return false, err
+		}
+
+		for _, artifact := range artifacts.Artifacts {
+
+			if !artifactNameGlob.Match(*artifact.Name) {
+				log.Infof("Skipping artifact %s", artifact.Name)
+
+				continue
+			}
+
+			log.Infof("Adding %s for %s/%s run %v to upload...", artifact.Name, owner, repo, runID)
+
+			// Set the labels based on the first artifact we find.
+			if len(archiveURLs) == 0 {
+				labels = chooseLabels(workflowRun, *artifact.Name, owner, repo)
+			}
+
+			archiveURLs = append(archiveURLs, *artifact.ArchiveDownloadURL)
+		}
+
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+
+	uploader, err := aeAPI.GetUploader(uploaderName)
+	if err != nil {
+		return false, fmt.Errorf("Failed to get uploader creds from Datastore: %w", err)
+	}
+
+	uploadClient := uc.NewClient(aeAPI)
+	err = uploadClient.CreateRun(
+		*workflowRun.HeadSHA,
+		uploader.Username,
+		uploader.Password,
+		nil,
+		nil,
+		archiveURLs,
+		shared.ToStringSlice(labels))
+
+	if err != nil {
+		return false, fmt.Errorf("Failed to create run: %w", err)
+	}
+
+	return true, nil
+}
+
+func chooseLabels( // nolint:ireturn // TODO: Fix ireturn lint error
+	workflowRun *github.WorkflowRun,
+	artifactName string,
+	owner string,
+	repo string,
+) mapset.Set {
+	labels := mapset.NewSet()
+
+	if (*workflowRun.Event == "push" &&
+		*workflowRun.HeadRepository.Owner.Login == owner &&
+		*workflowRun.HeadRepository.Name == repo) &&
+		(*workflowRun.HeadBranch == "master" ||
+			epochBranchesRegex.MatchString(*workflowRun.HeadBranch)) {
+		labels.Add(shared.MasterLabel)
+	}
+
+	if *workflowRun.Event == "pull_request" {
+		if prHeadRegex.MatchString(artifactName) {
+			labels.Add(shared.PRHeadLabel)
+		} else if prBaseRegex.MatchString(artifactName) {
+			labels.Add(shared.PRBaseLabel)
+		}
+	}
+
+	return labels
+}

--- a/api/ghactions/notify_test.go
+++ b/api/ghactions/notify_test.go
@@ -1,0 +1,132 @@
+//go:build small
+// +build small
+
+// Copyright 2024 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package ghactions
+
+import (
+	"testing"
+
+	"github.com/google/go-github/v47/github"
+	"github.com/stretchr/testify/assert"
+)
+
+func PointerTo[T any](v T) *T {
+	return &v
+}
+
+func TestArtifactRegexes(t *testing.T) {
+	assert.True(t, prHeadRegex.MatchString("safari-preview-1-affected-tests"))
+	assert.True(t, prBaseRegex.MatchString("safari-preview-1-affected-tests-without-changes"))
+
+	// Base and Head could be confused with substring matching
+	assert.False(t, prBaseRegex.MatchString("safari-preview-1-affected-tests"))
+	assert.False(t, prHeadRegex.MatchString("safari-preview-1-affected-tests-without-changes"))
+}
+
+func TestEpochBranchesRegex(t *testing.T) {
+	assert.True(t, epochBranchesRegex.MatchString("epochs/twelve_hourly"))
+	assert.True(t, epochBranchesRegex.MatchString("epochs/six_hourly"))
+	assert.True(t, epochBranchesRegex.MatchString("epochs/weekly"))
+	assert.True(t, epochBranchesRegex.MatchString("epochs/daily"))
+
+	assert.False(t, epochBranchesRegex.MatchString("weekly"))
+	assert.False(t, epochBranchesRegex.MatchString("a/epochs/weekly"))
+}
+
+func TestChooseLabels(t *testing.T) {
+	wptOrgUser := github.User{
+		Login: PointerTo("web-platform-tests"),
+	}
+
+	otherUser := github.User{
+		Login: PointerTo("xxx"),
+	}
+
+	wptRepo := github.Repository{
+		Name:     PointerTo("wpt"),
+		FullName: PointerTo("web-platform-tests/wpt"),
+		Owner:    &wptOrgUser,
+	}
+
+	otherRepo := github.Repository{
+		Name:     PointerTo("wpt"),
+		FullName: PointerTo("xxx/wpt"),
+		Owner:    &otherUser,
+	}
+
+	masterWorkflowRun := github.WorkflowRun{
+		HeadBranch:     PointerTo("master"),
+		Event:          PointerTo("push"),
+		Status:         PointerTo("completed"),
+		Conclusion:     PointerTo("success"),
+		HeadSHA:        PointerTo("74dc6f6f5b2ba16940e6b6075f0faf311361dbb2"),
+		Repository:     &wptRepo,
+		HeadRepository: &wptRepo,
+	}
+
+	masterOtherWorkflowRun := github.WorkflowRun{
+		HeadBranch:     PointerTo("master"),
+		Event:          PointerTo("push"),
+		Status:         PointerTo("completed"),
+		Conclusion:     PointerTo("success"),
+		HeadSHA:        PointerTo("74dc6f6f5b2ba16940e6b6075f0faf311361dbb2"),
+		Repository:     &otherRepo,
+		HeadRepository: &otherRepo,
+	}
+
+	prWorkflowRun := github.WorkflowRun{
+		HeadBranch:     PointerTo("new-branch"),
+		Event:          PointerTo("pull_request"),
+		Status:         PointerTo("completed"),
+		Conclusion:     PointerTo("success"),
+		HeadSHA:        PointerTo("74dc6f6f5b2ba16940e6b6075f0faf311361dbb2"),
+		Repository:     &wptRepo,
+		HeadRepository: &wptRepo,
+	}
+
+	prOtherWorkflowRun := github.WorkflowRun{
+		HeadBranch:     PointerTo("master"),
+		Event:          PointerTo("pull_request"),
+		Status:         PointerTo("completed"),
+		Conclusion:     PointerTo("success"),
+		HeadSHA:        PointerTo("74dc6f6f5b2ba16940e6b6075f0faf311361dbb2"),
+		Repository:     &wptRepo,
+		HeadRepository: &otherRepo,
+	}
+
+	assert.ElementsMatch(
+		t,
+		chooseLabels(&masterWorkflowRun, "results-safari-1", "web-platform-tests", "wpt").ToSlice(),
+		[]string{"master"},
+	)
+
+	assert.ElementsMatch(t,
+		chooseLabels(&masterOtherWorkflowRun, "results-safari-1", "web-platform-tests", "wpt").ToSlice(),
+		[]string{},
+	)
+
+	assert.ElementsMatch(t,
+		chooseLabels(&prWorkflowRun, "results-safari-1", "web-platform-tests", "wpt").ToSlice(),
+		[]string{},
+	)
+
+	assert.ElementsMatch(t,
+		chooseLabels(&prOtherWorkflowRun, "results-safari-1", "web-platform-tests", "wpt").ToSlice(),
+		[]string{},
+	)
+
+	assert.ElementsMatch(
+		t,
+		chooseLabels(&prWorkflowRun, "results-safari-1-affected-tests", "web-platform-tests", "wpt").ToSlice(),
+		[]string{"pr_head"},
+	)
+
+	assert.ElementsMatch(t,
+		chooseLabels(&prOtherWorkflowRun, "results-safari-1-affected-tests-without-changes", "web-platform-tests", "wpt").ToSlice(),
+		[]string{"pr_base"},
+	)
+}

--- a/api/ghactions/routes.go
+++ b/api/ghactions/routes.go
@@ -1,0 +1,16 @@
+// Copyright 2024 The WPT Dashboard Project. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package ghactions
+
+import "github.com/web-platform-tests/wpt.fyi/shared"
+
+// RegisterRoutes adds all the api route handlers.
+func RegisterRoutes() {
+	// notifyHandler exposes an endpoint for notifying wpt.fyi that it can collect
+	// the results of a GitHub Actions workflow run.
+	// The endpoint is insecure, because we'll only try to fetch (specifically) a
+	// web-platform-tests/wpt build with the given ID.
+	shared.AddRoute("/api/checks/github-actions/", "github-actions-notify", notifyHandler).Methods("POST")
+}

--- a/api/receiver/api.go
+++ b/api/receiver/api.go
@@ -44,7 +44,12 @@ type API interface {
 
 	AddTestRun(testRun *shared.TestRun) (shared.Key, error)
 	IsAdmin(*http.Request) bool
-	ScheduleResultsTask(uploader string, results, screenshots []string, extraParams map[string]string) (string, error)
+	ScheduleResultsTask(
+		uploader string,
+		results []string,
+		screenshots []string,
+		archives []string,
+		extraParams map[string]string) (string, error)
 	UpdatePendingTestRun(pendingRun shared.PendingTestRun) error
 	UploadToGCS(gcsPath string, f io.Reader, gzipped bool) error
 }
@@ -193,7 +198,7 @@ func (a *apiImpl) UploadToGCS(gcsPath string, f io.Reader, gzipped bool) error {
 }
 
 func (a apiImpl) ScheduleResultsTask(
-	uploader string, results, screenshots []string, extraParams map[string]string) (string, error) {
+	uploader string, results, screenshots []string, archives []string, extraParams map[string]string) (string, error) {
 	key, err := a.store.ReserveID("TestRun")
 	if err != nil {
 		return "", err
@@ -215,6 +220,7 @@ func (a apiImpl) ScheduleResultsTask(
 	payload := url.Values{
 		"results":     results,
 		"screenshots": screenshots,
+		"archives":    archives,
 	}
 	payload.Set("id", fmt.Sprint(key.IntID()))
 	payload.Set("uploader", uploader)

--- a/api/receiver/api_medium_test.go
+++ b/api/receiver/api_medium_test.go
@@ -167,7 +167,7 @@ func TestScheduleResultsTask(t *testing.T) {
 			id = taskName
 			return id, nil
 		})
-	task, err := a.ScheduleResultsTask("blade-runner", results, screenshots, nil)
+	task, err := a.ScheduleResultsTask("blade-runner", results, screenshots, nil, nil)
 	assert.Equal(t, id, task)
 	assert.Nil(t, err)
 

--- a/api/receiver/client/client.go
+++ b/api/receiver/client/client.go
@@ -29,6 +29,7 @@ type Client interface {
 		password string,
 		resultURLs []string,
 		screenshotURLs []string,
+		archiveURLs []string,
 		labels []string) error
 }
 
@@ -51,6 +52,7 @@ func (c client) CreateRun(
 	password string,
 	resultURLs []string,
 	screenshotURLs []string,
+	archiveURLs []string,
 	labels []string) error {
 	// https://github.com/web-platform-tests/wpt.fyi/blob/main/api/README.md#url-payload
 	payload := make(url.Values)
@@ -64,6 +66,9 @@ func (c client) CreateRun(
 	}
 	for _, url := range screenshotURLs {
 		payload.Add("screenshot_url", url)
+	}
+	for _, url := range archiveURLs {
+		payload.Add("archive_url", url)
 	}
 	if labels != nil {
 		payload.Add("labels", strings.Join(labels, ","))

--- a/api/receiver/client/client_test.go
+++ b/api/receiver/client/client_test.go
@@ -54,6 +54,7 @@ func TestCreateRun(t *testing.T) {
 		"password",
 		[]string{"https://wpt.fyi/results.json.gz"},
 		[]string{"https://wpt.fyi/screenshots.db.gz"},
+		nil,
 		[]string{"foo", "bar"},
 	))
 	assert.True(t, visited)

--- a/api/receiver/mock_receiver/api_mock.go
+++ b/api/receiver/mock_receiver/api_mock.go
@@ -259,18 +259,18 @@ func (mr *MockAPIMockRecorder) IsFeatureEnabled(arg0 any) *gomock.Call {
 }
 
 // ScheduleResultsTask mocks base method.
-func (m *MockAPI) ScheduleResultsTask(arg0 string, arg1, arg2 []string, arg3 map[string]string) (string, error) {
+func (m *MockAPI) ScheduleResultsTask(arg0 string, arg1, arg2, arg3 []string, arg4 map[string]string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ScheduleResultsTask", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "ScheduleResultsTask", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ScheduleResultsTask indicates an expected call of ScheduleResultsTask.
-func (mr *MockAPIMockRecorder) ScheduleResultsTask(arg0, arg1, arg2, arg3 any) *gomock.Call {
+func (mr *MockAPIMockRecorder) ScheduleResultsTask(arg0, arg1, arg2, arg3, arg4 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScheduleResultsTask", reflect.TypeOf((*MockAPI)(nil).ScheduleResultsTask), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScheduleResultsTask", reflect.TypeOf((*MockAPI)(nil).ScheduleResultsTask), arg0, arg1, arg2, arg3, arg4)
 }
 
 // ScheduleTask mocks base method.

--- a/api/taskcluster/webhook.go
+++ b/api/taskcluster/webhook.go
@@ -618,7 +618,7 @@ func CreateAllRuns(
 			}
 
 			uploadClient := uc.NewClient(aeAPI)
-			err := uploadClient.CreateRun(sha, username, password, urls.Results, urls.Screenshots, labelsForRun)
+			err := uploadClient.CreateRun(sha, username, password, urls.Results, urls.Screenshots, nil, labelsForRun)
 			if err != nil {
 				errors <- err
 

--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gobuffalo/logger v1.0.7 // indirect
 	github.com/gobuffalo/packd v1.0.2 // indirect
+	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/s2a-go v0.1.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -130,6 +130,8 @@ github.com/gobuffalo/packd v1.0.2 h1:Yg523YqnOxGIWCp69W12yYBKsoChwI7mtu6ceM9Bwfw
 github.com/gobuffalo/packd v1.0.2/go.mod h1:sUc61tDqGMXON80zpKGp92lDb86Km28jfvX7IAyxFT8=
 github.com/gobuffalo/packr/v2 v2.8.3 h1:xE1yzvnO56cUC0sTpKR3DIbxZgB54AftTFMhB2XEWlY=
 github.com/gobuffalo/packr/v2 v2.8.3/go.mod h1:0SahksCVcx4IMnigTjiFuyldmTrdTctXsOdiU5KwbKc=
+github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
+github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=

--- a/results-processor/processor_test.py
+++ b/results-processor/processor_test.py
@@ -47,7 +47,7 @@ class ProcessorTest(unittest.TestCase):
             p.download(
                 ['gs://wptd/foo/bar.json'],
                 ['https://wpt.fyi/test.txt.gz'],
-                None)
+                [])
             self.assertListEqual(p.results, ['/fake/bar.json'])
             self.assertListEqual(p.screenshots, ['/fake/test.txt.gz'])
 
@@ -57,7 +57,7 @@ class ProcessorTest(unittest.TestCase):
             p._download_http = self.fake_download(
                 'https://wpt.fyi/artifact.zip', 'artifact_test.zip')
 
-            p.download([], [], 'https://wpt.fyi/artifact.zip')
+            p.download([], [], ['https://wpt.fyi/artifact.zip'])
             self.assertEqual(len(p.results), 2)
             self.assertTrue(p.results[0].endswith(
                 '/artifact_test/wpt_report_1.json'))
@@ -79,10 +79,10 @@ class ProcessorTest(unittest.TestCase):
             with self.assertRaises(AssertionError):
                 p.download(['https://wpt.fyi/test.json.gz'],
                            [],
-                           'https://wpt.fyi/artifact.zip')
+                           ['https://wpt.fyi/artifact.zip'])
 
             # Download failure: no exceptions should be raised.
-            p.download([], [], 'https://wpt.fyi/artifact.zip')
+            p.download([], [], ['https://wpt.fyi/artifact.zip'])
             self.assertEqual(len(p.results), 0)
 
 
@@ -116,7 +116,7 @@ class MockProcessorTest(unittest.TestCase):
         mock.assert_has_calls([
             call.update_status('654321', 'WPTFYI_PROCESSING', None,
                                'https://test.wpt.fyi/api'),
-            call.download(['https://wpt.fyi/wpt_report.json.gz'], [], None),
+            call.download(['https://wpt.fyi/wpt_report.json.gz'], [], []),
         ])
         mock.report.update_metadata.assert_called_once_with(
             revision='21917b36553562d21c14fe086756a57cbe8a381b',
@@ -143,7 +143,7 @@ class MockProcessorTest(unittest.TestCase):
             process_report('12345', params)
         mock.assert_has_calls([
             call.update_status('654321', 'WPTFYI_PROCESSING', None, None),
-            call.download(['https://wpt.fyi/wpt_report.json.gz'], [], None),
+            call.download(['https://wpt.fyi/wpt_report.json.gz'], [], []),
             call.load_report(),
             call.update_status(
                 '654321', 'INVALID',
@@ -166,7 +166,7 @@ class MockProcessorTest(unittest.TestCase):
             process_report('12345', params)
         mock.assert_has_calls([
             call.update_status('654321', 'WPTFYI_PROCESSING', None, None),
-            call.download([], [], None),
+            call.download([], [], []),
             call.update_status('654321', 'EMPTY', None, None),
         ])
         mock.create_run.assert_not_called()
@@ -223,7 +223,7 @@ class ProcessorDownloadServerTest(unittest.TestCase):
                 p.download(
                     [self.url + '/download/test.txt', url_timeout],
                     [url_404],
-                    None)
+                    [])
             self.assertEqual(len(p.results), 1)
             self.assertTrue(p.results[0].endswith('.txt'))
             self.assertEqual(len(p.screenshots), 0)

--- a/webapp/components/product-info.js
+++ b/webapp/components/product-info.js
@@ -37,6 +37,7 @@ const DisplayNames = (() => {
   // Sources
   m.set('azure', 'Azure Pipelines');
   m.set('buildbot', 'Buildbot');
+  m.set('github-actions', 'GitHub Actions');
   m.set('msedge', 'MS Edge');
   m.set('taskcluster', 'Taskcluster');
   return m;
@@ -64,7 +65,7 @@ const DefaultProducts = DefaultProductSpecs.map(p => Object.freeze(parseProductS
 
 const CommitTypes = new Set(['pr_head', 'master']);
 const Channels = new Set(['stable', 'beta', 'experimental']);
-const Sources = new Set(['buildbot', 'taskcluster', 'msedge', 'azure']);
+const Sources = new Set(['buildbot', 'taskcluster', 'msedge', 'azure', 'github-actions']);
 const Platforms = new Set(['linux', 'win', 'mac', 'ios', 'android']);
 const SemanticLabels = [
   { property: '_channel', values: Channels },


### PR DESCRIPTION
This is very much a derivative of the implementation used for Azure Pipelines, perhaps unsurprising given the similarity between the two systems, but is very much different enough to justify a totally separate implementation.

Like Azure Pipelines, we rely on a notification from the workflow that it is complete, rather than relying on webhooks from GitHub (as Taskcluster does), as this allows the workflow to provide metadata to endpoint, rather than having to hard code so many magic strings in wpt.fyi (notably, the name of the artifacts we're looking for).

I'm not really sure how best to test this, and am welcome to feedback here.

Fixes #3906.