### PR TITLE
fix: update go version in Dockerfiles to 1.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # vim: set expandtab sw=4
-FROM golang:1.25.7-bookworm
+FROM golang:1.26.0-bookworm
 
 # Create a non-priviledged user to run browsers as (Firefox and Chrome do not
 # like to run as root).

--- a/api/query/cache/service/Dockerfile
+++ b/api/query/cache/service/Dockerfile
@@ -1,6 +1,6 @@
 # Production deployment spec for query cache service.
 
-FROM golang:1.25.7-bookworm as builder
+FROM golang:1.26.0-bookworm as builder
 
 RUN apt-get update
 RUN apt-get install -qy --no-install-suggests git

--- a/webapp/web/Dockerfile
+++ b/webapp/web/Dockerfile
@@ -1,6 +1,6 @@
 # Production deployment spec for the webapp.
 
-FROM golang:1.25.7-bookworm as builder
+FROM golang:1.26.0-bookworm as builder
 
 RUN apt-get update
 RUN apt-get install -qy --no-install-suggests git sudo


### PR DESCRIPTION
Currently blocking: https://github.com/web-platform-tests/wpt.fyi/pull/4772

```
go: go.mod requires go >= 1.26.0 (running go 1.25.7; GOTOOLCHAIN=local)
```