### PR TITLE
Use one-way bindings for the flags component

### DIFF
--- a/webapp/components/test/wpt-flags.html
+++ b/webapp/components/test/wpt-flags.html
@@ -70,9 +70,9 @@ suite('wpt-flags', () => {
     test('localStorage', () => {
       assert.isTrue(editor instanceof WPTFlagsEditor);
       editor.queryBuilder = true;
-      expect(window.localStorage.getItem("features.queryBuilder")).to.equal('true');
+      expect(window.localStorage.getItem('features.queryBuilder')).to.equal('true');
       editor.queryBuilder = false;
-      expect(window.localStorage.getItem("features.queryBuilder")).to.equal('false');
+      expect(window.localStorage.getItem('features.queryBuilder')).to.equal('false');
     });
   });
 });

--- a/webapp/components/test/wpt-flags.html
+++ b/webapp/components/test/wpt-flags.html
@@ -67,12 +67,28 @@ suite('wpt-flags', () => {
       sandbox.restore();
     });
 
-    test('localStorage', () => {
+    test('toggling checkboxes updates localStorage', () => {
       assert.isTrue(editor instanceof WPTFlagsEditor);
       editor.queryBuilder = true;
       expect(window.localStorage.getItem('features.queryBuilder')).to.equal('true');
       editor.queryBuilder = false;
       expect(window.localStorage.getItem('features.queryBuilder')).to.equal('false');
+    });
+
+    test('click updates localStorage', () => {
+      assert.isTrue(editor instanceof WPTFlagsEditor);
+      editor.queryBuilder = true;
+      expect(window.localStorage.getItem('features.queryBuilder')).to.equal('true');
+      const queryBuilder = editor.shadowRoot.querySelector('#queryBuilder');
+
+      const flagUpdated = new Promise(resolve => {
+        window.document.addEventListener("flagUpdated", () => resolve(), { once: true });
+      });
+
+      queryBuilder.dispatchEvent(new MouseEvent('click'));
+      return flagUpdated.then(() => {
+        expect(window.localStorage.getItem('features.queryBuilder')).to.equal('false');
+      });
     });
   });
 });

--- a/webapp/components/test/wpt-flags.html
+++ b/webapp/components/test/wpt-flags.html
@@ -82,7 +82,7 @@ suite('wpt-flags', () => {
       const queryBuilder = editor.shadowRoot.querySelector('#queryBuilder');
 
       const flagUpdated = new Promise(resolve => {
-        window.document.addEventListener("flagUpdated", () => resolve(), { once: true });
+        window.document.addEventListener('flagUpdated', () => resolve(), { once: true });
       });
 
       queryBuilder.dispatchEvent(new MouseEvent('click'));

--- a/webapp/components/test/wpt-flags.html
+++ b/webapp/components/test/wpt-flags.html
@@ -6,8 +6,6 @@
   <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
 </head>
 <body>
-  <wpt-flags-editor id="playground"></wpt-flags-editor>
-
   <test-fixture id="wpt-flags-editor-fixture">
     <template>
       <wpt-flags-editor></wpt-flags-editor>
@@ -15,7 +13,7 @@
   </test-fixture>
 
   <script type="module">
-import { WPTFlags } from '../wpt-flags.js';
+import { WPTFlags, WPTFlagsEditor } from '../wpt-flags.js';
 import { PolymerElement } from '../../node_modules/@polymer/polymer/polymer-element.js';
 
 suite('wpt-flags', () => {
@@ -54,6 +52,27 @@ suite('wpt-flags', () => {
 
     teardown(() => {
       editor.queryBuilder = queryBuilderStateBefore;
+    });
+  });
+
+  suite('persistence', () => {
+    let editor, sandbox;
+
+    setup(() => {
+      editor = fixture('wpt-flags-editor-fixture');
+      sandbox = sinon.sandbox.create();
+    });
+
+    teardown(() => {
+      sandbox.restore();
+    });
+
+    test('localStorage', () => {
+      assert.isTrue(editor instanceof WPTFlagsEditor);
+      editor.queryBuilder = true;
+      expect(window.localStorage.getItem("features.queryBuilder")).to.equal('true');
+      editor.queryBuilder = false;
+      expect(window.localStorage.getItem("features.queryBuilder")).to.equal('false');
     });
   });
 });

--- a/webapp/components/wpt-flags.js
+++ b/webapp/components/wpt-flags.js
@@ -85,7 +85,7 @@ const makeFeatureProperties = function(target, features, readOnly, useLocalStora
     }
     target[feature] = {
       type: Boolean,
-      readOnly: readOnly && !wpt.MUTABLE_FLAGS,
+      readOnly: readOnly,
       value: value,
     };
   }

--- a/webapp/components/wpt-flags.js
+++ b/webapp/components/wpt-flags.js
@@ -179,6 +179,10 @@ const FlagsEditorClass = (environmentFlags) =>
           JSON.stringify(value));
       }
     }
