### PR TITLE
Fix: Implement custom interactive legend to prevent text truncation

### DIFF
--- a/webapp/components/interop-dashboard.js
+++ b/webapp/components/interop-dashboard.js
@@ -251,6 +251,7 @@ class InteropDashboard extends WPTFlags(PolymerElement) {
           gap: 2ch;
           place-content: center;
           color: GrayText;
+          margin-bottom: 8px;
         }
 
         .compat-footer {


### PR DESCRIPTION
Fixes #4542

This change resolves an issue where Google Chart legend labels were being truncated with ellipses on mobile viewports. The default chart legend has been replaced with a custom-built, responsive HTML legend that maintains previous functionality.

### Before
<img width="374" height="457" alt="Screenshot 2025-09-06 1 46 15 PM" src="https://github.com/user-attachments/assets/d9ef790a-744f-4c91-b0d1-188d8b84a659" />

### After
[Screen recording 2025-09-06 1.44.26 PM.webm](https://github.com/user-attachments/assets/2fcf5ca1-e8b3-4cac-8c21-6033c932f84d)
