### PR TITLE
Fix blocking lint issues

### DIFF
--- a/api/azure/webhook_test.go
+++ b/api/azure/webhook_test.go
@@ -1,5 +1,4 @@
 //go:build small
-// +build small
 
 // Copyright 2018 The WPT Dashboard Project. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/api/bsf_handler_test.go
+++ b/api/bsf_handler_test.go
@@ -1,5 +1,4 @@
 //go:build small
-// +build small
 
 // Copyright 2020 The WPT Dashboard Project. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/api/checks/suites_medium_test.go
+++ b/api/checks/suites_medium_test.go
@@ -1,5 +1,4 @@
 //go:build medium
-// +build medium
 
 // Copyright 2018 The WPT Dashboard Project. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/api/checks/summaries/actions_test.go
+++ b/api/checks/summaries/actions_test.go
@@ -1,5 +1,4 @@
 //go:build small
-// +build small
 
 // Copyright 2018 The WPT Dashboard Project. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/api/checks/summaries/compile_test.go
+++ b/api/checks/summaries/compile_test.go
@@ -1,5 +1,4 @@
 //go:build medium
-// +build medium
 
 // Copyright 2018 The WPT Dashboard Project. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/api/checks/update_medium_test.go
+++ b/api/checks/update_medium_test.go
@@ -1,5 +1,4 @@
 //go:build medium
-// +build medium
 
 // Copyright 2018 The WPT Dashboard Project. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/api/checks/update_test.go
+++ b/api/checks/update_test.go
@@ -1,5 +1,4 @@
 //go:build small
-// +build small
 
 package checks
 
