### PR TITLE
Use 2025 label for 2026 anchor positioning

### DIFF
--- a/webapp/components/interop-data.js
+++ b/webapp/components/interop-data.js
@@ -1912,11 +1912,11 @@ export const interopData = {
         'description': 'CSS anchor positioning',
         'mdn': 'https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_anchor_positioning',
         'spec': 'https://drafts.csswg.org/css-anchor-position-1/',
-        'tests': '/results/css/css-anchor-position?label=master&product=chrome&product=edge&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2026-anchor-positioning',
-        'mobile_tests': '/results/css/css-anchor-position?label=master&product=chrome_android&product=firefox_android&aligned&view=interop&q=label%3Ainterop-2026-anchor-positioning',
+        'tests': '/results/css/css-anchor-position?label=master&product=chrome&product=edge&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2025-anchor-positioning',
+        'mobile_tests': '/results/css/css-anchor-position?label=master&product=chrome_android&product=firefox_android&aligned&view=interop&q=label%3Ainterop-2025-anchor-positioning',
         'countsTowardScore': true,
         'labels': [
-          'interop-2026-anchor-positioning'
+          'interop-2025-anchor-positioning'
         ]
       },
       'interop-2026-attr': {

--- a/webapp/static/interop-data.json
+++ b/webapp/static/interop-data.json
@@ -1877,11 +1877,11 @@
         "description": "CSS anchor positioning",
         "mdn": "https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_anchor_positioning",
         "spec": "https://drafts.csswg.org/css-anchor-position-1/",
-        "tests": "/results/css/css-anchor-position?label=master&product=chrome&product=edge&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2026-anchor-positioning",
-        "mobile_tests": "/results/css/css-anchor-position?label=master&product=chrome_android&product=firefox_android&aligned&view=interop&q=label%3Ainterop-2026-anchor-positioning",
+        "tests": "/results/css/css-anchor-position?label=master&product=chrome&product=edge&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2025-anchor-positioning",
+        "mobile_tests": "/results/css/css-anchor-position?label=master&product=chrome_android&product=firefox_android&aligned&view=interop&q=label%3Ainterop-2025-anchor-positioning",
         "countsTowardScore": true,
         "labels": [
-          "interop-2026-anchor-positioning"
+          "interop-2025-anchor-positioning"
         ]
       },
       "interop-2026-attr": {


### PR DESCRIPTION
Per discussion, no new tests are being added to the anchor positioning focus area, and the 2025 label will simply be reused. This means that the 2026 label is being removed from all tests, and we should just use the 2025 label in links to tests to represent the focus area.