### PR TITLE
Fix download of firefox for the tests: it is now a tar.xz file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,9 +177,9 @@ chromedriver: wget unzip chrome jq
 
 firefox: bzip2 wget
 	if [[ -z "$$(which firefox)" ]]; then \
-		wget -O firefox.tar.bz2 -q "https://download.mozilla.org/?product=firefox-latest&os=linux64&lang=en-US"; \
+		wget -O firefox.tar.xz -q "https://download.mozilla.org/?product=firefox-latest&os=linux64&lang=en-US"; \
 		mkdir -p $$HOME/browsers; \
-		tar -xjf firefox.tar.bz2 -C $$HOME/browsers; \
+		tar -xaf firefox.tar.xz -C $$HOME/browsers; \
 		sudo ln -s $$HOME/browsers/firefox/firefox $(FIREFOX_PATH); \
 	fi
 


### PR DESCRIPTION
On pr #4227 the tests are failing because the download of firefox fails:

```
2025-02-04T19:10:22.4216170Z if [[ "$(which bzip2)" == "" ]]; then sudo apt-get install -qqy --no-install-suggests bzip2; fi
2025-02-04T19:10:22.4241117Z if [[ "$(which wget)" == "" ]]; then sudo apt-get install -qqy --no-install-suggests wget; fi
2025-02-04T19:10:22.4263913Z if [[ -z "$(which firefox)" ]]; then \
2025-02-04T19:10:22.4264789Z 	wget -O firefox.tar.bz2 -q "https://download.mozilla.org/?product=firefox-latest&os=linux64&lang=en-US"; \
2025-02-04T19:10:22.4265763Z 	mkdir -p $HOME/browsers; \
2025-02-04T19:10:22.4266220Z 	tar -xjf firefox.tar.bz2 -C $HOME/browsers; \
2025-02-04T19:10:22.4266812Z 	sudo ln -s $HOME/browsers/firefox/firefox /usr/bin/firefox; \
2025-02-04T19:10:22.4267281Z fi
2025-02-04T19:10:22.9930402Z bzip2: (stdin) is not a bzip2 file.
2025-02-04T19:10:22.9930971Z tar: Child returned status 2
2025-02-04T19:10:22.9931413Z tar: Error is not recoverable: exiting now
```

It seems that the download is now a xz file instead of a bz2

```
$ wget -O /dev/stdout -q "https://download.mozilla.org/?product=firefox-latest&os=linux64&lang=en-US" | file -
/dev/stdin: XZ compressed data, checksum CRC64
```