### PR TITLE
Chromium bug searches should use the new URL

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -576,7 +576,7 @@ __`product`__ : browser[version[os[version]]]. e.g. `chrome-63.0-linux`
 
 #### Post Examples
 - POST /api/metadata?product=chrome\&product=firefox \
-    exists:='[{"link":"bugs.chromium.org"}]'
+    exists:='[{"link":"issues.chromium.org"}]'
 
 <details><summary><b>Example JSON</b></summary>
 
@@ -584,12 +584,12 @@ __`product`__ : browser[version[os[version]]]. e.g. `chrome-63.0-linux`
 {
   "/IndexedDB/bindings-inject-key.html": [
     {
-      "url": "bugs.chromium.org/p/chromium/issues/detail?id=934844"
+      "url": "issues.chromium.org/issues/934844"
     }
   ],
   "/html/browsers/history/the-history-interface/007.html": [
     {
-      "url": "bugs.chromium.org/p/chromium/issues/detail?id=592874"
+      "url": "issues.chromium.org/issues/592874"
     }
   ]
 }

--- a/api/metadata_handler_test.go
+++ b/api/metadata_handler_test.go
@@ -292,7 +292,7 @@ func TestMetadataHandler_POST_MissingProducts(t *testing.T) {
 	body :=
 		`{
         "exists": [{
-            "link": "bugs.chromium.org"
+            "link": "issues.chromium.org"
         }]
     }`
 	bodyReader := strings.NewReader(body)
@@ -309,7 +309,7 @@ func TestMetadataHandler_POST_NotLink(t *testing.T) {
 	body :=
 		`{
         "exists": [{
-            "pattern": "bugs.chromium.org"
+            "pattern": "issues.chromium.org/"
         }]
     }`
 	bodyReader := strings.NewReader(string(body))
@@ -327,7 +327,7 @@ func TestMetadataHandler_POST_NotJustLink(t *testing.T) {
 		`{
         "exists": [{
             "and": [
-                {"pattern": "bugs.chromium.org"},
+                {"pattern": "issues.chromium.org"},
                 {"link": "abc"}
             ]
         }]

--- a/api/query/README.md
+++ b/api/query/README.md
@@ -305,11 +305,11 @@ Same as satuts, but with a specific product-spec.
 
 Search untriaged issues -
 
-    chrome:fail and !link:bugs.chromium.org
+    chrome:fail and !link:issues.chromium.org
 
 Search triaged issues -
 
-    chrome:pass and link:bugs.chromium.org
+    chrome:pass and link:issues.chromium.org
 
 #### triaged
 

--- a/webapp/components/test/test-search.html
+++ b/webapp/components/test/test-search.html
@@ -372,8 +372,8 @@ suite('<test-search>', () => {
     test('simple link search', () => {
       assertQueryParse('link:2dcontext', {exists: [{link: '2dcontext'}]});
       assertQueryParse(
-        'link:bugs.chromium.org/p/chromium/issues/detail',
-        {exists: [{link: 'bugs.chromium.org/p/chromium/issues/detail'}]}
+        'link:issues.chromium.org/issues/',
+        {exists: [{link: 'issues.chromium.org/issues/'}]}
       );
     });
 

--- a/webapp/components/test/wpt-amend-metadata.html
+++ b/webapp/components/test/wpt-amend-metadata.html
@@ -154,12 +154,12 @@ suite('wpt-amend-metadata', () => {
       assert.deepEqual(appFixture.displayedMetadata, expected);
     });
     test('getSearchURL', () => {
-      expect(appFixture.getSearchURL('/a/b/*', 'chrome')).to.equal('https://bugs.chromium.org/p/chromium/issues/list?q="/a/b"');
-      expect(appFixture.getSearchURL('/a/b.html', 'chrome')).to.equal('https://bugs.chromium.org/p/chromium/issues/list?q="/a/b"');
-      expect(appFixture.getSearchURL('/a/b', 'chrome')).to.equal('https://bugs.chromium.org/p/chromium/issues/list?q="/a/b"');
-      expect(appFixture.getSearchURL('/a/b.any.html', 'chrome')).to.equal('https://bugs.chromium.org/p/chromium/issues/list?q="/a/b"');
-      expect(appFixture.getSearchURL('/a/b.worker.html', 'chrome')).to.equal('https://bugs.chromium.org/p/chromium/issues/list?q="/a/b"');
-      expect(appFixture.getSearchURL('/a/b.html', 'edge')).to.equal('https://bugs.chromium.org/p/chromium/issues/list?q="/a/b"');
+      expect(appFixture.getSearchURL('/a/b/*', 'chrome')).to.equal('https://issues.chromium.org/issues?q="/a/b"');
+      expect(appFixture.getSearchURL('/a/b.html', 'chrome')).to.equal('https://issues.chromium.org/issues?q="/a/b"');
+      expect(appFixture.getSearchURL('/a/b', 'chrome')).to.equal('https://issues.chromium.org/issues?q="/a/b"');
+      expect(appFixture.getSearchURL('/a/b.any.html', 'chrome')).to.equal('https://issues.chromium.org/issues?q="/a/b"');
+      expect(appFixture.getSearchURL('/a/b.worker.html', 'chrome')).to.equal('https://issues.chromium.org/issues?q="/a/b"');
+      expect(appFixture.getSearchURL('/a/b.html', 'edge')).to.equal('https://issues.chromium.org/issues?q="/a/b"');
       expect(appFixture.getSearchURL('/a/b.html', 'firefox')).to.equal('https://bugzilla.mozilla.org/buglist.cgi?quicksearch="/a/b"');
       expect(appFixture.getSearchURL('/a/b.html', 'safari')).to.equal('https://bugs.webkit.org/buglist.cgi?quicksearch="/a/b"');
       expect(appFixture.getSearchURL('/a/b.html', 'wktr')).to.equal('https://bugs.webkit.org/buglist.cgi?quicksearch="/a/b"');

--- a/webapp/components/wpt-amend-metadata.js
+++ b/webapp/components/wpt-amend-metadata.js
@@ -332,7 +332,7 @@ class AmendMetadata extends LoadingState(PathInfo(ProductInfo(PolymerElement))) 
     }
 
     if (product === 'chrome' || product === 'chromium' || product === 'edge') {
-      return `https://bugs.chromium.org/p/chromium/issues/list?q="${testName}"`;
+      return `https://issues.chromium.org/issues?q="${testName}"`;
     }
 
     if (product === 'deno') {

--- a/webapp/components/wpt-amend-metadata.js
+++ b/webapp/components/wpt-amend-metadata.js
@@ -438,6 +438,11 @@ class AmendMetadata extends LoadingState(PathInfo(ProductInfo(PolymerElement))) 
       this.fieldsFilled.filled[index] = true;
     }
 
+    this.set(path, event.target.value);
+    if (labelPath) {
+      this.set(labelPath, event.target.value);
+    }
+
     // If all triage items have input, triage can be submitted.
     this.triageSubmitDisabled = this.fieldsFilled.numEmpty > 0;
   }

--- a/webapp/components/wpt-amend-metadata.js
+++ b/webapp/components/wpt-amend-metadata.js
@@ -438,11 +438,6 @@ class AmendMetadata extends LoadingState(PathInfo(ProductInfo(PolymerElement))) 
       this.fieldsFilled.filled[index] = true;
     }
 
-    this.set(path, event.target.value);
-    if (labelPath) {
-      this.set(labelPath, event.target.value);
-    }
-
     // If all triage items have input, triage can be submitted.
     this.triageSubmitDisabled = this.fieldsFilled.numEmpty > 0;
   }


### PR DESCRIPTION
I noticed that the triage UI search functionality is currently broken for Chromium, in that the query to search for bugs mentioning the selected file name results in a search for all open bugs. This is caused by the migration from Monorail to Buganizer, which uses slightly different paths.

I took the opportunity to update all Chromium bug tracker URLs to the new format, with the exception of those in `metadata_util_test.go` that are trying to match the data included in an old archive from wpt-metadata. Arguably the test should be rewritten to not rely on explicit string values in those fields, but it doesn't seem very useful to update the actual archive as well to really eliminate every old URL instance.