### PR TITLE
Update golang-lint version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,8 @@ VERBOSE := -v
 GO_FILES := $(shell find $(WPTD_PATH) -type f -name '*.go')
 GO_TEST_FILES := $(shell find $(WPTD_PATH) -type f -name '*_test.go')
 # Golangci version should be updated periodically.
-# See: https://golangci-lint.run/welcome/install/
-GOLANGCI_LINT_VERSION := v2.1.6 
+# See: https://golangci-lint.run/welcome/install/  
+GOLANGCI_LINT_VERSION := v2.1.6
 
 build: go_build
 

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ GO_FILES := $(shell find $(WPTD_PATH) -type f -name '*.go')
 GO_TEST_FILES := $(shell find $(WPTD_PATH) -type f -name '*_test.go')
 # Golangci version should be updated periodically.
 # See: https://golangci-lint.run/welcome/install/
-GOLANGCI_LINT_VERSION := v2.1.6
+GOLANGCI_LINT_VERSION := v2.1.6 
 
 build: go_build
 

--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,8 @@ VERBOSE := -v
 GO_FILES := $(shell find $(WPTD_PATH) -type f -name '*.go')
 GO_TEST_FILES := $(shell find $(WPTD_PATH) -type f -name '*_test.go')
 # Golangci version should be updated periodically.
-# See: https://golangci-lint.run/welcome/install/  
-GOLANGCI_LINT_VERSION := v2.1.6
+# See: https://golangci-lint.run/welcome/install/
+GOLANGCI_LINT_VERSION := v2.12.1
 
 build: go_build
 

--- a/api/results_redirect_handler.go
+++ b/api/results_redirect_handler.go
@@ -49,5 +49,6 @@ func apiResultsRedirectHandler(w http.ResponseWriter, r *http.Request) {
 	test := r.URL.Query().Get("test")
 	resultsURL := shared.GetResultsURL(allRuns[0], test)
 
+	// #nosec G601 - URL is always on our own site.
 	http.Redirect(w, r, resultsURL, http.StatusFound)
 }

--- a/api/results_redirect_handler.go
+++ b/api/results_redirect_handler.go
@@ -49,6 +49,6 @@ func apiResultsRedirectHandler(w http.ResponseWriter, r *http.Request) {
 	test := r.URL.Query().Get("test")
 	resultsURL := shared.GetResultsURL(allRuns[0], test)
 
-	// #nosec G601 - URL is always on our own site.
+	// #nosec G710 - URL is always on our own site.
 	http.Redirect(w, r, resultsURL, http.StatusFound)
 }

--- a/api/screenshot_redirect_handler.go
+++ b/api/screenshot_redirect_handler.go
@@ -32,5 +32,6 @@ func apiScreenshotRedirectHandler(w http.ResponseWriter, r *http.Request) {
 		bucket = "wptd-screenshots"
 	}
 	url := fmt.Sprintf("https://storage.googleapis.com/%s/%s.png", bucket, shot)
+	// #nosec G601 - URL is always on within our storage bucket.
 	http.Redirect(w, r, url, http.StatusPermanentRedirect)
 }

--- a/api/screenshot_redirect_handler.go
+++ b/api/screenshot_redirect_handler.go
@@ -32,6 +32,6 @@ func apiScreenshotRedirectHandler(w http.ResponseWriter, r *http.Request) {
 		bucket = "wptd-screenshots"
 	}
 	url := fmt.Sprintf("https://storage.googleapis.com/%s/%s.png", bucket, shot)
-	// #nosec G601 - URL is always on within our storage bucket.
+	// #nosec G710 - URL is always on within our storage bucket.
 	http.Redirect(w, r, url, http.StatusPermanentRedirect)
 }


### PR DESCRIPTION
I believe that GitHub CI may have updated the version of golang-lint that is available to us.  All pending PRs seem to be failing with an error about a version mis-match.

With this change to use the new version that GitHub CI is offering us, hopefully pending dependabot PRs will pass.