+
+    handleChange(e) {
+      this.valueChanged(e.target.checked, e.target.id);
+    }
   };
 
 // WPTFlagsEditor is a Polymer custom element for modifying client-side feature
@@ -193,73 +197,73 @@ class WPTFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ false) {
       }
     </style>
     <paper-item>
-      <paper-checkbox checked="[[queryBuilder]]">
+      <paper-checkbox id="queryBuilder" checked="[[queryBuilder]]" on-change="handleChange">
         Query Builder component
       </paper-checkbox>
     </paper-item>
     <paper-item sub-item>
-      <paper-checkbox checked="[[queryBuilderSHA]]">
+      <paper-checkbox id="queryBuilderSHA" checked="[[queryBuilderSHA]]" on-change="handleChange">
         SHA input
       </paper-checkbox>
     </paper-item>
     <paper-item>
-      <paper-checkbox checked="[[diffFromAPI]]">
+      <paper-checkbox id="diffFromAPI" checked="[[diffFromAPI]]" on-change="handleChange">
         Compute diffs using /api/diff
       </paper-checkbox>
     </paper-item>
     <paper-item>
-      <paper-checkbox checked="[[colorHomepage]]">
+      <paper-checkbox id="colorHomepage" checked="[[colorHomepage]]" on-change="handleChange">
         Use pass-rate colors on the homepage
       </paper-checkbox>
     </paper-item>
     <paper-item>
-      <paper-checkbox checked="[[structuredQueries]]">
+      <paper-checkbox id="structuredQueries" checked="[[structuredQueries]]" on-change="handleChange">
         Interpret query strings as structured queries over test names and test
         status/result values
       </paper-checkbox>
     </paper-item>
     <paper-item>
-      <paper-checkbox checked="[[githubCommitLinks]]">
+      <paper-checkbox id="githubCommitLinks" checked="[[githubCommitLinks]]" on-change="handleChange">
         Show links to the commit on GitHub in the header row.
       </paper-checkbox>
     </paper-item>
     <paper-item>
-      <paper-checkbox checked="[[permalinks]]">
+      <paper-checkbox id="permalinks" checked="[[permalinks]]" on-change="handleChange">
         Show dialog for copying a permalink (on /results page).
       </paper-checkbox>
     </paper-item>
     <paper-item>
-      <paper-checkbox checked="[[webPlatformTestsLive]]">
+      <paper-checkbox id="webPlatformTestsLive" checked="[[webPlatformTestsLive]]" on-change="handleChange">
         Use wpt.live.
       </paper-checkbox>
     </paper-item>
     <paper-item>
-      <paper-checkbox checked="[[displayMetadata]]">
+      <paper-checkbox id="displayMetadata" checked="[[displayMetadata]]" on-change="handleChange">
         Show metadata Information on the wpt.fyi result page.
       </paper-checkbox>
     </paper-item>
       <paper-item>
-      <paper-checkbox checked="[[triageMetadataUI]]">
+      <paper-checkbox id="triageMetadataUI" checked="[[triageMetadataUI]]" on-change="handleChange">
         Show Triage Metadata UI on the wpt.fyi result page.
       </paper-checkbox>
     </paper-item>
     <paper-item>
-      <paper-checkbox checked="[[processorTab]]">
+      <paper-checkbox id="processorTab" checked="[[processorTab]]" on-change="handleChange">
         Show the "Processor" (status) tab.
       </paper-checkbox>
     </paper-item>
     <paper-item>
