### PR TITLE
Fix logging from github-actions

### DIFF
--- a/api/ghactions/notify.go
+++ b/api/ghactions/notify.go
@@ -124,12 +124,12 @@ func processBuild(
 		for _, artifact := range artifacts.Artifacts {
 
 			if !artifactNameGlob.Match(*artifact.Name) {
-				log.Infof("Skipping artifact %s", artifact.Name)
+				log.Infof("Skipping artifact %s", *artifact.Name)
 
 				continue
 			}
 
-			log.Infof("Adding %s for %s/%s run %v to upload...", artifact.Name, owner, repo, runID)
+			log.Infof("Adding %s for %s/%s run %v to upload...", *artifact.Name, owner, repo, runID)
 
 			// Set the labels based on the first artifact we find.
 			if len(archiveURLs) == 0 {


### PR DESCRIPTION
It turns out logging lines like `Skipping artifact %!s(*string=0xc0009bede0)` aren't super useful.

c.f. https://github.com/web-platform-tests/wpt.fyi/issues/4020#issuecomment-2375499942