### PR TITLE
Fix #3022: TestNamePattern should use case-insensitive matching

### DIFF
--- a/api/query/cache/index/filter.go
+++ b/api/query/cache/index/filter.go
@@ -169,7 +169,10 @@ func (tnp TestNamePattern) Filter(t TestID) bool {
 		return false
 	}
 
-	return strings.Contains(name, tnp.q.Pattern)
+	return strings.Contains(
+		strings.ToLower(name),
+		strings.ToLower(tnp.q.Pattern),
+	)
 }
 
 // Filter interprets a SubtestNamePattern as a filter function over TestIDs.


### PR DESCRIPTION
Update TestNamePattern.Filter() to use case-insensitive string
matching by converting both the test name and pattern to lowercase
before comparison, following the example of
SubtestNamePattern.Filter().

This makes test name matching for structured queries the same as the
unstructured search API.

Fixes #3022.
