### PR TITLE
Fix flaky web_components_test failure in wct-browser-legacy

### DIFF
--- a/util/wct.sh
+++ b/util/wct.sh
@@ -23,6 +23,7 @@ fi
 cd webapp
 # Patch wct-browser-legacy to avoid cross-origin error in ChildRunner.get
 # See https://github.com/web-platform-tests/wpt.fyi/issues/4754
+# This workaround can be phased out if/when wct-browser-legacy is updated or replaced.
 sed -i 's/return window.parent.WCT._ChildRunner.get(target, true);/try { return window.parent.WCT._ChildRunner.get(target, true); } catch (e) { return null; }/' node_modules/wct-browser-legacy/browser.js
 if [ "$UID" == "0" ]; then
   # Used in .github/actions/make-in-docker/Dockerfile

--- a/util/wct.sh
+++ b/util/wct.sh
@@ -21,6 +21,9 @@ if [ "$USE_FRAME_BUFFER" == "true" ]; then
 fi
 
 cd webapp
+# Patch wct-browser-legacy to avoid cross-origin error in ChildRunner.get
+# See https://github.com/web-platform-tests/wpt.fyi/issues/4754
+sed -i 's/return window.parent.WCT._ChildRunner.get(target, true);/try { return window.parent.WCT._ChildRunner.get(target, true); } catch (e) { return null; }/' node_modules/wct-browser-legacy/browser.js
 if [ "$UID" == "0" ]; then
   # Used in .github/actions/make-in-docker/Dockerfile
   sudo -u browser npm test


### PR DESCRIPTION
Resolves #4754

## Overview
Fixes flaky `web_components_test` failure by patching `wct-browser-legacy` to handle cross-origin errors when traversing parent frames.

## Root Cause / Motivation
The error `Failed to read a named property 'WCT' from 'Window': Blocked a frame with origin "http://localhost:8081" from accessing a cross-origin frame.` occurs because `ChildRunner.get` in `wct-browser-legacy/browser.js` attempts to access `window.parent.WCT`. If the parent frame is cross-origin, this access throws a `SecurityError` and fails the test run outside of a test function.

## Detailed Changelog
* **`util/wct.sh`**: Added a `sed` command to patch `node_modules/wct-browser-legacy/browser.js` on the fly before running tests, wrapping the failing line in a `try-catch` block to return `null` on cross-origin access failure.
