### PR TITLE
golangci-lint migration

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,36 +1,28 @@
+version: "2"
 linters:
-  # Disable all linters enabled by default.
-  # See: https://golangci-lint.run/usage/linters
-  disable-all: true  
-  # Enabling specified linters.
-  # See: https://github.com/web-platform-tests/wpt.fyi/issues/2983
-  enable: 
-    - staticcheck
-    - errcheck
-    - gosimple
-    - govet
-    - typecheck
-    - unused
-    - ineffassign
+  default: none
+  enable:
     - containedctx
-    - dupl
+    - copyloopvar
     - dogsled
+    - dupl
+    - errcheck
     - errname
     - errorlint
     - exhaustive
     - exhaustruct
-    - copyloopvar
     - gochecknoglobals
     - gocognit
     - goconst
     - gocyclo
     - godot
     - godox
-    - gofmt
     - goheader
     - gomoddirectives
     - gosec
+    - govet
     - importas
+    - ineffassign
     - ireturn
     - lll
     - misspell
@@ -38,27 +30,45 @@ linters:
     - nestif
     - nilerr
     - nilnil
-    - nlreturn  
+    - nlreturn
     - noctx
     - prealloc
     - revive
+    - staticcheck
     - unparam
+    - unused
     - usestdlibvars
+  settings:
+    exhaustruct:
+      exclude:
+        - github\.com/google/go-github/v65/github\.CheckRunOutput
+        - github\.com/google/go-github/v65/github\.ListCheckRunsOptions
+        - github\.com/google/go-github/v65/github\.ListOptions
+        - github\.com/golang-jwt/jwt\.StandardClaims
+        - net/http\.Client
+    gomoddirectives:
+      replace-allow-list:
+        - launchpad.net/gocheck
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
-linters-settings:
-  exhaustruct:
-    # List of regular expressions to exclude struct packages and names from check.
-    # We exclude third-party structs with entirely optional (omitempty) fields.
-    exclude: 
-      - 'github\.com/google/go-github/v65/github\.CheckRunOutput'
-      - 'github\.com/google/go-github/v65/github\.ListCheckRunsOptions'
-      - 'github\.com/google/go-github/v65/github\.ListOptions'
-      - 'github\.com/golang-jwt/jwt\.StandardClaims'
-      - 'net/http\.Client'
-  gomoddirectives:  
-    # List of allowed `replace directives`
-    # See: https://github.com/web-platform-tests/wpt.fyi/blob/main/go.mod
-    replace-allow-list:
-      - launchpad.net/gocheck
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/api/checks/jwt.go
+++ b/api/checks/jwt.go
@@ -91,7 +91,7 @@ func getSignedJWT(ctx context.Context, appID int64) (string, error) {
 	}
 	block, _ := pem.Decode([]byte(secret))
 	if block == nil {
-		return "", errors.New("Failed to decode private key")
+		return "", errors.New("failed to decode private key")
 	}
 	key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
 	if err != nil {

--- a/api/checks/runs.go
+++ b/api/checks/runs.go
@@ -128,10 +128,10 @@ func getExistingCheckRuns(ctx context.Context, suite shared.CheckSuite) ([]*gith
 		}
 
 		// Setup for the next call.
-		options.ListOptions.Page = response.NextPage
+		options.Page = response.NextPage
 	}
 
