### PR TITLE
Adjust more timeouts

### DIFF
--- a/webapp/web/nginx.conf
+++ b/webapp/web/nginx.conf
@@ -73,6 +73,23 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
             # Disable checking of the body size
             client_max_body_size 0;
+            # Disable timeout checks. Allow the application to determine the appropriate timeouts
+            client_body_timeout 0;
+            client_header_timeout 0;
+            send_timeout 0;
+            proxy_read_timeout 0;
+            proxy_connect_timeout 0;
+            # TODO(https://github.com/web-platform-tests/wpt.fyi/issues/4231)
+            # Nginx client keepalive timeout. Due to the use of nicehttp, the Go application's
+            # idle timeout is not configurable, and it defaults to no timeout as per Go 1.23.
+            # 10 minutes is a temporary high value until nicehttp can be replaced or configured.
+            # Consider reducing this timeout to a more reasonable value (e.g., 60s) to prevent
+            # excessive idle connections.
+            # IMPORTANT: The NGINX UPSTREAM keepalive timeout (configured in the upstream block)
+            # MUST be LESS than the Go application's idle timeout to avoid connection errors.
+            # However, since the Go application effectively has no timeout right now because of nicehttp,
+            # the upstream timeout must be set to a reasonably high value.
+            keepalive_timeout 10m;
         }
     }
 }


### PR DESCRIPTION
This change disables most NGINX timeout checks (e.g., client body, header, read timeouts) and sets the keepalive timeout to a high value. The goal is to let the Go application handle timeout configurations and prevent resource exhaustion on the NGINX side. This approach is temporary until the Go application can be migrated away from `nicehttp`.

Why this change:
- Previously, some requests were failing at 60 seconds, likely due to the NGINX timeout settings and the limited capacity of the smaller instances. This change disables or increases various NGINX timeouts (e.g., client body, header, read timeouts) and sets a high keepalive timeout to allow the Go application to handle timeout logic. I have not seen any requests taking longer than 60 seconds today after yesterday's changes. So this is a proactive change.
- This should prevent requests from failing with the larger instances, even under increased demand. It might also allow us to reduce the instance size slightly in the future.


