### PR TITLE
Add handlers for App Engine liveness and readiness checks

### DIFF
--- a/webapp/routes.go
+++ b/webapp/routes.go
@@ -5,6 +5,8 @@
 package webapp
 
 import (
+	"net/http"
+
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
@@ -57,7 +59,27 @@ func RegisterRoutes() {
 	shared.AddRoute("/results/", "results", testResultsHandler)
 	shared.AddRoute("/results/{path:.*}", "results", testResultsHandler)
 
+	// Service readiness and liveness check handlers.
+	shared.AddRoute("/_ah/liveness_check", "liveness-check", livenessCheckHandler)
+	shared.AddRoute("/_ah/readiness_check", "readiness-check", readinessCheckHandler)
+
 	// Legacy wildcard match
 	shared.AddRoute("/", "results-legacy", testResultsHandler)
 	shared.AddRoute("/{path:.*}", "results-legacy", testResultsHandler)
+}
+
+func livenessCheckHandler(w http.ResponseWriter, r *http.Request) {
+	_, err := w.Write([]byte("Alive"))
+	if err != nil {
+		logger := shared.GetLogger(r.Context())
+		logger.Warningf("Failed to write data in liveness check handler: %s", err.Error())
+	}
+}
+
+func readinessCheckHandler(w http.ResponseWriter, r *http.Request) {
+	_, err := w.Write([]byte("Ready"))
+	if err != nil {
+		logger := shared.GetLogger(r.Context())
+		logger.Warningf("Failed to write data in readiness check handler: %s", err.Error())
+	}
 }

--- a/webapp/web/app.staging.yaml
+++ b/webapp/web/app.staging.yaml
@@ -16,6 +16,12 @@ default_expiration: "1d"
 vpc_access_connector:
   name: projects/wptdashboard-staging/locations/us-east4/connectors/appengine-connector
 
+liveness_check:
+  path: "/_ah/liveness_check"
+
+readiness_check:
+  path: "/_ah/readiness_check"
+
 env_variables:
   REDISHOST: "10.171.142.203"
   REDISPORT: "6379"

--- a/webapp/web/app.yaml
+++ b/webapp/web/app.yaml
@@ -14,6 +14,12 @@ default_expiration: "1d"
 vpc_access_connector:
   name: projects/wptdashboard/locations/us-central1/connectors/appengine-connector
 
+liveness_check:
+  path: "/_ah/liveness_check"
+
+readiness_check:
+  path: "/_ah/readiness_check"
+
 env_variables:
   REDISHOST: "10.171.142.203"
   REDISPORT: "6379"


### PR DESCRIPTION
Implements handlers for the default liveness and readiness checks in the webapp, just like we do in the searchcache service.