### PR TITLE
Disable nginx body check

### DIFF
--- a/webapp/web/nginx.conf
+++ b/webapp/web/nginx.conf
@@ -71,6 +71,8 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+            # Disable checking of the body size
+            client_max_body_size 0;
         }
     }
 }


### PR DESCRIPTION
According to the docs, if we set client_max_body_size to 0, it won't check the size. This will make the behavior like before.

https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size:~:text=Setting%20size%20to%200%20disables%20checking%20of%20client%20request%20body%20size

<!--
Thanks for the PR, you probably worked hard on it! Before you submit it for review, please make sure you read our guidelines for contributing to this repository. 

Try to make the job easy for your reviewer! Below is a template you can use as a guide for what context your reviewer might need.  
If you changed any dev procedures, consider also updating the README.
-->

## Description
TODO
<!-- A detailed description explaining what your code accomplishes, and why this work is taking place. If this affects an open issue, please make sure to properly reference it. -->

## Review Information
TODO
<!-- Provide detailed instructions for how to run the code. -->

## Changes
TODO
<!-- Highlight the files that have changed and group them into concepts, or issues being solved -->

## Requirements
TODO
<!-- Describe any special configurations, environment requirements, or dependencies. -->
