### PR TITLE
[bugfix] Use latest java for datastore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,12 +18,12 @@ RUN export DISTRO_CODENAME=$(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-rele
 
 # Sort the package names!
 # firefox-esr: provides deps for Firefox (we don't use ESR directly)
-# java-11-amazon-corretto-jdk: provides JDK/JRE to Selenium & gcloud SDK
+# java-21-amazon-corretto-jdk: provides JDK/JRE to Selenium & gcloud SDK
 # python-crcmod: native module to speed up CRC checksum in gsutil
 RUN apt-get update -qqy && apt-get install -qqy --no-install-suggests \
         curl \
         firefox-esr \
-        java-11-amazon-corretto-jdk \
+        java-21-amazon-corretto-jdk \
         nodejs \
         python3.11 \
         python3-crcmod \

--- a/Makefile
+++ b/Makefile
@@ -239,7 +239,7 @@ wget: apt-get-wget
 java:
 	@ # java has a different apt-get package name.
 	if [[ "$$(which java)" == "" ]]; then \
-		sudo apt-get install -qqy --no-install-suggests java-11-amazon-corretto-jdk; \
+		sudo apt-get install -qqy --no-install-suggests java-21-amazon-corretto-jdk; \
 	fi
 
 gpg:


### PR DESCRIPTION
Currently, CI is broken because the latest datastore emulator version now requires java 21+

The message is:
ERROR: (gcloud.beta.emulators.datastore.start) The java executable on your PATH is not a Java 21+ JRE. The Google Cloud Datastore emulator requires a Java 21+ JRE installed and on your system PATH

The latest version of java with LTS is 21 (25 comes out soon though)

This change modifies the version to install 21 instead of 11.

