### PR TITLE
Update go-github from v69 to v70.

### DIFF
--- a/api/checks/api.go
+++ b/api/checks/api.go
@@ -12,7 +12,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/google/go-github/v69/github"
+	"github.com/google/go-github/v70/github"
 	"github.com/web-platform-tests/wpt.fyi/api/checks/summaries"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )

--- a/api/checks/jwt.go
+++ b/api/checks/jwt.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	jwt "github.com/golang-jwt/jwt"
-	"github.com/google/go-github/v69/github"
+	"github.com/google/go-github/v70/github"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 	"golang.org/x/oauth2"
 )

--- a/api/checks/mock_checks/api_mock.go
+++ b/api/checks/mock_checks/api_mock.go
@@ -16,7 +16,7 @@ import (
 	reflect "reflect"
 	time "time"
 
-	github "github.com/google/go-github/v69/github"
+	github "github.com/google/go-github/v70/github"
 	shared "github.com/web-platform-tests/wpt.fyi/shared"
 	gomock "go.uber.org/mock/gomock"
 )

--- a/api/checks/runs.go
+++ b/api/checks/runs.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/google/go-github/v69/github"
+	"github.com/google/go-github/v70/github"
 	"github.com/web-platform-tests/wpt.fyi/api/checks/summaries"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )

--- a/api/checks/summaries/actions.go
+++ b/api/checks/summaries/actions.go
@@ -4,7 +4,7 @@
 
 package summaries
 
-import "github.com/google/go-github/v69/github"
+import "github.com/google/go-github/v70/github"
 
 // RecomputeAction is an action that can be taken to
 // trigger a recompute of the diff, against the latest

