### PR TITLE
Update golang to 1.25.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # vim: set expandtab sw=4
-FROM golang:1.25.2-bookworm
+FROM golang:1.25.3-bookworm
 
 # Create a non-priviledged user to run browsers as (Firefox and Chrome do not
 # like to run as root).

--- a/api/query/cache/service/Dockerfile
+++ b/api/query/cache/service/Dockerfile
@@ -1,6 +1,6 @@
 # Production deployment spec for query cache service.
 
-FROM golang:1.25.2-bookworm as builder
+FROM golang:1.25.3-bookworm as builder
 
 RUN apt-get update
 RUN apt-get install -qy --no-install-suggests git

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/web-platform-tests/wpt.fyi
 
-go 1.25.2
+go 1.25.3
 
 require (
 	cloud.google.com/go/cloudtasks v1.13.7

--- a/webapp/web/Dockerfile
+++ b/webapp/web/Dockerfile
@@ -1,6 +1,6 @@
 # Production deployment spec for the webapp.
 
-FROM golang:1.25.2-bookworm as builder
+FROM golang:1.25.3-bookworm as builder
 
 RUN apt-get update
 RUN apt-get install -qy --no-install-suggests git sudo


### PR DESCRIPTION
This bumps the version of golang to 1.25.3, in order to unblock #4596 etc. I also ran go mod tidy, and go get -u ./..., which this time didn't have much to update.