### PR TITLE
Fix WebDriver timeout in TestQueryBuilder_MasterCheckedForMasterLabelQuery

### DIFF
--- a/webdriver/builder_test.go
+++ b/webdriver/builder_test.go
@@ -43,17 +43,29 @@ func TestQueryBuilder_MasterCheckedForMasterLabelQuery(t *testing.T) {
 		}
 
 		// Expand the builder
-		_, err = wd.ExecuteScript("arguments[0].editingQuery = true", []interface{}{e})
+		_, err = wd.ExecuteScript("document.querySelector('wpt-app').editingQuery = true", nil)
 		if err != nil {
 			assert.FailNow(t, fmt.Sprintf("Failed to expand builder: %s", err.Error()))
 		}
 		var cb selenium.WebElement
 		expanded := func(wd selenium.WebDriver) (bool, error) {
-			cb, err = FindShadowElement(wd, e, "test-runs-query-builder", "#master-checkbox")
+			result, err := wd.ExecuteScriptRaw(`
+				var app = document.querySelector('wpt-app');
+				if (!app || !app.shadowRoot) return null;
+				var builder = app.shadowRoot.querySelector('test-runs-query-builder');
+				if (!builder || !builder.shadowRoot) return null;
+				var cb = builder.shadowRoot.querySelector('#master-checkbox');
+				return cb ? [cb] : [];
+			`, nil)
 			if err != nil {
 				return false, err
 			}
-			return cb != nil, nil
+			elements, err := wd.DecodeElements(result)
+			if err != nil || len(elements) == 0 {
+				return false, nil
+			}
+			cb = elements[0]
+			return true, nil
 		}
 		if err := wd.WaitWithTimeout(expanded, LongTimeout); err != nil {
 			assert.FailNow(t, fmt.Sprintf("Error waiting for builder to expand: %s", err.Error()))


### PR DESCRIPTION
## Overview
This PR fixes a flaky timeout error in the `TestQueryBuilder_MasterCheckedForMasterLabelQuery` WebDriver test running on Firefox.

## Root Cause / Motivation
The test previously used `FindShadowElement`, which eagerly resolved the `<wpt-app>` element and passed it across multiple Javascript executions via Geckodriver to find the `#master-checkbox` inside the nested Shadow DOM of `test-runs-query-builder`. In Firefox, referencing this element before the Custom Element Polyfill finished upgrading it caused Geckodriver to fail to locate the nested element, leading to the 30-second timeout.

## Detailed Changelog
* **`webdriver/builder_test.go`**: Replaced the `FindShadowElement` call with a direct `ExecuteScriptRaw` invocation that evaluates `document.querySelector('wpt-app')` and its corresponding Shadow DOM down to the `#master-checkbox` in a single Javascript execution. It returns the element array for `DecodeElements`, ensuring the browser always queries the live DOM state and avoids stale references.