### PR TITLE
Add & use isTestMissing helper when calculating passes in view=test

### DIFF
--- a/webapp/components/test/wpt-results.html
+++ b/webapp/components/test/wpt-results.html
@@ -383,6 +383,17 @@ suite('<wpt-results>', () => {
       const formatted = trf.formatCellDisplay(passes, total, status, isDir);
       expect(formatted).to.equal('PASS');
     });
+
+    test('should display Missing for missing test (test view, file)', () => {
+      const passes = 0;
+      const total = 0;
+      const status = '';
+      const isDir = false;
+      trf.view = VIEW_ENUM.Test;
+      const formatted = trf.formatCellDisplay(passes, total, status, isDir);
+      // test-file-results-table.js takes care of capitalizing it to MISSING.
+      expect(formatted).to.equal('Missing');
+    });
   });
 
   teardown(() => {

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -75,9 +75,24 @@ export const VIEW_ENUM = {
  * @returns {boolean}
  */
 function isViewTestPass(total, passes, status) {
-  return (passes === total && (
+  return (passes === total && !isTestMissing(total, status) && (
     (status === undefined) || (status === '') || (PASSING_STATUSES.includes(status))
   ));
+}
+
+/**
+ * Determines if a test result is missing.
+ * This function is defined outside the WPTResults class to avoid 'this' binding issues.
+ * For example, if this function were a method of WPTResults and passed as a callback
+ * to another function (e.g., within a loop), the 'this' context within the callback
+ * might not refer to the WPTResults instance, leading to errors when trying to
+ * access component properties or methods.
+ * @param {number} total - The total number of subtests.
+ * @param {string | undefined} status - The status of the test.
+ * @returns {boolean}
+ */
+function isTestMissing(total, status) {
+  return status === '' && total === 0
 }
 
 class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathInfo(LoadingState(TestRunsUIBase)))))) {
@@ -784,7 +799,7 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
 
     for (let i = 0; i < rs.length; i++) {
       const status = rs[i].status;
-      const isMissing = status === '' && rs[i].total === 0;
+      const isMissing = isTestMissing(rs[i].total, status);
       row.results[i].singleSubtest = (rs[i].total === 0 && status && status !== 'O') || isMissing;
       row.results[i].status = status;
       let passes, total = 0;


### PR DESCRIPTION
Moves isMissing logic to a common method. It will continue to be used for calculating whether we have a single subtest. Additionally, it will be used with the new logic for view=test. Without this check, we will add missing tests as passing tests.

More details in #4293 

Fixes #4293