-	return nil, fmt.Errorf("More than 10 pages of CheckRuns returned for ref %s", suite.SHA)
+	return nil, fmt.Errorf("more than 10 pages of CheckRuns returned for ref %s", suite.SHA)
 }
 
 func updateExistingCheckRunSummary(

--- a/api/checks/summaries/compile.go
+++ b/api/checks/summaries/compile.go
@@ -37,8 +37,7 @@ func init() {
 
 // escapeMD returns the escaped MD equivalent of the plain text data s.
 func escapeMD(s string) string {
-	// nolint:staticcheck
-	return strings.Replace(s, `|`, `\|`, -1)
+	return strings.ReplaceAll(s, "|", `\|`)
 }
 
 // Summary is the generic interface of a summary template data type.

--- a/api/checks/summaries/compile.go
+++ b/api/checks/summaries/compile.go
@@ -37,6 +37,7 @@ func init() {
 
 // escapeMD returns the escaped MD equivalent of the plain text data s.
 func escapeMD(s string) string {
+	// nolint:staticcheck
 	return strings.Replace(s, `|`, `\|`, -1)
 }
 

--- a/api/checks/update.go
+++ b/api/checks/update.go
@@ -313,7 +313,7 @@ func getDiffSummary(
 			}
 		}
 		success := "success"
-		data.CheckState.Conclusion = &success
+		data.Conclusion = &success
 		summary = data
 	} else {
 		// nolint:exhaustruct // TODO: Fix exhaustruct lint error
@@ -333,7 +333,7 @@ func getDiffSummary(
 		}
 		if checksCanBeNonNeutral {
 			actionRequired := "action_required"
-			data.CheckState.Conclusion = &actionRequired
+			data.Conclusion = &actionRequired
 		}
 		summary = data
 	}

--- a/api/checks/webhook.go
+++ b/api/checks/webhook.go
@@ -18,13 +18,13 @@ import (
 const requestedAction = "requested"
 const rerequestedAction = "rerequested"
 
-// WebhookGithubEvent represents the allowed GitHub webhook event types.
-type WebhookGithubEvent string
+// webhookGithubEvent represents the allowed GitHub webhook event types.
+type webhookGithubEvent string
 
 const (
-	EventCheckSuite  WebhookGithubEvent = "check_suite"
-	EventCheckRun    WebhookGithubEvent = "check_run"
-	EventPullRequest WebhookGithubEvent = "pull_request"
+	eventCheckSuite  webhookGithubEvent = "check_suite"
+	eventCheckRun    webhookGithubEvent = "check_run"
+	eventPullRequest webhookGithubEvent = "pull_request"
 )
 
 var runNameRegex = regexp.MustCompile(`^(?:(?:staging\.)?wpt\.fyi - )(.*)$`)
@@ -50,9 +50,9 @@ func checkWebhookHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	event := r.Header.Get("X-GitHub-Event")
-	inputEvent := WebhookGithubEvent(event)
+	inputEvent := webhookGithubEvent(event)
 	switch inputEvent {
-	case EventCheckSuite, EventCheckRun, EventPullRequest:
+	case eventCheckSuite, eventCheckRun, eventPullRequest:
 		break
 	default:
 		log.Debugf("Ignoring %s event", event)
@@ -82,11 +82,11 @@ func checkWebhookHandler(w http.ResponseWriter, r *http.Request) {
 	var processed bool
 	api := NewAPI(ctx)
 	switch inputEvent {
-	case EventCheckSuite:
+	case eventCheckSuite:
 		processed, err = handleCheckSuiteEvent(api, payload)
-	case EventCheckRun:
+	case eventCheckRun:
 		processed, err = handleCheckRunEvent(api, payload)
-	case EventPullRequest:
+	case eventPullRequest:
 		processed, err = handlePullRequestEvent(api, payload)
 	}
 

--- a/api/checks/webhook.go
+++ b/api/checks/webhook.go
@@ -71,6 +71,7 @@ func checkWebhookHandler(w http.ResponseWriter, r *http.Request) {
 
 	var processed bool
 	api := NewAPI(ctx)
+	// nolint:staticcheck
 	if event == "check_suite" {
 		processed, err = handleCheckSuiteEvent(api, payload)
 	} else if event == "check_run" {
@@ -308,7 +309,7 @@ func scheduleProcessingForExistingRuns(ctx context.Context, sha string, products
 	products = shared.ProductSpecs(products).OrDefault()
 	runsByProduct, err := store.TestRunQuery().LoadTestRuns(products, nil, shared.SHAs{sha}, nil, nil, nil, nil)
 	if err != nil {
-		return false, fmt.Errorf("Failed to load test runs: %s", err.Error())
+		return false, fmt.Errorf("failed to load test runs: %s", err.Error())
 	}
 	createdSome := false
 	api := NewAPI(ctx)

--- a/api/ghactions/notify.go
+++ b/api/ghactions/notify.go
@@ -148,7 +148,7 @@ func processBuild(
 
 	uploader, err := aeAPI.GetUploader(uploaderName)
 	if err != nil {
-		return false, fmt.Errorf("Failed to get uploader creds from Datastore: %w", err)
+		return false, fmt.Errorf("failed to get uploader creds from Datastore: %w", err)
 	}
 
 	uploadClient := uc.NewClient(aeAPI)
@@ -162,7 +162,7 @@ func processBuild(
 		shared.ToStringSlice(labels))
 
 	if err != nil {
-		return false, fmt.Errorf("Failed to create run: %w", err)
+		return false, fmt.Errorf("failed to create run: %w", err)
 	}
 
 	return true, nil

--- a/api/manifest/api.go
+++ b/api/manifest/api.go
@@ -79,7 +79,7 @@ func getGitHubReleaseAssetForSHA(aeAPI shared.AppEngineAPI, sha string) (
 			return "", nil, err
 		}
 		if issues == nil || len(issues.Issues) < 1 {
-			return "", nil, fmt.Errorf("No search results found for SHA %s", sha)
+			return "", nil, fmt.Errorf("no search results found for SHA %s", sha)
 		}
 
 		releaseTag = fmt.Sprintf("merge_pr_%d", issues.Issues[0].GetNumber())
@@ -101,7 +101,7 @@ func getGitHubReleaseAssetForSHA(aeAPI shared.AppEngineAPI, sha string) (
 	if err != nil {
 		return "", nil, err
 	} else if release == nil || len(release.Assets) < 1 {
-		return "", nil, fmt.Errorf("No assets found for %s release", releaseTag)
+		return "", nil, fmt.Errorf("no assets found for %s release", releaseTag)
 	}
 	// Get (and unzip) the asset with name "MANIFEST-{sha}.json.gz"
 	for _, asset := range release.Assets {
@@ -121,7 +121,7 @@ func getGitHubReleaseAssetForSHA(aeAPI shared.AppEngineAPI, sha string) (
 		}
 	}
 
-	return "", nil, fmt.Errorf("No manifest asset found for release %s", releaseTag)
+	return "", nil, fmt.Errorf("no manifest asset found for release %s", releaseTag)
 }
 
 // NewRedis creates a new redisReadWritable with the given duration.

--- a/api/metadata_handler_test.go
+++ b/api/metadata_handler_test.go
@@ -84,7 +84,7 @@ func TestHandleMetadataTriage_FailToCachePr(t *testing.T) {
 	mocktm.EXPECT().Triage(gomock.Any()).Return("https://github.com/web-platform-tests/wpt-metadata/pull/1", nil)
 
 	mockSet := sharedtest.NewMockRedisSet(mockCtrl)
-	mockSet.EXPECT().Add(shared.PendingMetadataCacheKey, "1").Return(errors.New("Cache failed"))
+	mockSet.EXPECT().Add(shared.PendingMetadataCacheKey, "1").Return(errors.New("cache failed"))
 
 	handleMetadataTriage(ctx, mockgac, mocktm, nil, mockSet, w, req)
 
@@ -120,7 +120,7 @@ func TestHandleMetadataTriage_FailToCacheMetadata(t *testing.T) {
 	mockSet.EXPECT().Add(shared.PendingMetadataCacheKey, "1").Return(nil)
 
 	mockCache := sharedtest.NewMockObjectCache(mockCtrl)
-	mockCache.EXPECT().Put(shared.PendingMetadataCachePrefix+"1", gomock.Any()).Return(errors.New("Cache failed"))
+	mockCache.EXPECT().Put(shared.PendingMetadataCachePrefix+"1", gomock.Any()).Return(errors.New("cache failed"))
 
 	handleMetadataTriage(ctx, mockgac, mocktm, mockCache, mockSet, w, req)
 
@@ -487,7 +487,7 @@ func TestPendingMetadataHandler_EmptyObjectCache(t *testing.T) {
 		shared.PendingMetadataCachePrefix + "456",
 	}
 	for _, key := range keys {
-		mockCache.EXPECT().Get(key, gomock.Any()).Return(errors.New("Cache miss"))
+		mockCache.EXPECT().Get(key, gomock.Any()).Return(errors.New("cache miss"))
 	}
 
 	handlePendingMetadata(ctx, mockCache, mockSet, w, r)
@@ -510,7 +510,7 @@ func TestPendingMetadataHandler_Fail(t *testing.T) {
 
 	mockCache := sharedtest.NewMockObjectCache(mockCtrl)
 	mockSet := sharedtest.NewMockRedisSet(mockCtrl)
-	mockSet.EXPECT().GetAll(shared.PendingMetadataCacheKey).Return(nil, errors.New("Cache miss"))
+	mockSet.EXPECT().GetAll(shared.PendingMetadataCacheKey).Return(nil, errors.New("cache miss"))
 
 	handlePendingMetadata(ctx, mockCache, mockSet, w, r)
 

--- a/api/query/atoms.go
+++ b/api/query/atoms.go
@@ -562,7 +562,7 @@ func (rq *RunQuery) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	if len(data.RunIDs) == 0 {
-		return errors.New(`Missing run query property: "run_ids"`)
+		return errors.New(`missing run query property: "run_ids"`)
 	}
 	rq.RunIDs = data.RunIDs
 
@@ -588,7 +588,7 @@ func (tnp *TestNamePattern) UnmarshalJSON(b []byte) error {
 	}
 	patternMsg, ok := data["pattern"]
 	if !ok {
-		return errors.New(`Missing test name pattern property: "pattern"`)
+		return errors.New(`missing test name pattern property: "pattern"`)
 	}
 	var pattern string
 	if err := json.Unmarshal(*patternMsg, &pattern); err != nil {
@@ -609,11 +609,11 @@ func (tnp *SubtestNamePattern) UnmarshalJSON(b []byte) error {
 	}
 	subtestMsg, ok := data["subtest"]
 	if !ok {
-		return errors.New(`Missing subtest name pattern property: "subtest"`)
+		return errors.New(`missing subtest name pattern property: "subtest"`)
 	}
 	var subtest string
 	if err := json.Unmarshal(*subtestMsg, &subtest); err != nil {
-		return errors.New(`Subtest name property "subtest" is not a string`)
+		return errors.New(`subtest name property "subtest" is not a string`)
 	}
 	tnp.Subtest = subtest
 
@@ -630,11 +630,11 @@ func (tp *TestPath) UnmarshalJSON(b []byte) error {
 	}
 	pathMsg, ok := data["path"]
 	if !ok {
-		return errors.New(`Missing test name path property: "path"`)
+		return errors.New(`missing test name path property: "path"`)
 	}
 	var path string
 	if err := json.Unmarshal(*pathMsg, &path); err != nil {
-		return errors.New(`Missing test name path property "path" is not a string`)
+		return errors.New(`missing test name path property "path" is not a string`)
 	}
 
 	tp.Path = path
@@ -657,7 +657,7 @@ func (tse *TestStatusEq) UnmarshalJSON(b []byte) error {
 		data.Product = data.BrowserName
 	}
 	if len(data.Status) == 0 {
-		return errors.New(`Missing test status constraint property: "status"`)
+		return errors.New(`missing test status constraint property: "status"`)
 	}
 
 	var product *shared.ProductSpec
@@ -673,7 +673,7 @@ func (tse *TestStatusEq) UnmarshalJSON(b []byte) error {
 	status := shared.TestStatusValueFromString(statusStr)
 	statusStr2 := status.String()
 	if statusStr != statusStr2 {
-		return fmt.Errorf(`Invalid test status: "%s"`, data.Status)
+		return fmt.Errorf(`invalid test status: "%s"`, data.Status)
 	}
 
 	tse.Product = product
@@ -699,7 +699,7 @@ func (tsn *TestStatusNeq) UnmarshalJSON(b []byte) error {
 		data.Product = data.BrowserName
 	}
 	if len(data.Status.Not) == 0 {
-		return errors.New(`Missing test status constraint property: "status.not"`)
+		return errors.New(`missing test status constraint property: "status.not"`)
 	}
 
 	var product *shared.ProductSpec
@@ -715,7 +715,7 @@ func (tsn *TestStatusNeq) UnmarshalJSON(b []byte) error {
 	status := shared.TestStatusValueFromString(statusStr)
 	statusStr2 := status.String()
 	if statusStr != statusStr2 {
-		return fmt.Errorf(`Invalid test status: "%s"`, data.Status)
+		return fmt.Errorf(`invalid test status: "%s"`, data.Status)
 	}
 
 	tsn.Product = product
@@ -734,7 +734,7 @@ func (n *AbstractNot) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	if len(data.Not) == 0 {
-		return errors.New(`Missing negation property: "not"`)
+		return errors.New(`missing negation property: "not"`)
 	}
 
 	q, err := unmarshalQ(data.Not)
@@ -753,7 +753,7 @@ func (o *AbstractOr) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	if len(data.Or) == 0 {
-		return errors.New(`Missing disjunction property: "or"`)
+		return errors.New(`missing disjunction property: "or"`)
 	}
 
 	qs := make([]AbstractQuery, 0, len(data.Or))
@@ -779,7 +779,7 @@ func (a *AbstractAnd) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	if len(data.And) == 0 {
-		return errors.New(`Missing conjunction property: "and"`)
+		return errors.New(`missing conjunction property: "and"`)
 	}
 
 	qs := make([]AbstractQuery, 0, len(data.And))
@@ -805,7 +805,7 @@ func (e *AbstractExists) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	if len(data.Exists) == 0 {
-		return errors.New(`Missing conjunction property: "exists"`)
+		return errors.New(`missing conjunction property: "exists"`)
 	}
 
 	qs := make([]AbstractQuery, 0, len(data.Exists))
@@ -831,7 +831,7 @@ func (e *AbstractAll) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	if len(data.All) == 0 {
-		return errors.New(`Missing conjunction property: "all"`)
+		return errors.New(`missing conjunction property: "all"`)
 	}
 
 	qs := make([]AbstractQuery, 0, len(data.All))
@@ -857,7 +857,7 @@ func (e *AbstractNone) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	if len(data.None) == 0 {
-		return errors.New(`Missing conjunction property: "none"`)
+		return errors.New(`missing conjunction property: "none"`)
 	}
 
 	qs := make([]AbstractQuery, 0, len(data.None))
@@ -883,7 +883,7 @@ func (e *AbstractSequential) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	if len(data.Sequential) == 0 {
-		return errors.New(`Missing conjunction property: "sequential"`)
+		return errors.New(`missing conjunction property: "sequential"`)
 	}
 
 	qs := make([]AbstractQuery, 0, len(data.Sequential))
@@ -910,10 +910,10 @@ func (c *AbstractCount) UnmarshalJSON(b []byte) (err error) {
 		return err
 	}
 	if len(data.Count) == 0 {
-		return errors.New(`Missing count property: "count"`)
+		return errors.New(`missing count property: "count"`)
 	}
 	if len(data.Where) == 0 {
-		return errors.New(`Missing count property: "where"`)
+		return errors.New(`missing count property: "where"`)
 	}
 
 	if err := json.Unmarshal(data.Count, &c.Count); err != nil {
@@ -938,10 +938,10 @@ func (l *AbstractLessThan) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	if len(data.Count) == 0 {
-		return errors.New(`Missing lessThan property: "lessThan"`)
+		return errors.New(`missing lessThan property: "lessThan"`)
 	}
 	if len(data.Where) == 0 {
-		return errors.New(`Missing count property: "where"`)
+		return errors.New(`missing count property: "where"`)
 	}
 
 	err := json.Unmarshal(data.Count, &l.Count)
@@ -967,10 +967,10 @@ func (m *AbstractMoreThan) UnmarshalJSON(b []byte) (err error) {
 		return err
 	}
 	if len(data.Count) == 0 {
-		return errors.New(`Missing moreThan property: "moreThan"`)
+		return errors.New(`missing moreThan property: "moreThan"`)
 	}
 	if len(data.Where) == 0 {
-		return errors.New(`Missing count property: "where"`)
+		return errors.New(`missing count property: "where"`)
 	}
 
 	if err := json.Unmarshal(data.Count, &m.Count); err != nil {
@@ -993,11 +993,11 @@ func (l *AbstractLink) UnmarshalJSON(b []byte) error {
 	}
 	patternMsg, ok := data["link"]
 	if !ok {
-		return errors.New(`Missing Link pattern property: "link"`)
+		return errors.New(`missing Link pattern property: "link"`)
 	}
 	var pattern string
 	if err := json.Unmarshal(*patternMsg, &pattern); err != nil {
-		return errors.New(`Missing link pattern property "pattern" is not a string`)
+		return errors.New(`missing link pattern property "pattern" is not a string`)
 	}
 
 	l.Pattern = pattern
@@ -1014,11 +1014,11 @@ func (t *AbstractTestLabel) UnmarshalJSON(b []byte) error {
 	}
 	labelMsg, ok := data["label"]
 	if !ok {
-		return errors.New(`Missing label pattern property: "label"`)
+		return errors.New(`missing label pattern property: "label"`)
 	}
 	var label string
 	if err := json.Unmarshal(*labelMsg, &label); err != nil {
-		return errors.New(`Property "label" is not a string`)
+		return errors.New(`property"label" is not a string`)
 	}
 
 	t.Label = label
@@ -1040,11 +1040,11 @@ func (t *TestWebFeatureAtom) UnmarshalJSON(b []byte) error {
 	}
 	webFeatureMsg, ok := data["feature"]
 	if !ok {
-		return errors.New(`Missing web feature pattern property: "feature"`)
+		return errors.New(`missing web feature pattern property: "feature"`)
 	}
 	var webFeature string
 	if err := json.Unmarshal(*webFeatureMsg, &webFeature); err != nil {
-		return errors.New(`Property "feature" is not a string`)
+		return errors.New(`property"feature" is not a string`)
 	}
 
 	t.WebFeature = webFeature
@@ -1062,12 +1062,12 @@ func (t *AbstractTriaged) UnmarshalJSON(b []byte) error {
 
 	browserNameMsg, ok := data["triaged"]
 	if !ok {
-		return errors.New(`Missing Triaged property: "triaged"`)
+		return errors.New(`missing Triaged property: "triaged"`)
 	}
 
 	var browserName string
 	if err := json.Unmarshal(*browserNameMsg, &browserName); err != nil {
-		return errors.New(`Triaged property "triaged" is not a string`)
+		return errors.New(`triaged property "triaged" is not a string`)
 	}
 
 	var product *shared.ProductSpec
@@ -1093,7 +1093,7 @@ func (q *MetadataQuality) UnmarshalJSON(b []byte) (err error) {
 	}
 	is, ok := data["is"]
 	if !ok {
-		return errors.New(`Missing "is" pattern property: "is"`)
+		return errors.New(`missing "is" pattern property: "is"`)
 	}
 	var quality string
 	if err := json.Unmarshal(*is, &quality); err != nil {
@@ -1116,7 +1116,7 @@ func MetadataQualityFromString(quality string) (MetadataQuality, error) {
 		return MetadataQualityOptional, nil
 	}
 
-	return MetadataQualityUnknown, fmt.Errorf(`Unknown "is" quality "%s"`, quality)
+	return MetadataQualityUnknown, fmt.Errorf(`unknown "is" quality "%s"`, quality)
 }
 
 // nolint:ireturn // TODO: Fix ireturn lint error

--- a/api/query/cache/backfill/backfill.go
+++ b/api/query/cache/backfill/backfill.go
@@ -36,7 +36,7 @@ type backfillMonitor struct {
 // phases of search cache development.
 const bytesPerRun = uint64(6.5e+7)
 
-var errNilIndex = errors.New("Index to backfill is nil")
+var errNilIndex = errors.New("index to backfill is nil")
 
 // GetDatastore constructs a shared.Datastore interface that loads runs from Datastore
 // in reverse cronological order, by shared.TestRun.TimeStart.

--- a/api/query/cache/backfill/backfill_medium_test.go
+++ b/api/query/cache/backfill/backfill_medium_test.go
@@ -27,7 +27,7 @@ type countingIndex struct {
 	count int
 }
 
-var errNotImplemented = errors.New("Not implemented")
+var errNotImplemented = errors.New("not implemented")
 
 func (i *countingIndex) IngestRun(r shared.TestRun) error {
 	err := i.ProxyIndex.IngestRun(r)

--- a/api/query/cache/backfill/backfill_test.go
+++ b/api/query/cache/backfill/backfill_test.go
@@ -31,7 +31,7 @@ func TestFetchErr(t *testing.T) {
 	store := sharedtest.NewMockDatastore(ctrl)
 	query := sharedtest.NewMockTestRunQuery(ctrl)
 	idx := index.NewMockIndex(ctrl)
-	expected := errors.New("Fetch error")
+	expected := errors.New("fetch error")
 	store.EXPECT().TestRunQuery().Return(query)
 	query.EXPECT().LoadTestRuns(gomock.Any(), nil, nil, nil, nil, gomock.Any(), nil).Return(nil, expected)
 	_, err := FillIndex(store, nil, nil, 1, uint(10), uint64(1), 0.0, idx)

--- a/api/query/cache/index/filter.go
+++ b/api/query/cache/index/filter.go
@@ -437,7 +437,7 @@ func (n Not) Filter(t TestID) bool {
 // nolint:ireturn // TODO: Fix ireturn lint error
 func newFilter(idx index, q query.ConcreteQuery) (filter, error) {
 	if q == nil {
-		return nil, errors.New("Nil ConcreteQuery provided")
+		return nil, errors.New("nil ConcreteQuery provided")
 	}
 	switch v := q.(type) {
 	case query.True:
@@ -507,7 +507,7 @@ func newFilter(idx index, q query.ConcreteQuery) (filter, error) {
 
 		return Not{idx, f}, nil
 	default:
-		return nil, fmt.Errorf("Unknown ConcreteQuery type %s", reflect.TypeOf(q))
+		return nil, fmt.Errorf("unknown ConcreteQuery type %s", reflect.TypeOf(q))
 	}
 }
 

--- a/api/query/cache/index/index.go
+++ b/api/query/cache/index/index.go
@@ -27,14 +27,14 @@ import (
 )
 
 var (
-	errNilRun             = errors.New("Test run is nil")
-	errNoQuery            = errors.New("No query provided")
-	errNoRuns             = errors.New("No runs")
-	errRunExists          = errors.New("Run already exists in index")
-	errRunLoading         = errors.New("Run currently being loaded into index")
-	errSomeShardsRequired = errors.New("Index must have at least one shard")
-	errZeroRun            = errors.New("Cannot ingest run with ID of 0")
-	errEmptyReport        = errors.New("Report contains no results")
+	errNilRun             = errors.New("test run is nil")
+	errNoQuery            = errors.New("no query provided")
+	errNoRuns             = errors.New("no runs")
+	errRunExists          = errors.New("run already exists in index")
+	errRunLoading         = errors.New("run currently being loaded into index")
+	errSomeShardsRequired = errors.New("index must have at least one shard")
+	errZeroRun            = errors.New("cannot ingest run with ID of 0")
+	errEmptyReport        = errors.New("report contains no results")
 )
 
 // ErrRunExists returns the error associated with an attempt to perform
@@ -365,7 +365,7 @@ func (i *shardedWPTIndex) syncGetRun(id RunID) (shared.TestRun, error) {
 
 	run, loaded := i.runs[id]
 	if !loaded {
-		return shared.TestRun{}, fmt.Errorf("Unknown run ID: %v", id)
+		return shared.TestRun{}, fmt.Errorf("unknown run ID: %v", id)
 	}
 
 	return run, nil
@@ -379,7 +379,7 @@ func (i *shardedWPTIndex) syncGetRuns(ids []RunID) ([]shared.TestRun, error) {
 	for j := range ids {
 		run, ok := i.runs[ids[j]]
 		if !ok {
-			return nil, fmt.Errorf("Unknown run ID: %v", ids[j])
+			return nil, fmt.Errorf("unknown run ID: %v", ids[j])
 		}
 
 		runs[j] = run
@@ -442,7 +442,7 @@ func syncStoreRunOnShard(shard *wptIndex, id RunID, shardData map[TestID]testDat
 
 	runResults := NewRunResults()
 	for t, data := range shardData {
-		shard.tests.Add(t, data.testName.name, data.testName.subName)
+		shard.tests.Add(t, data.name, data.subName)
 		runResults.Add(data.ResultID, t)
 	}
 
@@ -513,7 +513,7 @@ func syncMakeIndex(shard *wptIndex, ids []RunID) (index, error) {
 	for _, id := range ids {
 		rrs := shard.results.ForRun(id)
 		if rrs == nil {
-			return index{}, fmt.Errorf("Run is unknown to shard: RunID=%v", id)
+			return index{}, fmt.Errorf("run is unknown to shard: RunID=%v", id)
 		}
 		runResults[id] = shard.results.ForRun(id)
 	}

--- a/api/query/cache/index/index_test.go
+++ b/api/query/cache/index/index_test.go
@@ -114,7 +114,7 @@ func TestIngestRun_loaderError(t *testing.T) {
 		ID:            1,
 		RawResultsURL: "http://example.com/results.json",
 	}
-	loaderErr := errors.New("Failed to load test results")
+	loaderErr := errors.New("failed to load test results")
 	loader.EXPECT().Load(run).Return(nil, loaderErr)
 	assert.Equal(t, loaderErr, i.IngestRun(run))
 }

--- a/api/query/cache/index/results.go
+++ b/api/query/cache/index/results.go
@@ -68,7 +68,7 @@ func NewRunResults() RunResults {
 func (rs *resultsMap) Add(ru RunID, rr RunResults) error {
 	_, wasLoaded := rs.byRunTest.LoadOrStore(ru, rr)
 	if wasLoaded {
-		return fmt.Errorf("Already loaded into results index: %v", ru)
+		return fmt.Errorf("already loaded into results index: %v", ru)
 	}
 
 	return nil
@@ -77,7 +77,7 @@ func (rs *resultsMap) Add(ru RunID, rr RunResults) error {
 func (rs *resultsMap) Delete(ru RunID) error {
 	_, ok := rs.byRunTest.Load(ru)
 	if !ok {
-		return fmt.Errorf(`No such run in results index; run ID: %v`, ru)
+		return fmt.Errorf(`no such run in results index; run ID: %v`, ru)
 	}
 
 	rs.byRunTest.Delete(ru)

--- a/api/query/cache/index/tests.go
+++ b/api/query/cache/index/tests.go
@@ -51,7 +51,7 @@ func (ts *testsMap) Add(t TestID, name string, subName *string) {
 func (ts *testsMap) GetName(id TestID) (string, *string, error) {
 	name, ok := ts.tests[id]
 	if !ok {
-		return "", nil, fmt.Errorf(`Test not found; ID: %v`, id)
+		return "", nil, fmt.Errorf(`test not found; ID: %v`, id)
 	}
 
 	return name.name, name.subName, nil
@@ -71,7 +71,7 @@ func computeTestID(name string, subPtr *string) (TestID, error) {
 	if subPtr != nil && *subPtr != "" {
 		s = farm.Fingerprint64([]byte(*subPtr))
 		if s == 0 {
-			return TestID{}, fmt.Errorf(`Subtest ID for string "%s" is 0`, *subPtr)
+			return TestID{}, fmt.Errorf(`subtest ID for string "%s" is 0`, *subPtr)
 		}
 	}
 

--- a/api/query/cache/lru/lru.go
+++ b/api/query/cache/lru/lru.go
@@ -41,7 +41,7 @@ type lruEntries []lruEntry
 // Satisfy the Sort interface requirements (https://golang.org/pkg/sort/#Sort)
 func (s lruEntries) Len() int           { return len(s) }
 func (s lruEntries) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
-func (s lruEntries) Less(i, j int) bool { return s[i].Time.Before(s[j].Time) }
+func (s lruEntries) Less(i, j int) bool { return (s[i].Time).Before(s[j].Time) }
 
 func (l *lru) Access(v int64) {
 	l.syncAccess(v)

--- a/api/query/cache/monitor/monitor.go
+++ b/api/query/cache/monitor/monitor.go
@@ -15,10 +15,10 @@ import (
 )
 
 var (
-	errStopped         = errors.New("Monitor stopped")
-	errRunning         = errors.New("Monitor running")
-	errNegativePercent = errors.New("Invalid percentage (negative)")
-	errPercentTooLarge = errors.New("Invalid percentage (greater than 1.00)")
+	errStopped         = errors.New("monitor stopped")
+	errRunning         = errors.New("monitor running")
+	errNegativePercent = errors.New("invalid percentage (negative)")
+	errPercentTooLarge = errors.New("invalid percentage (greater than 1.00)")
 )
 
 // Runtime is a wrapper for the go runtime package. It allows tests to mock

--- a/api/query/cache/service/search.go
+++ b/api/query/cache/service/search.go
@@ -155,7 +155,7 @@ func searchHandlerImpl(w http.ResponseWriter, r *http.Request) *searchError {
 	// Prepare user query based on `ids` that are (or at least were a moment ago)
 	// resident in `idx`. In the unlikely event that a run in `ids`/`runs` is no
 	// longer in `idx`, `idx.Bind()` below will return an error.
-	q := cq.PrepareUserQuery(ids, rq.AbstractQuery.BindToRuns(runs...))
+	q := cq.PrepareUserQuery(ids, rq.BindToRuns(runs...))
 
 	// Configure format, from request params.
 	urlQuery := r.URL.Query()

--- a/api/query/query.go
+++ b/api/query/query.go
@@ -144,7 +144,7 @@ func (qh queryHandler) loadSummaries(testRuns shared.TestRuns) ([]summary, error
 			s := summary{}
 			data, loadErr := qh.loadSummary(testRun)
 			if err == nil && loadErr != nil {
-				err = fmt.Errorf("Failed to load test run %v: %s", testRun.ID, loadErr.Error())
+				err = fmt.Errorf("failed to load test run %v: %s", testRun.ID, loadErr.Error())
 
 				return
 			}

--- a/api/query/query_test.go
+++ b/api/query/query_test.go
@@ -105,7 +105,7 @@ func TestLoadSummaries_fail(t *testing.T) {
 		[]byte(`{"/a/b/c":{"s":"O","c":[1,2]}}`),
 	}
 
-	storeMiss := errors.New("No such summary file")
+	storeMiss := errors.New("no such summary file")
 	cachedStore.EXPECT().Get(keys[0], urls[0], gomock.Any()).Do(func(cid, sid, iv interface{}) {
 		ptr := iv.(*[]byte)
 		*ptr = summaryBytes[0]

--- a/api/taskcluster/webhook.go
+++ b/api/taskcluster/webhook.go
@@ -85,11 +85,11 @@ type apiImpl struct {
 // GetStatusEventInfo turns a StatusEventPayload into an EventInfo struct.
 func GetStatusEventInfo(status StatusEventPayload, log shared.Logger, api API) (EventInfo, error) {
 	if status.SHA == nil {
-		return EventInfo{}, errors.New("No sha on taskcluster status event")
+		return EventInfo{}, errors.New("no sha on taskcluster status event")
 	}
 
 	if status.TargetURL == nil {
-		return EventInfo{}, errors.New("No target_url on taskcluster status event")
+		return EventInfo{}, errors.New("no target_url on taskcluster status event")
 	}
 
 	rootURL, taskGroupID, taskID := ParseTaskclusterURL(*status.TargetURL)
@@ -119,7 +119,7 @@ func GetStatusEventInfo(status StatusEventPayload, log shared.Logger, api API) (
 // GetCheckSuiteEventInfo turns a github.CheckSuiteEvent into an EventInfo struct.
 func GetCheckSuiteEventInfo(checkSuite github.CheckSuiteEvent, log shared.Logger, api API) (EventInfo, error) {
 	if checkSuite.GetCheckSuite().GetHeadSHA() == "" {
-		return EventInfo{}, errors.New("No sha on taskcluster check_suite event")
+		return EventInfo{}, errors.New("no sha on taskcluster check_suite event")
 	}
 
 	log.Debugf("Parsing check_suite event for commit %s", checkSuite.GetCheckSuite().GetHeadSHA())
@@ -129,7 +129,7 @@ func GetCheckSuiteEventInfo(checkSuite github.CheckSuiteEvent, log shared.Logger
 	if owner != shared.WPTRepoOwner || repo != shared.WPTRepoName {
 		log.Errorf("Received check_suite event from invalid repo %s/%s", owner, repo)
 
-		return EventInfo{}, errors.New("Invalid source repository")
+		return EventInfo{}, errors.New("invalid source repository")
 	}
 
 	runs, err := api.ListCheckRuns(owner, repo, checkSuite.GetCheckSuite().GetID())
@@ -140,7 +140,7 @@ func GetCheckSuiteEventInfo(checkSuite github.CheckSuiteEvent, log shared.Logger
 	}
 
 	if len(runs) == 0 {
-		return EventInfo{}, errors.New("No check_runs for check_suite")
+		return EventInfo{}, errors.New("no check_runs for check_suite")
 	}
 
 	log.Debugf("Found %d check_runs for check_suite", len(runs))
@@ -157,7 +157,7 @@ func GetCheckSuiteEventInfo(checkSuite github.CheckSuiteEvent, log shared.Logger
 				run.GetDetailsURL(),
 			)
 
-			return EventInfo{}, errors.New("Unable to parse check_run details URL")
+			return EventInfo{}, errors.New("unable to parse check_run details URL")
 		}
 		if rootURL != "" && rootURL != matches[1] {
 			log.Errorf(
@@ -167,7 +167,7 @@ func GetCheckSuiteEventInfo(checkSuite github.CheckSuiteEvent, log shared.Logger
 				matches[1],
 			)
 
-			return EventInfo{}, errors.New("Conflicting root URLs for runs in check_suite")
+			return EventInfo{}, errors.New("conflicting root URLs for runs in check_suite")
 		}
 		rootURL = matches[1]
 		taskID := matches[2]
@@ -502,10 +502,10 @@ func (api apiImpl) ListCheckRuns(owner string, repo string, checkSuiteID int64) 
 		}
 
 		// Setup for the next call.
-		options.ListOptions.Page = response.NextPage
+		options.Page = response.NextPage
 	}
 
-	return runs, errors.New("More than 500 CheckRuns returned for CheckSuite")
+	return runs, errors.New("more than 500 CheckRuns returned for CheckSuite")
 }
 
 // ArtifactURLs holds the results and screenshot URLs for a Taskcluster run.

--- a/shared/cache.go
+++ b/shared/cache.go
@@ -22,8 +22,8 @@ import (
 )
 
 var (
-	errNewReadCloserExpectedString       = errors.New("NewReadCloser(arg) expected arg string")
-	errRedisWriteCloserWriteAfterClose   = errors.New("redisWriteCloser: Write() after Close()")
+	errNewReadCloserExpectedString       = errors.New("newreadcloser(arg) expected arg string")
+	errRedisWriteCloserWriteAfterClose   = errors.New("rediswritecloser: Write() after Close()")
 	errRedisInvalidResponseType          = errors.New("redis: type received from GET is not []byte")
 	errByteCachedStoreExpectedByteSlice  = errors.New("contextualized byte CachedStore expected []byte output arg")
 	errDatastoreObjectStoreExpectedInt64 = errors.New("datastore ObjectStore expected int64 ID")
@@ -63,7 +63,7 @@ func (hr httpReadable) NewReadCloser(iURL interface{}) (io.ReadCloser, error) {
 	}
 
 	if r.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Unexpected status code from %s: %d", url, r.StatusCode)
+		return nil, fmt.Errorf("unexpected status code from %s: %d", url, r.StatusCode)
 	}
 
 	return r.Body, nil

--- a/shared/cache_test.go
+++ b/shared/cache_test.go
@@ -47,7 +47,7 @@ func TestGet_cacheMiss(t *testing.T) {
 	cs := shared.NewByteCachedStore(sharedtest.NewTestContext(), cache, store)
 
 	data := []byte("{}")
-	errMissing := errors.New("Failed to fetch from store")
+	errMissing := errors.New("failed to fetch from store")
 	cw := sharedtest.NewMockWriteCloser(t)
 	sr := sharedtest.NewMockReadCloser(t, data)
 	cache.EXPECT().NewReadCloser(&cacheID).Return(nil, errMissing)
@@ -71,7 +71,7 @@ func TestGet_missing(t *testing.T) {
 	store := sharedtest.NewMockReadable(mockCtrl)
 	cs := shared.NewByteCachedStore(sharedtest.NewTestContext(), cache, store)
 
-	errMissing := errors.New("Failed to fetch from store")
+	errMissing := errors.New("failed to fetch from store")
 	cache.EXPECT().NewReadCloser(&cacheID).Return(nil, errMissing)
 	store.EXPECT().NewReadCloser(&storeID).Return(nil, errMissing)
 

--- a/shared/datastore_cloud.go
+++ b/shared/datastore_cloud.go
@@ -94,7 +94,7 @@ func (d cloudDatastore) ReserveID(typeName string) (Key, error) {
 	if err != nil {
 		return nil, err
 	} else if len(keys) < 1 {
-		return nil, errors.New("Failed to create a key")
+		return nil, errors.New("failed to create a key")
 	}
 	return cloudKey{
 		key: keys[0],

--- a/shared/github_oauth.go
+++ b/shared/github_oauth.go
@@ -149,7 +149,7 @@ func (gaci githubAccessControlImpl) IsValidWPTMember() (bool, error) {
 		return false, err
 	}
 	if !valid {
-		return false, errors.New("Invalid access token")
+		return false, errors.New("invalid access token")
 	}
 	isMember, _, err := gaci.botClient.Organizations.IsMember(gaci.ctx, "web-platform-tests", gaci.user.GitHubHandle)
 	return isMember, err
@@ -161,7 +161,7 @@ func (gaci githubAccessControlImpl) IsValidAdmin() (bool, error) {
 		return false, err
 	}
 	if !valid {
-		return false, errors.New("Invalid access token")
+		return false, errors.New("invalid access token")
 	}
 	key := gaci.ds.NewNameKey("Admin", gaci.user.GitHubHandle)
 	var dst struct{}

--- a/shared/metadata_util.go
+++ b/shared/metadata_util.go
@@ -70,7 +70,7 @@ func getWPTMetadataArchiveWithURL(client *http.Client, url string, ref *string) 
 
 	statusCode := resp.StatusCode
 	if !(statusCode >= 200 && statusCode <= 299) {
-		err := fmt.Errorf("Bad status code:%d, Unable to download wpt-metadata", statusCode)
+		err := fmt.Errorf("bad status code:%d, Unable to download wpt-metadata", statusCode)
 		return nil, err
 	}
 

--- a/shared/params.go
+++ b/shared/params.go
@@ -58,7 +58,7 @@ func ParseSHA(shaParam string) (sha string, err error) {
 	if shaParam != "" && shaParam != "latest" {
 		sha = shaParam
 		if !SHARegex.MatchString(shaParam) {
-			return "latest", fmt.Errorf("Invalid sha param value: %s", shaParam)
+			return "latest", fmt.Errorf("invalid sha param value: %s", shaParam)
 		}
 	}
 	return sha, err
@@ -161,7 +161,7 @@ func ParseVersion(version string) (result *Version, err error) {
 	pieces := strings.Split(version, " ")
 	channel := ""
 	if len(pieces) > 2 {
-		return nil, fmt.Errorf("Invalid version: %s", version)
+		return nil, fmt.Errorf("invalid version: %s", version)
 	} else if len(pieces) > 1 {
 		channel = " " + pieces[1]
 		version = pieces[0]
@@ -176,13 +176,13 @@ func ParseVersion(version string) (result *Version, err error) {
 
 	pieces = strings.Split(version, ".")
 	if len(pieces) > 4 {
-		return nil, fmt.Errorf("Invalid version: %s", version)
+		return nil, fmt.Errorf("invalid version: %s", version)
 	}
 	numbers := make([]int, len(pieces))
 	for i, piece := range pieces {
 		n, err := strconv.ParseInt(piece, 10, 0)
 		if err != nil {
-			return nil, fmt.Errorf("Invalid version: %s", version)
+			return nil, fmt.Errorf("invalid version: %s", version)
 		}
 		numbers[i] = int(n)
 	}
@@ -214,7 +214,7 @@ func ParseBrowserParam(v url.Values) (product *Product, err error) {
 			BrowserName: browser,
 		}, nil
 	}
-	return nil, fmt.Errorf("Invalid browser param value: %s", browser)
+	return nil, fmt.Errorf("invalid browser param value: %s", browser)
 }
 
 // ParseBrowsersParam returns a list of browser params for the request.
@@ -227,7 +227,7 @@ func ParseBrowsersParam(v url.Values) (browsers []string, err error) {
 	}
 	for _, b := range browserParams {
 		if !IsBrowserName(b) {
-			return nil, fmt.Errorf("Invalid browser param value %s", b)
+			return nil, fmt.Errorf("invalid browser param value %s", b)
 		}
 		browsers = append(browsers, b)
 	}
@@ -502,7 +502,7 @@ func ParseQueryParamInt(v url.Values, key string) (*int, error) {
 	}
 	i, err := strconv.Atoi(value)
 	if err != nil {
-		return &i, fmt.Errorf("Invalid %s value: %s", key, value)
+		return &i, fmt.Errorf("invalid %s value: %s", key, value)
 	}
 	return &i, err
 }

--- a/shared/request_caching.go
+++ b/shared/request_caching.go
@@ -56,7 +56,7 @@ func (w *cachingResponseWriter) WriteHeader(statusCode int) {
 
 func (w *cachingResponseWriter) WriteTo(wtr io.Writer) (int64, error) {
 	if w.bufErr != nil {
-		return 0, fmt.Errorf("Error writing response data to caching response writer: %v", w.bufErr)
+		return 0, fmt.Errorf("error writing response data to caching response writer: %v", w.bufErr)
 	}
 
 	return w.b.WriteTo(wtr)

--- a/shared/request_caching_test.go
+++ b/shared/request_caching_test.go
@@ -23,7 +23,7 @@ type failReader struct{}
 type okHandler struct{}
 
 var (
-	errFailRead = errors.New("Failed read")
+	errFailRead = errors.New("failed read")
 	ok          = []byte("OK")
 )
 

--- a/shared/run_diff.go
+++ b/shared/run_diff.go
@@ -25,7 +25,7 @@ import (
 )
 
 // ErrRunNotInSearchCache is an error for 422 responses from the searchcache.
-var ErrRunNotInSearchCache = errors.New("Run is still being loaded into the searchcache")
+var ErrRunNotInSearchCache = errors.New("run is still being loaded into the searchcache")
 
 // DiffAPI is an abstraction for computing run differences.
 type DiffAPI interface {
@@ -353,11 +353,11 @@ func (d diffAPIImpl) GetRunsDiff(before, after TestRun, filter DiffFilterParam, 
 	}
 	beforeJSON, err := FetchRunResultsJSON(d.ctx, before)
 	if err != nil {
-		return diff, fmt.Errorf("Failed to fetch 'before' results: %s", err.Error())
+		return diff, fmt.Errorf("failed to fetch 'before' results: %s", err.Error())
 	}
 	afterJSON, err := FetchRunResultsJSON(d.ctx, after)
 	if err != nil {
-		return diff, fmt.Errorf("Failed to fetch 'after' results: %s", err.Error())
+		return diff, fmt.Errorf("failed to fetch 'after' results: %s", err.Error())
 	}
 
 	var renames map[string]string

--- a/shared/test_run_query.go
+++ b/shared/test_run_query.go
@@ -16,7 +16,7 @@ import (
 	mapset "github.com/deckarep/golang-set"
 )
 
-var errNoProducts = errors.New("No products specified in request to load test runs")
+var errNoProducts = errors.New("no products specified in request to load test runs")
 
 // TestRunQuery abstracts complex queries of TestRun entities.
 type TestRunQuery interface {

--- a/shared/triage_metadata.go
+++ b/shared/triage_metadata.go
@@ -171,7 +171,7 @@ func (tm triageMetadata) createWPTMetadataPR(sha *string, triagedMetadataMap map
 
 	if ref == nil {
 		log.Errorf("No error returned but the reference is nil")
-		return "", errors.New("No error returned but the reference is nil")
+		return "", errors.New("no error returned but the reference is nil")
 	}
 
 	tree, err := tm.getTree(ref, triagedMetadataMap)

--- a/shared/util.go
+++ b/shared/util.go
@@ -123,14 +123,14 @@ func StringSliceContains(ss []string, s string) bool {
 func MapStringKeys(m interface{}) ([]string, error) {
 	mapType := reflect.ValueOf(m)
 	if mapType.Kind() != reflect.Map {
-		return nil, errors.New("Interface is not a map type")
+		return nil, errors.New("interface is not a map type")
 	}
 	keys := mapType.MapKeys()
 	strKeys := make([]string, len(keys))
 	for i, key := range keys {
 		var ok bool
 		if strKeys[i], ok = key.Interface().(string); !ok {
-			return nil, fmt.Errorf("Key %v was not a string type", key)
+			return nil, fmt.Errorf("key %v was not a string type", key)
 		}
 	}
 	return strKeys, nil

--- a/shared/web_features_manifest_util_test.go
+++ b/shared/web_features_manifest_util_test.go
@@ -60,15 +60,15 @@ func TestGetWPTWebFeaturesManifest(t *testing.T) {
 		},
 		{
 			name:           "Downloader Error",
-			mockDownloader: &mockDownloader{returnErr: errors.New("Download failed")},
+			mockDownloader: &mockDownloader{returnErr: errors.New("download failed")},
 			// ... (mockParser doesn't matter in this case)
-			expectedError: errors.New("Download failed"),
+			expectedError: errors.New("download failed"),
 		},
 		{
 			name:           "Parser Error",
 			mockDownloader: &mockDownloader{returnData: io.NopCloser(strings.NewReader(`{}`))},
-			mockParser:     &mockParser{returnErr: errors.New("Parsing failed")},
-			expectedError:  errors.New("Parsing failed"),
+			mockParser:     &mockParser{returnErr: errors.New("parsing failed")},
+			expectedError:  errors.New("parsing failed"),
 		},
 	}
 

--- a/webdriver/search_test.go
+++ b/webdriver/search_test.go
@@ -98,7 +98,7 @@ func getSearchElement(wd selenium.WebDriver) (selenium.WebElement, error) {
 	if err != nil {
 		return nil, err
 	} else if len(inputs) < 1 {
-		return nil, errors.New("Failed to find any test-search input.query elements")
+		return nil, errors.New("failed to find any test-search input.query elements")
 	}
 	return inputs[0], err
 }


### PR DESCRIPTION
Fix #4339. Migrate [go-lint](https://golangci-lint.run/product/migration-guide/) and fix new lint errors:
- Changes in .golangci.yaml are made through `golangci-lint migrate`

For new lint errors:
-  Remove embedded field 
- Lower cap the first word of error messages
- Use switch statement in webhook.go and string replacement suggestions in compile.go
- For api/query/cache/lru/lru.go, add the correct parenthesis to compare time