### PR TITLE
Focus area name changes

### DIFF
--- a/webapp/components/interop-data.js
+++ b/webapp/components/interop-data.js
@@ -1439,7 +1439,7 @@ export const interopData = {
           'Accessibility Testing',
           'Gaming',
           'Mobile Testing',
-          'Privacy',
+          'Privacy Testing',
           'WebVTT'
         ],
         'score_as_group': true
@@ -1453,7 +1453,7 @@ export const interopData = {
       },
       {
         'name': 'Gaming',
-        'url': '',
+        'url': 'https://github.com/web-platform-tests/interop/issues/786',
         'scores_over_time': []
       },
       {
@@ -1462,13 +1462,13 @@ export const interopData = {
         'scores_over_time': []
       },
       {
-        'name': 'Privacy',
-        'url': '',
+        'name': 'Privacy Testing',
+        'url': 'https://github.com/web-platform-tests/interop/issues/831',
         'scores_over_time': []
       },
       {
         'name': 'WebVTT',
-        'url': '',
+        'url': 'https://github.com/web-platform-tests/interop/issues/860',
         'scores_over_time': []
       }
     ],
@@ -1613,7 +1613,7 @@ export const interopData = {
         ]
       },
       'interop-2025-navigation': {
-        'description': 'Navigation',
+        'description': 'Navigation API',
         'mdn': 'https://developer.mozilla.org/en-US/docs/Web/API/Navigation_API',
         'spec': 'https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigation-api',
         'tests': '/results/navigation-api?label=master&product=chrome&product=edge&product=firefox&product=safari&view=interop&q=label%3Ainterop-2025-navigation',

--- a/webapp/components/interop-data.js
+++ b/webapp/components/interop-data.js
@@ -1505,7 +1505,7 @@ export const interopData = {
           'Accessibility Testing',
           'Gaming',
           'Mobile Testing',
-          'Privacy',
+          'Privacy Testing',
           'WebVTT'
         ],
         'score_as_group': true

--- a/webapp/static/interop-data.json
+++ b/webapp/static/interop-data.json
@@ -1412,7 +1412,7 @@
           "Accessibility Testing",
           "Gaming",
           "Mobile Testing",
-          "Privacy",
+          "Privacy Testing",
           "WebVTT"
         ],
         "score_as_group": true

--- a/webapp/static/interop-data.json
+++ b/webapp/static/interop-data.json
@@ -1426,7 +1426,7 @@
       },
       {
         "name": "Gaming",
-        "url": "",
+        "url": "https://github.com/web-platform-tests/interop/issues/786",
         "scores_over_time": []
       },
       {
@@ -1435,13 +1435,13 @@
         "scores_over_time": []
       },
       {
-        "name": "Privacy",
-        "url": "",
+        "name": "Privacy Testing",
+        "url": "https://github.com/web-platform-tests/interop/issues/831",
         "scores_over_time": []
       },
       {
         "name": "WebVTT",
-        "url": "",
+        "url": "https://github.com/web-platform-tests/interop/issues/860",
         "scores_over_time": []
       }
     ],
@@ -1478,7 +1478,7 @@
           "Accessibility Testing",
           "Gaming",
           "Mobile Testing",
-          "Privacy",
+          "Privacy Testing",
           "WebVTT"
         ],
         "score_as_group": true
@@ -1582,7 +1582,7 @@
         ]
       },
       "interop-2025-navigation": {
-        "description": "Navigation",
+        "description": "Navigation API",
         "mdn": "https://developer.mozilla.org/en-US/docs/Web/API/Navigation_API",
         "spec": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigation-api",
         "tests": "/results/navigation-api?label=master&product=chrome&product=edge&product=firefox&product=safari&view=interop&q=label%3Ainterop-2025-navigation",


### PR DESCRIPTION
Some suggested name changes ahead of the release of the Interop 2025 dashboard. Additionally, adding some proposal links for the investigation areas.