### PR TITLE
Bump mobile investigation score from 30%->46%

### DIFF
--- a/webapp/components/interop-data.js
+++ b/webapp/components/interop-data.js
@@ -1470,7 +1470,8 @@ export const interopData = {
         'url': 'https://github.com/web-platform-tests/interop-mobile-testing',
         'scores_over_time': [
           { 'date': '2025-06-10', 'score': 120 },
-          { 'date': '2025-08-26', 'score': 300 }
+          { 'date': '2025-08-26', 'score': 300 },
+          { 'date': '2025-12-31', 'score': 460 }
         ]
       },
       {

--- a/webapp/static/interop-data.json
+++ b/webapp/static/interop-data.json
@@ -1443,7 +1443,8 @@
         "url": "https://github.com/web-platform-tests/interop-mobile-testing",
         "scores_over_time": [
           { "date": "2025-06-10", "score": 120 },
-          { "date": "2025-08-26", "score": 300 }
+          { "date": "2025-08-26", "score": 300 },
+          { "date": "2025-12-31", "score": 460 }
         ]
       },
       {


### PR DESCRIPTION
During today's
[discussion](https://docs.google.com/document/d/1N9wdlGCOIlBo7_Dr7dcsgO4GIFPC8dnlb8qo_MaF97s/edit?tab=t.0#heading=h.5hcp60i0xfcf), we decided to finalize the score for 2025 at 46%

