### PR TITLE
Add initial unit tests for process_test_history.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ prepush: go_build go_test lint
 
 python_test: python3 tox
 	tox -c results-processor/
+	tox -c scripts/
 
 # Contains setup necessary only for github actions.
 github_action_go_setup:

--- a/scripts/process_test_history.py
+++ b/scripts/process_test_history.py
@@ -42,10 +42,12 @@ parser.add_argument(
     help=('generate new statuses json and entities '
           'after entities have been deleted.'))
 
-parsed_args = parser.parse_args()
-# Function set to only print if verbose arg is active.
-verboseprint = (print if parsed_args.verbose
-                else lambda *a, **k: None)
+parsed_args = None
+
+
+def verboseprint(*args, **kwargs):
+    if parsed_args and parsed_args.verbose:
+        print(*args, **kwargs)
 
 
 class TestHistoryEntry(ndb.Model):
@@ -494,6 +496,14 @@ def delete_history_entities():
 
 # default parameters used for cloud functions.
 def main(args=None, topic=None) -> str:
+    global parsed_args
+    if parsed_args is None:
+        parsed_args = argparse.Namespace(
+            verbose=False,
+            delete_history_entities=False,
+            set_history_start_date=None,
+            generate_new_statuses_json=False
+        )
     client = ndb.Client(project=PROJECT_NAME)
     verboseprint('CLI args: ', parsed_args)
     with client.context():
@@ -541,4 +551,5 @@ def main(args=None, topic=None) -> str:
 
 
 if __name__ == '__main__':
+    parsed_args = parser.parse_args()
     main()

