### PR TITLE
Reduce log severity for searchcache cache misses

### DIFF
--- a/api/query/search.go
+++ b/api/query/search.go
@@ -196,7 +196,11 @@ func (sh structuredSearchHandler) useSearchcache(_ http.ResponseWriter, r *http.
 			msg = fmt.Sprintf("%s: %s", msg, string(errBody))
 			resp.Body = io.NopCloser(bytes.NewBuffer(errBody))
 		}
-		logger.Errorf(msg)
+		if resp.StatusCode == http.StatusUnprocessableEntity {
+			logger.Warningf(msg)
+		} else {
+			logger.Errorf(msg)
+		}
 	}
 
 	return resp, nil


### PR DESCRIPTION
The searchcache service returns a 422 Unprocessable Entity status when one or more requested test runs are not in its in-memory index. This is a cache-miss scenario, not a critical error.

This change reduces the log severity for these specific 422 responses from ERROR to WARNING to avoid unnecessary noise in the error logs.