### PR TITLE
Add interop and investigation scores to mobile results

### DIFF
--- a/webapp/components/interop-dashboard.js
+++ b/webapp/components/interop-dashboard.js
@@ -238,13 +238,10 @@ class InteropDashboard extends WPTFlags(PolymerElement) {
           padding: 0 5px;
         }
 
-        .warning {
+        #mobileWarning {
           background-color: khaki;
           border: 1px dashed rgba(0, 0, 0, .5);
           border-radius: 5px;
-        }
-
-        #mobileWarning {
           margin-bottom: 32px;
         }
 

--- a/webapp/components/interop-dashboard.js
+++ b/webapp/components/interop-dashboard.js
@@ -238,6 +238,16 @@ class InteropDashboard extends WPTFlags(PolymerElement) {
           padding: 0 5px;
         }
 
+        .warning {
+          background-color: khaki;
+          border: 1px dashed rgba(0, 0, 0, .5);
+          border-radius: 5px;
+        }
+
+        #mobileWarning {
+          margin-bottom: 32px;
+        }
+
         #featureSelect {
           padding: 0.5rem;
           font-size: 16px;
@@ -307,7 +317,7 @@ class InteropDashboard extends WPTFlags(PolymerElement) {
             <paper-button id="toggleExperimental" class\$="[[experimentalButtonClass(stable, isMobileScoresView)]]" on-click="clickExperimental">Experimental</paper-button>
             <paper-button id="toggleMobile" class\$="[[mobileButtonClass(isMobileScoresView)]]" on-click="clickMobile" hidden$="[[!shouldShowMobileScoresView()]]">Mobile</paper-button>
           </div>
-          <div class="text-center" hidden$="[[!isMobileScoresView]]">
+          <div class="text-center warning" id="mobileWarning" hidden$="[[!isMobileScoresView]]">
             <p><i>Mobile browser results and how they are obtained are a work in progress. Scores may not reflect the real level of support for a given feature.</i></p>
           </div>
         </div>

--- a/webapp/components/interop-data.js
+++ b/webapp/components/interop-data.js
@@ -865,6 +865,15 @@ export const interopData = {
           'interop-2023-url',
         ],
         'score_as_group': false
+      },
+      {
+        'name': 'Active Investigations',
+        'rows': [
+          'Accessibility Testing',
+          'Mobile Testing',
+          'WebAssembly Testing'
+        ],
+        'score_as_group': true
       }
     ],
     'mobile_focus_areas': [

--- a/webapp/components/interop-summary.js
+++ b/webapp/components/interop-summary.js
@@ -196,8 +196,8 @@ class InteropSummary extends PolymerElement {
     }
 
     const summaryDiv = this.shadowRoot.querySelector('.summary-container');
-    // Don't display the interop score for Interop 2021 or mobile view.
-    if (this.year === '2021' || this.isMobileScoresView) {
+    // Don't display the interop score for Interop 2021.
+    if (this.year === '2021') {
       const interopDiv = this.shadowRoot.querySelector('#interopSummary');
       interopDiv.style.display = 'none';
       summaryDiv.style.minHeight = '275px';
@@ -213,7 +213,7 @@ class InteropSummary extends PolymerElement {
 
   shouldDisplayInvestigationNumber() {
     const scores = this.dataManager.getYearProp('investigationScores');
-    return scores !== null && scores !== undefined && !this.isMobileScoresView;
+    return scores !== null && scores !== undefined;
   }
 
   // roundScore defines the rounding rules for the top-level scores.
@@ -252,10 +252,8 @@ class InteropSummary extends PolymerElement {
         (this.isMobileScoresView && scoreElements.length !== scores.length + 1)) {
       return;
     }
-    if (!this.isMobileScoresView) {
-      // Update interop summary number first.
-      this.updateSummaryScore(scoreElements[0], scores[scores.length - 1][summaryFeatureName]);
-    }
+    // Update interop summary number first.
+    this.updateSummaryScore(scoreElements[0], scores[scores.length - 1][summaryFeatureName]);
     // Update the rest of the browser scores.
     for (let i = 1; i < scores.length; i++) {
       this.updateSummaryScore(scoreElements[i], scores[i - 1][summaryFeatureName]);

--- a/webapp/static/interop-data.json
+++ b/webapp/static/interop-data.json
@@ -842,6 +842,15 @@
         "interop-2023-url"
       ],
       "score_as_group": false
+    },
+    {
+      "name": "Active Investigations",
+      "rows": [
+        "Accessibility Testing",
+        "Mobile Testing",
+        "WebAssembly Testing"
+      ],
+      "score_as_group": true
     }
     ],
     "mobile_focus_areas": [


### PR DESCRIPTION
Small change to add the "Interop" and "Investigations" scores to the mobile results view, as well as the Investigations scores table.