### PR TITLE
Fix #3929: Web Feature queries missing uppercase test names

### DIFF
--- a/shared/web_features.go
+++ b/shared/web_features.go
@@ -90,7 +90,7 @@ func (d webFeaturesManifestV1Data) prepareTestWebFeatureFilter() WebFeaturesData
 	testToWebFeaturesMap := make(map[string]map[string]interface{})
 	for webFeature, tests := range d {
 		for _, test := range tests {
-			key := strings.ToLower(test)
+			key := test
 			value := strings.ToLower(webFeature)
 			if set, found := testToWebFeaturesMap[key]; found {
 				set[value] = nil

--- a/shared/web_features_test.go
+++ b/shared/web_features_test.go
@@ -46,6 +46,39 @@ func TestWebFeaturesData_TestMatchesWithWebFeature(t *testing.T) {
 			webFeature: "feature1",
 			expected:   false,
 		},
+		{
+			name: "test name with uppercase characters matches exact case",
+			data: WebFeaturesData{
+				"/custom-elements/Document-createElement-customized-builtins.html": map[string]interface{}{
+					"customized-built-in-elements": nil,
+				},
+			},
+			test:       "/custom-elements/Document-createElement-customized-builtins.html",
+			webFeature: "customized-built-in-elements",
+			expected:   true,
+		},
+		{
+			name: "test name case must match exactly",
+			data: WebFeaturesData{
+				"/custom-elements/Document-createElement-customized-builtins.html": map[string]interface{}{
+					"customized-built-in-elements": nil,
+				},
+			},
+			test:       "/custom-elements/document-createelement-customized-builtins.html",
+			webFeature: "customized-built-in-elements",
+			expected:   false,
+		},
+		{
+			name: "web feature name remains case-insensitive",
+			data: WebFeaturesData{
+				"/custom-elements/Document-createElement-customized-builtins.html": map[string]interface{}{
+					"customized-built-in-elements": nil,
+				},
+			},
+			test:       "/custom-elements/Document-createElement-customized-builtins.html",
+			webFeature: "Customized-Built-In-Elements",
+			expected:   true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -123,10 +156,14 @@ func TestWebFeaturesManifestV1Data_prepareTestWebFeatureFilter(t *testing.T) {
 		},
 		"feature2": []string{
 			"/test2",
+		},
+		"Feature3": []string{
+			"/Test3",
 		}}
 	expectedResult := WebFeaturesData{
 		"/test1": {"feature1": nil},
 		"/test2": {"feature1": nil, "feature2": nil},
+		"/Test3": {"feature3": nil},
 	}
 	result := data.prepareTestWebFeatureFilter()
 	assert.Equal(t, expectedResult, result)

--- a/util/deploy-staging.sh
+++ b/util/deploy-staging.sh
@@ -22,8 +22,8 @@ if [[ "${APP_PATH}" == ""  ]]; then fatal "app path not specified."; fi
 
 APP_DEPS="${APP_PATH}"
 if [[ "${APP_PATH}" == webapp/web* ]]; then APP_DEPS="webapp|api|shared"; fi
-# Be more conservative: only deploy searchcache when it's directly modified.
-if [[ "${APP_PATH}" == api/query/cache/service* ]]; then APP_DEPS="api/query"; fi
+# Be more conservative: only deploy searchcache when it or shared are modified.
+if [[ "${APP_PATH}" == api/query/cache/service* ]]; then APP_DEPS="api/query|shared"; fi
 if [[ "${APP_PATH}" == "results-processor/app.staging.yaml" ]]; then APP_DEPS="results-processor"; fi
 APP_DEPS_REGEX="^(${APP_DEPS})/"
 


### PR DESCRIPTION
Remove case normalization at ingestion time to preserve original test names from `WEB_FEATURES.yml`. The Python manifest generator already preserves case (e.g., `Document-createElement-customized-builtins.html`), but the Go ingestion code was lowercasing all test names, causing queries to fail to match tests with uppercase characters.

Fixes #3929.