### PR TITLE
Remove rounding on interop test results totals cells

### DIFF
--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -1176,7 +1176,7 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
       return `${this.getTestNumbersDisplay(passes, total, isDir)} subtests`;
     }
 
-    const formatPercent = parseFloat((passes / total * 100).toFixed(1));
+    const formatPercent = parseFloat((Math.floor(passes / total * 1000)) / 10);
     let cellDisplay = '';
     // Show flat 0% or 100% only if none or all tests/subtests pass.
     if (passes === 0) {


### PR DESCRIPTION
Fixes #4107 

This change removes totals percentage rounding up when aggregating the interop percentages on the test results page. The first fix landed for this still utilized rounding to the nearest tenth of one percent, which is not in line with the actual interop score aggregation, [which does not implement any rounding up](https://github.com/web-platform-tests/results-analysis/blob/d64417c4761ead5058c6470be99d5b8ea68aa0e5/interop-scoring/main.js#L245-L247).