### PR TITLE
Use the new docker image on PRs that change it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Docker config check
+        uses: dorny/paths-filter@v3
+        id: dockerchanges
+        with:
+          filters: |
+            dockerconf:
+              - 'Dockerfile'
+        # run only if Docker configuration was changed
+      - if: steps.dockerchanges.outputs.dockerconf == 'true'
+        name: Rebuild Docker image
+        run: docker build -t webplatformtests/wpt.fyi:latest .
       - uses: ./.github/actions/make-in-docker
         with:
           target: lint
@@ -16,6 +27,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Docker config check
+        uses: dorny/paths-filter@v3
+        id: dockerchanges
+        with:
+          filters: |
+            dockerconf:
+              - 'Dockerfile'
+        # run only if Docker configuration was changed
+      - if: steps.dockerchanges.outputs.dockerconf == 'true'
+        name: Rebuild Docker image
+        run: docker build -t webplatformtests/wpt.fyi:latest .
       - uses: ./.github/actions/make-in-docker
         with:
           target: python_test
@@ -23,6 +45,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Docker config check
+        uses: dorny/paths-filter@v3
+        id: dockerchanges
+        with:
+          filters: |
+            dockerconf:
+              - 'Dockerfile'
+        # run only if Docker configuration was changed
+      - if: steps.dockerchanges.outputs.dockerconf == 'true'
+        name: Rebuild Docker image
+        run: docker build -t webplatformtests/wpt.fyi:latest .
       - uses: ./.github/actions/make-in-docker
         with:
           target: go_test
@@ -30,6 +63,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Docker config check
+        uses: dorny/paths-filter@v3
+        id: dockerchanges
+        with:
+          filters: |
+            dockerconf:
+              - 'Dockerfile'
+        # run only if Docker configuration was changed
+      - if: steps.dockerchanges.outputs.dockerconf == 'true'
+        name: Rebuild Docker image
+        run: docker build -t webplatformtests/wpt.fyi:latest .
       - uses: ./.github/actions/make-in-docker
         with:
           target: web_components_test
@@ -37,6 +81,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Docker config check
+        uses: dorny/paths-filter@v3
+        id: dockerchanges
+        with:
+          filters: |
+            dockerconf:
+              - 'Dockerfile'
+        # run only if Docker configuration was changed
+      - if: steps.dockerchanges.outputs.dockerconf == 'true'
+        name: Rebuild Docker image
+        run: docker build -t webplatformtests/wpt.fyi:latest .
       - uses: ./.github/actions/make-in-docker
         with:
           target: go_chrome_test
@@ -44,6 +99,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Docker config check
+        uses: dorny/paths-filter@v3
+        id: dockerchanges
+        with:
+          filters: |
+            dockerconf:
+              - 'Dockerfile'
+        # run only if Docker configuration was changed
+      - if: steps.dockerchanges.outputs.dockerconf == 'true'
+        name: Rebuild Docker image
+        run: docker build -t webplatformtests/wpt.fyi:latest .
       - uses: ./.github/actions/make-in-docker
         with:
           target: go_firefox_test
@@ -74,10 +140,26 @@ jobs:
       - name: Set DOCKER_INSTANCE
         run: echo "DOCKER_INSTANCE=wptd-dev-$(echo $RANDOM)" >> $GITHUB_ENV
 
+      - name: Docker config check
+        uses: dorny/paths-filter@v3
+        id: dockerchanges
+        with:
+          filters: |
+            dockerconf:
+              - 'Dockerfile'
+
+      # run only if Docker configuration was changed
+      - if: steps.dockerchanges.outputs.dockerconf == 'true'
+        name: Rebuild Docker image
+        run: docker build -t webplatformtests/wpt.fyi:latest .
+
+      # run only if Docker configuration was not changed
+      - if: steps.dockerchanges.outputs.dockerconf == 'false'
+        name: Fetch latest Docker image
+        run: docker pull "${DOCKER_IMAGE}"
+
       - name: pre-installation
-        run: |
-          docker pull "${DOCKER_IMAGE}"
-          bash ./util/docker-dev/run.sh -d -q
+        run: bash ./util/docker-dev/run.sh -d -q
 
       - name: run tests with "cloud" build tag
         run: docker exec -t "${DOCKER_INSTANCE}" make go_cloud_test;

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,10 +30,26 @@ jobs:
       - name: Set DOCKER_INSTANCE
         run: echo "DOCKER_INSTANCE=wptd-dev-$(echo $RANDOM)" >> $GITHUB_ENV
 
+      - name: Docker config check
+        uses: dorny/paths-filter@v3
+        id: dockerchanges
+        with:
+          filters: |
+            dockerconf:
+              - 'Dockerfile'
+
+      # run only if Docker configuration was changed
+      - if: steps.dockerchanges.outputs.dockerconf == 'true'
+        name: Rebuild Docker image
+        run: docker build -t webplatformtests/wpt.fyi:latest .
+
+      # run only if Docker configuration was not changed
+      - if: steps.dockerchanges.outputs.dockerconf == 'false'
+        name: Fetch latest Docker image
+        run: docker pull "${DOCKER_IMAGE}"
+
       - name: pre-installation
-        run: |
-          docker pull "${DOCKER_IMAGE}"
-          bash ./util/docker-dev/run.sh -d -q
+        run: bash ./util/docker-dev/run.sh -d -q
 
       - name: installation
         run: docker exec -t "${DOCKER_INSTANCE}" make go_build;


### PR DESCRIPTION
Fixes #3187.

The idea that I had in that issue doesn't work for a number of reasons. I will note that docker-update.yml runs not only for `Dockerfile` changes, but also for `.github/workflows/docker-update.yml` changes, which doesn't apply in this case.