### PR TITLE
Fix #4009: reorder the registration of routes

### DIFF
--- a/webapp/web/main.go
+++ b/webapp/web/main.go
@@ -18,15 +18,24 @@ import (
 )
 
 func init() {
-	// webapp.RegisterRoutes has a catch-all, so needs to go last.
-	api.RegisterRoutes()
+	// API routes:
+
+	// /api/checks/ routes:
 	azure.RegisterRoutes()
-	checks.RegisterRoutes()
 	ghactions.RegisterRoutes()
+	// checks.RegisterRoutes has a catch-all for /api/checks/, so needs to go last.
+	checks.RegisterRoutes()
+
+	// The rest of /api/:
+	api.RegisterRoutes()
 	query.RegisterRoutes()
 	receiver.RegisterRoutes()
 	screenshot.RegisterRoutes()
 	taskcluster.RegisterRoutes()
+
+	// The actual Web App:
+
+	// webapp.RegisterRoutes has a catch-all, so needs to go last.
 	webapp.RegisterRoutes()
 }
 


### PR DESCRIPTION
Per the mux docs, "Routes are tested in the order they were added to the router. If two routes match, the first one wins."

This means that `checks.RegisterRoutes()` needs to be called after everything else defining a route in /api/checks/ as it otherwise matches every path under /api/checks/.

Fixes #4009; see also #4010. @past said in the latter said:

> > Oh, that would probably work, too.
> 
> Turns out it doesn't and I don't know why.

In way of minimal testing:

```
gsnedders@gsnedders-milk wpt.fyi % curl -v -Li --data-urlencode 'run_id=10906214822' --data-urlencode 'owner=web-platform-tests' --data-urlencode 'repo=wpt' --data-urlencode 'artifact_name=safari-technology-preview-results-%2A' 'http://localhost:8080/api/checks/github-actions/'
* Host localhost:8080 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying [::1]:8080...
* connect to ::1 port 8080 from ::1 port 52803 failed: Connection refused
*   Trying 127.0.0.1:8080...
* Connected to localhost (127.0.0.1) port 8080
> POST /api/checks/github-actions/ HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/8.7.1
> Accept: */*
> Content-Length: 106
> Content-Type: application/x-www-form-urlencoded
> 
} [106 bytes data]
* upload completely sent off: 106 bytes
< HTTP/1.1 500 Internal Server Error
< Content-Type: text/plain; charset=utf-8
< Strict-Transport-Security: max-age=31536000; preload
< X-Content-Type-Options: nosniff
< Date: Tue, 24 Sep 2024 21:24:46 GMT
< Content-Length: 105
< 
{ [105 bytes data]

100   211  100   105  100   106    404    408 --:--:-- --:--:-- --:--:--   814
* Connection #0 to host localhost left intact
HTTP/1.1 500 Internal Server Error
Content-Type: text/plain; charset=utf-8
Strict-Transport-Security: max-age=31536000; preload
X-Content-Type-Options: nosniff
Date: Tue, 24 Sep 2024 21:24:46 GMT
Content-Length: 105

GET https://api.github.com/repos/web-platform-tests/wpt/actions/runs/10906214822: 401 Bad credentials []
```