### PR TITLE
Actually fetch favicon

### DIFF
--- a/webapp/templates/_head_common.html
+++ b/webapp/templates/_head_common.html
@@ -2,5 +2,6 @@
 <title>web-platform-tests dashboard</title>
 {{ template "_ga.html" }}
 <link rel="stylesheet" href="/static/common.css">
+<link rel="icon" href="/static/favicon.ico">
 <script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 <script type="module" src="/components/wpt-header.js"></script>


### PR DESCRIPTION
Follow-up of #416, which doesn't actually add the favicon to the page source. This still appears to be the case on the live site.
