### PR TITLE
Update rounding logic for results page

### DIFF
--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -1176,7 +1176,7 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
       return `${this.getTestNumbersDisplay(passes, total, isDir)} subtests`;
     }
 
-    const formatPercent = parseFloat((passes / total * 100).toFixed(0));
+    const formatPercent = parseFloat((passes / total * 100).toFixed(1));
     let cellDisplay = '';
     // Show flat 0% or 100% only if none or all tests/subtests pass.
     if (passes === 0) {


### PR DESCRIPTION
Fixes https://github.com/web-platform-tests/wpt.fyi/issues/4107

The test results page was handling score rounding slightly differently than the interop dashboard (rounding to the nearest whole percent rather than nearest tenth of a percent). In order to avoid rounding up to 100% in cases where there were still some tests/subtests failing, [some logic was added to instead display the score as 99.9% in those cases](https://github.com/web-platform-tests/wpt.fyi/blob/b2c8fe3da11a55d5ad22f8d2d89b2f45c1fad94f/webapp/views/wpt-results.js#L1191-L1193). This created a situation in which the interop dashboard and the results page looked close enough to each other (99.7% vs. 99.9%) that it seemed as if there was a calculation error on one of the pages. I hadn't looked at this logic in some time and also assumed this was some calculation error. :sweat_smile: 

This very simple change makes it so the results page rounds the score in the same way as the interop dashboard, so this confusion will not come up again.

### Before
![C66AS3UueX5yAnL](https://github.com/user-attachments/assets/afda73ed-e897-4152-aa04-04dc217a6ec4)

### After
![7hqcLeTCmKGhfNA](https://github.com/user-attachments/assets/87c9100a-81b0-4e13-b1bf-ae1d40e7807a)
