### PR TITLE
Add UI toggle for /third_party tests in BSF chart

### DIFF
--- a/api/bsf_handler.go
+++ b/api/bsf_handler.go
@@ -54,7 +54,13 @@ func (b BSFHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		isExperimental = *val
 	}
 
-	lines, err := b.fetcher.Fetch(isExperimental)
+	includeThirdParty := false
+	val, _ = shared.ParseBooleanParam(q, "includeThirdParty")
+	if val != nil {
+		includeThirdParty = *val
+	}
+
+	lines, err := b.fetcher.Fetch(isExperimental, includeThirdParty)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 

--- a/api/bsf_handler_test.go
+++ b/api/bsf_handler_test.go
@@ -32,7 +32,7 @@ func TestBSFHandler_Success(t *testing.T) {
 	dataRow := []string{"1", "2018-08-18", "70.0.3521.2 dev", "605.3869030161061", "63.0a1", "1521.908686731921", "12.1", "2966.686195133767"}
 	rawBSFData = append(rawBSFData, fieldsRow)
 	rawBSFData = append(rawBSFData, dataRow)
-	mockBSFFetcher.EXPECT().Fetch(false).Return(rawBSFData, nil)
+	mockBSFFetcher.EXPECT().Fetch(false, false).Return(rawBSFData, nil)
 
 	BSFHandler{mockBSFFetcher}.ServeHTTP(w, r)
 
@@ -64,7 +64,7 @@ func TestBSFHandler_Success_WithParams(t *testing.T) {
 	rawBSFData = append(rawBSFData, dataRow2)
 	rawBSFData = append(rawBSFData, dataRow3)
 	rawBSFData = append(rawBSFData, dataRow4)
-	mockBSFFetcher.EXPECT().Fetch(true).Return(rawBSFData, nil)
+	mockBSFFetcher.EXPECT().Fetch(true, false).Return(rawBSFData, nil)
 
 	BSFHandler{mockBSFFetcher}.ServeHTTP(w, r)
 
@@ -76,4 +76,56 @@ func TestBSFHandler_Success_WithParams(t *testing.T) {
 	assert.Equal(t, 2, len(bsfData.Data))
 	assert.Equal(t, dataRow2, bsfData.Data[0])
 	assert.Equal(t, dataRow3, bsfData.Data[1])
+}
+
+func TestBSFHandler_Success_IncludeThirdParty(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	r := httptest.NewRequest("GET", "/api/bsf?includeThirdParty=true", nil)
+	w := httptest.NewRecorder()
+	mockBSFFetcher := sharedtest.NewMockFetchBSF(mockCtrl)
+
+	var rawBSFData [][]string
+	fieldsRow := []string{"sha", "date", "chrome-version", "chrome", "firefox-version", "firefox", "safari-version", "safari"}
+	dataRow := []string{"1", "2018-08-18", "70.0.3521.2 dev", "605.3869030161061", "63.0a1", "1521.908686731921", "12.1", "2966.686195133767"}
+	rawBSFData = append(rawBSFData, fieldsRow)
+	rawBSFData = append(rawBSFData, dataRow)
+	mockBSFFetcher.EXPECT().Fetch(false, true).Return(rawBSFData, nil)
+
+	BSFHandler{mockBSFFetcher}.ServeHTTP(w, r)
+
+	var bsfData shared.BSFData
+	assert.Equal(t, http.StatusOK, w.Code)
+	json.Unmarshal([]byte(w.Body.String()), &bsfData)
+	assert.Equal(t, "1", bsfData.LastUpdateRevision)
+	assert.Equal(t, fieldsRow, bsfData.Fields)
+	assert.Equal(t, 1, len(bsfData.Data))
+	assert.Equal(t, dataRow, bsfData.Data[0])
+}
+
+func TestBSFHandler_Success_ExperimentalIncludeThirdParty(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	r := httptest.NewRequest("GET", "/api/bsf?experimental=true&includeThirdParty=true", nil)
+	w := httptest.NewRecorder()
+	mockBSFFetcher := sharedtest.NewMockFetchBSF(mockCtrl)
+
+	var rawBSFData [][]string
+	fieldsRow := []string{"sha", "date", "chrome-version", "chrome", "firefox-version", "firefox", "safari-version", "safari"}
+	dataRow := []string{"1", "2018-08-18", "70.0.3521.2 dev", "605.3869030161061", "63.0a1", "1521.908686731921", "12.1", "2966.686195133767"}
+	rawBSFData = append(rawBSFData, fieldsRow)
+	rawBSFData = append(rawBSFData, dataRow)
+	mockBSFFetcher.EXPECT().Fetch(true, true).Return(rawBSFData, nil)
+
+	BSFHandler{mockBSFFetcher}.ServeHTTP(w, r)
+
+	var bsfData shared.BSFData
+	assert.Equal(t, http.StatusOK, w.Code)
+	json.Unmarshal([]byte(w.Body.String()), &bsfData)
+	assert.Equal(t, "1", bsfData.LastUpdateRevision)
+	assert.Equal(t, fieldsRow, bsfData.Fields)
+	assert.Equal(t, 1, len(bsfData.Data))
+	assert.Equal(t, dataRow, bsfData.Data[0])
 }

--- a/shared/fetch_bsf.go
+++ b/shared/fetch_bsf.go
@@ -15,11 +15,17 @@ import (
 
 const (
 	// experimentalBSFURL is the GitHub URL for fetching the experimental BSF data
-	// for Chrome, Firefox and Safari.
+	// for Chrome, Firefox and Safari. First party tests only.
 	experimentalBSFURL = "https://raw.githubusercontent.com/web-platform-tests/results-analysis/gh-pages/data/experimental-browser-specific-failures.csv"
 	// stableBSFURL is the GitHub URL for fetching the stable BSF data
-	// for Chrome, Firefox and Safari.
+	// for Chrome, Firefox and Safari. First party tests only.
 	stableBSFURL = "https://raw.githubusercontent.com/web-platform-tests/results-analysis/gh-pages/data/stable-browser-specific-failures.csv"
+	// experimentalBSFWithThirdPartyURL is the GitHub URL for fetching the experimental BSF data
+	// for Chrome, Firefox and Safari. All tests (first and third party) included.
+	experimentalBSFWithThirdPartyURL = "https://raw.githubusercontent.com/web-platform-tests/results-analysis/gh-pages/data/experimental-browser-specific-failures-with-third-party.csv"
+	// stableBSFWithThirdPartyURL is the GitHub URL for fetching the stable BSF data
+	// for Chrome, Firefox and Safari. All tests (first and third party) included.
+	stableBSFWithThirdPartyURL = "https://raw.githubusercontent.com/web-platform-tests/results-analysis/gh-pages/data/stable-browser-specific-failures-with-third-party.csv"
 )
 
 // BSFData stores BSF data of the latest WPT revision.
@@ -90,25 +96,33 @@ func FilterandExtractBSFData(rawBSFdata [][]string, from *time.Time, to *time.Ti
 	return response
 }
 
-// FetchBSF encapsulates the Fetch(isExperimental bool) method for testing.
+// FetchBSF encapsulates the Fetch(isExperimental, includeThirdParty bool) method for testing.
 type FetchBSF interface {
-	Fetch(isExperimental bool) ([][]string, error)
+	Fetch(isExperimental, includeThirdParty bool) ([][]string, error)
 }
 
 type fetchBSF struct{}
 
 // Fetch() fetches BSF Data in CSV from GitHub given query options, in chronological order.
-func (f fetchBSF) Fetch(isExperimental bool) ([][]string, error) {
+func (f fetchBSF) Fetch(isExperimental, includeThirdParty bool) ([][]string, error) {
 	url := ""
 	if isExperimental {
-		url = experimentalBSFURL
+		if includeThirdParty {
+			url = experimentalBSFWithThirdPartyURL
+		} else {
+			url = experimentalBSFURL
+		}
 	} else {
-		url = stableBSFURL
+		if includeThirdParty {
+			url = stableBSFWithThirdPartyURL
+		} else {
+			url = stableBSFURL
+		}
 	}
 
 	resp, err := http.Get(url)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("BSF fetch from %q failed: %w", url, err)
 	}
 
 	defer resp.Body.Close()
@@ -118,7 +132,7 @@ func (f fetchBSF) Fetch(isExperimental bool) ([][]string, error) {
 
 	data, err := csv.NewReader(resp.Body).ReadAll()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("BSF CSV parse from %q failed: %w", url, err)
 	}
 
 	return data, nil

--- a/shared/sharedtest/fetch_bsf_mock.go
+++ b/shared/sharedtest/fetch_bsf_mock.go
@@ -40,16 +40,16 @@ func (m *MockFetchBSF) EXPECT() *MockFetchBSFMockRecorder {
 }
 
 // Fetch mocks base method.
-func (m *MockFetchBSF) Fetch(isExperimental bool) ([][]string, error) {
+func (m *MockFetchBSF) Fetch(isExperimental, includeThirdParty bool) ([][]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Fetch", isExperimental)
+	ret := m.ctrl.Call(m, "Fetch", isExperimental, includeThirdParty)
 	ret0, _ := ret[0].([][]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Fetch indicates an expected call of Fetch.
-func (mr *MockFetchBSFMockRecorder) Fetch(isExperimental any) *gomock.Call {
+func (mr *MockFetchBSFMockRecorder) Fetch(isExperimental, includeThirdParty any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Fetch", reflect.TypeOf((*MockFetchBSF)(nil).Fetch), isExperimental)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Fetch", reflect.TypeOf((*MockFetchBSF)(nil).Fetch), isExperimental, includeThirdParty)
 }

--- a/webapp/components/wpt-bsf.js
+++ b/webapp/components/wpt-bsf.js
@@ -30,19 +30,13 @@ class WPTBSF extends LoadingState(PolymerElement) {
           height: 350px;
           width: 800px;
         }
-        .sha {
-          display: inline-flex;
-          height: 25px;
-          margin-top: 0px;
-        }
         h5 {
           margin-top: 20px;
           margin-left: 8px;
         }
-        .channel {
+        .toggle {
           display: inline-flex;
-          height: 35px;
-          margin-top: 0px;
+          align-items: center;
         }
         .link {
           text-decoration: none;
@@ -63,14 +57,16 @@ class WPTBSF extends LoadingState(PolymerElement) {
         <div class="left">
           <h5>Browser-specific failures are the number of WPT tests which fail in exactly one browser. This graph shows the BSF scores for Chrome, Firefox and Safari.</h5>
           <h5>Channel</h5>
-          <div class="channel">
+          <div class="toggle">
             <paper-button class\$="[[experimentalButtonClass(isExperimental)]]" onclick="[[clickExperimental]]">Experimental</paper-button>
             <paper-button class\$="[[stableButtonClass(isExperimental)]]" onclick="[[clickStable]]">Stable</paper-button>
           </div>
-          <h5>Last updated WPT revision</h5>
-          <div class="sha">
-            <a class="link" href="[[githubHref]]" target="_blank"><paper-button>[[shortSHA]]</paper-button></a>
+          <h5>Test scope</h5>
+          <div class="toggle">
+            <paper-button class\$="[[firstPartyButtonClass(includeThirdParty)]]" onclick="[[clickFirstParty]]">WPT</paper-button>
+            <paper-button class\$="[[includeThirdPartyButtonClass(includeThirdParty)]]" onclick="[[clickIncludeThirdParty]]">WPT + Test262</paper-button>
           </div>
+          <h5>Last update: <a class="link" href="[[githubHref]]" target="_blank">[[shortSHA]]</a></h5>
           <h5>Click + drag on graph to zoom, right click to un-zoom</h5>
         </div>
         <google-chart type="line"
@@ -105,6 +101,10 @@ class WPTBSF extends LoadingState(PolymerElement) {
       isExperimental: {
         type: Boolean,
         value: true,
+      },
+      includeThirdParty: {
+        type: Boolean,
+        value: false,
       },
       chartOptions: {
         type: Object,
@@ -149,6 +149,20 @@ class WPTBSF extends LoadingState(PolymerElement) {
       this.isExperimental = true;
       this.loadBSFData();
     };
+    this.clickFirstParty = () => {
+      if (!this.includeThirdParty) {
+        return;
+      }
+      this.includeThirdParty = false;
+      this.loadBSFData();
+    };
+    this.clickIncludeThirdParty = () => {
+      if (this.includeThirdParty) {
+        return;
+      }
+      this.includeThirdParty = true;
+      this.loadBSFData();
+    };
     this.enterChart = () => {
       this.isInteracting = true;
       const event = new CustomEvent('interactingchanged', {
@@ -182,10 +196,21 @@ class WPTBSF extends LoadingState(PolymerElement) {
     return isExperimental ? 'selected' : 'unselected';
   }
 
+  firstPartyButtonClass(includeThirdParty) {
+    return includeThirdParty ? 'unselected' : 'selected';
+  }
+
+  includeThirdPartyButtonClass(includeThirdParty) {
+    return includeThirdParty ? 'selected' : 'unselected';
+  }
+
   loadBSFData() {
     const url = new URL('/api/bsf', window.location);
     if (this.isExperimental) {
       url.searchParams.set('experimental', true);
+    }
+    if (this.includeThirdParty) {
+      url.searchParams.set('includeThirdParty', true);
     }
 
     this.load(


### PR DESCRIPTION
Adds an `includeThirdParty` query parameter to `/api/bsf` (default false)
that selects between the existing CSV (which now excludes `/third_party`
tests) and the new `-with-third-party.csv` variant. The wpt-bsf component
exposes this as a "Test scope" toggle next to the existing channel toggle,
defaulting to exclude third-party tests by default to prioritize tests
written for WPT and following the WPT subtest convention.

Also hardens fetchBSF.Fetch against malformed-but-successful responses
(empty CSV, missing "date" column), which previously slipped past the
status-code check and surfaced on the frontend as a silent blank chart.

The companion change in results-analysis must land and publish both CSVs
to gh-pages before this is deployed.