### PR TITLE
perf: Optimize test history memory usage

### DIFF
--- a/api/test_history.go
+++ b/api/test_history.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"sort"
 
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
@@ -57,7 +58,7 @@ func testHistoryHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	store := shared.NewAppEngineDatastore(ctx, false)
-	q := store.NewQuery("TestHistoryEntry").Filter("TestName =", reqBody.TestName).Order("Date")
+	q := store.NewQuery("TestHistoryEntry").Filter("TestName =", reqBody.TestName)
 
 	var runs []shared.TestHistoryEntry
 	_, err = store.GetAll(q, &runs)
@@ -65,6 +66,11 @@ func testHistoryHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Print(err)
 	}
+
+	// Sort runs in chronological order
+	sort.Slice(runs, func(i, j int) bool {
+		return runs[i].Date < runs[j].Date
+	})
 
 	// Convert datastore data to correct JSON format
 	resultMap := map[string]map[string]Browser{}

--- a/api/test_history.go
+++ b/api/test_history.go
@@ -5,13 +5,16 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"sort"
 
 	"github.com/web-platform-tests/wpt.fyi/shared"
 )
 
 // Subtest represents the final format for subtest data.
-type Subtest map[string]string
+type Subtest struct {
+	Date   string `json:"date"`
+	Status string `json:"status"`
+	RunID  string `json:"run_id"`
+}
 
 // Browser represents the final format for browser data.
 type Browser map[string][]Subtest
@@ -54,7 +57,7 @@ func testHistoryHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	store := shared.NewAppEngineDatastore(ctx, false)
-	q := store.NewQuery("TestHistoryEntry").Filter("TestName =", reqBody.TestName)
+	q := store.NewQuery("TestHistoryEntry").Filter("TestName =", reqBody.TestName).Order("Date")
 
 	var runs []shared.TestHistoryEntry
 	_, err = store.GetAll(q, &runs)
@@ -62,11 +65,6 @@ func testHistoryHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Print(err)
 	}
-
-	// Sort runs in chronological order
-	sort.Slice(runs, func(i, j int) bool {
-		return runs[i].Date < runs[j].Date
-	})
 
 	// Convert datastore data to correct JSON format
 	resultMap := map[string]map[string]Browser{}
@@ -81,9 +79,9 @@ func testHistoryHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		subdata := Subtest{
-			"date":   run.Date,
-			"status": run.Status,
-			"run_id": run.RunID,
+			Date:   run.Date,
+			Status: run.Status,
+			RunID:  run.RunID,
 		}
 
 		testsByBrowser[run.BrowserName][run.SubtestName] =

--- a/api/test_history_test.go
+++ b/api/test_history_test.go
@@ -54,9 +54,9 @@ func TestHistoryHandler(t *testing.T) {
 			"chrome": {
 				"subtest": {
 					{
-						"date":   "2022-06-02T06:02:55.000Z",
-						"status": "PASS",
-						"run_id": "123",
+						Date:   "2022-06-02T06:02:55.000Z",
+						Status: "PASS",
+						RunID:  "123",
 					},
 				},
 			},


### PR DESCRIPTION
## Overview
This PR improves the memory efficiency and execution time of the `testHistoryHandler` by removing expensive map allocations.

## Root Cause / Motivation
Previously, the test history API modeled each subtest entry as a `map[string]string`. When processing historical records for a test suite across multiple browsers, instantiating thousands of small maps incurs massive memory overhead, high garbage collection pressure, and slow allocation speeds compared to standard Go structs. 

## Detailed Changelog
* **`api/test_history.go`**: Refactored `Subtest` from a `map[string]string` to a strongly-typed `struct` with JSON tags. This drastically reduces heap allocations and memory fragmentation when assembling the final JSON response tree.
* **`api/test_history_test.go`**: Updated the unit test assertions to match the new `Subtest` struct format.