### PR TITLE
Fix test262 uploads from taskcluster

### DIFF
--- a/api/taskcluster/webhook.go
+++ b/api/taskcluster/webhook.go
@@ -33,7 +33,7 @@ const completedState = "completed"
 var (
 	// TaskNameRegex is based on task names in
 	// https://github.com/web-platform-tests/wpt/blob/master/tools/ci/tc/tasks/test.yml.
-	TaskNameRegex = regexp.MustCompile(`^wpt-([a-z_]+-[a-z]+)-([a-z]+(?:-[a-z]+)*)(?:-\d+)?$`)
+	TaskNameRegex = regexp.MustCompile(`^wpt-([a-z_]+-[a-z]+)-([a-z]+(?:-[a-z]+)*|test262)(?:-\d+)?$`)
 	// Taskcluster has used different forms of URLs in their Check & Status
 	// updates in history. We accept all of them.
 	// See TestExtractTaskGroupID for examples.

--- a/api/taskcluster/webhook_test.go
+++ b/api/taskcluster/webhook_test.go
@@ -123,12 +123,13 @@ func TestParseTaskclusterURL(t *testing.T) {
 }
 
 func TestExtractArtifactURLs_all_success_master(t *testing.T) {
-	group := &tc.TaskGroupInfo{Tasks: make([]tc.TaskInfo, 5)}
+	group := &tc.TaskGroupInfo{Tasks: make([]tc.TaskInfo, 6)}
 	group.Tasks[0].Name = "wpt-firefox-nightly-testharness-1"
 	group.Tasks[1].Name = "wpt-firefox-nightly-testharness-2"
 	group.Tasks[2].Name = "wpt-chrome-dev-testharness-1"
 	group.Tasks[3].Name = "wpt-chrome-dev-reftest-1"
 	group.Tasks[4].Name = "wpt-chrome-dev-crashtest-1"
+	group.Tasks[5].Name = "wpt-chrome-dev-test262-1"
 	for i := 0; i < len(group.Tasks); i++ {
 		group.Tasks[i].State = "completed"
 		group.Tasks[i].TaskID = fmt.Sprint(i)
@@ -153,11 +154,13 @@ func TestExtractArtifactURLs_all_success_master(t *testing.T) {
 					"https://tc.example.com/api/queue/v1/task/2/artifacts/public/results/wpt_report.json.gz",
 					"https://tc.example.com/api/queue/v1/task/3/artifacts/public/results/wpt_report.json.gz",
 					"https://tc.example.com/api/queue/v1/task/4/artifacts/public/results/wpt_report.json.gz",
+					"https://tc.example.com/api/queue/v1/task/5/artifacts/public/results/wpt_report.json.gz",
 				},
 				Screenshots: []string{
 					"https://tc.example.com/api/queue/v1/task/2/artifacts/public/results/wpt_screenshot.txt.gz",
 					"https://tc.example.com/api/queue/v1/task/3/artifacts/public/results/wpt_screenshot.txt.gz",
 					"https://tc.example.com/api/queue/v1/task/4/artifacts/public/results/wpt_screenshot.txt.gz",
+					"https://tc.example.com/api/queue/v1/task/5/artifacts/public/results/wpt_screenshot.txt.gz",
 				},
 			},
 		}, urls)

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -35,7 +35,7 @@ import { html } from '../node_modules/@polymer/polymer/polymer-element.js';
 import { PathInfo } from '../components/path.js';
 import { Pluralizer } from '../components/pluralize.js';
 
-const TEST_TYPES = ['manual', 'reftest', 'testharness', 'visual', 'wdspec'];
+const TEST_TYPES = ['manual', 'reftest', 'testharness', 'visual', 'wdspec', 'test262'];
 
 // Map of abbreviations for status values stored in summary files.
 // This is used to expand the status to its full value after being


### PR DESCRIPTION
Results are currently getting filtered out due to the regex for taskcluster tasks

This change fixes that. Instead of being very permissive with the task name, I explicitly only allow test262 since otherwise, numbers are not allowed.

Fixes #4670

See that bug for more info

Other changes:
- Add test262 test type to frontend
