### PR TITLE
Be lax about what event triggered a workflow for the `master` label

### DIFF
--- a/api/ghactions/notify.go
+++ b/api/ghactions/notify.go
@@ -175,15 +175,14 @@ func chooseLabels( // nolint:ireturn // TODO: Fix ireturn lint error
 ) mapset.Set {
 	labels := mapset.NewSet()
 
-	if (*workflowRun.Event == "push" &&
-		*workflowRun.HeadRepository.Owner.Login == owner &&
+	// We don't actually check the event here, provided it meets
+	// the criteria to be a run on master.
+	if (*workflowRun.HeadRepository.Owner.Login == owner &&
 		*workflowRun.HeadRepository.Name == repo) &&
 		(*workflowRun.HeadBranch == "master" ||
 			epochBranchesRegex.MatchString(*workflowRun.HeadBranch)) {
 		labels.Add(shared.MasterLabel)
-	}
-
-	if *workflowRun.Event == "pull_request" {
+	} else if *workflowRun.Event == "pull_request" {
 		if prHeadRegex.MatchString(artifactName) {
 			labels.Add(shared.PRHeadLabel)
 		} else if prBaseRegex.MatchString(artifactName) {


### PR DESCRIPTION
We don't actually really care, provided the workflow was run against the right thing.

Fixes #4063. If we were to stick with `workflow_run` for https://github.com/web-platform-tests/wpt/issues/48659, we would end up with this being wrong (as we couldn't trust the Workflow Run metadata from GitHub then), but I don't think we are.

And, importantly, this gets runs actually showing up.