### PR TITLE
Use non-conflicting route for GitHub actions

### DIFF
--- a/api/ghactions/routes.go
+++ b/api/ghactions/routes.go
@@ -12,5 +12,5 @@ func RegisterRoutes() {
 	// the results of a GitHub Actions workflow run.
 	// The endpoint is insecure, because we'll only try to fetch (specifically) a
 	// web-platform-tests/wpt build with the given ID.
-	shared.AddRoute("/api/checks/github-actions/", "github-actions-notify", notifyHandler).Methods("POST")
+	shared.AddRoute("/api/github-actions/", "github-actions-notify", notifyHandler).Methods("POST")
 }


### PR DESCRIPTION
This should fix #4009. According to [mux docs](https://pkg.go.dev/github.com/gorilla/mux#readme-matching-routes) "Routes are tested in the order they were added to the router. If two routes match, the first one wins." The route `/api/checks/github-actions` is picked up by the handler for route `/api/checks/{commit}`. Presumably the route addition happens as packages are initialized in lexicographic order and `checks` comes before `ghactions`.

Tested locally with cURL, but #3981 would have helped here.