### PR TITLE
Add subtle striping for table in `<wpt-results/>`

### DIFF
--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -93,6 +93,9 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
         top: 0;
         z-index: 1;
       }
+      path-part {
+        vertical-align: bottom;
+      }
       .path {
         margin-bottom: 16px;
       }

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -74,6 +74,9 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
         width: 100%;
         border-collapse: collapse;
       }
+      tr:nth-child(2n) {
+        background-color: #7F7F7F1F;
+      }
       tr.spec {
         background-color: var(--paper-grey-200);
       }

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -74,10 +74,7 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
         width: 100%;
         border-collapse: collapse;
       }
-      tr:nth-child(2n) {
-        background-color: #7F7F7F1F;
-      }
-      tr.spec {
+      tr:nth-child(2n), tr.spec {
         background-color: var(--paper-grey-200);
       }
       tr td {


### PR DESCRIPTION
## Description
Resolves #1783/#2217 by adding a grey background to every other row in the table.
Before/after:
![comparison](https://github.com/user-attachments/assets/3adf1cea-42f1-415a-b995-55ada331900d)
Untested because I'm on NixOS and Docker isn't trivial, though based on #3840 I'm guessing it wouldn't have worked anyway. The above screenshot was taken by adding the rule via the dev tools.

## Review Information
idk man

## Changes
Added a single CSS rule. edit: two now

## Requirements
N/A