### PR TITLE
Try not using vpc_access_connector.

### DIFF
--- a/docs/app-engine.md
+++ b/docs/app-engine.md
@@ -54,15 +54,6 @@ files above. They need to be done using the `gcloud` CLI or on the GCP
 dashboard, and are not currently version-controlled (TODO: consider using
 Terraform).
 
-### Serverless VPC Access
-
-By default, App Engine **standard** environment is separated from the "internal"
-(VPC) network (including Compute Engine and any resource with an internal IP
-such as Cloud Memorystore). To connect to these resources, follow this doc to
-enable Serverless VPC Access and configure the connector:
-https://cloud.google.com/appengine/docs/standard/go/connecting-vpc (note: we do
-not use "Shared VPC")
-
 ### Cloud Memorystore (Redis)
 
 Follow this doc to set up Cloud Memorystore (Redis):

--- a/webapp/web/app.staging.yaml
+++ b/webapp/web/app.staging.yaml
@@ -19,11 +19,6 @@ inbound_services:
 
 default_expiration: "1d"
 
-# TODO: can we remove this now that service 'default' is not App Engine
-# Standard? Same change for app.yaml and the VPC mention in app-engine.md.
-vpc_access_connector:
-  name: projects/wptdashboard-staging/locations/us-east4/connectors/appengine-connector
-
 liveness_check:
   path: "/_ah/liveness_check"
 

--- a/webapp/web/app.yaml
+++ b/webapp/web/app.yaml
@@ -19,9 +19,6 @@ inbound_services:
 
 default_expiration: "1d"
 
-vpc_access_connector:
-  name: projects/wptdashboard/locations/us-central1/connectors/appengine-connector
-
 liveness_check:
   path: "/_ah/liveness_check"
 


### PR DESCRIPTION
Our deployments have been failing with the error message: 
```This field cannot be set for an App Engine Flexible Environment.
    field: version.vpc_access_connector
```
The vpc_access_connector might never have been needed in AppEngine Flex.

This PR tries simply removing it.