### PR TITLE
Bump node version from v18 to 20v as the yargs package now requires v20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN chmod a+rx $HOME && useradd --uid 9999 --user-group --create-home browser
 RUN export DISTRO_CODENAME=$(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) && \
     echo "deb [signed-by=/usr/share/keyrings/corretto.gpg] https://apt.corretto.aws stable main" > /etc/apt/sources.list.d/corretto.list && \
     curl -s https://apt.corretto.aws/corretto.key | gpg --dearmor -o /usr/share/keyrings/corretto.gpg && \
-    export NODE_VERSION="18.x" && \
+    export NODE_VERSION="20.x" && \
     export ARCH=$(dpkg --print-architecture) && \
     echo "deb [arch=$ARCH signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_VERSION nodistro main" > /etc/apt/sources.list.d/nodesource.list && \
     curl -s https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg && \

--- a/Makefile
+++ b/Makefile
@@ -270,7 +270,7 @@ inotifywait:
 
 node: curl gpg
 	if [[ "$$(which node)" == "" ]]; then \
-		curl -sL https://deb.nodesource.com/setup_18.x | sudo -E bash -; \
+		curl -sL https://deb.nodesource.com/setup_20.x | sudo -E bash -; \
 		sudo apt-get install -qqy nodejs; \
 	fi
 


### PR DESCRIPTION
This is required for PR #4782 to succeed.