### PR TITLE
Adjust log level for failing to cache empty search results

### DIFF
--- a/api/query/search.go
+++ b/api/query/search.go
@@ -304,7 +304,7 @@ var shouldCacheSearchResponse = func(ctx context.Context, statusCode int, payloa
 	}
 
 	if len(resp.Results) == 0 {
-		shared.GetLogger(ctx).Errorf("Query yielded no results; not caching")
+		shared.GetLogger(ctx).Infof("Query yielded no results; not caching")
 
 		return false
 	}


### PR DESCRIPTION
Changes the log severity for empty search results from ERROR to INFO.

Previously, a POST request to /api/search that yielded no results would log an error. This caused the Google App Engine request log to be marked with ERROR severity, even for successful HTTP 200 responses.

This change lowers the log level to INFO to avoid treating empty search results as an error condition, ensuring that request logs accurately reflect the status of the operation.