### PR TITLE
Remove old feature flags

### DIFF
--- a/api/checks/api.go
+++ b/api/checks/api.go
@@ -24,8 +24,7 @@ const (
 	wptRepoInstallationID        = int64(577173)
 	wptRepoStagingInstallationID = int64(449270)
 
-	wptRepoID                = int64(3618133)
-	checksForAllUsersFeature = "checksAllUsers"
+	wptRepoID = int64(3618133)
 )
 
 // API abstracts all the API calls used externally.

--- a/api/checks/update.go
+++ b/api/checks/update.go
@@ -25,7 +25,6 @@ import (
 const CheckProcessingQueue = "check-processing"
 
 const failChecksOnRegressionFeature = "failChecksOnRegression"
-const onlyChangesAsRegressionsFeature = "onlyChangesAsRegressions"
 
 // updateCheckHandler handles /api/checks/[commit] POST requests.
 func updateCheckHandler(w http.ResponseWriter, r *http.Request) {
@@ -251,17 +250,13 @@ func getDiffSummary(
 	}
 
 	var regressions mapset.Set
-	if aeAPI.IsFeatureEnabled(onlyChangesAsRegressionsFeature) {
-		// nolint:exhaustruct // TODO: Fix exhaustruct lint error.
-		regressionFilter := shared.DiffFilterParam{Changed: true} // Only changed items
-		changeOnlyDiff, err := diffAPI.GetRunsDiff(baseRun, headRun, regressionFilter, nil)
-		if err != nil {
-			return nil, err
-		}
-		regressions = changeOnlyDiff.Differences.Regressions()
-	} else {
-		regressions = diff.Differences.Regressions()
+	// nolint:exhaustruct // TODO: Fix exhaustruct lint error.
+	regressionFilter := shared.DiffFilterParam{Changed: true} // Only changed items
+	changeOnlyDiff, err := diffAPI.GetRunsDiff(baseRun, headRun, regressionFilter, nil)
+	if err != nil {
+		return nil, err
 	}
+	regressions = changeOnlyDiff.Differences.Regressions()
 	hasRegressions := regressions.Cardinality() > 0
 	neutral := "neutral"
 	checkState.Conclusion = &neutral

--- a/api/checks/update_test.go
+++ b/api/checks/update_test.go
@@ -17,42 +17,33 @@ import (
 )
 
 func TestGetDiffSummary_Regressed(t *testing.T) {
-	testSummary := func(enabled bool) {
-		t.Run(fmt.Sprintf("%s=%v", onlyChangesAsRegressionsFeature, enabled), func(t *testing.T) {
-			mockCtrl := gomock.NewController(t)
-			defer mockCtrl.Finish()
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
 
-			before, after := getBeforeAndAfterRuns()
-			runDiff := shared.RunDiff{
-				Differences: shared.ResultsDiff{"/foo.html": shared.TestDiff{0, 1, 0}},
-			}
-
-			aeAPI := sharedtest.NewMockAppEngineAPI(mockCtrl)
-			aeAPI.EXPECT().Context().AnyTimes().Return(context.Background())
-			aeAPI.EXPECT().IsFeatureEnabled(onlyChangesAsRegressionsFeature).Return(enabled)
-			aeAPI.EXPECT().IsFeatureEnabled(failChecksOnRegressionFeature).Return(false)
-			aeAPI.EXPECT().GetHostname()
-			diffAPI := sharedtest.NewMockDiffAPI(mockCtrl)
-			diffAPI.EXPECT().GetRunsDiff(before, after, sharedtest.SameDiffFilter("ADC"), gomock.Any()).Return(runDiff, nil)
-			if enabled {
-				diffAPI.EXPECT().GetRunsDiff(before, after, sharedtest.SameDiffFilter("C"), gomock.Any()).Return(runDiff, nil)
-			}
-			diffURL, _ := url.Parse("https://wpt.fyi/results?diff")
-			diffAPI.EXPECT().GetDiffURL(before, after, gomock.Any()).Return(diffURL)
-			diffAPI.EXPECT().GetMasterDiffURL(after, sharedtest.SameDiffFilter("ACU")).Return(diffURL)
-			suite := shared.CheckSuite{
-				PRNumbers: []int{123},
-			}
-
-			summary, err := getDiffSummary(aeAPI, diffAPI, suite, before, after)
-			assert.Nil(t, err)
-			_, ok := summary.(summaries.Regressed)
-			assert.True(t, ok)
-			assert.Equal(t, suite.PRNumbers, summary.GetCheckState().PRNumbers)
-		})
+	before, after := getBeforeAndAfterRuns()
+	runDiff := shared.RunDiff{
+		Differences: shared.ResultsDiff{"/foo.html": shared.TestDiff{0, 1, 0}},
 	}
-	testSummary(false)
-	testSummary(true)
+
+	aeAPI := sharedtest.NewMockAppEngineAPI(mockCtrl)
+	aeAPI.EXPECT().Context().AnyTimes().Return(context.Background())
+	aeAPI.EXPECT().IsFeatureEnabled(failChecksOnRegressionFeature).Return(false)
+	aeAPI.EXPECT().GetHostname()
+	diffAPI := sharedtest.NewMockDiffAPI(mockCtrl)
+	diffAPI.EXPECT().GetRunsDiff(before, after, sharedtest.SameDiffFilter("ADC"), gomock.Any()).Return(runDiff, nil)
+	diffAPI.EXPECT().GetRunsDiff(before, after, sharedtest.SameDiffFilter("C"), gomock.Any()).Return(runDiff, nil)
+	diffURL, _ := url.Parse("https://wpt.fyi/results?diff")
+	diffAPI.EXPECT().GetDiffURL(before, after, gomock.Any()).Return(diffURL)
+	diffAPI.EXPECT().GetMasterDiffURL(after, sharedtest.SameDiffFilter("ACU")).Return(diffURL)
+	suite := shared.CheckSuite{
+		PRNumbers: []int{123},
+	}
+
+	summary, err := getDiffSummary(aeAPI, diffAPI, suite, before, after)
+	assert.Nil(t, err)
+	_, ok := summary.(summaries.Regressed)
+	assert.True(t, ok)
+	assert.Equal(t, suite.PRNumbers, summary.GetCheckState().PRNumbers)
 }
 
 func TestGetDiffSummary_Completed(t *testing.T) {
@@ -66,11 +57,11 @@ func TestGetDiffSummary_Completed(t *testing.T) {
 
 	aeAPI := sharedtest.NewMockAppEngineAPI(mockCtrl)
 	aeAPI.EXPECT().Context().AnyTimes().Return(context.Background())
-	aeAPI.EXPECT().IsFeatureEnabled(onlyChangesAsRegressionsFeature).Return(false)
 	aeAPI.EXPECT().IsFeatureEnabled(failChecksOnRegressionFeature).Return(false)
 	aeAPI.EXPECT().GetHostname()
 	diffAPI := sharedtest.NewMockDiffAPI(mockCtrl)
-	diffAPI.EXPECT().GetRunsDiff(before, after, gomock.Any(), gomock.Any()).Return(runDiff, nil)
+	diffAPI.EXPECT().GetRunsDiff(before, after, sharedtest.SameDiffFilter("ADC"), gomock.Any()).Return(runDiff, nil)
+	diffAPI.EXPECT().GetRunsDiff(before, after, sharedtest.SameDiffFilter("C"), gomock.Any()).Return(runDiff, nil)
 	diffURL, _ := url.Parse("https://wpt.fyi/results?diff")
 	diffAPI.EXPECT().GetDiffURL(before, after, gomock.Any()).Return(diffURL)
 	diffAPI.EXPECT().GetMasterDiffURL(after, sharedtest.SameDiffFilter("ACU")).Return(diffURL)

--- a/api/checks/webhook.go
+++ b/api/checks/webhook.go
@@ -137,13 +137,6 @@ func handleCheckSuiteEvent(api API, payload []byte) (bool, error) {
 		return false, nil
 	}
 
-	login := checkSuite.GetSender().GetLogin()
-	if !checksEnabledForUser(api, login) {
-		log.Infof("Checks not enabled for sender %s", login)
-
-		return false, nil
-	}
-
 	// nolint:nestif // TODO: Fix nestif lint error
 	if action == requestedAction || action == rerequestedAction {
 		pullRequests := checkSuite.GetCheckSuite().PullRequests
@@ -206,11 +199,6 @@ func handleCheckRunEvent(
 	}
 
 	login := checkRun.GetSender().GetLogin()
-	if !checksEnabledForUser(api, login) {
-		log.Infof("Checks not enabled for sender %s", login)
-
-		return false, nil
-	}
 
 	// Determine whether or not we need to schedule processing the results
 	// of a CheckRun. The 'requested_action' event occurs when a user
@@ -284,13 +272,6 @@ func handlePullRequestEvent(api API, payload []byte) (bool, error) {
 	var pullRequest github.PullRequestEvent
 	if err := json.Unmarshal(payload, &pullRequest); err != nil {
 		return false, err
-	}
-
-	login := pullRequest.GetPullRequest().GetUser().GetLogin()
-	if !checksEnabledForUser(api, login) {
-		log.Infof("Checks not enabled for sender %s", login)
-
-		return false, nil
 	}
 
 	switch pullRequest.GetAction() {
@@ -369,24 +350,4 @@ func createCheckRun(ctx context.Context, suite shared.CheckSuite, opts github.Cr
 	}
 
 	return true, nil
-}
-
-// checksEnabledForUser returns if a commit from a given GitHub username should
-// cause wpt.fyi or staging.wpt.fyi summary results to show up in the GitHub
-// UI. Currently this is enabled for all users on prod, but only for some users
-// on staging to avoid having a confusing double-set of checks appear.
-func checksEnabledForUser(api API, login string) bool {
-	if api.IsFeatureEnabled(checksForAllUsersFeature) {
-		return true
-	}
-	enabledLogins := []string{
-		"chromium-wpt-export-bot",
-		"gsnedders",
-		"jgraham",
-		"jugglinmike",
-		"lukebjerring",
-		"Ms2ger",
-	}
-
-	return shared.StringSliceContains(enabledLogins, login)
 }

--- a/api/checks/webhook_test.go
+++ b/api/checks/webhook_test.go
@@ -52,24 +52,6 @@ func TestHandleCheckRunEvent_Created_Completed(t *testing.T) {
 
 	api := mock_checks.NewMockAPI(mockCtrl)
 	api.EXPECT().Context().AnyTimes().Return(sharedtest.NewTestContext())
-	api.EXPECT().IsFeatureEnabled(checksForAllUsersFeature).Return(false)
-
-	processed, err := handleCheckRunEvent(api, payload)
-	assert.Nil(t, err)
-	assert.False(t, processed)
-}
-
-func TestHandleCheckRunEvent_Created_Pending_ChecksNotEnabledForUser(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	sha := strings.Repeat("0123456789", 4)
-	event := getCheckRunCreatedEvent("pending", "user-without-checks", sha)
-	payload, _ := json.Marshal(event)
-
-	api := mock_checks.NewMockAPI(mockCtrl)
-	api.EXPECT().Context().AnyTimes().Return(sharedtest.NewTestContext())
-	api.EXPECT().IsFeatureEnabled(checksForAllUsersFeature).Return(false)
 
 	processed, err := handleCheckRunEvent(api, payload)
 	assert.Nil(t, err)
@@ -86,7 +68,6 @@ func TestHandleCheckRunEvent_Created_Pending(t *testing.T) {
 
 	api := mock_checks.NewMockAPI(mockCtrl)
 	api.EXPECT().Context().AnyTimes().Return(sharedtest.NewTestContext())
-	api.EXPECT().IsFeatureEnabled(checksForAllUsersFeature).Return(false)
 	api.EXPECT().ScheduleResultsProcessing(sha, sharedtest.SameProductSpec("chrome")).Return(nil)
 
 	processed, err := handleCheckRunEvent(api, payload)
@@ -129,7 +110,6 @@ func TestHandleCheckRunEvent_ActionRequested_Ignore(t *testing.T) {
 
 			api := mock_checks.NewMockAPI(mockCtrl)
 			api.EXPECT().Context().AnyTimes().Return(sharedtest.NewTestContext())
-			api.EXPECT().IsFeatureEnabled(checksForAllUsersFeature).Return(false)
 			api.EXPECT().IgnoreFailure(username, owner, repo, event.GetCheckRun(), event.GetInstallation())
 
 			processed, err := handleCheckRunEvent(api, payload)
@@ -174,7 +154,6 @@ func TestHandleCheckRunEvent_ActionRequested_Recompute(t *testing.T) {
 
 			api := mock_checks.NewMockAPI(mockCtrl)
 			api.EXPECT().Context().AnyTimes().Return(sharedtest.NewTestContext())
-			api.EXPECT().IsFeatureEnabled(checksForAllUsersFeature).Return(false)
 			api.EXPECT().ScheduleResultsProcessing(sha, sharedtest.SameProductSpec("chrome[experimental]")).Return(nil)
 
 			processed, err := handleCheckRunEvent(api, payload)
@@ -198,7 +177,6 @@ func TestHandleCheckRunEvent_ActionRequested_Cancel(t *testing.T) {
 
 	api := mock_checks.NewMockAPI(mockCtrl)
 	api.EXPECT().Context().AnyTimes().Return(sharedtest.NewTestContext())
-	api.EXPECT().IsFeatureEnabled(checksForAllUsersFeature).Return(false)
 	api.EXPECT().CancelRun(username, shared.WPTRepoOwner, shared.WPTRepoName, event.GetCheckRun(), event.GetInstallation())
 
 	processed, err := handleCheckRunEvent(api, payload)
@@ -228,23 +206,6 @@ func getCheckRunCreatedEvent(status, sender, sha string) github.CheckRunEvent {
 	}
 }
 
-func TestHandlePullRequestEvent_ChecksNotEnabledForUser(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-
-	sha := strings.Repeat("1234567890", 4)
-	event := getOpenedPREvent("user-without-checks", sha)
-	payload, _ := json.Marshal(event)
-
-	api := mock_checks.NewMockAPI(mockCtrl)
-	api.EXPECT().Context().AnyTimes().Return(sharedtest.NewTestContext())
-	api.EXPECT().IsFeatureEnabled(checksForAllUsersFeature).Return(false)
-
-	processed, err := handlePullRequestEvent(api, payload)
-	assert.Nil(t, err)
-	assert.False(t, processed)
-}
-
 func TestHandlePullRequestEvent_ChecksEnabledForUser(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
@@ -255,7 +216,6 @@ func TestHandlePullRequestEvent_ChecksEnabledForUser(t *testing.T) {
 
 	api := mock_checks.NewMockAPI(mockCtrl)
 	api.EXPECT().Context().AnyTimes().Return(sharedtest.NewTestContext())
-	api.EXPECT().IsFeatureEnabled(checksForAllUsersFeature).Return(false)
 	api.EXPECT().GetWPTRepoAppInstallationIDs().Return(wptfyiStagingCheckAppID, wptRepoStagingInstallationID)
 	api.EXPECT().CreateWPTCheckSuite(wptfyiStagingCheckAppID, wptRepoStagingInstallationID, sha, 123).Return(true, nil)
 

--- a/api/test_runs.go
+++ b/api/test_runs.go
@@ -15,7 +15,6 @@ import (
 
 // nolint:gosec // TODO: Fix gosec lint error (G101)
 const nextPageTokenHeaderName = "wpt-next-page"
-const paginationTokenFeatureFlagName = "paginationTokens"
 
 // apiTestRunsHandler is responsible for emitting test-run JSON for all the runs at a given SHA.
 //
@@ -69,11 +68,9 @@ func apiTestRunsHandler(w http.ResponseWriter, r *http.Request) {
 
 		if err == nil {
 			testRuns = runsByProduct.AllRuns()
-			if aeAPI.IsFeatureEnabled(paginationTokenFeatureFlagName) {
-				nextPage := filters.NextPage(runsByProduct)
-				if nextPage != nil {
-					nextPageToken, _ = nextPage.Token()
-				}
+			nextPage := filters.NextPage(runsByProduct)
+			if nextPage != nil {
+				nextPageToken, _ = nextPage.Token()
 			}
 		}
 	}

--- a/api/test_runs.go
+++ b/api/test_runs.go
@@ -55,7 +55,7 @@ func apiTestRunsHandler(w http.ResponseWriter, r *http.Request) {
 
 			return
 		}
-		if pr != nil && aeAPI.IsFeatureEnabled("runsByPRNumber") {
+		if pr != nil {
 			filters.SHAs = getPRCommits(aeAPI, *pr)
 			if len(filters.SHAs) < 1 {
 				log.Warningf("PR %v returned no commits from GitHub", *pr)

--- a/api/test_runs_medium_test.go
+++ b/api/test_runs_medium_test.go
@@ -233,17 +233,8 @@ func TestGetTestRuns_Pagination(t *testing.T) {
 
 	r, _ = i.NewRequest("GET", "/api/runs?product=chrome&max-count=2", nil)
 	resp := httptest.NewRecorder()
-
-	// Feature disabled
 	apiTestRunsHandler(resp, r)
 	next := resp.Header().Get(nextPageTokenHeaderName)
-	assert.Equal(t, "", next)
-
-	// Feature enabled
-	shared.SetFeature(store, shared.Flag{Name: paginationTokenFeatureFlagName, Enabled: true})
-	resp = httptest.NewRecorder()
-	apiTestRunsHandler(resp, r)
-	next = resp.Header().Get(nextPageTokenHeaderName)
 	assert.NotEqual(t, "", next)
 
 	body, _ := io.ReadAll(resp.Result().Body)

--- a/api/user.go
+++ b/api/user.go
@@ -21,13 +21,6 @@ type loginFailureResponse struct {
 
 func apiUserHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	aeAPI := shared.NewAppEngineAPI(ctx)
-	if !aeAPI.IsFeatureEnabled("githubLogin") {
-		http.Error(w, "Feature not enabled", http.StatusNotImplemented)
-
-		return
-	}
-
 	ds := shared.NewAppEngineDatastore(ctx, false)
 	user, _ := shared.GetUserFromCookie(ctx, ds, r)
 	if user == nil {

--- a/shared/run_diff.go
+++ b/shared/run_diff.go
@@ -347,37 +347,6 @@ func FetchRunResultsJSON(ctx context.Context, run TestRun) (results ResultsSumma
 
 // GetRunsDiff returns a RunDiff for the given runs.
 func (d diffAPIImpl) GetRunsDiff(before, after TestRun, filter DiffFilterParam, paths mapset.Set) (diff RunDiff, err error) {
-	store := NewAppEngineDatastore(d.ctx, false)
-	if IsFeatureEnabled(store, "searchcacheDiffs") {
-		return d.getRunsDiffFromSearchCache(before, after, filter, paths)
-	}
-	beforeJSON, err := FetchRunResultsJSON(d.ctx, before)
-	if err != nil {
-		return diff, fmt.Errorf("failed to fetch 'before' results: %s", err.Error())
-	}
-	afterJSON, err := FetchRunResultsJSON(d.ctx, after)
-	if err != nil {
-		return diff, fmt.Errorf("failed to fetch 'after' results: %s", err.Error())
-	}
-
-	var renames map[string]string
-	beforeSHA := before.FullRevisionHash
-	// Use HEAD...[sha] for PR results, since PR run results always override the value of 'revision' to the PRs HEAD revision.
-	if before.FullRevisionHash == after.FullRevisionHash && before.IsPRBase() {
-		beforeSHA = "HEAD"
-	}
-	renames = getDiffRenames(d.aeAPI, beforeSHA, after.FullRevisionHash)
-	return RunDiff{
-		Before:        before,
-		BeforeSummary: beforeJSON,
-		After:         after,
-		AfterSummary:  afterJSON,
-		Differences:   GetResultsDiff(beforeJSON, afterJSON, filter, paths, renames),
-		Renames:       renames,
-	}, nil
-}
-
-func (d diffAPIImpl) getRunsDiffFromSearchCache(before, after TestRun, filter DiffFilterParam, paths mapset.Set) (diff RunDiff, err error) {
 	diffURL, _ := url.Parse(fmt.Sprintf("https://%s/api/search", d.aeAPI.GetVersionedHostname()))
 	query := diffURL.Query()
 	query.Set("diff", "")

--- a/shared/run_diff.go
+++ b/shared/run_diff.go
@@ -361,14 +361,12 @@ func (d diffAPIImpl) GetRunsDiff(before, after TestRun, filter DiffFilterParam, 
 	}
 
 	var renames map[string]string
-	if d.aeAPI.IsFeatureEnabled("diffRenames") {
-		beforeSHA := before.FullRevisionHash
-		// Use HEAD...[sha] for PR results, since PR run results always override the value of 'revision' to the PRs HEAD revision.
-		if before.FullRevisionHash == after.FullRevisionHash && before.IsPRBase() {
-			beforeSHA = "HEAD"
-		}
-		renames = getDiffRenames(d.aeAPI, beforeSHA, after.FullRevisionHash)
+	beforeSHA := before.FullRevisionHash
+	// Use HEAD...[sha] for PR results, since PR run results always override the value of 'revision' to the PRs HEAD revision.
+	if before.FullRevisionHash == after.FullRevisionHash && before.IsPRBase() {
+		beforeSHA = "HEAD"
 	}
+	renames = getDiffRenames(d.aeAPI, beforeSHA, after.FullRevisionHash)
 	return RunDiff{
 		Before:        before,
 		BeforeSummary: beforeJSON,
@@ -427,14 +425,12 @@ func RunDiffFromSearchResponse(aeAPI AppEngineAPI, before, after TestRun, scDiff
 	}
 
 	var renames map[string]string
-	if aeAPI.IsFeatureEnabled("diffRenames") {
-		beforeSHA := before.FullRevisionHash
-		// Use HEAD...[sha] for PR results, since PR run results always override the value of 'revision' to the PRs HEAD revision.
-		if before.FullRevisionHash == after.FullRevisionHash && before.IsPRBase() {
-			beforeSHA = "HEAD"
-		}
-		renames = getDiffRenames(aeAPI, beforeSHA, after.FullRevisionHash)
+	beforeSHA := before.FullRevisionHash
+	// Use HEAD...[sha] for PR results, since PR run results always override the value of 'revision' to the PRs HEAD revision.
+	if before.FullRevisionHash == after.FullRevisionHash && before.IsPRBase() {
+		beforeSHA = "HEAD"
 	}
+	renames = getDiffRenames(aeAPI, beforeSHA, after.FullRevisionHash)
 
 	return RunDiff{
 		Before:        before,

--- a/shared/run_diff_test.go
+++ b/shared/run_diff_test.go
@@ -238,7 +238,6 @@ func TestRunDiffFromSearchResponse(t *testing.T) {
 	defer mockCtrl.Finish()
 	aeAPI := sharedtest.NewMockAppEngineAPI(mockCtrl)
 	aeAPI.EXPECT().Context().AnyTimes().Return(context.Background())
-	aeAPI.EXPECT().IsFeatureEnabled("diffRenames").Return(false)
 
 	diff, err := shared.RunDiffFromSearchResponse(aeAPI, shared.TestRun{}, shared.TestRun{}, scDiff)
 	assert.Nil(t, err)

--- a/util/populate_dev_data.go
+++ b/util/populate_dev_data.go
@@ -163,7 +163,6 @@ func main() {
 
 	log.Print("Adding flag defaults...")
 	addFlag(store, "diffFilter", enabledFlag)
-	addFlag(store, "diffFromAPI", enabledFlag)
 
 	log.Print("Adding uploader \"test\"...")
 	addData(store, "Uploader", []interface{}{

--- a/util/populate_dev_data.go
+++ b/util/populate_dev_data.go
@@ -162,7 +162,6 @@ func main() {
 	})
 
 	log.Print("Adding flag defaults...")
-	addFlag(store, "queryBuilder", enabledFlag)
 	addFlag(store, "diffFilter", enabledFlag)
 	addFlag(store, "diffFromAPI", enabledFlag)
 	addFlag(store, "structuredQueries", enabledFlag)

--- a/util/populate_dev_data.go
+++ b/util/populate_dev_data.go
@@ -164,7 +164,6 @@ func main() {
 	log.Print("Adding flag defaults...")
 	addFlag(store, "diffFilter", enabledFlag)
 	addFlag(store, "diffFromAPI", enabledFlag)
-	addFlag(store, "paginationTokens", enabledFlag)
 
 	log.Print("Adding uploader \"test\"...")
 	addData(store, "Uploader", []interface{}{

--- a/util/populate_dev_data.go
+++ b/util/populate_dev_data.go
@@ -164,7 +164,6 @@ func main() {
 	log.Print("Adding flag defaults...")
 	addFlag(store, "diffFilter", enabledFlag)
 	addFlag(store, "diffFromAPI", enabledFlag)
-	addFlag(store, "structuredQueries", enabledFlag)
 	addFlag(store, "diffRenames", enabledFlag)
 	addFlag(store, "paginationTokens", enabledFlag)
 

--- a/util/populate_dev_data.go
+++ b/util/populate_dev_data.go
@@ -164,7 +164,6 @@ func main() {
 	log.Print("Adding flag defaults...")
 	addFlag(store, "diffFilter", enabledFlag)
 	addFlag(store, "diffFromAPI", enabledFlag)
-	addFlag(store, "diffRenames", enabledFlag)
 	addFlag(store, "paginationTokens", enabledFlag)
 
 	log.Print("Adding uploader \"test\"...")

--- a/webapp/components/test-file-results-table.js
+++ b/webapp/components/test-file-results-table.js
@@ -450,7 +450,7 @@ class TestFileResultsTable extends WPTFlags(Pluralizer(AmendMetadataMixin(WPTCol
   }
 
   canAmendMetadata(status) {
-    return this.hasFailed(status) && this.triageMetadataUI && this.isTriageMode;
+    return this.hasFailed(status) && this.isTriageMode;
   }
 
   hasFailed(status) {

--- a/webapp/components/test-file-results-table.js
+++ b/webapp/components/test-file-results-table.js
@@ -504,7 +504,7 @@ class TestFileResultsTable extends WPTFlags(Pluralizer(AmendMetadataMixin(WPTCol
       return false;
     }
 
-    return this.displayMetadata && this.getMetadataUrlForSubtest(index, subtestname, metadataMap) !== '';
+    return this.getMetadataUrlForSubtest(index, subtestname, metadataMap) !== '';
   }
 
   shouldShowTotals(totals) {

--- a/webapp/components/test-file-results.js
+++ b/webapp/components/test-file-results.js
@@ -115,7 +115,7 @@ class TestFileResults extends WPTFlags(LoadingState(PathInfo(
   }
 
   async fetchSearchResults(path, testRuns, structuredSearch) {
-    if (!testRuns || !testRuns.length || !this.structuredQueries || !structuredSearch) {
+    if (!testRuns || !testRuns.length || !structuredSearch) {
       return;
     }
 

--- a/webapp/components/test-run.js
+++ b/webapp/components/test-run.js
@@ -66,15 +66,10 @@ class TestRun extends WPTFlags(ProductInfo(PolymerElement)) {
         <div>{{displayName(testRun.browser_name)}} {{shortVersion(testRun.browser_name, testRun.browser_version)}}</div>
         <template is="dom-if" if="{{ !isDiff(testRun.browser_name) }}">
           <div>{{displayName(testRun.os_name)}} {{testRun.os_version}}</div>
-          <template is="dom-if" if="[[githubCommitLinks]]">
-            <a class="github" href="https://github.com/web-platform-tests/wpt/commit/[[testRun.revision]]">
-              <img src="/static/github.svg" alt="GitHub logo">
-              [[sevenCharSHA(testRun.revision)]]
-            </a>
-          </template>
-          <template is="dom-if" if="[[!githubCommitLinks]]">
-            <div class="revision">@<a href="?sha={{testRun.revision}}">{{testRun.revision}}</a></div>
-          </template>
+          <a class="github" href="https://github.com/web-platform-tests/wpt/commit/[[testRun.revision]]">
+            <img src="/static/github.svg" alt="GitHub logo">
+            [[sevenCharSHA(testRun.revision)]]
+          </a>
           <div>{{dateFormat(testRun.time_start)}}</div>
         </template>
       </template>

--- a/webapp/components/test-runs-query-builder.js
+++ b/webapp/components/test-runs-query-builder.js
@@ -96,15 +96,13 @@ class TestRunsQueryBuilder extends WPTFlags(TestRunsUIQuery(PolymerElement)) {
       <paper-input label="Labels" always-float-label placeholder="e.g. stable,buildbot" value="{{ labelsString::input }}">
       </paper-input>
     </paper-item>
-    <template is="dom-if" if="[[queryBuilderSHA]]">
-      <paper-item>
-        <paper-input-container always-float-label>
-          <label slot="label">SHA</label>
-          <input name="os_version" placeholder="(Latest)" list="shas-datalist" value="{{ _sha::input }}" slot="input">
-          <datalist id="shas-datalist"></datalist>
-        </paper-input-container>
-      </paper-item>
-    </template>
+    <paper-item>
+      <paper-input-container always-float-label>
+        <label slot="label">SHA</label>
+        <input name="os_version" placeholder="(Latest)" list="shas-datalist" value="{{ _sha::input }}" slot="input">
+        <datalist id="shas-datalist"></datalist>
+      </paper-input-container>
+    </paper-item>
     <br>
     <paper-button raised id="add-button" onclick="[[addProduct]]">
       <iron-icon icon="add"></iron-icon> Add product
@@ -239,7 +237,7 @@ class TestRunsQueryBuilder extends WPTFlags(TestRunsUIQuery(PolymerElement)) {
 
   // Respond to newly fetched shas, or user input, by filtering the autocomplete list.
   shasUpdated(sha, matchingSHAs) {
-    if (!matchingSHAs || !matchingSHAs.length || !this.queryBuilderSHA) {
+    if (!matchingSHAs || !matchingSHAs.length) {
       return;
     }
     if (sha) {

--- a/webapp/components/test-search.js
+++ b/webapp/components/test-search.js
@@ -474,16 +474,14 @@ class TestSearch extends WPTFlags(PolymerElement) {
 
   queryUpdated(query) {
     this.queryInput = query;
-    if (this.structuredQueries) {
-      if (!query) {
-        this.structuredQuery = null;
-      } else {
-        try {
-          this.structuredQuery = Object.freeze(this.parseAndInterpretQuery(query));
-        // eslint-disable-next-line no-unused-vars
-        } catch (err) {
-          // TODO: Handle query parse/interpret error.
-        }
+    if (!query) {
+      this.structuredQuery = null;
+    } else {
+      try {
+        this.structuredQuery = Object.freeze(this.parseAndInterpretQuery(query));
+      // eslint-disable-next-line no-unused-vars
+      } catch (err) {
+        // TODO: Handle query parse/interpret error.
       }
     }
   }

--- a/webapp/components/test/test-search.html
+++ b/webapp/components/test/test-search.html
@@ -1013,7 +1013,6 @@ suite('<test-search>', () => {
 
       setup(() => {
         search_fixture = fixture('test-search-fixture');
-        search_fixture._setStructuredQueries(true);
       });
 
       test('does not lowerCase', () => {

--- a/webapp/components/test/wpt-flags.html
+++ b/webapp/components/test/wpt-flags.html
@@ -28,30 +28,30 @@ suite('wpt-flags', () => {
       flags = document.createElement('wpt-flags');
     });
 
-    test('queryBuilder', () => {
-      const before = flags.queryBuilder;
-      flags.queryBuilder = !flags.queryBuilder;
-      expect(flags.queryBuilder).to.equal(before);
+    test('colorHomepage', () => {
+      const before = flags.colorHomepage;
+      flags.colorHomepage = !flags.colorHomepage;
+      expect(flags.colorHomepage).to.equal(before);
     });
   });
 
   suite('WPTFlagsEditor', () => {
-    let editor, queryBuilderStateBefore;
+    let editor, colorHomepageStateBefore;
 
     setup(() => {
       editor = fixture('wpt-flags-editor-fixture');
-      queryBuilderStateBefore = editor.queryBuilder;
+      colorHomepageStateBefore = editor.colorHomepage;
     });
 
-    test('queryBuilder', () => {
-      editor.queryBuilder = true;
-      expect(editor.queryBuilder).to.equal(true);
-      editor.queryBuilder = false;
-      expect(editor.queryBuilder).to.equal(false);
+    test('colorHomepage', () => {
+      editor.colorHomepage = true;
+      expect(editor.colorHomepage).to.equal(true);
+      editor.colorHomepage = false;
+      expect(editor.colorHomepage).to.equal(false);
     });
 
     teardown(() => {
-      editor.queryBuilder = queryBuilderStateBefore;
+      editor.colorHomepage = colorHomepageStateBefore;
     });
   });
 
@@ -59,35 +59,43 @@ suite('wpt-flags', () => {
     let editor, sandbox;
 
     setup(() => {
+      // Clear localStorage to ensure tests start with a clean state
+      window.localStorage.removeItem('features.colorHomepage');
       editor = fixture('wpt-flags-editor-fixture');
       sandbox = sinon.sandbox.create();
     });
 
     teardown(() => {
       sandbox.restore();
+      // Clean up localStorage after tests
+      window.localStorage.removeItem('features.colorHomepage');
     });
 
     test('toggling checkboxes updates localStorage', () => {
       assert.isTrue(editor instanceof WPTFlagsEditor);
-      editor.queryBuilder = true;
-      expect(window.localStorage.getItem('features.queryBuilder')).to.equal('true');
-      editor.queryBuilder = false;
-      expect(window.localStorage.getItem('features.queryBuilder')).to.equal('false');
+      // Ensure we're starting from a different value to trigger the setter
+      editor.colorHomepage = false;
+      editor.colorHomepage = true;
+      expect(window.localStorage.getItem('features.colorHomepage')).to.equal('true');
+      editor.colorHomepage = false;
+      expect(window.localStorage.getItem('features.colorHomepage')).to.equal('false');
     });
 
     test('click updates localStorage', () => {
       assert.isTrue(editor instanceof WPTFlagsEditor);
-      editor.queryBuilder = true;
-      expect(window.localStorage.getItem('features.queryBuilder')).to.equal('true');
-      const queryBuilder = editor.shadowRoot.querySelector('#queryBuilder');
+      // Ensure we're starting from a different value to trigger the setter
+      editor.colorHomepage = false;
+      editor.colorHomepage = true;
+      expect(window.localStorage.getItem('features.colorHomepage')).to.equal('true');
+      const colorHomepage = editor.shadowRoot.querySelector('#colorHomepage');
 
       const flagUpdated = new Promise(resolve => {
         window.document.addEventListener('flagUpdated', () => resolve(), { once: true });
       });
 
-      queryBuilder.dispatchEvent(new MouseEvent('click'));
+      colorHomepage.dispatchEvent(new MouseEvent('click'));
       return flagUpdated.then(() => {
-        expect(window.localStorage.getItem('features.queryBuilder')).to.equal('false');
+        expect(window.localStorage.getItem('features.colorHomepage')).to.equal('false');
       });
     });
   });

--- a/webapp/components/test/wpt-results.html
+++ b/webapp/components/test/wpt-results.html
@@ -20,8 +20,12 @@ import { TEST_RUNS_DATA } from './util/helpers.js';
 
 suiteSetup(() => {
   window.fetch = (url) => {
-    const href = url instanceof URL ? url.href : 'unknown';
-    assert.fail('actual', 'expected', `uncaptured fetch: ${href}`);
+    const uCurrent = new URL(location.href);
+    const u = url instanceof URL ? url : new URL(url, uCurrent);
+    if (uCurrent.origin === u.origin && (u.pathname === '/api/shas' || u.pathname === '/api/versions')) {
+      return Promise.resolve(new Response(JSON.stringify([])));
+    }
+    assert.fail('actual', 'expected', `uncaptured fetch: ${u.href}`);
   };
 });
 

--- a/webapp/components/test/wpt-results.html
+++ b/webapp/components/test/wpt-results.html
@@ -22,7 +22,7 @@ suiteSetup(() => {
   window.fetch = (url) => {
     const uCurrent = new URL(location.href);
     const u = url instanceof URL ? url : new URL(url, uCurrent);
-    if (uCurrent.origin === u.origin && (u.pathname === '/api/shas' || u.pathname === '/api/versions')) {
+    if (uCurrent.origin === u.origin && (u.pathname === '/api/shas' || u.pathname === '/api/versions' || u.pathname === '/api/metadata/pending' || u.pathname === '/api/metadata')) {
       return Promise.resolve(new Response(JSON.stringify([])));
     }
     assert.fail('actual', 'expected', `uncaptured fetch: ${u.href}`);

--- a/webapp/components/wpt-flags.js
+++ b/webapp/components/wpt-flags.js
@@ -40,7 +40,6 @@ Object.defineProperty(wpt, 'ClientSideFeatures', {
       'colorHomepage',
       'displayMetadata',
       'githubLogin',
-      'processorTab',
       'showBSF',
       'showMobileScoresView',
       'triageMetadataUI',
@@ -201,11 +200,6 @@ class WPTFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ false) {
       <paper-item>
       <paper-checkbox id="triageMetadataUI" checked="[[triageMetadataUI]]" on-change="handleChange">
         Show Triage Metadata UI on the wpt.fyi result page.
-      </paper-checkbox>
-    </paper-item>
-    <paper-item>
-      <paper-checkbox id="processorTab" checked="[[processorTab]]" on-change="handleChange">
-        Show the "Processor" (status) tab.
       </paper-checkbox>
     </paper-item>
     <paper-item>

--- a/webapp/components/wpt-flags.js
+++ b/webapp/components/wpt-flags.js
@@ -40,7 +40,6 @@ Object.defineProperty(wpt, 'ClientSideFeatures', {
       'colorHomepage',
       'displayMetadata',
       'githubLogin',
-      'permalinks',
       'processorTab',
       'showBSF',
       'showMobileScoresView',
@@ -194,11 +193,6 @@ class WPTFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ false) {
     <paper-item>
       <paper-checkbox id="colorHomepage" checked="[[colorHomepage]]" on-change="handleChange">
         Use pass-rate colors on the homepage
-      </paper-checkbox>
-    </paper-item>
-    <paper-item>
-      <paper-checkbox id="permalinks" checked="[[permalinks]]" on-change="handleChange">
-        Show dialog for copying a permalink (on /results page).
       </paper-checkbox>
     </paper-item>
     <paper-item>

--- a/webapp/components/wpt-flags.js
+++ b/webapp/components/wpt-flags.js
@@ -38,7 +38,6 @@ Object.defineProperty(wpt, 'ClientSideFeatures', {
   get: function() {
     return [
       'colorHomepage',
-      'displayMetadata',
       'showMobileScoresView',
     ];
   }
@@ -184,11 +183,6 @@ class WPTFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ false) {
     <paper-item>
       <paper-checkbox id="colorHomepage" checked="[[colorHomepage]]" on-change="handleChange">
         Use pass-rate colors on the homepage
-      </paper-checkbox>
-    </paper-item>
-    <paper-item>
-      <paper-checkbox id="displayMetadata" checked="[[displayMetadata]]" on-change="handleChange">
-        Show metadata Information on the wpt.fyi result page.
       </paper-checkbox>
     </paper-item>
     <paper-item>

--- a/webapp/components/wpt-flags.js
+++ b/webapp/components/wpt-flags.js
@@ -40,7 +40,6 @@ Object.defineProperty(wpt, 'ClientSideFeatures', {
       'colorHomepage',
       'diffFromAPI',
       'displayMetadata',
-      'githubCommitLinks',
       'githubLogin',
       'permalinks',
       'processorTab',
@@ -202,11 +201,6 @@ class WPTFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ false) {
     <paper-item>
       <paper-checkbox id="colorHomepage" checked="[[colorHomepage]]" on-change="handleChange">
         Use pass-rate colors on the homepage
-      </paper-checkbox>
-    </paper-item>
-    <paper-item>
-      <paper-checkbox id="githubCommitLinks" checked="[[githubCommitLinks]]" on-change="handleChange">
-        Show links to the commit on GitHub in the header row.
       </paper-checkbox>
     </paper-item>
     <paper-item>

--- a/webapp/components/wpt-flags.js
+++ b/webapp/components/wpt-flags.js
@@ -38,7 +38,6 @@ Object.defineProperty(wpt, 'ClientSideFeatures', {
   get: function() {
     return [
       'colorHomepage',
-      'diffFromAPI',
       'displayMetadata',
       'githubLogin',
       'permalinks',
@@ -193,11 +192,6 @@ class WPTFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ false) {
         margin-left: 32px;
       }
     </style>
-    <paper-item>
-      <paper-checkbox id="diffFromAPI" checked="[[diffFromAPI]]" on-change="handleChange">
-        Compute diffs using /api/diff
-      </paper-checkbox>
-    </paper-item>
     <paper-item>
       <paper-checkbox id="colorHomepage" checked="[[colorHomepage]]" on-change="handleChange">
         Use pass-rate colors on the homepage

--- a/webapp/components/wpt-flags.js
+++ b/webapp/components/wpt-flags.js
@@ -44,7 +44,6 @@ Object.defineProperty(wpt, 'ClientSideFeatures', {
       'githubLogin',
       'permalinks',
       'processorTab',
-      'queryBuilderSHA',
       'showBSF',
       'showMobileScoresView',
       'structuredQueries',
@@ -199,11 +198,6 @@ class WPTFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ false) {
         margin-left: 32px;
       }
     </style>
-    <paper-item sub-item>
-      <paper-checkbox id="queryBuilderSHA" checked="[[queryBuilderSHA]]" on-change="handleChange">
-        SHA input
-      </paper-checkbox>
-    </paper-item>
     <paper-item>
       <paper-checkbox id="diffFromAPI" checked="[[diffFromAPI]]" on-change="handleChange">
         Compute diffs using /api/diff

--- a/webapp/components/wpt-flags.js
+++ b/webapp/components/wpt-flags.js
@@ -49,7 +49,6 @@ Object.defineProperty(wpt, 'ServerSideFeatures', {
     return [
       'failChecksOnRegression',
       'ignoreHarnessInTotal',
-      'pendingChecks',
     ];
   }
 });
@@ -231,11 +230,6 @@ class WPTEnvironmentFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ tr
     <paper-item>
       <paper-checkbox id="failChecksOnRegression" checked="[[failChecksOnRegression]]" on-change="handleChange">
         Set the wpt.fyi GitHub status check to action_required if regressions are found.
-      </paper-checkbox>
-    </paper-item>
-    <paper-item>
-      <paper-checkbox id="pendingChecks" checked="[[pendingChecks]]" on-change="handleChange">
-        Create pending GitHub status check when results first arrive, and are being processed.
       </paper-checkbox>
     </paper-item>
 `;

--- a/webapp/components/wpt-flags.js
+++ b/webapp/components/wpt-flags.js
@@ -60,7 +60,6 @@ Object.defineProperty(wpt, 'ServerSideFeatures', {
       'ignoreHarnessInTotal',
       'onlyChangesAsRegressions',
       'pendingChecks',
-      'runsByPRNumber',
       'searchcacheDiffs',
     ];
   }
@@ -269,11 +268,6 @@ class WPTEnvironmentFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ tr
     ${WPTFlagsEditor.template}
 
     <h3>Server-side only features</h3>
-    <paper-item>
-      <paper-checkbox id="runsByPRNumber" checked="[[runsByPRNumber]]" on-change="handleChange">
-        Allow /api/runs?pr=[GitHub PR number]
-      </paper-checkbox>
-    </paper-item>
     <paper-item>
       <paper-checkbox id="ignoreHarnessInTotal" checked="[[ignoreHarnessInTotal]]" on-change="handleChange">
         Ignore "OK" harness status in test summary numbers.

--- a/webapp/components/wpt-flags.js
+++ b/webapp/components/wpt-flags.js
@@ -44,7 +44,6 @@ Object.defineProperty(wpt, 'ClientSideFeatures', {
       'githubLogin',
       'permalinks',
       'processorTab',
-      'queryBuilder',
       'queryBuilderSHA',
       'showBSF',
       'showMobileScoresView',
@@ -200,11 +199,6 @@ class WPTFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ false) {
         margin-left: 32px;
       }
     </style>
-    <paper-item>
-      <paper-checkbox id="queryBuilder" checked="[[queryBuilder]]" on-change="handleChange">
-        Query Builder component
-      </paper-checkbox>
-    </paper-item>
     <paper-item sub-item>
       <paper-checkbox id="queryBuilderSHA" checked="[[queryBuilderSHA]]" on-change="handleChange">
         SHA input

--- a/webapp/components/wpt-flags.js
+++ b/webapp/components/wpt-flags.js
@@ -54,7 +54,6 @@ Object.defineProperty(wpt, 'ServerSideFeatures', {
       'failChecksOnRegression',
       'githubLogin',
       'ignoreHarnessInTotal',
-      'onlyChangesAsRegressions',
       'pendingChecks',
     ];
   }
@@ -249,12 +248,6 @@ class WPTEnvironmentFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ tr
       </paper-checkbox>
     </paper-item>
     <h4>GitHub Status Checks</h4>
-    <paper-item sub-item>
-      <paper-checkbox id="onlyChangesAsRegressions" checked="[[onlyChangesAsRegressions]]" on-change="handleChange">
-        Only treat C (changed) differences as possible regressions.
-        (<a href="https://github.com/web-platform-tests/wpt.fyi/blob/main/api/README.md#apidiff">See docs for definition</a>)
-      </paper-checkbox>
-    </paper-item>
     <paper-item>
       <paper-checkbox id="failChecksOnRegression" checked="[[failChecksOnRegression]]" on-change="handleChange">
         Set the wpt.fyi GitHub status check to action_required if regressions are found.

--- a/webapp/components/wpt-flags.js
+++ b/webapp/components/wpt-flags.js
@@ -55,7 +55,6 @@ Object.defineProperty(wpt, 'ServerSideFeatures', {
   get: function() {
     return [
       'checksAllUsers',
-      'diffRenames',
       'failChecksOnRegression',
       'githubLogin',
       'ignoreHarnessInTotal',
@@ -271,11 +270,6 @@ class WPTEnvironmentFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ tr
     ${WPTFlagsEditor.template}
 
     <h3>Server-side only features</h3>
-    <paper-item>
-      <paper-checkbox id="diffRenames" checked="[[diffRenames]]" on-change="handleChange">
-        Compute renames in diffs with the GitHub API
-      </paper-checkbox>
-    </paper-item>
     <paper-item>
       <paper-checkbox id="paginationTokens" checked="[[paginationTokens]]" on-change="handleChange">
         Return "wpt-next-page" pagination token HTTP header in /api/runs

--- a/webapp/components/wpt-flags.js
+++ b/webapp/components/wpt-flags.js
@@ -46,7 +46,6 @@ Object.defineProperty(wpt, 'ClientSideFeatures', {
       'processorTab',
       'showBSF',
       'showMobileScoresView',
-      'structuredQueries',
       'triageMetadataUI',
       'webPlatformTestsLive',
     ];
@@ -206,12 +205,6 @@ class WPTFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ false) {
     <paper-item>
       <paper-checkbox id="colorHomepage" checked="[[colorHomepage]]" on-change="handleChange">
         Use pass-rate colors on the homepage
-      </paper-checkbox>
-    </paper-item>
-    <paper-item>
-      <paper-checkbox id="structuredQueries" checked="[[structuredQueries]]" on-change="handleChange">
-        Interpret query strings as structured queries over test names and test
-        status/result values
       </paper-checkbox>
     </paper-item>
     <paper-item>

--- a/webapp/components/wpt-flags.js
+++ b/webapp/components/wpt-flags.js
@@ -41,7 +41,6 @@ Object.defineProperty(wpt, 'ClientSideFeatures', {
       'displayMetadata',
       'showBSF',
       'showMobileScoresView',
-      'triageMetadataUI',
     ];
   }
 });
@@ -192,11 +191,6 @@ class WPTFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ false) {
     <paper-item>
       <paper-checkbox id="displayMetadata" checked="[[displayMetadata]]" on-change="handleChange">
         Show metadata Information on the wpt.fyi result page.
-      </paper-checkbox>
-    </paper-item>
-      <paper-item>
-      <paper-checkbox id="triageMetadataUI" checked="[[triageMetadataUI]]" on-change="handleChange">
-        Show Triage Metadata UI on the wpt.fyi result page.
       </paper-checkbox>
     </paper-item>
     <paper-item>

--- a/webapp/components/wpt-flags.js
+++ b/webapp/components/wpt-flags.js
@@ -45,7 +45,6 @@ Object.defineProperty(wpt, 'ClientSideFeatures', {
       'showBSF',
       'showMobileScoresView',
       'triageMetadataUI',
-      'webPlatformTestsLive',
     ];
   }
 });
@@ -200,11 +199,6 @@ class WPTFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ false) {
     <paper-item>
       <paper-checkbox id="permalinks" checked="[[permalinks]]" on-change="handleChange">
         Show dialog for copying a permalink (on /results page).
-      </paper-checkbox>
-    </paper-item>
-    <paper-item>
-      <paper-checkbox id="webPlatformTestsLive" checked="[[webPlatformTestsLive]]" on-change="handleChange">
-        Use wpt.live.
       </paper-checkbox>
     </paper-item>
     <paper-item>

--- a/webapp/components/wpt-flags.js
+++ b/webapp/components/wpt-flags.js
@@ -49,7 +49,6 @@ Object.defineProperty(wpt, 'ClientSideFeatures', {
 Object.defineProperty(wpt, 'ServerSideFeatures', {
   get: function() {
     return [
-      'checksAllUsers',
       'failChecksOnRegression',
       'githubLogin',
       'ignoreHarnessInTotal',
@@ -245,11 +244,6 @@ class WPTEnvironmentFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ tr
     <paper-item>
       <paper-checkbox id="failChecksOnRegression" checked="[[failChecksOnRegression]]" on-change="handleChange">
         Set the wpt.fyi GitHub status check to action_required if regressions are found.
-      </paper-checkbox>
-    </paper-item>
-    <paper-item>
-      <paper-checkbox id="checksAllUsers" checked="[[checksAllUsers]]" on-change="handleChange">
-        Run the wpt.fyi GitHub status check for all users.
       </paper-checkbox>
     </paper-item>
     <paper-item>

--- a/webapp/components/wpt-flags.js
+++ b/webapp/components/wpt-flags.js
@@ -56,7 +56,6 @@ Object.defineProperty(wpt, 'ServerSideFeatures', {
       'ignoreHarnessInTotal',
       'onlyChangesAsRegressions',
       'pendingChecks',
-      'searchcacheDiffs',
     ];
   }
 });
@@ -250,11 +249,6 @@ class WPTEnvironmentFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ tr
       </paper-checkbox>
     </paper-item>
     <h4>GitHub Status Checks</h4>
-    <paper-item>
-      <paper-checkbox id="searchcacheDiffs" checked="[[searchcacheDiffs]]" on-change="handleChange">
-        Use searchcache (not summaries) to compute diffs when processing check run events.
-      </paper-checkbox>
-    </paper-item>
     <paper-item sub-item>
       <paper-checkbox id="onlyChangesAsRegressions" checked="[[onlyChangesAsRegressions]]" on-change="handleChange">
         Only treat C (changed) differences as possible regressions.

--- a/webapp/components/wpt-flags.js
+++ b/webapp/components/wpt-flags.js
@@ -59,7 +59,6 @@ Object.defineProperty(wpt, 'ServerSideFeatures', {
       'githubLogin',
       'ignoreHarnessInTotal',
       'onlyChangesAsRegressions',
-      'paginationTokens',
       'pendingChecks',
       'runsByPRNumber',
       'searchcacheDiffs',
@@ -270,11 +269,6 @@ class WPTEnvironmentFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ tr
     ${WPTFlagsEditor.template}
 
     <h3>Server-side only features</h3>
-    <paper-item>
-      <paper-checkbox id="paginationTokens" checked="[[paginationTokens]]" on-change="handleChange">
-        Return "wpt-next-page" pagination token HTTP header in /api/runs
-      </paper-checkbox>
-    </paper-item>
     <paper-item>
       <paper-checkbox id="runsByPRNumber" checked="[[runsByPRNumber]]" on-change="handleChange">
         Allow /api/runs?pr=[GitHub PR number]

--- a/webapp/components/wpt-flags.js
+++ b/webapp/components/wpt-flags.js
@@ -39,7 +39,6 @@ Object.defineProperty(wpt, 'ClientSideFeatures', {
     return [
       'colorHomepage',
       'displayMetadata',
-      'githubLogin',
       'showBSF',
       'showMobileScoresView',
       'triageMetadataUI',
@@ -50,7 +49,6 @@ Object.defineProperty(wpt, 'ServerSideFeatures', {
   get: function() {
     return [
       'failChecksOnRegression',
-      'githubLogin',
       'ignoreHarnessInTotal',
       'pendingChecks',
     ];
@@ -199,11 +197,6 @@ class WPTFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ false) {
       <paper-item>
       <paper-checkbox id="triageMetadataUI" checked="[[triageMetadataUI]]" on-change="handleChange">
         Show Triage Metadata UI on the wpt.fyi result page.
-      </paper-checkbox>
-    </paper-item>
-    <paper-item>
-      <paper-checkbox id="githubLogin" checked="[[githubLogin]]" on-change="handleChange">
-        Enable GitHub OAuth login
       </paper-checkbox>
     </paper-item>
     <paper-item>

--- a/webapp/components/wpt-flags.js
+++ b/webapp/components/wpt-flags.js
@@ -39,7 +39,6 @@ Object.defineProperty(wpt, 'ClientSideFeatures', {
     return [
       'colorHomepage',
       'displayMetadata',
-      'showBSF',
       'showMobileScoresView',
     ];
   }
@@ -190,11 +189,6 @@ class WPTFlagsEditor extends FlagsEditorClass(/*environmentFlags*/ false) {
     <paper-item>
       <paper-checkbox id="displayMetadata" checked="[[displayMetadata]]" on-change="handleChange">
         Show metadata Information on the wpt.fyi result page.
-      </paper-checkbox>
-    </paper-item>
-    <paper-item>
-      <paper-checkbox id="showBSF" checked="[[showBSF]]" on-change="handleChange">
-        Enable Browser Specific Failures graph
       </paper-checkbox>
     </paper-item>
     <paper-item>

--- a/webapp/components/wpt-header.js
+++ b/webapp/components/wpt-header.js
@@ -188,11 +188,9 @@ class WPTHeader extends WPTFlags(PolymerElement) {
           <a class="mobile-title" href="/">WPT dashboard</a>
         <h1>
       </div>
-      <template is="dom-if" if="[[githubLogin]]">
-        <div id="desktop-login">
+      <div id="desktop-login">
           <github-login user="[[user]]" is-triage-mode="[[isTriageMode]]"></github-login>
         </div>
-      </template>
       <button
           class$="[[_computeMenuButtonClass(_isMenuOpen)]]"
           on-click="_toggleMenu"
@@ -222,9 +220,7 @@ class WPTHeader extends WPTFlags(PolymerElement) {
         <a href="/insights">Insights</a>
         <a href="/status">Processor</a>
         <a href="/about">About</a>
-        <template is="dom-if" if="[[githubLogin]]">
-          <github-login user="[[user]]" is-triage-mode="[[isTriageMode]]"></github-login>
-        </template>
+        <github-login user="[[user]]" is-triage-mode="[[isTriageMode]]"></github-login>
       </div>
     </header>
 `;

--- a/webapp/components/wpt-header.js
+++ b/webapp/components/wpt-header.js
@@ -211,9 +211,7 @@ class WPTHeader extends WPTFlags(PolymerElement) {
         <a href="/runs">Recent Runs</a>
         <a href="/interop">&#10024;Interop 2026&#10024;</a>
         <a href="/insights">Insights</a>
-        <template is="dom-if" if="[[processorTab]]">
-          <a href="/status">Processor</a>
-        </template>
+        <a href="/status">Processor</a>
         <a href="/about">About</a>
       </nav>
 
@@ -222,9 +220,7 @@ class WPTHeader extends WPTFlags(PolymerElement) {
         <a href="/runs">Recent Runs</a>
         <a href="/interop">&#10024;Interop 2026&#10024;</a>
         <a href="/insights">Insights</a>
-        <template is="dom-if" if="[[processorTab]]">
-          <a href="/status">Processor</a>
-        </template>
+        <a href="/status">Processor</a>
         <a href="/about">About</a>
         <template is="dom-if" if="[[githubLogin]]">
           <github-login user="[[user]]" is-triage-mode="[[isTriageMode]]"></github-login>

--- a/webapp/components/wpt-runs.js
+++ b/webapp/components/wpt-runs.js
@@ -142,21 +142,19 @@ class WPTRuns extends Pluralizer(WPTFlags(SelfNavigation(LoadingState(TestRunsUI
       </info-banner>
     </template>
 
-    <template is="dom-if" if="[[queryBuilder]]">
-      <iron-collapse opened="[[editingQuery]]">
-        <test-runs-query-builder product-specs="[[productSpecs]]"
-                                 labels="[[labels]]"
-                                 master="[[master]]"
-                                 shas="[[shas]]"
-                                 aligned="[[aligned]]"
-                                 on-submit="[[submitQuery]]"
-                                 from="[[from]]"
-                                 to="[[to]]"
-                                 diff="[[diff]]"
-                                 show-time-range>
-        </test-runs-query-builder>
-      </iron-collapse>
-    </template>
+    <iron-collapse opened="[[editingQuery]]">
+      <test-runs-query-builder product-specs="[[productSpecs]]"
+                               labels="[[labels]]"
+                               master="[[master]]"
+                               shas="[[shas]]"
+                               aligned="[[aligned]]"
+                               on-submit="[[submitQuery]]"
+                               from="[[from]]"
+                               to="[[to]]"
+                               diff="[[diff]]"
+                               show-time-range>
+      </test-runs-query-builder>
+    </iron-collapse>
 
     <template is="dom-if" if="[[loadingFailed]]">
       <info-banner type="error">

--- a/webapp/components/wpt-runs.js
+++ b/webapp/components/wpt-runs.js
@@ -455,9 +455,6 @@ class WPTRuns extends Pluralizer(WPTFlags(SelfNavigation(LoadingState(TestRunsUI
   }
 
   commitType(runsByBrowser) {
-    if (!this.githubCommitLinks) {
-      return;
-    }
     const types = CommitTypes;
     for (const runs of Object.values(runsByBrowser)) {
       for (const r of runs) {

--- a/webapp/login.go
+++ b/webapp/login.go
@@ -18,12 +18,6 @@ import (
 
 func loginHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	aeAPI := shared.NewAppEngineAPI(ctx)
-	if !aeAPI.IsFeatureEnabled("githubLogin") {
-		http.Error(w, "Feature not enabled", http.StatusNotImplemented)
-		return
-	}
-
 	githubOauthImp, err := shared.NewGitHubOAuth(ctx)
 	if err != nil {
 		http.Error(w, "Error creating githuboauthImp", http.StatusInternalServerError)

--- a/webapp/views/wpt-app.js
+++ b/webapp/views/wpt-app.js
@@ -100,15 +100,8 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
                 (<a href\$="https://github.com/web-platform-tests/wpt/blob/master[[path]]" target="_blank">master branch</a>)
               </li>
 
-              <template is="dom-if" if="[[ !webPlatformTestsLive ]]">
-                <li><a href\$="[[scheme]]://w3c-test.org[[path]]" target="_blank">Run in your
-                browser on w3c-test.org</a></li>
-              </template>
-
-              <template is="dom-if" if="[[ webPlatformTestsLive ]]">
-                <li><a href\$="[[scheme]]://wpt.live[[path]]" target="_blank">Run in your
-                  browser on wpt.live</a></li>
-              </template>
+              <li><a href\$="[[scheme]]://wpt.live[[path]]" target="_blank">Run in your
+                browser on wpt.live</a></li>
             </ul>
           </div>
         </template>

--- a/webapp/views/wpt-app.js
+++ b/webapp/views/wpt-app.js
@@ -200,7 +200,7 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
       },
       showBSFGraph: {
         type: Boolean,
-        computed: 'computeShowBSFGraph(page, queryParams, pathIsRootDir, showBSF)',
+        computed: 'computeShowBSFGraph(page, queryParams, pathIsRootDir)',
       },
       isBSFCollapsed: {
         type: Boolean,
@@ -438,7 +438,7 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
   // Currently we only have BSF data for the entirety of the WPT test suite. To avoid
   // confusing the user, we only display the graph when they are looking at top-level
   // test results and hide it when in a subdirectory.
-  computeShowBSFGraph(page, queryParams, pathIsRootDir, showBSF) {
+  computeShowBSFGraph(page, queryParams, pathIsRootDir) {
     // Only show on the results page.
     if (page !== 'results') {
       return false;
@@ -449,7 +449,7 @@ class WPTApp extends PathInfo(WPTFlags(TestRunsUIBase)) {
       return false;
     }
 
-    return pathIsRootDir && showBSF;
+    return pathIsRootDir;
   }
 
   computeIsBSFCollapsed() {

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -455,10 +455,6 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
         type: Boolean,
         computed: 'computePathIsASubfolderOrFile(pathIsASubfolder, pathIsATestFile)'
       },
-      liveTestDomain: {
-        type: String,
-        computed: 'computeLiveTestDomain()',
-      },
       structuredSearch: Object,
       searchResults: {
         type: Array,
@@ -545,13 +541,6 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
 
   computePathIsASubfolderOrFile(isSubfolder, isFile) {
     return isSubfolder || isFile;
-  }
-
-  computeLiveTestDomain() {
-    if (this.webPlatformTestsLive) {
-      return 'wpt.live';
-    }
-    return 'w3c-test.org';
   }
 
   computeTestPaths(searchResults) {

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -960,7 +960,7 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
     // It is always possible in triage mode to amend metadata for a problem
     // with a test file itself.
     if (index === undefined) {
-      return !node.isDir && this.triageMetadataUI && this.isTriageMode;
+      return !node.isDir && this.isTriageMode;
     }
 
     // Triage can occur if a status doesn't pass.
@@ -968,7 +968,7 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
     const failStatus = status && !PASSING_STATUSES.includes(status);
     const totalTests = this.getNodeResultDataByPropertyName(node, index, testRun, 'total');
     const passedTests = this.getNodeResultDataByPropertyName(node, index, testRun, 'passes');
-    return ((totalTests - passedTests) > 0 || failStatus) && this.triageMetadataUI && this.isTriageMode;
+    return ((totalTests - passedTests) > 0 || failStatus) && this.isTriageMode;
   }
 
   testResultClass(node, index, testRun, prop) {

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -667,7 +667,7 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
     if (q) {
       body.query = q;
     }
-    if (this.diff && this.diffFromAPI) {
+    if (this.diff) {
       url.searchParams.set('diff', true);
       url.searchParams.set('filter', this.diffFilter);
     }
@@ -713,9 +713,6 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
   }
 
   fetchDiff() {
-    if (!this.diffFromAPI) {
-      return;
-    }
     this.load(
       window.fetch(this.diffURL)
         .then(r => {

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -428,14 +428,12 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
       </div>
     </template>
 
-    <template is="dom-if" if="[[displayMetadata]]">
-      <wpt-metadata products="[[displayedProducts]]"
-                    path="[[path]]"
-                    search-results="[[searchResults]]"
-                    metadata-map="[[metadataMap]]"
-                    label-map="[[labelMap}]]"
-                    triage-notifier="[[triageNotifier]]"></wpt-metadata>
-    </template>
+    <wpt-metadata products="[[displayedProducts]]"
+                  path="[[path]]"
+                  search-results="[[searchResults]]"
+                  metadata-map="[[metadataMap]]"
+                  label-map="[[labelMap}]]"
+                  triage-notifier="[[triageNotifier]]"></wpt-metadata>
     <wpt-amend-metadata id="amend" selected-metadata="[[selectedMetadata]]" path="[[path]]"></wpt-amend-metadata>
 `;
   }
@@ -1538,7 +1536,7 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
   }
 
   shouldDisplayTestLabel(testname, labelMap) {
-    return this.displayMetadata && this.getTestLabel(testname, labelMap) !== '';
+    return this.getTestLabel(testname, labelMap) !== '';
   }
 
   shouldDisplayTotals(displayedTotals, diffRun) {
@@ -1570,7 +1568,7 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
   }
 
   shouldDisplayMetadata(index, testname, metadataMap) {
-    return !this.pathIsRootDir && this.displayMetadata && this.getMetadataUrl(index, testname, metadataMap) !== '';
+    return !this.pathIsRootDir && this.getMetadataUrl(index, testname, metadataMap) !== '';
   }
 
   getMetadataUrl(index, testname, metadataMap) {

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -274,13 +274,11 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
       </info-banner>
     </template>
 
-    <template is="dom-if" if="[[queryBuilder]]">
-      <iron-collapse opened="[[editingQuery]]">
-        <test-runs-query-builder query="[[query]]"
-                                 on-submit="[[submitQuery]]">
-        </test-runs-query-builder>
-      </iron-collapse>
-    </template>
+    <iron-collapse opened="[[editingQuery]]">
+      <test-runs-query-builder query="[[query]]"
+                               on-submit="[[submitQuery]]">
+      </test-runs-query-builder>
+    </iron-collapse>
 
     <template is="dom-if" if="[[testRuns]]">
       <template is="dom-if" if="{{ pathIsATestFile }}">

--- a/webapp/views/wpt-results.js
+++ b/webapp/views/wpt-results.js
@@ -614,8 +614,7 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
     this.load(
       this.loadRuns().then(async runs => {
         // Pass current (un)structured query is passed to fetchResults().
-        this.fetchResults(
-          this.structuredQueries && this.structuredSearch || this.search);
+        this.fetchResults(this.structuredSearch || this.search);
 
         // Load a diff data into this.diffRun, if needed.
         if (this.diff && runs && runs.length === 2) {
@@ -662,29 +661,20 @@ class WPTResults extends AmendMetadataMixin(Pluralizer(WPTColors(WPTFlags(PathIn
     let url = new URL('/api/search', window.location);
     let fetchOpts;
 
-    if (this.structuredQueries) {
-      const body = {
-        run_ids: this.testRuns.map(r => r.id),
-      };
-      if (q) {
-        body.query = q;
-      }
-      if (this.diff && this.diffFromAPI) {
-        url.searchParams.set('diff', true);
-        url.searchParams.set('filter', this.diffFilter);
-      }
-      fetchOpts = {
-        method: 'POST',
-        body: JSON.stringify(body),
-      };
-    } else {
-      url.searchParams.set(
-        'run_ids',
-        this.testRuns.map(r => r.id.toString()).join(','));
-      if (q) {
-        url.searchParams.set('q', q);
-      }
+    const body = {
+      run_ids: this.testRuns.map(r => r.id),
+    };
+    if (q) {
+      body.query = q;
     }
+    if (this.diff && this.diffFromAPI) {
+      url.searchParams.set('diff', true);
+      url.searchParams.set('filter', this.diffFilter);
+    }
+    fetchOpts = {
+      method: 'POST',
+      body: JSON.stringify(body),
+    };
     this.sortCol = new Array(this.testRuns.length).fill(false);
 
     // Fetch search results and refresh display nodes. If fetch error is HTTP'


### PR DESCRIPTION
This removes a lot of old feature flags — all of these have been enabled for many years and the code hasn't been changed in years.

My underlying motivation for this was https://github.com/web-platform-tests/wpt.fyi/pull/3577#issuecomment-3801912731 where I couldn't figure out why the tests were failing for years, because we were testing in a different configuration that there's no reason for it to exist.