### PR TITLE
Increase the min number of instances and the cool down period

### DIFF
--- a/webapp/web/app.staging.yaml
+++ b/webapp/web/app.staging.yaml
@@ -4,7 +4,11 @@
 
 runtime: custom
 env: flex
-instance_class: F4_1G
+
+automatic_scaling:
+  min_num_instances: 4
+  max_num_instances: 20
+  cool_down_period_sec: 180
 
 inbound_services:
 - warmup

--- a/webapp/web/app.yaml
+++ b/webapp/web/app.yaml
@@ -4,7 +4,11 @@
 
 runtime: custom
 env: flex
-instance_class: F4_1G
+
+automatic_scaling:
+  min_num_instances: 4
+  max_num_instances: 20
+  cool_down_period_sec: 180
 
 inbound_services:
 - warmup


### PR DESCRIPTION
The current webapp VM configuration is:
```
automatic_scaling:
  cool_down_period: 120s
  min_num_instances: 2
  max_num_instances: 20
  cpu_utilization:
    target_utilization: 0.5
```

This change removes the `instance_class` that is only applicable to the standard environment (c.f. [flex docs](https://cloud.google.com/appengine/docs/flexible/reference/app-yaml?tab=go)), doubles the minimum number of instances and increases the cool down period to avoid health check errors during instance initialization.