### PR TITLE
Use one-way bindings for wpt-metadata and wpt-amend-metadata

### DIFF
--- a/webapp/components/test-file-results-table.js
+++ b/webapp/components/test-file-results-table.js
@@ -195,7 +195,7 @@ class TestFileResultsTable extends WPTFlags(Pluralizer(AmendMetadataMixin(WPTCol
     </template>
   </tbody>
 </table>
-<wpt-amend-metadata id="amend" selected-metadata="{{selectedMetadata}}" path="[[path]]"></wpt-amend-metadata>
+<wpt-amend-metadata id="amend" selected-metadata="[[selectedMetadata]]" path="[[path]]"></wpt-amend-metadata>
 `;
   }
 

--- a/webapp/components/test-file-results-table.js
+++ b/webapp/components/test-file-results-table.js
@@ -295,6 +295,7 @@ class TestFileResultsTable extends WPTFlags(Pluralizer(AmendMetadataMixin(WPTCol
     this.toggleDiffFilter = () => {
       this.onlyShowDifferences = !this.onlyShowDifferences;
     };
+    this.addEventListener('selected-metadata-changed', this.selectedMetadataChanged);
   }
 
   computeDisplayedProducts(testRuns) {
@@ -457,7 +458,13 @@ class TestFileResultsTable extends WPTFlags(Pluralizer(AmendMetadataMixin(WPTCol
   }
 
   clearSelectedCells(selectedMetadata) {
-    this.handleClear(selectedMetadata);
+    if (this.selectedMetadata.length === 0) {
+      this.handleClear(this.selectedMetadata);
+    }
+  }
+
+  selectedMetadataChanged(e) {
+    this.selectedMetadata = e.detail.value;
   }
 
   handleTriageMode(isTriageMode) {

--- a/webapp/components/test-file-results-table.js
+++ b/webapp/components/test-file-results-table.js
@@ -457,7 +457,7 @@ class TestFileResultsTable extends WPTFlags(Pluralizer(AmendMetadataMixin(WPTCol
     return ['FAIL', 'ERROR', 'TIMEOUT'].includes(status);
   }
 
-  clearSelectedCells(selectedMetadata) {
+  clearSelectedCells() {
     if (this.selectedMetadata.length === 0) {
       this.handleClear(this.selectedMetadata);
     }

--- a/webapp/components/wpt-amend-metadata.js
+++ b/webapp/components/wpt-amend-metadata.js
@@ -243,6 +243,11 @@ class AmendMetadata extends LoadingState(PathInfo(ProductInfo(PolymerElement))) 
     this.dialog.removeEventListener('keydown', this.enter);
     this.triageSubmitDisabled = true;
     this.set('selectedMetadata', []);
+    this.dispatchEvent(new CustomEvent('selected-metadata-changed', {
+      bubbles: true,
+      composed: true,
+      detail: { value: [] }
+    }));
     this.fieldsFilled = {filled: [], numEmpty: 0};
     this.dialog.close();
   }

--- a/webapp/components/wpt-amend-metadata.js
+++ b/webapp/components/wpt-amend-metadata.js
@@ -409,8 +409,13 @@ class AmendMetadata extends LoadingState(PathInfo(ProductInfo(PolymerElement))) 
   handleFieldInput(event) {
     // Detect which input was filled.
     const index = event.model.__data.index;
+    const isLabel = event.target.label === 'Label';
     const path = `displayedMetadata.${index}.url`;
     const labelPath = `displayedMetadata.${index}.label`;
+    const updatedPath = isLabel ? labelPath : path;
+
+    const newValue = event.target.value;
+    this.set(updatedPath, newValue);
 
     const url = this.get(path);
     const label = this.get(labelPath);
@@ -426,11 +431,6 @@ class AmendMetadata extends LoadingState(PathInfo(ProductInfo(PolymerElement))) 
       // If the field was previously empty, it is now considered filled.
       this.fieldsFilled.numEmpty--;
       this.fieldsFilled.filled[index] = true;
-    }
-
-    this.set(path, event.target.value);
-    if (labelPath) {
-      this.set(labelPath, event.target.value);
     }
 
     // If all triage items have input, triage can be submitted.

--- a/webapp/components/wpt-metadata.js
+++ b/webapp/components/wpt-metadata.js
@@ -307,7 +307,17 @@ class WPTMetadata extends PathInfo(LoadingState(PolymerElement)) {
     }
 
     this.set('labelMap', labelMap);
+    this.dispatchEvent(new CustomEvent('label-map-changed', {
+      bubbles: true,
+      composed: true,
+      detail: { value: labelMap }
+    }));
     this.set('metadataMap', metadataMap);
+    this.dispatchEvent(new CustomEvent('metadata-map-changed', {
+      bubbles: true,
+      composed: true,
+      detail: { value: metadataMap }
+    }));
     this._resetSelectors();
     return displayedMetadata;
   }

--- a/webapp/components/wpt-metadata.js
+++ b/webapp/components/wpt-metadata.js
@@ -13,7 +13,7 @@ import {
   PolymerElement
 } from '../node_modules/@polymer/polymer/polymer-element.js';
 import { LoadingState } from './loading-state.js';
-import { PathInfo } from '../components/path.js';
+import { PathInfo } from './path.js';
 import { ProductInfo } from './product-info.js';
 
 class WPTMetadataNode extends ProductInfo(PolymerElement) {
@@ -100,7 +100,7 @@ class WPTMetadata extends PathInfo(LoadingState(PolymerElement)) {
               ></wpt-metadata-node>
             </template>
           </iron-collapse>
-          <paper-button id="metadata-toggle" onclick="[[openCollapsible]]">
+          <paper-button id="metadata-toggle" on-click="handleOpenCollapsible">
             Show more
           </paper-button>
         </template>
@@ -146,20 +146,15 @@ class WPTMetadata extends PathInfo(LoadingState(PolymerElement)) {
       },
       metadataMap: {
         type: Object,
-        notify: true,
       },
       labelMap: {
         type: Object,
-        notify: true,
       },
-      triageNotifier: Boolean,
+      triageNotifier: {
+        type: Boolean,
+        observer: 'loadPendingMetadata',
+      },
     };
-  }
-
-  static get observers() {
-    return [
-      'loadPendingMetadata(triageNotifier)',
-    ];
   }
 
   constructor() {
@@ -179,6 +174,10 @@ class WPTMetadata extends PathInfo(LoadingState(PolymerElement)) {
 
   // loadMergedMetadata is called when products is changed.
   loadMergedMetadata(products) {
+    if (!products) {
+      return;
+    }
+
     let productVal = [];
     for (let i = 0; i < products.length; i++) {
       productVal.push(products[i].browser_name);
@@ -308,8 +307,8 @@ class WPTMetadata extends PathInfo(LoadingState(PolymerElement)) {
       }
     }
 
-    this.labelMap = labelMap;
-    this.metadataMap = metadataMap;
+    this.set('labelMap', labelMap);
+    this.set('metadataMap', metadataMap);
     this._resetSelectors();
     return displayedMetadata;
   }

--- a/webapp/components/wpt-metadata.js
+++ b/webapp/components/wpt-metadata.js
@@ -160,7 +160,6 @@ class WPTMetadata extends PathInfo(LoadingState(PolymerElement)) {
   constructor() {
     super();
     this.loadPendingMetadata();
-    this.openCollapsible = this.handleOpenCollapsible.bind(this);
   }
 
   _resetSelectors() {

--- a/webapp/components/wpt-metadata.js
+++ b/webapp/components/wpt-metadata.js
@@ -254,7 +254,7 @@ class WPTMetadata extends PathInfo(LoadingState(PolymerElement)) {
     }
 
     // This loop constructs both the metadataMap, which is used to show inline
-    // bug icons in the test results, and displayedMetdata, which is the list of
+    // bug icons in the test results, and displayedMetadata, which is the list of
     // metadata links shown at the bottom of the page.
     let metadataMap = {};
     let labelMap = {};

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -1483,7 +1483,7 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
     this.handleTriageModeChange(isTriageMode, this.$['selected-toast']);
   }
 
-  clearSelectedCells(selectedMetadata) {
+  clearSelectedCells() {
     if (this.selectedMetadata.length === 0) {
       this.handleClear(this.selectedMetadata);
     }

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -401,11 +401,11 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
       <wpt-metadata products="[[displayedProducts]]"
                     path="[[path]]"
                     search-results="[[searchResults]]"
-                    metadata-map="{{metadataMap}}"
-                    label-map="{{labelMap}}"
+                    metadata-map="[[metadataMap]]"
+                    label-map="[[labelMap}]]"
                     triage-notifier="[[triageNotifier]]"></wpt-metadata>
     </template>
-    <wpt-amend-metadata id="amend" selected-metadata="{{selectedMetadata}}" path="[[path]]"></wpt-amend-metadata>
+    <wpt-amend-metadata id="amend" selected-metadata="[[selectedMetadata]]" path="[[path]]"></wpt-amend-metadata>
 `;
   }
 

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -563,6 +563,8 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
     this.reloadPendingMetadata = this.handleReloadPendingMetadata.bind(this);
     this.sortTestName = this.sortTestName.bind(this);
     this.addEventListener('selected-metadata-changed', this.selectedMetadataChanged);
+    this.addEventListener('metadata-map-changed', this.metadataMapChanged);
+    this.addEventListener('label-map-changed', this.labelMapChanged);
   }
 
   connectedCallback() {
@@ -1491,6 +1493,14 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
 
   selectedMetadataChanged(e) {
     this.selectedMetadata = e.detail.value;
+  }
+
+  metadataMapChanged(e) {
+    this.metadataMap = e.detail.value;
+  }
+
+  labelMapChanged(e) {
+    this.labelMap = e.detail.value;
   }
 
   handleTriageHover() {

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -562,6 +562,7 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
     this.dismissToast = e => e.target.closest('paper-toast').close();
     this.reloadPendingMetadata = this.handleReloadPendingMetadata.bind(this);
     this.sortTestName = this.sortTestName.bind(this);
+    this.addEventListener('selected-metadata-changed', this.selectedMetadataChanged);
   }
 
   connectedCallback() {
@@ -1483,7 +1484,13 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
   }
 
   clearSelectedCells(selectedMetadata) {
-    this.handleClear(selectedMetadata);
+    if (this.selectedMetadata.length === 0) {
+      this.handleClear(this.selectedMetadata);
+    }
+  }
+
+  selectedMetadataChanged(e) {
+    this.selectedMetadata = e.detail.value;
   }
 
   handleTriageHover() {


### PR DESCRIPTION
This migration was a bit larger than usual due to the fact that the metadata component and the triage component interact so closely. The main changes are:

- Removal of `notify: true` and change double angle brackets to double brackets.
- Use get/set to let Polymer properly detect array property updates.
- DOM manipulation logic is now encapsulated within methods to better adhere to Polymer's data flow principles.