### PR TITLE
Make result tables more readable

### DIFF
--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -80,6 +80,9 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
       tr td {
         padding: 0.25em 0.5em;
       }
+      tr:nth-of-type(2n) td:first-child {
+        background-color: var(--paper-grey-100);
+      }
       tr.spec td {
         padding: 0.2em 0.5em;
         border: solid 1px var(--paper-grey-300);


### PR DESCRIPTION
<!--
Thanks for the PR, you probably worked hard on it! Before you submit it for review, please make sure you read our guidelines for contributing to this repository. 

Try to make the job easy for your reviewer! Below is a template you can use as a guide for what context your reviewer might need.  
If you changed any dev procedures, consider also updating the README.
-->

## Description
This makes the first column in tables of test results alternate between white and light gray for the background color of its rows, making it easier to see which test scores line up with which test.
The backgrounds for the scores themselves are left unaltered, as those have actual meaning.
![image](https://github.com/user-attachments/assets/aa3f1ce0-b475-4d28-a97b-57a5f050fa94)


## Review Information
Personally, I wrote this css into the inline stylesheet on the production site (can use [this page](https://wpt.fyi/results/css/css-grid/layout-algorithm?product=ladybird) to test) and then copy-pasted it into that same inline stylesheet in the code, using the Github web-editor.
If I were reviewing this, I'd probably just do the reverse, as that sounds more straight-forward than cloning this into a dev environment and shows the change just as well.

## Changes
I added a single new CSS rule in the inline stylesheet in [wpt-results.js](https://github.com/web-platform-tests/wpt.fyi/compare/main...Psychpsyo:wpt.fyi:patch-1#diff-abbf3bf2a90942dca90efd6c6489b8395b24bf97bdbd33cc160934058dc64e43).
The rule looks like this:
```css
tr:nth-of-type(2n) td:first-child {
    background-color: var(--paper-grey-100);
}
```
`2n` conveniently starts selecting on the second row, so that the headers don't get styled.

## Requirements
You need to be able to look at the results of any test, with this rule inserted into the stylesheet.
