### PR TITLE
Upgrade major versions of Go dependencies

### DIFF
--- a/api/checks/api.go
+++ b/api/checks/api.go
@@ -12,7 +12,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/google/go-github/v80/github"
+	"github.com/google/go-github/v82/github"
 	"github.com/web-platform-tests/wpt.fyi/api/checks/summaries"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )

--- a/api/checks/jwt.go
+++ b/api/checks/jwt.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	jwt "github.com/golang-jwt/jwt"
-	"github.com/google/go-github/v80/github"
+	"github.com/google/go-github/v82/github"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 	"golang.org/x/oauth2"
 )

--- a/api/checks/mock_checks/api_mock.go
+++ b/api/checks/mock_checks/api_mock.go
@@ -16,7 +16,7 @@ import (
 	reflect "reflect"
 	time "time"
 
-	github "github.com/google/go-github/v80/github"
+	github "github.com/google/go-github/v82/github"
 	shared "github.com/web-platform-tests/wpt.fyi/shared"
 	gomock "go.uber.org/mock/gomock"
 )

--- a/api/checks/runs.go
+++ b/api/checks/runs.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/google/go-github/v80/github"
+	"github.com/google/go-github/v82/github"
 	"github.com/web-platform-tests/wpt.fyi/api/checks/summaries"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )

--- a/api/checks/summaries/actions.go
+++ b/api/checks/summaries/actions.go
@@ -4,7 +4,7 @@
 
 package summaries
 
-import "github.com/google/go-github/v80/github"
+import "github.com/google/go-github/v82/github"
 
 // RecomputeAction is an action that can be taken to
 // trigger a recompute of the diff, against the latest

