### PR TITLE
Fix: Stabilize App Engine readiness checks to resolve 503 errors

### DIFF
--- a/webapp/web/app.yaml
+++ b/webapp/web/app.yaml
@@ -26,6 +26,11 @@ liveness_check:
 
 readiness_check:
   path: "/_ah/readiness_check"
+  app_start_timeout_sec: 300
+  check_interval_sec: 30
+  timeout_sec: 10
+  failure_threshold: 4
+  success_threshold: 2
 
 env_variables:
   REDISHOST: "10.171.142.203"


### PR DESCRIPTION
We are observing a high volume of 503 Service Unavailable errors in our logs, originating from the App Engine flexible environment's readiness_check. This is triggering some thresholds to alert the team via email.

This likely occurs because new instances are taking longer to initialize and start the web server than the default health check configuration allows. The readiness probe attempts to connect before the application is ready to accept traffic, resulting in a failed check that App Engine reports as a 503 error.

This PR updates the `readiness_check` configuration in `app.yaml` to be more tolerant of our application's startup behavior.

Hopefully this change will decrease the number of non-actionable alerts we've been receiving.

[See readiness check docs for configuration descriptions.](https://cloud.google.com/appengine/docs/flexible/reference/app-yaml?tab=python#readiness_checks)