### PR TITLE
Remove redundant suiteSetup since there is only one top-level suite

### DIFF
--- a/webapp/components/test/wpt-app.html
+++ b/webapp/components/test/wpt-app.html
@@ -19,13 +19,6 @@
 import '../../views/wpt-app.js';
 import { TEST_RUNS_DATA } from './util/helpers.js';
 
-suiteSetup(() => {
-  window.fetch = (url) => {
-    const href = url instanceof URL ? url.href : 'unknown';
-    assert.fail('actual', 'expected', `uncaptured fetch: ${href}`);
-  };
-});
-
 suite('<wpt-app>', () => {
   let sandbox;
 


### PR DESCRIPTION
Fixes #3090. 

The error happens when the fetches are executed after the top-level [suite](https://github.com/web-platform-tests/wpt.fyi/blob/c96d81c013414e912bb21b25586630c31df02102/webapp/components/test/wpt-app.html#L29) is done (after the top-level [teardown()](https://github.com/web-platform-tests/wpt.fyi/blob/c96d81c013414e912bb21b25586630c31df02102/webapp/components/test/wpt-app.html#L47) has been called), but before the test is finished. It seems that [suiteSetup()](https://github.com/web-platform-tests/wpt.fyi/blob/c96d81c013414e912bb21b25586630c31df02102/webapp/components/test/wpt-app.html#L22) is mostly redundant since there is only one parent suite() in the file and it already throws for captured URLs.