### PR TITLE
Fix test history timeline end date using last processed date

### DIFF
--- a/api/test_history.go
+++ b/api/test_history.go
@@ -16,6 +16,12 @@ type Subtest map[string]string
 // Browser represents the final format for browser data.
 type Browser map[string][]Subtest
 
+// TestHistoryResponse is the response format for test history.
+type TestHistoryResponse struct {
+	Results       map[string]Browser `json:"results"`
+	LastProcessed string             `json:"last_processed,omitempty"`
+}
+
 // RequestBody is the expected format of requests for specific test run data.
 type RequestBody struct {
 	TestName string `json:"test_name"`
@@ -69,8 +75,18 @@ func testHistoryHandler(w http.ResponseWriter, r *http.Request) {
 	})
 
 	// Convert datastore data to correct JSON format
-	resultMap := map[string]map[string]Browser{}
 	testsByBrowser := map[string]Browser{}
+
+	qp := store.NewQuery("MostRecentHistoryProcessed")
+	var historyProcessed []shared.MostRecentHistoryProcessed
+	_, err = store.GetAll(qp, &historyProcessed)
+	if err != nil {
+		logger.Errorf("Failed to fetch MostRecentHistoryProcessed: %v", err)
+	}
+	var lastProcessed string
+	if len(historyProcessed) > 0 {
+		lastProcessed = historyProcessed[0].Date
+	}
 
 	for _, run := range runs {
 
@@ -90,9 +106,12 @@ func testHistoryHandler(w http.ResponseWriter, r *http.Request) {
 			append(testsByBrowser[run.BrowserName][run.SubtestName], subdata)
 	}
 
-	resultMap["results"] = testsByBrowser
+	response := TestHistoryResponse{
+		Results:       testsByBrowser,
+		LastProcessed: lastProcessed,
+	}
 
-	jsonStr, jsonErr := json.Marshal(resultMap)
+	jsonStr, jsonErr := json.Marshal(response)
 
 	if jsonErr != nil {
 		logger.Errorf("Unable to get json %s", jsonErr.Error())

--- a/api/test_history_test.go
+++ b/api/test_history_test.go
@@ -33,6 +33,10 @@ func TestHistoryHandler(t *testing.T) {
 		Status:      "PASS",
 	}
 
+	lastProcessedRun := shared.MostRecentHistoryProcessed{
+		Date: "2022-06-03T06:02:55.000Z",
+	}
+
 	body :=
 		`{
 			"test_name": "test name"
@@ -43,14 +47,18 @@ func TestHistoryHandler(t *testing.T) {
 	_, err = store.Put(key, &sampleRun)
 	assert.Nil(t, err)
 
+	keyLP := store.NewIncompleteKey("MostRecentHistoryProcessed")
+	_, err = store.Put(keyLP, &lastProcessedRun)
+	assert.Nil(t, err)
+
 	bodyReader := strings.NewReader(body)
 	r := httptest.NewRequest("POST", "/api/history", bodyReader)
 	w := httptest.NewRecorder()
 	testHistoryHandler(w, r)
 	results := parseHistoryResponse(t, w)
 
-	want := map[string]map[string]Browser{
-		"results": {
+	want := TestHistoryResponse{
+		Results: map[string]Browser{
 			"chrome": {
 				"subtest": {
 					{
@@ -61,15 +69,16 @@ func TestHistoryHandler(t *testing.T) {
 				},
 			},
 		},
+		LastProcessed: "2022-06-03T06:02:55.000Z",
 	}
 
 	assert.Equal(t, want, results)
 }
 
-func parseHistoryResponse(t *testing.T, w *httptest.ResponseRecorder) map[string]map[string]Browser {
+func parseHistoryResponse(t *testing.T, w *httptest.ResponseRecorder) TestHistoryResponse {
 	assert.Equal(t, http.StatusOK, w.Result().StatusCode)
 	out, _ := io.ReadAll(w.Body)
-	var result map[string]map[string]Browser
+	var result TestHistoryResponse
 	json.Unmarshal(out, &result)
 	return result
 }

--- a/shared/models.go
+++ b/shared/models.go
@@ -309,6 +309,11 @@ type TestHistoryEntry struct {
 	Status      string
 }
 
+// MostRecentHistoryProcessed stores the date of the most recent history run processed.
+type MostRecentHistoryProcessed struct {
+	Date string
+}
+
 // CheckSuite entities represent a GitHub check request that has been noted by
 // wpt.fyi, and will cause creation of a completed check_run when results arrive
 // for the PR.

--- a/webapp/components/test-results-history-timeline.js
+++ b/webapp/components/test-results-history-timeline.js
@@ -166,7 +166,12 @@ class TestResultsTimeline extends PathInfo(PolymerElement) {
     this.dataTable.addColumn({ type: 'date', id: 'End' });
 
     const dataTableRows = [];
-    const now = new Date();
+    // Use the last processed date as the end date of the timeline.
+    // We add 1 hour padding to ensure that if a status change occurred in the
+    // last processed run, it will still be visible as a segment with non-zero duration.
+    const defaultEndDate = this.lastProcessed
+      ? new Date(new Date(this.lastProcessed).getTime() + 60 * 60 * 1000)
+      : new Date();
     this.chartRunIDs[chartIndex] = [];
 
     // Create a row for each subtest
@@ -180,7 +185,7 @@ class TestResultsTimeline extends PathInfo(PolymerElement) {
 
         // Use the next entry as the end date, or use present time if this
         // is the last entry
-        let endDate = now;
+        let endDate = defaultEndDate;
         if (i + 1 !== browserTestData[subtestName].length) {
           const nextDataPoint = browserTestData[subtestName][i + 1];
           endDate = new Date(nextDataPoint.date);
@@ -257,6 +262,7 @@ class TestResultsTimeline extends PathInfo(PolymerElement) {
     if(this.historicalData) {
       this.historicalData = {};
     }
+    this.lastProcessed = null;
 
     const options = {
       method: 'POST',
@@ -266,8 +272,9 @@ class TestResultsTimeline extends PathInfo(PolymerElement) {
       body: JSON.stringify({ test_name: path})
     };
 
-    this.historicalData = await fetch('/api/history', options)
-      .then(r => r.json()).then(data => data.results);
+    const data = await fetch('/api/history', options).then(r => r.json());
+    this.historicalData = data.results;
+    this.lastProcessed = data.last_processed;
   }
 }
 

--- a/webapp/components/test-results-history-timeline.js
+++ b/webapp/components/test-results-history-timeline.js
@@ -169,9 +169,13 @@ class TestResultsTimeline extends PathInfo(PolymerElement) {
     // Use the last processed date as the end date of the timeline.
     // We add 1 hour padding to ensure that if a status change occurred in the
     // last processed run, it will still be visible as a segment with non-zero duration.
-    const defaultEndDate = this.lastProcessed
-      ? new Date(new Date(this.lastProcessed).getTime() + 60 * 60 * 1000)
-      : new Date();
+    let defaultEndDate = new Date();
+    if (this.lastProcessed) {
+      const lastProcessedTime = new Date(this.lastProcessed).getTime();
+      if (!isNaN(lastProcessedTime)) {
+        defaultEndDate = new Date(lastProcessedTime + 60 * 60 * 1000);
+      }
+    }
     this.chartRunIDs[chartIndex] = [];
 
     // Create a row for each subtest


### PR DESCRIPTION
Resolves #4953

## Overview
This PR fixes the end date of the test results history timeline to use the last processed date instead of `Date.now()`. It also adds a 1-hour padding to the end date on the frontend to ensure visibility of the last run's status changes.

## Root Cause / Motivation
Previously, the timeline used `Date.now()` as the end date. If the test history processing was delayed or stopped, the timeline would still extend to the current time, hiding the lack of recent updates. By using the actual last processed date, we correctly reflect data freshness. Additionally, if a status change occurred in the very last processed run, the last segment would have 0 duration and be invisible; adding a 1-hour padding solves this.

## Detailed Changelog
* **`shared/models.go`**:
    * Added `MostRecentHistoryProcessed` struct to map the Datastore entity that stores the last processed date.
* **`api/test_history.go`**:
    * Query `MostRecentHistoryProcessed` in `testHistoryHandler`.
    * Defined `TestHistoryResponse` struct to include `last_processed` date.
    * Return the `last_processed` date in the API response.
* **`api/test_history_test.go`**:
    * Updated `TestHistoryHandler` test to include `MostRecentHistoryProcessed` in the mock datastore and assert it is returned in the response.
* **`webapp/components/test-results-history-timeline.js`**:
    * Store `last_processed` from API response.
    * Use `last_processed` with a 1-hour padding as the default end date for the timeline.
