### PR TITLE
[Processor] Correct cap for secret access

### DIFF
--- a/results-processor/processor.py
+++ b/results-processor/processor.py
@@ -118,7 +118,7 @@ class Processor(object):
     def _secret(self, token_name):
         _log.info('Reading secret: %s', token_name)
         key = self.datastore.key('Token', token_name)
-        return self.datastore.get(key)['secret']
+        return self.datastore.get(key)['Secret']
 
     @property
     def _github_token(self):


### PR DESCRIPTION
Fix an issue in https://github.com/web-platform-tests/wpt.fyi/issues/4020. The self.datastore.get(key)['Secret'] should be capitalized. See [here](https://pantheon.corp.google.com/datastore/databases/-default-/entities;kind=Token;ns=__$DEFAULT$__/query/kind?inv=1&invt=Abe2ew&project=wptdashboard)