### PR TITLE
Add interop-2023-webcomponents as a previous focus area in 2024

### DIFF
--- a/webapp/components/interop-data.js
+++ b/webapp/components/interop-data.js
@@ -807,7 +807,8 @@ export const interopData = {
           'interop-2022-viewport',
           'interop-2023-webcodecs',
           'interop-2022-webcompat',
-          'interop-2023-webcompat'
+          'interop-2023-webcompat',
+          'interop-2023-webcomponents'
         ],
         'score_as_group': false
       }

--- a/webapp/static/interop-data.json
+++ b/webapp/static/interop-data.json
@@ -784,7 +784,8 @@
           "interop-2022-viewport",
           "interop-2023-webcodecs",
           "interop-2022-webcompat",
-          "interop-2023-webcompat"
+          "interop-2023-webcompat",
+          "interop-2023-webcomponents"
         ],
         "score_as_group": false
       }


### PR DESCRIPTION
This appears to have been omitted, while I believe everything else is present.