### PR TITLE
Lower severity of "runs not found" to warning

### DIFF
--- a/api/checks/update.go
+++ b/api/checks/update.go
@@ -67,7 +67,7 @@ func updateCheckHandler(w http.ResponseWriter, r *http.Request) {
 	headRun, baseRun, err := loadRunsToCompare(ctx, filter)
 	if err != nil {
 		msg := "Could not find runs to compare: " + err.Error()
-		log.Errorf(msg)
+		log.Warningf(msg)
 		http.Error(w, msg, http.StatusNotFound)
 
 		return


### PR DESCRIPTION
When a test run is not found, it is not necessarily an error. This change lowers the severity of the log message from ERROR to WARNING.