--- a/scripts/process_test_history_test.py
+++ b/scripts/process_test_history_test.py
@@ -1,0 +1,142 @@
+# Copyright 2026 The WPT Dashboard Project. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import json
+import unittest
+from unittest.mock import MagicMock, patch, call
+from datetime import datetime
+from google.cloud import ndb
+
+import process_test_history
+
+
+class ProcessTestHistoryTest(unittest.TestCase):
+
+    @patch('process_test_history.MostRecentHistoryProcessed')
+    def test_get_processing_start_date_success(self, mock_model):
+        mock_entity = MagicMock()
+        mock_entity.Date = '2025-10-03T00:00:00.000Z'
+        mock_model.query.return_value.get.return_value = mock_entity
+
+        res = process_test_history.get_processing_start_date()
+        self.assertEqual(res, mock_entity)
+        self.assertEqual(res.Date, '2025-10-03T00:00:00.000Z')
+
+    @patch('process_test_history.MostRecentHistoryProcessed')
+    def test_get_processing_start_date_none(self, mock_model):
+        mock_model.query.return_value.get.return_value = None
+        with self.assertRaises(process_test_history.NoRecentDateError):
+            process_test_history.get_processing_start_date()
+
+    @patch('process_test_history.requests.get')
+    @patch('process_test_history.update_recent_processed_date')
+    def test_get_aligned_run_info_empty(self, mock_update_date, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = []
+        mock_get.return_value = mock_resp
+
+        mock_date_entity = MagicMock()
+        mock_date_entity.Date = '2025-10-03T00:00:00.000Z'
+
+        # Mock datetime.now to ensure yesterday calculation is stable
+        with patch('process_test_history.datetime') as mock_datetime:
+            mock_datetime.now.return_value = datetime(2025, 10, 10)
+            mock_datetime.strptime = datetime.strptime
+
+            res = process_test_history.get_aligned_run_info(mock_date_entity)
+            self.assertEqual(res, [])
+            mock_update_date.assert_called_once()
+
+    @patch('process_test_history.requests.get')
+    def test_get_aligned_run_info_success(self, mock_get):
+        mock_resp = MagicMock()
+        mock_runs = [
+            {'id': 1, 'browser_name': 'chrome', 'revision': 'abc', 'time_start': '2025-10-03T00:00:00Z'},
+            {'id': 2, 'browser_name': 'firefox', 'revision': 'abc', 'time_start': '2025-10-03T00:00:00Z'},
+            {'id': 3, 'browser_name': 'edge', 'revision': 'abc', 'time_start': '2025-10-03T00:00:00Z'},
+            {'id': 4, 'browser_name': 'safari', 'revision': 'abc', 'time_start': '2025-10-03T00:00:00Z'},
+        ]
+        mock_resp.json.return_value = mock_runs
+        mock_get.return_value = mock_resp
+
+        mock_date_entity = MagicMock()
+        mock_date_entity.Date = '2025-10-03T00:00:00.000Z'
+
+        with patch('process_test_history.datetime') as mock_datetime:
+            mock_datetime.now.return_value = datetime(2025, 10, 10)
+            mock_datetime.strptime = datetime.strptime
+
+            res = process_test_history.get_aligned_run_info(mock_date_entity)
+            self.assertEqual(len(res), 4)
+
+    @patch('process_test_history.TestHistoryEntry')
+    def test_should_process_run_true(self, mock_entry):
+        mock_entry.query.return_value.get.return_value = None
+        run = {'id': '1'}
+        self.assertTrue(process_test_history.should_process_run(run))
+
+    @patch('process_test_history.TestHistoryEntry')
+    def test_should_process_run_false(self, mock_entry):
+        mock_entry.query.return_value.get.return_value = MagicMock()
+        run = {'id': '1'}
+        self.assertFalse(process_test_history.should_process_run(run))
+
+    @patch('process_test_history.ndb')
+    @patch('process_test_history.storage.Client')
+    @patch('process_test_history.requests.get')
+    def test_process_single_run(self, mock_get, mock_storage, mock_ndb):
+        # Mock GCS
+        mock_bucket = mock_storage.return_value.bucket.return_value
+        mock_blob = mock_bucket.blob.return_value
+        mock_blob.download_as_string.return_value = json.dumps([])
+
+        # Mock Raw Results
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            'results': [
+                {
+                    'test': '/test1.html',
+                    'status': 'OK',
+                    'subtests': [
+                        {'name': 'sub1', 'status': 'PASS'}
+                    ]
+                }
+            ]
+        }
+        mock_get.return_value = mock_resp
+
+        run_metadata = {
+            'id': '123',
+            'browser_name': 'chrome',
+            'raw_results_url': 'http://results.json',
+            'time_start': '2025-10-03T00:00:00Z'
+        }
+
+        with patch('process_test_history.parsed_args') as mock_args:
+            mock_args.generate_new_statuses_json = False
+            process_test_history.process_single_run(run_metadata)
+
+        # Verify GCS download
+        mock_bucket.blob.assert_called_with('chrome_recent_statuses.json')
+        mock_blob.download_as_string.assert_called_once()
+
+        # Verify GCS upload
+        mock_blob.upload_from_string.assert_called_once()
+        uploaded_data = json.loads(mock_blob.upload_from_string.call_args[0][0])
+        self.assertEqual(len(uploaded_data), 2)
+
+        # Verify NDB put_multi
+        mock_ndb.put_multi.assert_called_once()
+        entities = mock_ndb.put_multi.call_args[0][0]
+        self.assertEqual(len(entities), 2)
+        self.assertEqual(entities[0].TestName, '/test1.html')
+        self.assertEqual(entities[0].SubtestName, '')
+        self.assertEqual(entities[0].Status, 'OK')
+        self.assertEqual(entities[1].TestName, '/test1.html')
+        self.assertEqual(entities[1].SubtestName, 'sub1')
+        self.assertEqual(entities[1].Status, 'PASS')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/tox.ini
+++ b/scripts/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist = py311
+skipsdist=True
+
+[testenv]
+download=True
+deps =
+    google-cloud-ndb
+    google-cloud-storage
+    requests
+commands =
+    python -m unittest discover -s {toxinidir} -p "*_test.py"


### PR DESCRIPTION
## Overview
This PR adds initial unit tests and CI integration for `process_test_history.py`. This establishes a baseline for testing subsequent optimizations and refactorings.

## Root Cause / Motivation
We currently do not have any tests for this script, nor are any run in CI. Having tests and running them in CI is critical to ensure that our optimizations (parallelization, caching, checkpointing) do not introduce regressions and that future changes are safe.

## Detailed Changelog
* **`process_test_history.py`**:
    *   Deferred argparse parsing to `main` (only when run as script) to avoid conflicts with `unittest discover` arguments.
*   **`process_test_history_test.py`**:
    *   Created new test file with 7 tests for core script logic using mocks.
*   **`tox.ini`**:
    *   Created tox configuration to run script tests in python 3.11 with dependencies.
*   **`Makefile`**:
    *   Updated `python_test` target to run `tox` for `scripts/` in addition to `results-processor/`.