-      <paper-checkbox checked="[[githubLogin]]">
+      <paper-checkbox id="githubLogin" checked="[[githubLogin]]" on-change="handleChange">
         Enable GitHub OAuth login
       </paper-checkbox>
     </paper-item>
     <paper-item>
-      <paper-checkbox checked="[[showBSF]]">
+      <paper-checkbox id="showBSF" checked="[[showBSF]]" on-change="handleChange">
         Enable Browser Specific Failures graph
       </paper-checkbox>
     </paper-item>
     <paper-item>
-      <paper-checkbox checked="[[showMobileScoresView]]">
+      <paper-checkbox id="showMobileScoresView" checked="[[showMobileScoresView]]" on-change="handleChange">
         Enable mobile results view on Interop dashboard
       </paper-checkbox>
     </paper-item>
@@ -283,49 +287,49 @@ class WPTEnvironmentFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ tr
 
     <h3>Server-side only features</h3>
     <paper-item>
-      <paper-checkbox checked="[[diffRenames]]">
+      <paper-checkbox id="diffRenames" checked="[[diffRenames]]" on-change="handleChange">
         Compute renames in diffs with the GitHub API
       </paper-checkbox>
     </paper-item>
     <paper-item>
-      <paper-checkbox checked="[[paginationTokens]]">
+      <paper-checkbox id="paginationTokens" checked="[[paginationTokens]]" on-change="handleChange">
         Return "wpt-next-page" pagination token HTTP header in /api/runs
       </paper-checkbox>
     </paper-item>
     <paper-item>
-      <paper-checkbox checked="[[runsByPRNumber]]">
+      <paper-checkbox id="runsByPRNumber" checked="[[runsByPRNumber]]" on-change="handleChange">
         Allow /api/runs?pr=[GitHub PR number]
       </paper-checkbox>
     </paper-item>
     <paper-item>
-      <paper-checkbox checked="[[ignoreHarnessInTotal]]">
+      <paper-checkbox id="ignoreHarnessInTotal" checked="[[ignoreHarnessInTotal]]" on-change="handleChange">
         Ignore "OK" harness status in test summary numbers.
       </paper-checkbox>
     </paper-item>
     <h4>GitHub Status Checks</h4>
     <paper-item>
-      <paper-checkbox checked="[[searchcacheDiffs]]">
+      <paper-checkbox id="searchcacheDiffs" checked="[[searchcacheDiffs]]" on-change="handleChange">
         Use searchcache (not summaries) to compute diffs when processing check run events.
       </paper-checkbox>
     </paper-item>
     <paper-item sub-item>
-      <paper-checkbox checked="[[onlyChangesAsRegressions]]">
+      <paper-checkbox id="onlyChangesAsRegressions" checked="[[onlyChangesAsRegressions]]" on-change="handleChange">
         Only treat C (changed) differences as possible regressions.
         (<a href="https://github.com/web-platform-tests/wpt.fyi/blob/main/api/README.md#apidiff">See docs for definition</a>)
       </paper-checkbox>
     </paper-item>
     <paper-item>
-      <paper-checkbox checked="[[failChecksOnRegression]]">
+      <paper-checkbox id="failChecksOnRegression" checked="[[failChecksOnRegression]]" on-change="handleChange">
         Set the wpt.fyi GitHub status check to action_required if regressions are found.
       </paper-checkbox>
     </paper-item>
     <paper-item>
-      <paper-checkbox checked="[[checksAllUsers]]">
+      <paper-checkbox id="checksAllUsers" checked="[[checksAllUsers]]" on-change="handleChange">
         Run the wpt.fyi GitHub status check for all users.
       </paper-checkbox>
     </paper-item>
     <paper-item>
-      <paper-checkbox checked="[[pendingChecks]]">
+      <paper-checkbox id="pendingChecks" checked="[[pendingChecks]]" on-change="handleChange">
         Create pending GitHub status check when results first arrive, and are being processed.
       </paper-checkbox>
     </paper-item>

