### PR TITLE
Fix test history cron job crash and optimize performance

### DIFF
--- a/scripts/process_test_history.py
+++ b/scripts/process_test_history.py
@@ -3,11 +3,14 @@
 # found in the LICENSE file.
 
 import argparse
+import gzip
+import hashlib
 import json
 import re
 import requests
 import time
 from datetime import datetime, timedelta
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Optional, TypedDict
 
 from google.cloud import ndb, storage
@@ -17,6 +20,10 @@ BUCKET_NAME = 'wpt-recent-statuses-staging'
 PROJECT_NAME = 'wptdashboard-staging'
 RUNS_API_URL = 'https://staging.wpt.fyi/api/runs'
 TIMEOUT_SECONDS = 3600
+BATCH_SIZE = 500
+WHITESPACE_RE = re.compile(r'\s')
+_prev_test_statuses_cache = {}
+CHECKPOINT_INTERVAL = 20
 
 parser = argparse.ArgumentParser()
 parser.add_argument(
@@ -41,8 +48,19 @@ parser.add_argument(
     action='store_true',
     help=('generate new statuses json and entities '
           'after entities have been deleted.'))
+parser.add_argument(
+    '--force', action='store_true',
+    help='force operations (like setting start date) even if Datastore is not empty.')
+parser.add_argument(
+    '--prod', action='store_true',
+    help='Use production environment instead of staging.')
 
 parsed_args = parser.parse_args()
+
+if parsed_args.prod:
+    BUCKET_NAME = 'wpt-recent-statuses'
+    PROJECT_NAME = 'wptdashboard'
+    RUNS_API_URL = 'https://wpt.fyi/api/runs'
 # Function set to only print if verbose arg is active.
 verboseprint = (print if parsed_args.verbose
                 else lambda *a, **k: None)
@@ -92,14 +110,24 @@ class MetadataDict(TypedDict):
     labels: list[str]
 
 
+def _get_entry_key_name(run_id: str, test_name: str, subtest_name: str) -> str:
+    # We use SHA-256 to hash the test and subtest names to ensure they fit in key name limits
+    # and are deterministic.
+    name_hash = hashlib.sha256(f"{test_name}\n{subtest_name}".encode('utf-8')).hexdigest()
+    return f"{run_id}_{name_hash}"
+
+
 def _build_new_test_history_entry(
         test_name: str,
         subtest_name: str,
         run_metadata: MetadataDict,
         run_date: str,
         current_status: str) -> TestHistoryEntry:
+    run_id = str(run_metadata['id'])
+    key_name = _get_entry_key_name(run_id, test_name, subtest_name)
     return TestHistoryEntry(
-        RunID=str(run_metadata['id']),
+        id=key_name,
+        RunID=run_id,
         BrowserName=run_metadata['browser_name'],
         Date=run_date,
         TestName=test_name,
@@ -115,17 +143,16 @@ def create_entity_if_needed(
         run_metadata: MetadataDict,
         run_date: str,
         current_status: str,
-        entities_to_write: list[TestHistoryEntry],
-        unique_entities_to_write: set[tuple[str, str]]) -> None:
+        unique_entities_to_write: set[tuple[str, str]]) -> Optional[TestHistoryEntry]:
     """Check if an entity should be created for a test status delta,
-    and create one if necessary.
+    and return it if necessary.
     """
     # Test results are stored in dictionary with a tuple key
     # in the form of (testname, subtest_name).
     # The overall test status has an empty string as the subtest name.
     test_key = (test_name, subtest_name)
     if test_key in unique_entities_to_write:
-        return
+        return None
 
     should_create_new_entry = (
         test_key not in prev_test_statuses or
@@ -139,101 +166,120 @@ def create_entity_if_needed(
             run_date=run_date,
             current_status=current_status
         )
-        entities_to_write.append(test_status_entry)
         unique_entities_to_write.add(test_key)
-    prev_test_statuses[test_key] = current_status
+        prev_test_statuses[test_key] = current_status
+        return test_status_entry
+    return None
 
 
 def process_single_run(run_metadata: MetadataDict) -> None:
     """Process a single aligned run and save and deltas to history."""
-    verboseprint('Obtaining the raw results JSON for the test run '
-                 f'at {run_metadata["raw_results_url"]}')
-    try:
-        run_resp = requests.get(run_metadata['raw_results_url'])
-        run_data = run_resp.json()
-    except requests.exceptions.RequestException as e:
-        raise requests.exceptions.RequestException(
-            'Failed to fetch raw results', e)
+    client = ndb.Client(project=PROJECT_NAME)
+    with client.context():
+        if not should_process_run(run_metadata):
+            print('Run has already been processed! '
+                  'TestHistoryEntry values already exist for this run.')
+            return
 
-    # Keep a dictionary of the previous test statuses
-    # from runs we've processed.
-    prev_test_statuses = _populate_previous_statuses(
-        run_metadata['browser_name'])
+        verboseprint('Obtaining the raw results JSON for the test run '
+                     f'at {run_metadata["raw_results_url"]}')
+        try:
+            run_resp = requests.get(run_metadata['raw_results_url'])
+            run_data = run_resp.json()
+        except requests.exceptions.RequestException as e:
+            raise requests.exceptions.RequestException(
+                'Failed to fetch raw results', e)
 
-    # Keep track of every single test result that's in the dataset of
-    # runs we've previously seen. If they're not in the run we're processing,
-    # we'll mark them as missing.
-    tests_not_seen: set[tuple[str, str]] = set(prev_test_statuses.keys())
+        # Keep a dictionary of the previous test statuses
+        # from runs we've processed.
+        prev_test_statuses = _populate_previous_statuses(
+            run_metadata['browser_name'])
 
-    run_date = run_metadata["time_start"]
-    entities_to_write: list[TestHistoryEntry] = []
-    unique_entities_to_write: set[tuple[str, str]] = set()
-    # Iterate through each test.
-    for test_data in run_data['results']:
-        # Format the test name.
-        test_name = re.sub(r'\s', ' ', test_data['test'])
+        # Keep track of every single test result that's in the dataset of
+        # runs we've previously seen. If they're not in the run we're processing,
+        # we'll mark them as missing.
+        tests_not_seen: set[tuple[str, str]] = set(prev_test_statuses.keys())
 
-        # Specifying the subtest name as empty string means that we're dealing
-        # with the overall test status rather than a subtest status.
-        create_entity_if_needed(
-            test_name,
-            subtest_name='',
-            prev_test_statuses=prev_test_statuses,
-            run_metadata=run_metadata,
-            run_date=run_date,
-            current_status=test_data['status'],
-            entities_to_write=entities_to_write,
-            unique_entities_to_write=unique_entities_to_write
-        )
+        run_date = run_metadata["time_start"]
+        entities_to_write: list[TestHistoryEntry] = []
+        unique_entities_to_write: set[tuple[str, str]] = set()
 
-        # Now that we've seen this test status, we can remove it from the
-        # the set of tests we haven't seen yet.
-        tests_not_seen.discard((test_name, ''))
+        total_entities_written = 0
 
-        # Do the same basic process for each subtest.
-        for subtest_data in test_data['subtests']:
-            # Format the subtest name.
-            subtest_name = re.sub(r'\s', ' ', subtest_data['name'])
-            # Truncate a subtest name if it's too long to be indexed in
-            # Datastore. The subtest name stored can be at most 1500 bytes.
-            # At least 1 subtest violates this size.
-            if len(subtest_name) > 1000:
-                subtest_name = subtest_name[:1000]
-            subtest_key = (test_name, subtest_name)
+        def add_entity(entity: Optional[TestHistoryEntry]):
+            nonlocal total_entities_written
+            if entity is None:
+                return
+            entities_to_write.append(entity)
+            if len(entities_to_write) >= BATCH_SIZE:
+                ndb.put_multi(entities_to_write)
+                total_entities_written += len(entities_to_write)
+                entities_to_write.clear()
 
-            create_entity_if_needed(
+        # Iterate through each test.
+        for test_data in run_data['results']:
+            # Format the test name.
+            test_name = WHITESPACE_RE.sub(' ', test_data['test'])
+
+            # Specifying the subtest name as empty string means that we're dealing
+            # with the overall test status rather than a subtest status.
+            add_entity(create_entity_if_needed(
+                test_name,
+                subtest_name='',
+                prev_test_statuses=prev_test_statuses,
+                run_metadata=run_metadata,
+                run_date=run_date,
+                current_status=test_data['status'],
+                unique_entities_to_write=unique_entities_to_write
+            ))
+
+            # Now that we've seen this test status, we can remove it from the
+            # the set of tests we haven't seen yet.
+            tests_not_seen.discard((test_name, ''))
+
+            # Do the same basic process for each subtest.
+            for subtest_data in test_data['subtests']:
+                # Format the subtest name.
+                subtest_name = WHITESPACE_RE.sub(' ', subtest_data['name'])
+                # Truncate a subtest name if it's too long to be indexed in
+                # Datastore. The subtest name stored can be at most 1500 bytes.
+                # At least 1 subtest violates this size.
+                if len(subtest_name) > 1000:
+                    subtest_name = subtest_name[:1000]
+                subtest_key = (test_name, subtest_name)
+
+                add_entity(create_entity_if_needed(
+                    test_name,
+                    subtest_name=subtest_name,
+                    prev_test_statuses=prev_test_statuses,
+                    run_metadata=run_metadata,
+                    run_date=run_date,
+                    current_status=subtest_data['status'],
+                    unique_entities_to_write=unique_entities_to_write
+                ))
+
+                tests_not_seen.discard(subtest_key)
+
+        # Write MISSING status for tests/subtests not seen.
+        for test_name, subtest_name in tests_not_seen:
+            # Only write a row as missing if it's not already marked as missing.
+            add_entity(create_entity_if_needed(
                 test_name,
                 subtest_name=subtest_name,
                 prev_test_statuses=prev_test_statuses,
                 run_metadata=run_metadata,
                 run_date=run_date,
-                current_status=subtest_data['status'],
-                entities_to_write=entities_to_write,
+                current_status='MISSING',
                 unique_entities_to_write=unique_entities_to_write
-            )
+            ))
 
-            tests_not_seen.discard(subtest_key)
-
-    # Write MISSING status for tests/subtests not seen.
-    for test_name, subtest_name in tests_not_seen:
-        # Only write a row as missing if it's not already marked as missing.
-        create_entity_if_needed(
-            test_name,
-            subtest_name=subtest_name,
-            prev_test_statuses=prev_test_statuses,
-            run_metadata=run_metadata,
-            run_date=run_date,
-            current_status='MISSING',
-            entities_to_write=entities_to_write,
-            unique_entities_to_write=unique_entities_to_write
-        )
-
-    print(f'Entities to write: {len(entities_to_write)}')
-    if len(entities_to_write) > 0:
-        ndb.put_multi(entities_to_write)
-    update_previous_statuses(
-        prev_test_statuses, run_metadata['browser_name'])
-    print(f'Finished {run_metadata["browser_name"]} run!')
+        print(f'Entities to write (remainder): {len(entities_to_write)}')
+        if len(entities_to_write) > 0:
+            ndb.put_multi(entities_to_write)
+            total_entities_written += len(entities_to_write)
+            entities_to_write.clear()
+        print(f'Total entities written: {total_entities_written}')
+        print(f'Finished {run_metadata["browser_name"]} run!')
 
 
 def get_previous_statuses(browser_name: str) -> Any:
@@ -242,16 +288,23 @@ def get_previous_statuses(browser_name: str) -> Any:
     storage_client = storage.Client(project=PROJECT_NAME)
     bucket = storage_client.bucket(BUCKET_NAME)
     blob = bucket.blob(f'{browser_name}_recent_statuses.json')
-    return blob.download_as_string()
+    data = blob.download_as_string()
+    try:
+        return gzip.decompress(data)
+    except (gzip.BadGzipFile, OSError, ValueError):
+        verboseprint('Data is not gzip compressed, using raw data.')
+        return data
 
 
-def update_previous_statuses(
-        prev_test_statuses: dict, browser_name: str) -> None:
-    """Update the JSON of most recently seen statuses
-    for use in the next invocation.
-    """
+def flush_previous_statuses_to_gcs(browser_name: str) -> None:
+    """Upload the cached in-memory statuses for browser to GCS."""
+    if browser_name not in _prev_test_statuses_cache:
+        verboseprint(f'No cached statuses to flush for {browser_name}')
+        return
+
+    prev_test_statuses = _prev_test_statuses_cache[browser_name]
     new_statuses = []
-    print('Updating recent statuses JSON...')
+    print(f'Flushing recent statuses JSON for {browser_name} to GCS...')
     for test_name, subtest_name in prev_test_statuses.keys():
         new_statuses.append({
             'test_name': test_name,
@@ -263,8 +316,10 @@ def update_previous_statuses(
 
     # Replace old revision number with new number.
     blob = bucket.blob(f'{browser_name}_recent_statuses.json')
-    blob.upload_from_string(json.dumps(new_statuses))
-    verboseprint('JSON updated.')
+    json_data = json.dumps(new_statuses).encode('utf-8')
+    compressed_data = gzip.compress(json_data)
+    blob.upload_from_string(compressed_data, content_type='application/octet-stream')
+    verboseprint(f'GCS file for {browser_name} updated (compressed).')
 
 
 def _populate_previous_statuses(browser_name: str) -> dict:
@@ -275,6 +330,11 @@ def _populate_previous_statuses(browser_name: str) -> dict:
         # initial recent statuses file and all of the first history entries.
         verboseprint('Generating new statuses, so returning empty dict.')
         return {}
+
+    if browser_name in _prev_test_statuses_cache:
+        verboseprint(f'Using cached recent statuses for {browser_name}')
+        return _prev_test_statuses_cache[browser_name]
+
     # If the JSON file is not found, then an exception should be raised
     # or the file should be generated, depending on the constant's value.
     statuses_json_str = get_previous_statuses(browser_name)
@@ -288,7 +348,8 @@ def _populate_previous_statuses(browser_name: str) -> dict:
     # Turn the list of recent statuses into a dictionary for quick referencing.
     prev_test_statuses = {(t['test_name'], t['subtest_name']): t['status']
                           for t in test_statuses}
-    verboseprint('Most recent previous statuses dictionary populated.')
+    _prev_test_statuses_cache[browser_name] = prev_test_statuses
+    verboseprint('Most recent previous statuses dictionary populated and cached.')
     return prev_test_statuses
 
 
@@ -300,58 +361,45 @@ def should_process_run(run_metadata: MetadataDict) -> bool:
     return test_entry is None
 
 
-def process_runs(
-        runs_list: list[MetadataDict],
-        process_start_entity: MostRecentHistoryProcessed) -> None:
-    """Process each aligned run and update the
-    most recent processed date afterward."""
-    revisions_processed = {}
-    # Go through each aligned run.
-
+def process_runs(runs_list: list[MetadataDict]) -> None:
+    """Process each aligned run in parallel."""
     start = time.time()
-    verboseprint('Beginning processing of each aligned runs set...')
-    for run_metadata in runs_list:
-        browser_name = run_metadata['browser_name']
-        revision = run_metadata['full_revision_hash']
-        verboseprint(f'Revision: {revision}')
+    verboseprint('Beginning processing of each aligned runs set in parallel...')
 
-        # Keep track of the runs that have been processed.
-        # The process start date entity is only updated once all aligned runs
-        # for a given revision are processed.
-        if revision not in revisions_processed:
-            revisions_processed[revision] = {
-                'chrome': False,
-                'edge': False,
-                'firefox': False,
-                'safari': False,
-            }
+    failed = False
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        futures = {executor.submit(process_single_run, run): run for run in runs_list}
 
-        if should_process_run(run_metadata):
-            process_single_run(run_metadata)
-        else:
-            print('Run has already been processed! '
-                  'TestHistoryEntry values already exist for this run.')
+        for future in as_completed(futures):
+            run = futures[future]
+            try:
+                future.result()
+                verboseprint(f"Finished processing {run['browser_name']} run.")
+            except Exception as exc:
+                print(f"{run['browser_name']} run generated an exception: {exc}")
+                failed = True
 
-        revisions_processed[revision][browser_name] = True
-        # If all runs for this revision have been processed, we can update
-        # the most recently processed date to the run's start time.
-        if (revisions_processed[revision]['chrome'] and
-                revisions_processed[revision]['edge'] and
-                revisions_processed[revision]['firefox'] and
-                revisions_processed[revision]['safari']):
-            print(f'All browsers have been processed for {revision}. '
-                  'Updating date.')
-            update_recent_processed_date(
-                process_start_entity, run_metadata['time_start'])
+    if failed:
+        raise Exception("One or more browser runs failed to process.")
+
+    print('All browsers have been processed.')
     print('Set of runs processed after '
           f'{round(time.time() - start, 0)} seconds.')
 
 
+def _parse_datetime(date_str: str) -> datetime:
+    for fmt in ('%Y-%m-%dT%H:%M:%S.%fZ', '%Y-%m-%dT%H:%M:%SZ'):
+        try:
+            return datetime.strptime(date_str, fmt)
+        except ValueError:
+            pass
+    raise ValueError(f"time data {date_str!r} does not match formats "
+                     "('%Y-%m-%dT%H:%M:%S.%fZ', '%Y-%m-%dT%H:%M:%SZ')")
+
+
 # Get the list of metadata for the most recent aligned runs.
-def get_aligned_run_info(
-        date_entity: MostRecentHistoryProcessed) -> Optional[list]:
-    date_start = date_entity.Date
-    date_start_obj = datetime.strptime(date_start, '%Y-%m-%dT%H:%M:%S.%fZ')
+def get_aligned_run_info(date_start: str) -> tuple[Optional[list], str]:
+    date_start_obj = _parse_datetime(date_start)
 
     # Since aligned runs need to all be completed runs to be fetched,
     # a time window buffer of 24 hours is kept to allow runs to finish before
@@ -374,19 +422,18 @@ def get_aligned_run_info(
     # an empty list and attempt the fetch again.
     except requests.exceptions.ReadTimeout as e:
         verboseprint('Request timed out!', e)
-        return []
+        return [], date_start
     runs_list: list[MetadataDict] = resp.json()
 
     # If we have no runs to process in this date interval,
     # we can skip this interval for processing from now on.
     if len(runs_list) == 0:
         print('No runs found for this interval.')
-        update_recent_processed_date(date_entity, end_interval_string)
         # If we've processed up to (now - 24 hours), then return null,
         # which signals we're done processing.
         if end_interval == yesterday:
-            return None
-        return runs_list
+            return None, end_interval_string
+        return runs_list, end_interval_string
 
     # Sort by revision -> then time start, so that the aligned runs are
     # processed in groups with each other.
@@ -404,7 +451,7 @@ def get_aligned_run_info(
     for run in runs_list:
         print(f'ID: {run["id"]}, {run["browser_name"]} {run["time_start"]}')
 
-    return runs_list
+    return runs_list, runs_list[-1]['time_start']
 
 
 def update_recent_processed_date(
@@ -416,17 +463,15 @@ def update_recent_processed_date(
     verboseprint('Date updated.')
 
 
-def set_history_start_date(new_date: str) -> None:
+def set_history_start_date(new_date: str, force: bool = False) -> None:
     """Update the history processing starting date based on date input."""
     # Datastore should be empty before manipulating
     # the history processing start date.
-    check_if_db_empty()
+    if not force:
+        check_if_db_empty()
     # Make sure the new date is a valid format.
     verboseprint(f'Checking if given date {new_date} is valid...')
-    try:
-        datetime.strptime(new_date, '%Y-%m-%dT%H:%M:%S.%fZ')
-    except ValueError as e:
-        raise e
+    _parse_datetime(new_date)
 
     # Query for the existing entity if it exists.
     date_entity = MostRecentHistoryProcessed.query().get()
@@ -493,6 +538,19 @@ def delete_history_entities():
 
 
 # default parameters used for cloud functions.
+def commit_checkpoint(date_entity: MostRecentHistoryProcessed, new_date: str) -> None:
+    """Commit the checkpoint: update date in Datastore and flush GCS caches."""
+    print(f"Committing checkpoint at {new_date}...")
+    # 1. Update date in Datastore
+    update_recent_processed_date(date_entity, new_date)
+
+    # 2. Flush GCS caches
+    for browser in ('chrome', 'edge', 'firefox', 'safari'):
+        flush_previous_statuses_to_gcs(browser)
+    print("Checkpoint committed.")
+
+
+# default parameters used for cloud functions.
 def main(args=None, topic=None) -> str:
     client = ndb.Client(project=PROJECT_NAME)
     verboseprint('CLI args: ', parsed_args)
@@ -506,39 +564,56 @@ def main(args=None, topic=None) -> str:
         # If the flag to set the processing date is specified,
         # handle it and exit.
         if parsed_args.set_history_start_date:
-            set_history_start_date(parsed_args.set_history_start_date)
+            set_history_start_date(parsed_args.set_history_start_date, parsed_args.force)
             exit()
 
         # If we're generating new JSON files, the database should be empty
         # of test history data.
-        if parsed_args.generate_new_statuses_json:
+        if parsed_args.generate_new_statuses_json and not parsed_args.force:
             check_if_db_empty()
 
         processing_start = time.time()
         run_sets_processed = 0
+        revisions_since_checkpoint = 0
+
+        process_start_entity = get_processing_start_date()
+        current_date = process_start_entity.Date
+
         # If we're generating new status JSON files, only 1 set of aligned runs
         # should be processed to create the baseline statuses.
         while (not parsed_args.generate_new_statuses_json
                or run_sets_processed == 0):
-            process_start_entity = get_processing_start_date()
-            runs_list = get_aligned_run_info(process_start_entity)
+            runs_list, next_date = get_aligned_run_info(current_date)
             # A return value of None means that the processing is complete
             # and up-to-date. Stop the processing.
             if runs_list is None:
+                current_date = next_date # ensure we save the final date
                 break
             # A return value of an empty list means that no aligned runs
             # were found at the given interval.
             if len(runs_list) == 0:
+                current_date = next_date
+                revisions_since_checkpoint += 1
                 continue
-            process_runs(runs_list, process_start_entity)
+            process_runs(runs_list)
+            current_date = next_date
             run_sets_processed += 1
+            revisions_since_checkpoint += 1
+
+            if revisions_since_checkpoint >= CHECKPOINT_INTERVAL:
+                commit_checkpoint(process_start_entity, current_date)
+                revisions_since_checkpoint = 0
+
             # Check if we've passed the soft timeout marker
             # and stop processing if so.
             if round(time.time() - processing_start, 0) > TIMEOUT_SECONDS:
+                commit_checkpoint(process_start_entity, current_date)
                 return ('Timed out after successfully processing '
                         f'{run_sets_processed} sets of aligned runs.')
+        # Final commit
+        commit_checkpoint(process_start_entity, current_date)
     return 'Test history processing complete.'
 
 
 if __name__ == '__main__':
-    main()
+    print(main())


### PR DESCRIPTION
## Overview
This PR fixes a ValueError crash in the test history cron job and implements major performance optimizations (caching, parallelization, and checkpointing) to speed up processing and catch up on months of missing history. It also adds support for running in the production environment.

## Root Cause / Motivation
- **Bug**: The cron job crashed when the WPT API returned a start time without microseconds (e.g. `2025-10-02T15:34:39Z`), because the script strictly expected `%Y-%m-%dT%H:%M:%S.%fZ`.
- **Performance**: The script was very slow because it downloaded and uploaded large (~10MB) JSON status files from GCS for each of the 4 browsers sequentially, for every single revision. During a catch-up run, this network overhead was prohibitive.
- **Environments**: The script had hardcoded staging values. We need to be able to run it against production to catch up production history as well.

## Detailed Changelog
* **`process_test_history.py`**:
    *   Added `--prod` CLI flag to support production environment (default is staging), overriding GCS bucket, Google Cloud Project, and WPT API URL.
    *   Added `_parse_datetime` helper to support datetime parsing with/without microseconds.
    *   Implemented global in-memory cache `_prev_test_statuses_cache` for GCS status files.
    *   Refactored `process_single_run` to run within thread-local NDB contexts and use the GCS cache.
    *   Parallelized browser processing using `ThreadPoolExecutor` (4 workers).
    *   Implemented deterministic keys for `TestHistoryEntry` based on SHA-256 hashes of test names to ensure idempotency.
    *   Implemented checkpointing in `main` loop to commit date and flush GCS cache every 20 revisions.
    *   Increased Datastore batch write size to 500.
    *   Added `--force` CLI flag to bypass empty Datastore check when manually setting start date.
    *   Pre-compiled whitespace regex for faster string substitution.
    *   Printed `main()` return value on exit.
