### PR TITLE
Fix the info about investigation areas

### DIFF
--- a/webapp/components/interop-data.js
+++ b/webapp/components/interop-data.js
@@ -1447,22 +1447,22 @@ export const interopData = {
     ],
     'investigation_scores': [
       {
-        'name': 'Accessibility Testing',
+        'name': 'Accessibility testing',
         'url': 'https://github.com/web-platform-tests/interop-accessibility',
         'scores_over_time': []
       },
       {
-        'name': 'Gaming',
+        'name': 'Gaming API testing',
         'url': 'https://github.com/web-platform-tests/interop/issues/786',
         'scores_over_time': []
       },
       {
-        'name': 'Mobile Testing',
+        'name': 'Mobile testing',
         'url': 'https://github.com/web-platform-tests/interop-mobile-testing',
         'scores_over_time': []
       },
       {
-        'name': 'Privacy Testing',
+        'name': 'Privacy testing',
         'url': 'https://github.com/web-platform-tests/interop/issues/831',
         'scores_over_time': []
       },

--- a/webapp/components/interop-data.js
+++ b/webapp/components/interop-data.js
@@ -1452,7 +1452,7 @@ export const interopData = {
         'scores_over_time': []
       },
       {
-        'name': 'Gaming API testing',
+        'name': 'Gamepad API testing',
         'url': 'https://github.com/web-platform-tests/interop/issues/786',
         'scores_over_time': []
       },

--- a/webapp/static/interop-data.json
+++ b/webapp/static/interop-data.json
@@ -1420,22 +1420,22 @@
     ],
     "investigation_scores": [
       {
-        "name": "Accessibility Testing",
+        "name": "Accessibility testing",
         "url": "https://github.com/web-platform-tests/interop-accessibility",
         "scores_over_time": []
       },
       {
-        "name": "Gaming",
+        "name": "Gaming API testing",
         "url": "https://github.com/web-platform-tests/interop/issues/786",
         "scores_over_time": []
       },
       {
-        "name": "Mobile Testing",
+        "name": "Mobile testing",
         "url": "https://github.com/web-platform-tests/interop-mobile-testing",
         "scores_over_time": []
       },
       {
-        "name": "Privacy Testing",
+        "name": "Privacy testing",
         "url": "https://github.com/web-platform-tests/interop/issues/831",
         "scores_over_time": []
       },

--- a/webapp/static/interop-data.json
+++ b/webapp/static/interop-data.json
@@ -1425,7 +1425,7 @@
         "scores_over_time": []
       },
       {
-        "name": "Gaming API testing",
+        "name": "Gamepad API testing",
         "url": "https://github.com/web-platform-tests/interop/issues/786",
         "scores_over_time": []
       },


### PR DESCRIPTION
## Description
For the dashboard to work, names need to be the same between the table sections and the investigation scores.
For now, all investigation areas have `#` as link on the dashboard because the corresponding info is not found (they would also fail to display a score, even though this is not yet different as no investigation area has a score registered yet)

## Review Information

## Changes
I updated the `investigation_scores` section to use the same names that table sections.

## Requirements
n/a