--- a/webapp/components/wpt-flags.js
+++ b/webapp/components/wpt-flags.js
@@ -107,6 +107,8 @@ wpt.FlagsClass = (superClass, readOnly, useLocalStorage) => class extends superC
 
   setLocalStorageFlag(value, feature) {
     localStorage.setItem(`features.${feature}`, JSON.stringify(value));
+    // flagUpdated is used in tests.
+    window.document.dispatchEvent(new CustomEvent('flagUpdated', { bubbles: true }));
   }
 
   getLocalStorageFlag(feature) {
@@ -174,10 +176,12 @@ const FlagsEditorClass = (environmentFlags) =>
           alert(`Failed to save feature ${feature}.\n\n${e}`);
         });
       } else {
-        return localStorage.setItem(
+        localStorage.setItem(
           `features.${feature}`,
           JSON.stringify(value));
       }
+    // flagUpdated is used in tests.
+    window.document.dispatchEvent(new CustomEvent('flagUpdated', { bubbles: true }));
     }
 
     handleChange(e) {

--- a/webapp/components/wpt-flags.js
+++ b/webapp/components/wpt-flags.js
@@ -86,7 +86,6 @@ const makeFeatureProperties = function(target, features, readOnly, useLocalStora
     target[feature] = {
       type: Boolean,
       readOnly: readOnly && !wpt.MUTABLE_FLAGS,
-      notify: true,
       value: value,
     };
   }
@@ -194,73 +193,73 @@ class WPTFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ false) {
       }
     </style>
     <paper-item>
-      <paper-checkbox checked="{{queryBuilder}}">
+      <paper-checkbox checked="[[queryBuilder]]">
         Query Builder component
       </paper-checkbox>
     </paper-item>
     <paper-item sub-item>
-      <paper-checkbox checked="{{queryBuilderSHA}}">
+      <paper-checkbox checked="[[queryBuilderSHA]]">
         SHA input
       </paper-checkbox>
     </paper-item>
     <paper-item>
-      <paper-checkbox checked="{{diffFromAPI}}">
+      <paper-checkbox checked="[[diffFromAPI]]">
         Compute diffs using /api/diff
       </paper-checkbox>
     </paper-item>
     <paper-item>
-      <paper-checkbox checked="{{colorHomepage}}">
+      <paper-checkbox checked="[[colorHomepage]]">
         Use pass-rate colors on the homepage
       </paper-checkbox>
     </paper-item>
     <paper-item>
-      <paper-checkbox checked="{{structuredQueries}}">
+      <paper-checkbox checked="[[structuredQueries]]">
         Interpret query strings as structured queries over test names and test
         status/result values
       </paper-checkbox>
     </paper-item>
     <paper-item>
-      <paper-checkbox checked="{{githubCommitLinks}}">
+      <paper-checkbox checked="[[githubCommitLinks]]">
         Show links to the commit on GitHub in the header row.
       </paper-checkbox>
     </paper-item>
     <paper-item>
-      <paper-checkbox checked="{{permalinks}}">
+      <paper-checkbox checked="[[permalinks]]">
         Show dialog for copying a permalink (on /results page).
       </paper-checkbox>
     </paper-item>
     <paper-item>
-      <paper-checkbox checked="{{webPlatformTestsLive}}">
+      <paper-checkbox checked="[[webPlatformTestsLive]]">
         Use wpt.live.
       </paper-checkbox>
     </paper-item>
     <paper-item>
-      <paper-checkbox checked="{{displayMetadata}}">
+      <paper-checkbox checked="[[displayMetadata]]">
         Show metadata Information on the wpt.fyi result page.
       </paper-checkbox>
     </paper-item>
       <paper-item>
-      <paper-checkbox checked="{{triageMetadataUI}}">
+      <paper-checkbox checked="[[triageMetadataUI]]">
         Show Triage Metadata UI on the wpt.fyi result page.
       </paper-checkbox>
     </paper-item>
     <paper-item>
-      <paper-checkbox checked="{{processorTab}}">
+      <paper-checkbox checked="[[processorTab]]">
         Show the "Processor" (status) tab.
       </paper-checkbox>
     </paper-item>
     <paper-item>
-      <paper-checkbox checked="{{githubLogin}}">
+      <paper-checkbox checked="[[githubLogin]]">
         Enable GitHub OAuth login
       </paper-checkbox>
     </paper-item>
     <paper-item>