@@ -10,11 +9,11 @@ import (
 	"strings"
 	"testing"
 
-	"go.uber.org/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/web-platform-tests/wpt.fyi/api/checks/summaries"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
+	"go.uber.org/mock/gomock"
 )
 
 func TestGetDiffSummary_Regressed(t *testing.T) {

--- a/api/checks/webhook_test.go
+++ b/api/checks/webhook_test.go
@@ -1,5 +1,4 @@
 //go:build small
-// +build small
 
 // Copyright 2018 The WPT Dashboard Project. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/api/ghactions/notify_test.go
+++ b/api/ghactions/notify_test.go
@@ -1,5 +1,4 @@
 //go:build small
-// +build small
 
 // Copyright 2024 The WPT Dashboard Project. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/api/labels_medium_test.go
+++ b/api/labels_medium_test.go
@@ -1,5 +1,4 @@
 //go:build medium
-// +build medium
 
 // Copyright 2019 The WPT Dashboard Project. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/api/manifest/util_test.go
+++ b/api/manifest/util_test.go
@@ -1,5 +1,4 @@
 //go:build small
-// +build small
 
 // Copyright 2017 The WPT Dashboard Project. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/api/manifest_test.go
+++ b/api/manifest_test.go
@@ -1,5 +1,4 @@
 //go:build small
-// +build small
 
 // Copyright 2018 The WPT Dashboard Project. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/api/metadata_handler_test.go
+++ b/api/metadata_handler_test.go
@@ -1,5 +1,4 @@
 //go:build small
-// +build small
 
 // Copyright 2018 The WPT Dashboard Project. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/api/pending_test_runs_medium_test.go
+++ b/api/pending_test_runs_medium_test.go
@@ -1,5 +1,4 @@
 //go:build medium
-// +build medium
 
 package api
 

--- a/api/query/atoms_test.go
+++ b/api/query/atoms_test.go
@@ -1,5 +1,4 @@
 //go:build small
-// +build small
 
 // Copyright 2018 The WPT Dashboard Project. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
@@ -11,10 +10,10 @@ import (
 	"encoding/json"
 	"testing"
 
-	"go.uber.org/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
+	"go.uber.org/mock/gomock"
 )
 
 func TestStructuredQuery_empty(t *testing.T) {

--- a/api/query/cache/backfill/backfill_medium_test.go
+++ b/api/query/cache/backfill/backfill_medium_test.go
@@ -1,5 +1,4 @@
 //go:build medium
-// +build medium
 
 // Copyright 2018 The WPT Dashboard Project. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
@@ -12,13 +11,13 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/web-platform-tests/wpt.fyi/api/query"
 	"github.com/web-platform-tests/wpt.fyi/api/query/cache/index"
 	"github.com/web-platform-tests/wpt.fyi/api/query/cache/monitor"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
+	"go.uber.org/mock/gomock"
 )
 
 type countingIndex struct {

--- a/api/query/cache/backfill/backfill_test.go
+++ b/api/query/cache/backfill/backfill_test.go
@@ -1,5 +1,4 @@
 //go:build small
-// +build small
 
 // Copyright 2018 The WPT Dashboard Project. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
@@ -11,10 +10,10 @@ import (
 	"errors"
 	"testing"
 
-	gomock "go.uber.org/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/web-platform-tests/wpt.fyi/api/query/cache/index"
 	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
+	gomock "go.uber.org/mock/gomock"
 )
 
 func TestNilIndex(t *testing.T) {

--- a/api/query/cache/index/index_filter_test.go
+++ b/api/query/cache/index/index_filter_test.go
@@ -1,5 +1,4 @@
 //go:build small
-// +build small
 
 // Copyright 2018 The WPT Dashboard Project. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/api/query/cache/index/index_medium_test.go
+++ b/api/query/cache/index/index_medium_test.go
@@ -1,5 +1,4 @@
 //go:build medium
-// +build medium
 
 // Copyright 2018 The WPT Dashboard Project. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
@@ -12,10 +11,10 @@ import (
 	"strconv"
 	"testing"
 
-	"go.uber.org/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 	metrics "github.com/web-platform-tests/wpt.fyi/shared/metrics"
+	"go.uber.org/mock/gomock"
 )
 
 const (

--- a/api/query/cache/index/index_test.go
+++ b/api/query/cache/index/index_test.go
@@ -1,5 +1,4 @@
 //go:build small
-// +build small
 
 // Copyright 2018 The WPT Dashboard Project. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
@@ -16,10 +15,10 @@ import (
 
 	"github.com/web-platform-tests/wpt.fyi/api/query"
 
-	"go.uber.org/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 	metrics "github.com/web-platform-tests/wpt.fyi/shared/metrics"
+	"go.uber.org/mock/gomock"
 )
 
 func TestInvalidNumShards(t *testing.T) {

--- a/api/query/cache/index/results_test.go
+++ b/api/query/cache/index/results_test.go
@@ -1,5 +1,4 @@
 //go:build small
-// +build small
 
 // Copyright 2018 The WPT Dashboard Project. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/api/query/cache/index/tests_test.go
+++ b/api/query/cache/index/tests_test.go
@@ -1,5 +1,4 @@
 //go:build small
-// +build small
 
 // Copyright 2018 The WPT Dashboard Project. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/api/query/cache/lru/lru_test.go
+++ b/api/query/cache/lru/lru_test.go
@@ -1,5 +1,4 @@
 //go:build small
-// +build small
 
 // Copyright 2018 The WPT Dashboard Project. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/api/query/cache/monitor/monitor_test.go
+++ b/api/query/cache/monitor/monitor_test.go
@@ -1,5 +1,4 @@
 //go:build small
-// +build small
 
 // Copyright 2018 The WPT Dashboard Project. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
@@ -12,8 +11,8 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
 
 	"github.com/web-platform-tests/wpt.fyi/api/query/cache/index"
 	"github.com/web-platform-tests/wpt.fyi/shared"

--- a/api/query/cache/poll/poll_test.go
+++ b/api/query/cache/poll/poll_test.go
@@ -1,5 +1,4 @@
 //go:build small
-// +build small
 
 // Copyright 2024 The WPT Dashboard Project. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/api/query/cache/query/query_test.go
+++ b/api/query/cache/query/query_test.go
@@ -1,5 +1,4 @@
 //go:build small
-// +build small
 
 // Copyright 2018 The WPT Dashboard Project. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/api/query/query_test.go
+++ b/api/query/query_test.go
@@ -1,5 +1,4 @@
 //go:build small
-// +build small
 
 // Copyright 2018 The WPT Dashboard Project. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
@@ -14,10 +13,10 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
+	"go.uber.org/mock/gomock"
 )
 
 func TestGetRedisKey(t *testing.T) {

--- a/api/query/search_medium_test.go
+++ b/api/query/search_medium_test.go
@@ -1,5 +1,4 @@
 //go:build medium
-// +build medium
 
 // Copyright 2017 The WPT Dashboard Project. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
@@ -19,10 +18,10 @@ import (
 	"testing"
 	time "time"
 
-	"go.uber.org/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
+	"go.uber.org/mock/gomock"
 )
 
 type shouldCache struct {

--- a/api/query/search_test.go
+++ b/api/query/search_test.go
@@ -1,5 +1,4 @@
 //go:build small
-// +build small
 
 // Copyright 2018 The WPT Dashboard Project. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/api/receiver/api_cloud_test.go
+++ b/api/receiver/api_cloud_test.go
@@ -1,5 +1,4 @@
 //go:build cloud
-// +build cloud
 
 // Copyright 2018 The WPT Dashboard Project. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/api/receiver/api_medium_test.go
+++ b/api/receiver/api_medium_test.go
@@ -1,5 +1,4 @@
 //go:build medium
-// +build medium
 
 // Copyright 2018 The WPT Dashboard Project. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
@@ -20,8 +19,8 @@ import (
 	"strings"
 	"testing"
 
-	"go.uber.org/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
 
 	"github.com/web-platform-tests/wpt.fyi/shared"
 	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"

--- a/api/receiver/azure_test.go
+++ b/api/receiver/azure_test.go
@@ -1,5 +1,4 @@
 //go:build small
-// +build small
 
 // Copyright 2018 The WPT Dashboard Project. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/api/receiver/client/client_test.go
+++ b/api/receiver/client/client_test.go
@@ -1,5 +1,4 @@
 //go:build small
-// +build small
 
 // Copyright 2020 The WPT Dashboard Project. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
@@ -13,9 +12,9 @@ import (
 	"net/url"
 	"testing"
 
-	"go.uber.org/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
+	"go.uber.org/mock/gomock"
 )
 
 func TestCreateRun(t *testing.T) {

--- a/api/receiver/create_run_test.go
+++ b/api/receiver/create_run_test.go
@@ -1,5 +1,4 @@
 //go:build small
-// +build small
 
 // Copyright 2018 The WPT Dashboard Project. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
@@ -16,12 +15,12 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/web-platform-tests/wpt.fyi/api/checks/mock_checks"
 	"github.com/web-platform-tests/wpt.fyi/api/receiver/mock_receiver"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 	"github.com/web-platform-tests/wpt.fyi/shared/sharedtest"
+	"go.uber.org/mock/gomock"
 )
 
 func TestHandleResultsCreate(t *testing.T) {

--- a/api/receiver/receive_results_test.go
+++ b/api/receiver/receive_results_test.go
@@ -1,5 +1,4 @@
 //go:build small
-// +build small
 
 // Copyright 2018 The WPT Dashboard Project. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
@@ -18,8 +17,8 @@ import (
 	"strings"
 	"testing"
 
-	"go.uber.org/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
 
 	"github.com/web-platform-tests/wpt.fyi/api/receiver/mock_receiver"
 	"github.com/web-platform-tests/wpt.fyi/shared"

--- a/api/receiver/update_pending_run_test.go
+++ b/api/receiver/update_pending_run_test.go
@@ -1,5 +1,4 @@
 //go:build small
-// +build small
 
 // Copyright 2019 The WPT Dashboard Project. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
@@ -14,9 +13,9 @@ import (
 	"strings"
 	"testing"
 
-	"go.uber.org/mock/gomock"
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
 
 	"github.com/web-platform-tests/wpt.fyi/api/receiver/mock_receiver"
 	"github.com/web-platform-tests/wpt.fyi/shared"

--- a/api/screenshot/model_medium_test.go
+++ b/api/screenshot/model_medium_test.go
@@ -1,5 +1,4 @@
 //go:build medium
-// +build medium
 
 // Copyright 2019 The WPT Dashboard Project. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/api/shas_medium_test.go
+++ b/api/shas_medium_test.go
@@ -1,5 +1,4 @@
 //go:build medium
-// +build medium
 
 package api
 

--- a/api/taskcluster/webhook_test.go
+++ b/api/taskcluster/webhook_test.go
@@ -1,5 +1,4 @@
 //go:build small
-// +build small
 
 // Copyright 2018 The WPT Dashboard Project. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/api/test_history_test.go
+++ b/api/test_history_test.go
@@ -1,5 +1,4 @@
 //go:build small
-// +build small
 
 // Copyright 2023 The WPT Dashboard Project. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/api/test_run_medium_test.go
+++ b/api/test_run_medium_test.go
@@ -1,5 +1,4 @@
 //go:build medium
-// +build medium
 
 package api
 

--- a/api/test_runs_medium_test.go
+++ b/api/test_runs_medium_test.go
@@ -1,5 +1,4 @@
 //go:build medium
-// +build medium
 
 package api
 

--- a/api/versions_medium_test.go
+++ b/api/versions_medium_test.go
@@ -1,5 +1,4 @@
 //go:build medium
-// +build medium
 
 package api
 


### PR DESCRIPTION
Seems like the linter was updated.

As a result, builds are currently blocked.

Fixes #4623

Other changes:
- Go formatter reordered some of the imports automatically.

We have the newer syntax already. So this is a no-op
