### PR TITLE
Go lint preallocate capacity

### DIFF
--- a/api/query/atoms.go
+++ b/api/query/atoms.go
@@ -226,7 +226,7 @@ type AbstractCount struct {
 // number of runs that match the criteria.
 // nolint:ireturn // TODO: Fix ireturn lint error
 func (c AbstractCount) BindToRuns(runs ...shared.TestRun) ConcreteQuery {
-	byRun := []ConcreteQuery{}
+	byRun := make([]ConcreteQuery, 0, len(runs))
 	for _, run := range runs {
 		byRun = append(byRun, c.Where.BindToRuns(run))
 	}


### PR DESCRIPTION
Since the linter sees we are iterating over runs, it knows the maximum number of items we will add is len(runs). We can be explicit by allocating that memory once at the beginning.