### PR TITLE
Add tooltip regarding results page totals differences

### DIFF
--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -176,6 +176,11 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
       .pointer {
         cursor: help;
       }
+      .interop-totals {
+        cursor: help;
+        border-bottom: 1px dotted #000;
+        text-decoration: none;
+      }
       
       .channel-area {
         display: flex;
@@ -359,7 +364,16 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
                 </td>
                 <template is="dom-repeat" items="[[displayedTotals]]" as="columnTotal">
                   <td class\$="numbers [[ getTotalsClass(columnTotal) ]]">
-                    <span class\$="total [[ getTotalsClass(columnTotal) ]]">{{ getTotalDisplay(columnTotal) }}</span>
+                    <template is="dom-if" if="[[ isInteropView() ]]">
+                      <span class\$="total [[ getTotalsClass(columnTotal) ]]">
+                        <span class="interop-totals" title="This number may contain slight differences compared to the Interop Dashboard. Please reference the Interop Dashboard for accurate interop scores.">
+                          {{ getTotalDisplay(columnTotal) }}
+                        </span>
+                      </span>
+                    </template>
+                    <template is="dom-if" if="[[ !isInteropView() ]]">
+                      <span class\$="total [[ getTotalsClass(columnTotal) ]]">{{ getTotalDisplay(columnTotal) }}</span>
+                    </template>
                   </td>
                 </template>
               </tr>


### PR DESCRIPTION
Explained in #4146 

Adds a small tooltip on hover over the results page totals in interop view regarding score totals.

![Screenshot from 2024-12-07 21-10-09](https://github.com/user-attachments/assets/a15f433c-eb3c-4ed0-a400-e704646205af)

Wording can be updated as suggested. :slightly_smiling_face: 