### PR TITLE
Allow negation of root queries in search grammar

### DIFF
--- a/webapp/components/test-search.js
+++ b/webapp/components/test-search.js
@@ -48,6 +48,7 @@ const QUERY_GRAMMAR = ohm.grammar(`
       | Sequential
       | Exists
       | "(" Root ")"   -- parenRoot
+      | not Q          -- not
 
     All = "all(" ListOf<Exp, space*> ")"
 
@@ -249,6 +250,7 @@ const QUERY_SEMANTICS = QUERY_GRAMMAR.createSemantics().addOperation('eval', {
   OrQ: orConjunction,
   AndQ: andConjunction,
   Q_parenRoot: (_, r, __) => r.eval(),
+  Q_not: evalNot,
   EmptyListOf: function() {
     return [];
   },

--- a/webapp/components/test/test-search.html
+++ b/webapp/components/test/test-search.html
@@ -351,39 +351,54 @@ suite('<test-search>', () => {
 
       suite('root query (Q-level) negation', () => {
         test('not all', () => {
-          assertQueryFail('not all(status:PASS)');
+          assertQueryParse('not all(status:PASS)', {not: {all: [{status: 'PASS'}]}});
         });
 
         test('! shorthand', () => {
-          assertQueryFail('!all(status:PASS)');
+          assertQueryParse('!all(status:PASS)', {not: {all: [{status: 'PASS'}]}});
         });
 
         test('not count', () => {
-          assertQueryFail('not count:2(status:PASS)');
+          assertQueryParse('not count:2(status:PASS)', {not: {count: 2, where: {status: 'PASS'}}});
         });
 
         test('! on sequential', () => {
-          assertQueryFail('!seq(status:PASS status:FAIL)');
+          assertQueryParse('!seq(status:PASS status:FAIL)', {not: {sequential: [{status: 'PASS'}, {status: 'FAIL'}]}});
         });
 
         test('not exists', () => {
-          assertQueryFail('not exists(status:PASS)');
+          assertQueryParse('not exists(status:PASS)', {not: {exists: [{status: 'PASS'}]}});
         });
 
         test('combining negated queries with or', () => {
-          assertQueryFail('not all(status:PASS) or not all(status:OK)');
+          assertQueryParse('not all(status:PASS) or not all(status:OK)', {
+            or: [
+              {not: {all: [{status: 'PASS'}]}},
+              {not: {all: [{status: 'OK'}]}}
+            ]
+          });
         });
 
         test('not none query', () => {
-          assertQueryFail('not none(status:fail)');
+          assertQueryParse('not none(status:fail)', {not: {none: [{status: 'FAIL'}]}});
         });
 
         test('not query in and expression', () => {
-          assertQueryFail('not all(status:pass) and status:fail');
+          assertQueryParse('not all(status:pass) and status:fail', {
+            and: [
+              {not: {all: [{status: 'PASS'}]}},
+              {exists: [{status: 'FAIL'}]}
+            ]
+          });
         });
 
         test('multiple negations with and/or', () => {
-          assertQueryFail('!all(status:pass) and !none(status:fail)');
+          assertQueryParse('!all(status:pass) and !none(status:fail)', {
+            and: [
+              {not: {all: [{status: 'PASS'}]}},
+              {not: {none: [{status: 'FAIL'}]}}
+            ]
+          });
         });
       });
     });


### PR DESCRIPTION
Building on top of https://github.com/web-platform-tests/wpt.fyi/pull/4727, https://github.com/web-platform-tests/wpt.fyi/pull/4728, and https://github.com/web-platform-tests/wpt.fyi/pull/4729:

This enables not only top-level negation like 'not all(...)' but also allows one to easily negate entire queries.

This further closes the gap in what the query language can express compared with structured queries.