--- a/api/checks/summaries/actions_test.go
+++ b/api/checks/summaries/actions_test.go
@@ -10,7 +10,7 @@ package summaries
 import (
 	"testing"
 
-	"github.com/google/go-github/v69/github"
+	"github.com/google/go-github/v70/github"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/api/checks/summaries/compile.go
+++ b/api/checks/summaries/compile.go
@@ -14,7 +14,7 @@ import (
 
 	mapset "github.com/deckarep/golang-set"
 
-	"github.com/google/go-github/v69/github"
+	"github.com/google/go-github/v70/github"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 

--- a/api/checks/summaries/completed.go
+++ b/api/checks/summaries/completed.go
@@ -5,7 +5,7 @@
 package summaries
 
 import (
-	"github.com/google/go-github/v69/github"
+	"github.com/google/go-github/v70/github"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 

--- a/api/checks/summaries/pending.go
+++ b/api/checks/summaries/pending.go
@@ -4,7 +4,7 @@
 
 package summaries
 
-import "github.com/google/go-github/v69/github"
+import "github.com/google/go-github/v70/github"
 
 // Pending is the struct for pending.md.
 type Pending struct {

--- a/api/checks/summaries/regressed.go
+++ b/api/checks/summaries/regressed.go
@@ -5,7 +5,7 @@
 package summaries
 
 import (
-	"github.com/google/go-github/v69/github"
+	"github.com/google/go-github/v70/github"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 

--- a/api/checks/webhook.go
+++ b/api/checks/webhook.go
@@ -11,7 +11,7 @@ import (
 	"net/http"
 	"regexp"
 
-	"github.com/google/go-github/v69/github"
+	"github.com/google/go-github/v70/github"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 

--- a/api/checks/webhook_test.go
+++ b/api/checks/webhook_test.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-github/v69/github"
+	"github.com/google/go-github/v70/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/web-platform-tests/wpt.fyi/api/checks/mock_checks"
 	"github.com/web-platform-tests/wpt.fyi/shared"

--- a/api/ghactions/notify.go
+++ b/api/ghactions/notify.go
@@ -13,7 +13,7 @@ import (
 
 	mapset "github.com/deckarep/golang-set"
 	"github.com/gobwas/glob"
-	"github.com/google/go-github/v69/github"
+	"github.com/google/go-github/v70/github"
 	uc "github.com/web-platform-tests/wpt.fyi/api/receiver/client"
 
 	"github.com/web-platform-tests/wpt.fyi/shared"

--- a/api/ghactions/notify_test.go
+++ b/api/ghactions/notify_test.go
@@ -10,7 +10,7 @@ package ghactions
 import (
 	"testing"
 
-	"github.com/google/go-github/v69/github"
+	"github.com/google/go-github/v70/github"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/api/manifest/api.go
+++ b/api/manifest/api.go
@@ -13,7 +13,7 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/google/go-github/v69/github"
+	"github.com/google/go-github/v70/github"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 

--- a/api/metadata_cache.go
+++ b/api/metadata_cache.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/google/go-github/v69/github"
+	"github.com/google/go-github/v70/github"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 

--- a/api/query/cache/poll/poll.go
+++ b/api/query/cache/poll/poll.go
@@ -11,7 +11,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/google/go-github/v69/github"
+	"github.com/google/go-github/v70/github"
 	"github.com/web-platform-tests/wpt.fyi/api/query"
 	"github.com/web-platform-tests/wpt.fyi/api/query/cache/index"
 	"github.com/web-platform-tests/wpt.fyi/shared"

--- a/api/receiver/mock_receiver/api_mock.go
+++ b/api/receiver/mock_receiver/api_mock.go
@@ -17,7 +17,7 @@ import (
 	reflect "reflect"
 	time "time"
 
-	github "github.com/google/go-github/v69/github"
+	github "github.com/google/go-github/v70/github"
 	shared "github.com/web-platform-tests/wpt.fyi/shared"
 	gomock "go.uber.org/mock/gomock"
 )

--- a/api/taskcluster/mock_taskcluster/webhook_mock.go
+++ b/api/taskcluster/mock_taskcluster/webhook_mock.go
@@ -12,7 +12,7 @@ package mock_taskcluster
 import (
 	reflect "reflect"
 
-	github "github.com/google/go-github/v69/github"
+	github "github.com/google/go-github/v70/github"
 	taskcluster "github.com/web-platform-tests/wpt.fyi/api/taskcluster"
 	gomock "go.uber.org/mock/gomock"
 )

--- a/api/taskcluster/webhook.go
+++ b/api/taskcluster/webhook.go
@@ -17,7 +17,7 @@ import (
 	"sync"
 
 	mapset "github.com/deckarep/golang-set"
-	"github.com/google/go-github/v69/github"
+	"github.com/google/go-github/v70/github"
 	tcurls "github.com/taskcluster/taskcluster-lib-urls"
 	"github.com/taskcluster/taskcluster/v83/clients/client-go/tcqueue"
 	uc "github.com/web-platform-tests/wpt.fyi/api/receiver/client"

--- a/api/taskcluster/webhook_test.go
+++ b/api/taskcluster/webhook_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-github/v69/github"
+	"github.com/google/go-github/v70/github"
 	"github.com/stretchr/testify/assert"
 	uc "github.com/web-platform-tests/wpt.fyi/api/receiver/client"
 	tc "github.com/web-platform-tests/wpt.fyi/api/taskcluster"

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/gobwas/glob v0.2.3
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/gomodule/redigo v1.9.2
-	github.com/google/go-github/v69 v69.2.0
+	github.com/google/go-github/v70 v70.0.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/handlers v1.5.2
 	github.com/gorilla/mux v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -110,8 +110,8 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/go-github/v27 v27.0.4/go.mod h1:/0Gr8pJ55COkmv+S/yPKCczSkUPIM/LnFyubufRNIS0=
-github.com/google/go-github/v69 v69.2.0 h1:wR+Wi/fN2zdUx9YxSmYE0ktiX9IAR/BeePzeaUUbEHE=
-github.com/google/go-github/v69 v69.2.0/go.mod h1:xne4jymxLR6Uj9b7J7PyTpkMYstEMMwGZa0Aehh1azM=
+github.com/google/go-github/v70 v70.0.0 h1:/tqCp5KPrcvqCc7vIvYyFYTiCGrYvaWoYMGHSQbo55o=
+github.com/google/go-github/v70 v70.0.0/go.mod h1:xBUZgo8MI3lUL/hwxl3hlceJW1U8MVnXP3zUyI+rhQY=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=

--- a/shared/appengine.go
+++ b/shared/appengine.go
@@ -21,7 +21,7 @@ import (
 	gclog "cloud.google.com/go/logging"
 	secretmanager "cloud.google.com/go/secretmanager/apiv1"
 	"github.com/gomodule/redigo/redis"
-	"github.com/google/go-github/v69/github"
+	"github.com/google/go-github/v70/github"
 	apps "google.golang.org/api/appengine/v1"
 	"google.golang.org/api/option"
 	mrpb "google.golang.org/genproto/googleapis/api/monitoredres"

--- a/shared/github_oauth.go
+++ b/shared/github_oauth.go
@@ -13,7 +13,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/google/go-github/v69/github"
+	"github.com/google/go-github/v70/github"
 	"github.com/gorilla/securecookie"
 	"golang.org/x/oauth2"
 	ghOAuth "golang.org/x/oauth2/github"

--- a/shared/metadata_util.go
+++ b/shared/metadata_util.go
@@ -16,7 +16,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/google/go-github/v69/github"
+	"github.com/google/go-github/v70/github"
 )
 
 // PendingMetadataCacheKey is the key for the set that stores a list of

--- a/shared/run_diff.go
+++ b/shared/run_diff.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/v69/github"
+	"github.com/google/go-github/v70/github"
 
 	mapset "github.com/deckarep/golang-set"
 )

--- a/shared/sharedtest/appengine_mock.go
+++ b/shared/sharedtest/appengine_mock.go
@@ -16,7 +16,7 @@ import (
 	reflect "reflect"
 	time "time"
 
-	github "github.com/google/go-github/v69/github"
+	github "github.com/google/go-github/v70/github"
 	shared "github.com/web-platform-tests/wpt.fyi/shared"
 	gomock "go.uber.org/mock/gomock"
 )

--- a/shared/sharedtest/github_oauth_mock.go
+++ b/shared/sharedtest/github_oauth_mock.go
@@ -13,7 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
-	github "github.com/google/go-github/v69/github"
+	github "github.com/google/go-github/v70/github"
 	shared "github.com/web-platform-tests/wpt.fyi/shared"
 	gomock "go.uber.org/mock/gomock"
 	oauth2 "golang.org/x/oauth2"

--- a/shared/triage_metadata.go
+++ b/shared/triage_metadata.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/v69/github"
+	"github.com/google/go-github/v70/github"
 	"gopkg.in/yaml.v3"
 )
 

--- a/shared/web_features_manifest_github_download.go
+++ b/shared/web_features_manifest_github_download.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/v69/github"
+	"github.com/google/go-github/v70/github"
 )
 
 // WebFeatureManifestRepo is where the web feature manifest is published.

--- a/shared/web_features_manifest_github_download_test.go
+++ b/shared/web_features_manifest_github_download_test.go
@@ -18,7 +18,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/google/go-github/v69/github"
+	"github.com/google/go-github/v70/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/webapp/login_test.go
+++ b/webapp/login_test.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-github/v69/github"
+	"github.com/google/go-github/v70/github"
 	"github.com/gorilla/securecookie"
 	"github.com/stretchr/testify/assert"
 


### PR DESCRIPTION
## Description

This is more progress on the once-a-month rotation task to upgrade major go dependencies.  In this PR, I am upgrading go-github from v69 to v70, including all references to v69.