### PR TITLE
Update Wasm testing investigation score to 66.6%

### DIFF
--- a/webapp/components/interop-data.js
+++ b/webapp/components/interop-data.js
@@ -842,6 +842,7 @@ export const interopData = {
         'url': 'https://github.com/web-platform-tests/interop-2024-wasm',
         'scores_over_time': [
           { 'date': '2024-11-19', 'score': 333 },
+          { "date": "2024-12-20", "score": 666 },
         ]
       }
     ],

--- a/webapp/components/interop-data.js
+++ b/webapp/components/interop-data.js
@@ -842,7 +842,7 @@ export const interopData = {
         'url': 'https://github.com/web-platform-tests/interop-2024-wasm',
         'scores_over_time': [
           { 'date': '2024-11-19', 'score': 333 },
-          { "date": "2024-12-20", "score": 666 },
+          { 'date': '2024-12-20', 'score': 666 },
         ]
       }
     ],

--- a/webapp/static/interop-data.json
+++ b/webapp/static/interop-data.json
@@ -818,7 +818,8 @@
         "name": "WebAssembly Testing",
         "url": "https://github.com/web-platform-tests/interop-2024-wasm",
         "scores_over_time": [
-          { "date": "2024-11-19", "score": 333 }
+          { "date": "2024-11-19", "score": 333 },
+          { "date": "2024-12-20", "score": 666 }
         ]
       }
     ],


### PR DESCRIPTION
The PR that imports Wasm tests was merged in https://github.com/web-platform-tests/wpt/pull/49277 and is now approved and running.

Per the [scoring guidelines](https://github.com/web-platform-tests/interop-2024-wasm?tab=readme-ov-file#scoring), this is worth 1/3 of the overall score for this investigation.

CC @dschuff, @ajklein 