### PR TITLE
Change interop year to 2026 on mobile

### DIFF
--- a/webapp/components/wpt-header.js
+++ b/webapp/components/wpt-header.js
@@ -220,7 +220,7 @@ class WPTHeader extends WPTFlags(PolymerElement) {
       <div id="mobile-navigation" class$="[[_computeNavLinksClass(_isMenuOpen)]]">
         <a href="/">Latest Run</a>
         <a href="/runs">Recent Runs</a>
-        <a href="/interop">&#10024;Interop 2025&#10024;</a>
+        <a href="/interop">&#10024;Interop 2026&#10024;</a>
         <a href="/insights">Insights</a>
         <template is="dom-if" if="[[processorTab]]">
           <a href="/status">Processor</a>


### PR DESCRIPTION
This can only be seen in the hamburger menu on the Interop dashboard.

A version with this change has already been deployed ahead of the Interop 2026 dashboard release. 😅 