--- a/api/checks/summaries/actions_test.go
+++ b/api/checks/summaries/actions_test.go
@@ -9,7 +9,7 @@ package summaries
 import (
 	"testing"
 
-	"github.com/google/go-github/v80/github"
+	"github.com/google/go-github/v82/github"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/api/checks/summaries/compile.go
+++ b/api/checks/summaries/compile.go
@@ -14,7 +14,7 @@ import (
 
 	mapset "github.com/deckarep/golang-set"
 
-	"github.com/google/go-github/v80/github"
+	"github.com/google/go-github/v82/github"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 

--- a/api/checks/summaries/completed.go
+++ b/api/checks/summaries/completed.go
@@ -5,7 +5,7 @@
 package summaries
 
 import (
-	"github.com/google/go-github/v80/github"
+	"github.com/google/go-github/v82/github"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 

--- a/api/checks/summaries/pending.go
+++ b/api/checks/summaries/pending.go
@@ -4,7 +4,7 @@
 
 package summaries
 
-import "github.com/google/go-github/v80/github"
+import "github.com/google/go-github/v82/github"
 
 // Pending is the struct for pending.md.
 type Pending struct {

--- a/api/checks/summaries/regressed.go
+++ b/api/checks/summaries/regressed.go
@@ -5,7 +5,7 @@
 package summaries
 
 import (
-	"github.com/google/go-github/v80/github"
+	"github.com/google/go-github/v82/github"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 

--- a/api/checks/webhook.go
+++ b/api/checks/webhook.go
@@ -11,7 +11,7 @@ import (
 	"net/http"
 	"regexp"
 
-	"github.com/google/go-github/v80/github"
+	"github.com/google/go-github/v82/github"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 

--- a/api/checks/webhook_test.go
+++ b/api/checks/webhook_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-github/v80/github"
+	"github.com/google/go-github/v82/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/web-platform-tests/wpt.fyi/api/checks/mock_checks"
 	"github.com/web-platform-tests/wpt.fyi/shared"

--- a/api/ghactions/notify.go
+++ b/api/ghactions/notify.go
@@ -13,7 +13,7 @@ import (
 
 	mapset "github.com/deckarep/golang-set"
 	"github.com/gobwas/glob"
-	"github.com/google/go-github/v80/github"
+	"github.com/google/go-github/v82/github"
 	uc "github.com/web-platform-tests/wpt.fyi/api/receiver/client"
 
 	"github.com/web-platform-tests/wpt.fyi/shared"

--- a/api/ghactions/notify_test.go
+++ b/api/ghactions/notify_test.go
@@ -9,7 +9,7 @@ package ghactions
 import (
 	"testing"
 
-	"github.com/google/go-github/v80/github"
+	"github.com/google/go-github/v82/github"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/api/manifest/api.go
+++ b/api/manifest/api.go
@@ -13,7 +13,7 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/google/go-github/v80/github"
+	"github.com/google/go-github/v82/github"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 

--- a/api/metadata_cache.go
+++ b/api/metadata_cache.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/google/go-github/v80/github"
+	"github.com/google/go-github/v82/github"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 

--- a/api/query/cache/poll/poll.go
+++ b/api/query/cache/poll/poll.go
@@ -11,7 +11,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/google/go-github/v80/github"
+	"github.com/google/go-github/v82/github"
 	"github.com/web-platform-tests/wpt.fyi/api/query"
 	"github.com/web-platform-tests/wpt.fyi/api/query/cache/index"
 	"github.com/web-platform-tests/wpt.fyi/shared"

--- a/api/receiver/mock_receiver/api_mock.go
+++ b/api/receiver/mock_receiver/api_mock.go
@@ -17,7 +17,7 @@ import (
 	reflect "reflect"
 	time "time"
 
-	github "github.com/google/go-github/v80/github"
+	github "github.com/google/go-github/v82/github"
 	shared "github.com/web-platform-tests/wpt.fyi/shared"
 	gomock "go.uber.org/mock/gomock"
 )

--- a/api/taskcluster/mock_taskcluster/webhook_mock.go
+++ b/api/taskcluster/mock_taskcluster/webhook_mock.go
@@ -12,7 +12,7 @@ package mock_taskcluster
 import (
 	reflect "reflect"
 
-	github "github.com/google/go-github/v80/github"
+	github "github.com/google/go-github/v82/github"
 	taskcluster "github.com/web-platform-tests/wpt.fyi/api/taskcluster"
 	gomock "go.uber.org/mock/gomock"
 )

--- a/api/taskcluster/webhook.go
+++ b/api/taskcluster/webhook.go
@@ -17,9 +17,9 @@ import (
 	"sync"
 
 	mapset "github.com/deckarep/golang-set"
-	"github.com/google/go-github/v80/github"
+	"github.com/google/go-github/v82/github"
 	tcurls "github.com/taskcluster/taskcluster-lib-urls"
-	"github.com/taskcluster/taskcluster/v95/clients/client-go/tcqueue"
+	"github.com/taskcluster/taskcluster/v96/clients/client-go/tcqueue"
 	uc "github.com/web-platform-tests/wpt.fyi/api/receiver/client"
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )

--- a/api/taskcluster/webhook_test.go
+++ b/api/taskcluster/webhook_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-github/v80/github"
+	"github.com/google/go-github/v82/github"
 	"github.com/stretchr/testify/assert"
 	uc "github.com/web-platform-tests/wpt.fyi/api/receiver/client"
 	tc "github.com/web-platform-tests/wpt.fyi/api/taskcluster"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/web-platform-tests/wpt.fyi
 
-go 1.25.5
+go 1.25.6
 
 require (
 	cloud.google.com/go/cloudtasks v1.13.7
@@ -13,7 +13,7 @@ require (
 	github.com/gobwas/glob v0.2.3
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/gomodule/redigo v1.9.3
-	github.com/google/go-github/v80 v80.0.0
+	github.com/google/go-github/v82 v82.0.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/handlers v1.5.2
 	github.com/gorilla/mux v1.8.1
@@ -23,7 +23,7 @@ require (
 	github.com/sirupsen/logrus v1.9.4
 	github.com/stretchr/testify v1.11.1
 	github.com/taskcluster/taskcluster-lib-urls v13.0.1+incompatible
-	github.com/taskcluster/taskcluster/v95 v95.1.4
+	github.com/taskcluster/taskcluster/v96 v96.1.0
 	github.com/tebeka/selenium v0.9.9
 	go.uber.org/mock v0.6.0
 	golang.org/x/lint v0.0.0-20241112194109-818c5a804067

--- a/go.sum
+++ b/go.sum
@@ -112,8 +112,8 @@ github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/go-github/v27 v27.0.4/go.mod h1:/0Gr8pJ55COkmv+S/yPKCczSkUPIM/LnFyubufRNIS0=
-github.com/google/go-github/v80 v80.0.0 h1:BTyk3QOHekrk5VF+jIGz1TNEsmeoQG9K/UWaaP+EWQs=
-github.com/google/go-github/v80 v80.0.0/go.mod h1:pRo4AIMdHW83HNMGfNysgSAv0vmu+/pkY8nZO9FT9Yo=
+github.com/google/go-github/v82 v82.0.0 h1:OH09ESON2QwKCUVMYmMcVu1IFKFoaZHwqYaUtr/MVfk=
+github.com/google/go-github/v82 v82.0.0/go.mod h1:hQ6Xo0VKfL8RZ7z1hSfB4fvISg0QqHOqe9BP0qo+WvM=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=
 github.com/google/go-querystring v1.2.0/go.mod h1:8IFJqpSRITyJ8QhQ13bmbeMBDfmeEJZD5A0egEOmkqU=
@@ -181,8 +181,8 @@ github.com/taskcluster/slugid-go v1.1.0 h1:SWsUplliyamdYzOKVM4+lDohZKuL63fKreGkv
 github.com/taskcluster/slugid-go v1.1.0/go.mod h1:5sOAcPHjqso1UkKxSl77CkKgOwha0D9X0msBKBj0AOg=
 github.com/taskcluster/taskcluster-lib-urls v13.0.1+incompatible h1:Q3kagxQiHw7QNckRoeeBV16FDvyQC+iSmda99bJEK+U=
 github.com/taskcluster/taskcluster-lib-urls v13.0.1+incompatible/go.mod h1:ALqTgi15AmJGEGubRKM0ydlLAFatlQPrQrmal9YZpQs=
-github.com/taskcluster/taskcluster/v95 v95.1.4 h1:hW6P2FcjKXZLe+5uwnQrwhwLMdlaWZJcpQLdZSv/xJ8=
-github.com/taskcluster/taskcluster/v95 v95.1.4/go.mod h1:st4nmuI3LVBQWmnd46qUgjb38raZlsFjwq/R5z+I5ZM=
+github.com/taskcluster/taskcluster/v96 v96.1.0 h1:PHlnhew8jd69Z8b2zh+n9Vhf5VM6SapXuJbGvE66zJw=
+github.com/taskcluster/taskcluster/v96 v96.1.0/go.mod h1:8G/WLhy/QWA1udjVnfYoM717ptoNqhmxxlf3bWDDcAc=
 github.com/tebeka/selenium v0.9.9 h1:cNziB+etNgyH/7KlNI7RMC1ua5aH1+5wUlFQyzeMh+w=
 github.com/tebeka/selenium v0.9.9/go.mod h1:5Fr8+pUvU6B1OiPfkdCKdXZyr5znvVkxuPd0NOdZCQc=
 github.com/tent/hawk-go v0.0.0-20161026210932-d341ea318957 h1:6Fre/uvwovW5YY4nfHZk66cAg9HjT9YdFSAJHUUgOyQ=

--- a/shared/appengine.go
+++ b/shared/appengine.go
@@ -21,7 +21,7 @@ import (
 	gclog "cloud.google.com/go/logging"
 	secretmanager "cloud.google.com/go/secretmanager/apiv1"
 	"github.com/gomodule/redigo/redis"
-	"github.com/google/go-github/v80/github"
+	"github.com/google/go-github/v82/github"
 	apps "google.golang.org/api/appengine/v1"
 	"google.golang.org/api/option"
 	mrpb "google.golang.org/genproto/googleapis/api/monitoredres"

--- a/shared/github_oauth.go
+++ b/shared/github_oauth.go
@@ -13,7 +13,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/google/go-github/v80/github"
+	"github.com/google/go-github/v82/github"
 	"github.com/gorilla/securecookie"
 	"golang.org/x/oauth2"
 	ghOAuth "golang.org/x/oauth2/github"

--- a/shared/metadata_util.go
+++ b/shared/metadata_util.go
@@ -16,7 +16,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/google/go-github/v80/github"
+	"github.com/google/go-github/v82/github"
 )
 
 // PendingMetadataCacheKey is the key for the set that stores a list of

--- a/shared/run_diff.go
+++ b/shared/run_diff.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/v80/github"
+	"github.com/google/go-github/v82/github"
 
 	mapset "github.com/deckarep/golang-set"
 )

--- a/shared/sharedtest/appengine_mock.go
+++ b/shared/sharedtest/appengine_mock.go
@@ -16,7 +16,7 @@ import (
 	reflect "reflect"
 	time "time"
 
-	github "github.com/google/go-github/v80/github"
+	github "github.com/google/go-github/v82/github"
 	shared "github.com/web-platform-tests/wpt.fyi/shared"
 	gomock "go.uber.org/mock/gomock"
 )

--- a/shared/sharedtest/github_oauth_mock.go
+++ b/shared/sharedtest/github_oauth_mock.go
@@ -13,7 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
-	github "github.com/google/go-github/v80/github"
+	github "github.com/google/go-github/v82/github"
 	shared "github.com/web-platform-tests/wpt.fyi/shared"
 	gomock "go.uber.org/mock/gomock"
 	oauth2 "golang.org/x/oauth2"

--- a/shared/triage_metadata.go
+++ b/shared/triage_metadata.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/v80/github"
+	"github.com/google/go-github/v82/github"
 	"gopkg.in/yaml.v3"
 )
 

--- a/shared/web_features_manifest_github_download.go
+++ b/shared/web_features_manifest_github_download.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/v80/github"
+	"github.com/google/go-github/v82/github"
 )
 
 // WebFeatureManifestRepo is where the web feature manifest is published.

--- a/shared/web_features_manifest_github_download_test.go
+++ b/shared/web_features_manifest_github_download_test.go
@@ -18,7 +18,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/google/go-github/v80/github"
+	"github.com/google/go-github/v82/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/webapp/login_test.go
+++ b/webapp/login_test.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/go-github/v80/github"
+	"github.com/google/go-github/v82/github"
 	"github.com/gorilla/securecookie"
 	"github.com/stretchr/testify/assert"
 


### PR DESCRIPTION
Part of the Interop Tooling rotation for the first full week of the month.

```
find . -name "*.go"| xargs sed -i 's/go-github\/v80/go-github\/v82/'
find . -name "*.go"| xargs sed -i 's/taskcluster\/v95/taskcluster\/v96/'
```

```
go get -u ./...
go mod tidy
```