### PR TITLE
Bump flags 0.2.2 to flg 3.0.0

### DIFF
--- a/webdriver/package-lock.json
+++ b/webdriver/package-lock.json
@@ -4,15 +4,15 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "wptdashboard-webdriver",
       "license": "BSD-3-Clause",
       "dependencies": {
         "chai": "5.2.0",
         "debug": "4.4.0",
-        "flags": "0.2.2",
+        "flg": "^3.0.0",
         "mocha": "11.1.0",
         "puppeteer": "24.3.0"
-      },
-      "devDependencies": {}
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.26.2",
@@ -910,12 +910,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/flags": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/flags/-/flags-0.2.2.tgz",
-      "integrity": "sha512-io/l8F1LPmOWGWmgJSzRDhMwBhRpw0m/ZATweM8iV1yvpbM5kkMlYM4wnuHSDfJ5NUDMeSyLbF0FtoNWR0f+WQ==",
-      "deprecated": "The package formerly known as flags has been renamed to flg. Migrate from flags to flg at your convenience to ensure you receive upcoming releases and avoid this deprecation notice. See https://github.com/dpup/node-flags#package-name-update"
-    },
     "node_modules/flat": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
@@ -923,6 +917,11 @@
       "bin": {
         "flat": "cli.js"
       }
+    },
+    "node_modules/flg": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/flg/-/flg-3.0.0.tgz",
+      "integrity": "sha512-HEnIsVEDGzYEO9beb0KR8i/has6iIGQETEvo3sor+2Dsq89GRrO6dKuHSVw4yU31s5BWB/379qHEXSdO9H/aVA=="
     },
     "node_modules/foreground-child": {
       "version": "3.3.0",

--- a/webdriver/package.json
+++ b/webdriver/package.json
@@ -6,14 +6,13 @@
     "type": "git",
     "url": "https://github.com/web-platform-tests/wpt.fyi.git"
   },
-  "devDependencies": {},
   "scripts": {
     "test": "mocha --ui tdd --timeout 12000 webdriver.js"
   },
   "dependencies": {
     "chai": "5.2.0",
     "debug": "4.4.0",
-    "flags": "0.2.2",
+    "flg": "^3.0.0",
     "mocha": "11.1.0",
     "puppeteer": "24.3.0"
   }


### PR DESCRIPTION
A month ago flags [migrated](https://github.com/dpup/node-flags?tab=readme-ov-file#package-name-update) to flg, and a couple weeks ago @vercel/flags [became](https://vercel.com/changelog/npm-i-flags) flags. This was enough to confuse dependabot into generating #4287, but this PR implements the proper migration.