### PR TITLE
Use the same number of processor instances in staging as in prod

### DIFF
--- a/results-processor/app.staging.yaml
+++ b/results-processor/app.staging.yaml
@@ -7,7 +7,7 @@ runtime: custom
 env: flex
 
 manual_scaling:
-  instances: 3
+  instances: 5
 resources:
   cpu: 2
   memory_gb: 4


### PR DESCRIPTION
We often get alerts due to the results-arrival queue depth exceeding the alert threshold for a long time. Given that task queue configuration is the same across staging and production, let's try to use more CPU for staging to avoid that problem.