### PR TITLE
Call ghactions.RegisterRoutes()

### DIFF
--- a/webapp/web/main.go
+++ b/webapp/web/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/web-platform-tests/wpt.fyi/api"
 	"github.com/web-platform-tests/wpt.fyi/api/azure"
 	"github.com/web-platform-tests/wpt.fyi/api/checks"
+	"github.com/web-platform-tests/wpt.fyi/api/ghactions"
 	"github.com/web-platform-tests/wpt.fyi/api/query"
 	"github.com/web-platform-tests/wpt.fyi/api/receiver"
 	"github.com/web-platform-tests/wpt.fyi/api/screenshot"
@@ -21,6 +22,7 @@ func init() {
 	api.RegisterRoutes()
 	azure.RegisterRoutes()
 	checks.RegisterRoutes()
+	ghactions.RegisterRoutes()
 	query.RegisterRoutes()
 	receiver.RegisterRoutes()
 	screenshot.RegisterRoutes()


### PR DESCRIPTION
This was omitted before and means the path currently fails.

See, e.g., https://github.com/web-platform-tests/wpt/actions/runs/10894890454/job/30236033515