### PR TITLE
Migrate info-banner component from Polymer to Lit

### DIFF
--- a/webapp/components/info-banner.js
+++ b/webapp/components/info-banner.js
@@ -9,7 +9,7 @@
 of type info, warning, or error.
 */
 import '../node_modules/@polymer/paper-styles/color.js';
-import { LitElement, html, css } from '../node_modules/lit/index.js';
+import { LitElement, html, css } from 'lit';
 
 class InfoBanner extends LitElement {
   static get styles() {

--- a/webapp/components/info-banner.js
+++ b/webapp/components/info-banner.js
@@ -9,12 +9,11 @@
 of type info, warning, or error.
 */
 import '../node_modules/@polymer/paper-styles/color.js';
-import { html, PolymerElement } from '../node_modules/@polymer/polymer/polymer-element.js';
+import { LitElement, html, css } from '../node_modules/lit/index.js';
 
-class InfoBanner extends PolymerElement {
-  static get template() {
-    return html`
-    <style>
+class InfoBanner extends LitElement {
+  static get styles() {
+    return css`
       :host {
         display: block;
         margin-bottom: 1em;
@@ -38,9 +37,12 @@ class InfoBanner extends PolymerElement {
         background-color: var(--paper-red-100);
         border-left: solid 4px var(--paper-red-300);
       }
-    </style>
+    `;
+  }
 
-    <section class\$="banner [[type]]">
+  render() {
+    return html`
+    <section class="banner ${this.type}">
       <span class="main">
         <slot></slot>
       </span>
@@ -59,10 +61,14 @@ class InfoBanner extends PolymerElement {
     return {
       type: {
         type: String,
-        value: 'info',
-        reflectToAttribute: true,
+        reflect: true,
       },
     };
+  }
+
+  constructor() {
+    super();
+    this.type = 'info';
   }
 }
 

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -40,6 +40,7 @@
         "@vaadin/vaadin-grid": "5.7.13",
         "@webcomponents/webcomponentsjs": "2.8.0",
         "countup.js": "2.10.0",
+        "lit": "^3.3.2",
         "pluralize": "8.0.0"
       },
       "devDependencies": {
@@ -1474,6 +1475,21 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
@@ -2506,6 +2522,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
     },
     "node_modules/@types/ua-parser-js": {
       "version": "0.7.36",
@@ -8870,6 +8892,17 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
     "node_modules/lit-element": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-2.5.1.tgz",
@@ -8882,6 +8915,26 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
       "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA=="
+    },
+    "node_modules/lit/node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit/node_modules/lit-html": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
     },
     "node_modules/load-json-file": {
       "version": "1.1.0",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -92,6 +92,7 @@
     "@vaadin/vaadin-grid": "5.7.13",
     "@webcomponents/webcomponentsjs": "2.8.0",
     "countup.js": "2.10.0",
+    "lit": "^3.3.2",
     "pluralize": "8.0.0"
   }
 }

--- a/webapp/templates/_head_common.html
+++ b/webapp/templates/_head_common.html
@@ -3,5 +3,20 @@
 {{ template "_ga.html" }}
 <link rel="stylesheet" href="/static/common.css">
 <link rel="icon" href="/static/favicon.ico">
+<script type="importmap">
+{
+  "imports": {
+    "lit": "/node_modules/lit/index.js",
+    "lit/": "/node_modules/lit/",
+    "lit-html": "/node_modules/lit-html/lit-html.js",
+    "lit-html/": "/node_modules/lit-html/",
+    "lit-element/lit-element.js": "/node_modules/lit-element/lit-element.js",
+    "lit-element/": "/node_modules/lit-element/",
+    "@lit/reactive-element": "/node_modules/@lit/reactive-element/reactive-element.js",
+    "@lit/reactive-element/": "/node_modules/@lit/reactive-element/",
+    "/node_modules/@lit/reactive-element": "/node_modules/@lit/reactive-element/reactive-element.js"
+  }
+}
+</script>
 <script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 <script type="module" src="/components/wpt-header.js"></script>

--- a/webapp/templates/_head_common.html
+++ b/webapp/templates/_head_common.html
@@ -8,10 +8,10 @@
   "imports": {
     "lit": "/node_modules/lit/index.js",
     "lit/": "/node_modules/lit/",
-    "lit-html": "/node_modules/lit-html/lit-html.js",
-    "lit-html/": "/node_modules/lit-html/",
-    "lit-element/lit-element.js": "/node_modules/lit-element/lit-element.js",
-    "lit-element/": "/node_modules/lit-element/",
+    "lit-html": "/node_modules/lit/node_modules/lit-html/lit-html.js",
+    "lit-html/": "/node_modules/lit/node_modules/lit-html/",
+    "lit-element/lit-element.js": "/node_modules/lit/node_modules/lit-element/lit-element.js",
+    "lit-element/": "/node_modules/lit/node_modules/lit-element/",
     "@lit/reactive-element": "/node_modules/@lit/reactive-element/reactive-element.js",
     "@lit/reactive-element/": "/node_modules/@lit/reactive-element/",
     "/node_modules/@lit/reactive-element": "/node_modules/@lit/reactive-element/reactive-element.js"


### PR DESCRIPTION
## Overview
This PR migrates the `info-banner` web component from Polymer 3 to Lit, serving as a proof of concept for modernizing the project's frontend stack.

## Root Cause / Motivation
The Polymer project officially recommends migrating to Lit, as Lit is its modern, lighter-weight successor. Moving components to Lit ensures better long-term maintainability, standardizes the usage of modern JavaScript features (like tagged template literals and class properties), and slightly reduces framework overhead. Starting with the simple, stateless `info-banner` component validates that the visual styling and component behavior remain identical before proceeding with more complex components.

## Detailed Changelog
* **`webapp/package.json`** & **`webapp/package-lock.json`**: Added `lit` as a dependency.
* **`webapp/components/info-banner.js`**: 
  - Converted the base class from `PolymerElement` to `LitElement`.
  - Replaced `static get template()` with Lit's `render()` function and `html` tagged template literal.
  - Extracted inline CSS into a static `styles` getter utilizing the `css` tagged template literal for improved performance.
  - Updated the `properties` definition to use Lit's `reflect: true` and initialized the default value in the `constructor()`.
