### PR TITLE
Update Wasm testing investigation score to 33.3%

### DIFF
--- a/webapp/components/interop-data.js
+++ b/webapp/components/interop-data.js
@@ -840,7 +840,9 @@ export const interopData = {
       {
         'name': 'WebAssembly Testing',
         'url': 'https://github.com/web-platform-tests/interop-2024-wasm',
-        'scores_over_time': []
+        'scores_over_time': [
+          { 'date': '2024-11-19', 'score': 333 },
+        ]
       }
     ],
     'investigation_weight': 0.0,

--- a/webapp/static/interop-data.json
+++ b/webapp/static/interop-data.json
@@ -817,7 +817,9 @@
       {
         "name": "WebAssembly Testing",
         "url": "https://github.com/web-platform-tests/interop-2024-wasm",
-        "scores_over_time": []
+        "scores_over_time": [
+          { "date": "2024-11-19", "score": 333 }
+        ]
       }
     ],
     "investigation_weight": 0.0,


### PR DESCRIPTION
A Github action that imports Wasm core tests into WPT is up for review in https://github.com/web-platform-tests/wpt/pull/49277.

Per the [scoring guidelines](https://github.com/web-platform-tests/interop-2024-wasm?tab=readme-ov-file#scoring), this is worth 1/3 of the overall score for this investigation.