### PR TITLE
Allow root-level parenthetical expressions in query grammar

### DIFF
--- a/webapp/components/test-search.js
+++ b/webapp/components/test-search.js
@@ -47,6 +47,7 @@ const QUERY_GRAMMAR = ohm.grammar(`
       | Count
       | Sequential
       | Exists
+      | "(" Root ")"   -- parenRoot
 
     All = "all(" ListOf<Exp, space*> ")"
 
@@ -247,6 +248,7 @@ const QUERY_SEMANTICS = QUERY_GRAMMAR.createSemantics().addOperation('eval', {
   },
   OrQ: orConjunction,
   AndQ: andConjunction,
+  Q_parenRoot: (_, r, __) => r.eval(),
   EmptyListOf: function() {
     return [];
   },

--- a/webapp/components/test/test-search.html
+++ b/webapp/components/test/test-search.html
@@ -661,43 +661,69 @@ suite('<test-search>', () => {
 
       suite('parenthesized roots', () => {
         test('all', () => {
-          assertQueryFail('(all(status:PASS))');
+          assertQueryParse('(all(status:PASS))', {all: [{status: 'PASS'}]});
         });
 
         test('exists', () => {
-          assertQueryFail('(exists(status:PASS))');
+          assertQueryParse('(exists(status:PASS))', {exists: [{status: 'PASS'}]});
         });
 
         test('implicit-exists and explicit-exists', () => {
-          assertQueryFail('(path:/css and exists(display contents))');
+          assertQueryParse('(path:/css and exists(display contents))', {
+            and: [
+              {exists: [{path: '/css'}]},
+              {exists: [{pattern: 'display'}, {pattern: 'contents'}]},
+            ],
+          });
         });
 
         test('(all) or (none)', () => {
-          assertQueryFail('(all(status:PASS)) or (none(status:FAIL))');
+          assertQueryParse('(all(status:PASS)) or (none(status:FAIL))', {
+            or: [
+              {all: [{status: 'PASS'}]},
+              {none: [{status: 'FAIL'}]},
+            ],
+          });
         });
 
         test('implicit-exists with implicit-and', () => {
-          assertQueryFail('(foo bar)');
+          assertQueryParse('(foo bar)', {
+            exists: [{pattern: 'foo'}, {pattern: 'bar'}],
+          });
         });
 
         test('count and none with implicit-and', () => {
-          assertQueryFail('(count:2(status:PASS) none(status:FAIL))');
+          assertQueryParse('(count:2(status:PASS) none(status:FAIL))', {
+            and: [
+              {count: 2, where: {status: 'PASS'}},
+              {none: [{status: 'FAIL'}]},
+            ],
+          });
         });
 
         test('count', () => {
-          assertQueryFail('(count:2(status:pass))');
+          assertQueryParse('(count:2(status:pass))', {
+            count: 2,
+            where: {status: 'PASS'},
+          });
         });
 
         test('none', () => {
-          assertQueryFail('(none(status:fail))');
+          assertQueryParse('(none(status:fail))', {
+            none: [{status: 'FAIL'}],
+          });
         });
 
         test('seq', () => {
-          assertQueryFail('(seq(status:pass status:fail))');
+          assertQueryParse('(seq(status:pass status:fail))', {
+            sequential: [{status: 'PASS'}, {status: 'FAIL'}],
+          });
         });
 
         test('double parentheses', () => {
-          assertQueryFail('((all(status:pass)))');
+          assertQueryParse('((all(status:pass)))', {
+            all: [{status: 'PASS'}],
+          });
         });
       });
     });


### PR DESCRIPTION
Adds support for wrapping root-level queries in parentheses (e.g., `(all(...))`  or `(exists(...) and path:/foo)`), making the grammar more flexible and allowing better grouping for complex queries.

This makes complex and/or combinations possible that weren't before, closing a gap in what the query language can express compared with structured queries.

This builds on top of #4727.