-      <paper-checkbox checked="{{showBSF}}">
+      <paper-checkbox checked="[[showBSF]]">
         Enable Browser Specific Failures graph
       </paper-checkbox>
     </paper-item>
     <paper-item>
-      <paper-checkbox checked="{{showMobileScoresView}}">
+      <paper-checkbox checked="[[showMobileScoresView]]">
         Enable mobile results view on Interop dashboard
       </paper-checkbox>
     </paper-item>
@@ -284,49 +283,49 @@ class WPTEnvironmentFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ tr
 
     <h3>Server-side only features</h3>
     <paper-item>
-      <paper-checkbox checked="{{diffRenames}}">
+      <paper-checkbox checked="[[diffRenames]]">
         Compute renames in diffs with the GitHub API
       </paper-checkbox>
     </paper-item>
     <paper-item>
-      <paper-checkbox checked="{{paginationTokens}}">
+      <paper-checkbox checked="[[paginationTokens]]">
         Return "wpt-next-page" pagination token HTTP header in /api/runs
       </paper-checkbox>
     </paper-item>
     <paper-item>
-      <paper-checkbox checked="{{runsByPRNumber}}">
+      <paper-checkbox checked="[[runsByPRNumber]]">
         Allow /api/runs?pr=[GitHub PR number]
       </paper-checkbox>
     </paper-item>
     <paper-item>
-      <paper-checkbox checked="{{ignoreHarnessInTotal}}">
+      <paper-checkbox checked="[[ignoreHarnessInTotal]]">
         Ignore "OK" harness status in test summary numbers.
       </paper-checkbox>
     </paper-item>
     <h4>GitHub Status Checks</h4>
     <paper-item>
-      <paper-checkbox checked="{{searchcacheDiffs}}">
+      <paper-checkbox checked="[[searchcacheDiffs]]">
         Use searchcache (not summaries) to compute diffs when processing check run events.
       </paper-checkbox>
     </paper-item>
     <paper-item sub-item>
-      <paper-checkbox checked="{{onlyChangesAsRegressions}}">
+      <paper-checkbox checked="[[onlyChangesAsRegressions]]">
         Only treat C (changed) differences as possible regressions.
         (<a href="https://github.com/web-platform-tests/wpt.fyi/blob/main/api/README.md#apidiff">See docs for definition</a>)
       </paper-checkbox>
     </paper-item>
     <paper-item>
-      <paper-checkbox checked="{{failChecksOnRegression}}">
+      <paper-checkbox checked="[[failChecksOnRegression]]">
         Set the wpt.fyi GitHub status check to action_required if regressions are found.
       </paper-checkbox>
     </paper-item>
     <paper-item>
-      <paper-checkbox checked="{{checksAllUsers}}">
+      <paper-checkbox checked="[[checksAllUsers]]">
         Run the wpt.fyi GitHub status check for all users.
       </paper-checkbox>
     </paper-item>
     <paper-item>
-      <paper-checkbox checked="{{pendingChecks}}">
+      <paper-checkbox checked="[[pendingChecks]]">
         Create pending GitHub status check when results first arrive, and are being processed.
       </paper-checkbox>
     </paper-item>

--- a/webapp/components/wpt-flags.js
+++ b/webapp/components/wpt-flags.js
@@ -180,8 +180,8 @@ const FlagsEditorClass = (environmentFlags) =>
           `features.${feature}`,
           JSON.stringify(value));
       }
-    // flagUpdated is used in tests.
-    window.document.dispatchEvent(new CustomEvent('flagUpdated', { bubbles: true }));
+      // flagUpdated is used in tests.
+      window.document.dispatchEvent(new CustomEvent('flagUpdated', { bubbles: true }));
     }
 
     handleChange(e) {

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -9700,7 +9700,8 @@
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
       "integrity": "sha512-RTBwDHhNuOx4F0hqzItc/siXCasGfC4DeWcBamclWd+6jWtBaeB/SGbMkGf0eiQoW7ib8JpvOgnUsmgMHI3Mfw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/mocha/node_modules/has-flag": {
       "version": "1.0.0",


### PR DESCRIPTION
Added a test for the persistence of flags. This is another step in the migration from Polymer to Lit.