### PR TITLE
chore: bump webapp Dockerfile version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -68,3 +68,17 @@ updates:
       update-types:
         - "version-update:semver-major"
         - "version-update:semver-minor"
+- package-ecosystem: "docker"
+  directory: "/webapp/web"
+  schedule:
+    interval: "weekly"
+  # Searchcache Docker image should ignore major and minor updates to Docker Go Image
+  # Searchcache follows the bring-your-own-container paradigm because it uses
+  # App Engine Flex. While we could use the latest version, we want this Go
+  # version to follow the same version used in the webapp above (which uses
+  # App Engine Standard).
+  ignore:
+    - dependency-name: "*"
+      update-types:
+        - "version-update:semver-major"
+        - "version-update:semver-minor"

--- a/webapp/web/Dockerfile
+++ b/webapp/web/Dockerfile
@@ -1,6 +1,6 @@
 # Production deployment spec for the webapp.
 
-FROM golang:1.24.3-bookworm as builder
+FROM golang:1.24.4-bookworm as builder
 
 RUN apt-get update
 RUN apt-get install -qy --no-install-suggests git sudo


### PR DESCRIPTION
Also add the Dockerfile to the dependabot config so that it will update automatically in the future (added the same comment used for other Go Dockerfiles).
