### PR TITLE
Try specifying more disk space.

### DIFF
--- a/api/query/cache/service/app.staging.yaml
+++ b/api/query/cache/service/app.staging.yaml
@@ -8,6 +8,7 @@ service: searchcache
 resources:
   cpu: 2
   memory_gb: 10
+  disk_size_gb: 20
 
 manual_scaling:
   instances: 1

--- a/api/query/cache/service/app.yaml
+++ b/api/query/cache/service/app.yaml
@@ -12,6 +12,7 @@ resources:
   # available on AppEngine Flex.
   cpu: 32
   memory_gb: 207.5 # Max: FloorToNearest256MB(32 vCPU * 6.5 - 0.4) = 207.5 GB
+  disk_size_gb: 20
 
 manual_scaling:
   instances: 2

--- a/results-processor/app.staging.yaml
+++ b/results-processor/app.staging.yaml
@@ -11,7 +11,7 @@ manual_scaling:
 resources:
   cpu: 2
   memory_gb: 4
-  disk_size_gb: 10
+  disk_size_gb: 20
 
 liveness_check:
   path: "/_ah/liveness_check"

--- a/results-processor/app.yaml
+++ b/results-processor/app.yaml
@@ -7,7 +7,7 @@ manual_scaling:
 resources:
   cpu: 2
   memory_gb: 4
-  disk_size_gb: 10
+  disk_size_gb: 20
 
 liveness_check:
   path: "/_ah/liveness_check"

--- a/webapp/web/app.staging.yaml
+++ b/webapp/web/app.staging.yaml
@@ -7,6 +7,7 @@ env: flex
 resources:
   cpu: 2
   memory_gb: 4
+  disk_size_gb: 20
 
 automatic_scaling:
   min_num_instances: 4

--- a/webapp/web/app.yaml
+++ b/webapp/web/app.yaml
@@ -7,6 +7,7 @@ env: flex
 resources:
   cpu: 2
   memory_gb: 4
+  disk_size_gb: 20
 
 automatic_scaling:
   min_num_instances: 4


### PR DESCRIPTION
Flexible VMs default to 13 GB disk space.  Since our staging deployments are failing due to running out of disk space, try 20 GB.