### PR TITLE
Patch wct-browser-legacy to avoid cross-origin errors in CI

### DIFF
--- a/util/wct.sh
+++ b/util/wct.sh
@@ -21,10 +21,12 @@ if [ "$USE_FRAME_BUFFER" == "true" ]; then
 fi
 
 cd webapp
-# Patch wct-browser-legacy to avoid cross-origin error in ChildRunner.get
-# See https://github.com/web-platform-tests/wpt.fyi/issues/4754
+# Patch wct-browser-legacy to avoid cross-origin errors.
+# See https://github.com/web-platform-tests/wpt.fyi/issues/4754 and #4956
 # This workaround can be phased out if/when wct-browser-legacy is updated or replaced.
 sed -i 's/return window.parent.WCT._ChildRunner.get(target, true);/try { return window.parent.WCT._ChildRunner.get(target, true); } catch (e) { return null; }/' node_modules/wct-browser-legacy/browser.js
+sed -i 's/if (this.iframe.contentWindow.WCT) {/var hasWCT = false; try { hasWCT = !!this.iframe.contentWindow.WCT; } catch (e) {} if (hasWCT) {/' node_modules/wct-browser-legacy/browser.js
+sed -i 's/return target.removeEventListener(type, listener);/try { return target.removeEventListener(type, listener); } catch (e) {}/' node_modules/wct-browser-legacy/browser.js
 if [ "$UID" == "0" ]; then
   # Used in .github/actions/make-in-docker/Dockerfile
   sudo -u browser npm test


### PR DESCRIPTION
Resolves #4956

## Overview
This PR patches `wct-browser-legacy` helper script to prevent same-origin policy errors during Web Component Tests (WCT) in the CI environment.

## Root Cause / Motivation
The `web_components_test` job occasionally fails with `SecurityError: Blocked a frame with origin "http://localhost:8081" from accessing a cross-origin frame.`
This happens because `wct-browser-legacy` attempts to access properties on windows/frames that have navigated to cross-origin URLs (e.g., during test execution or teardown/cleanup).
Specifically, access to `this.iframe.contentWindow.WCT` in the `loaded` handler and calling `removeEventListener` on `iframe.contentWindow` in `removeAllEventListeners` were unprotected.

## Detailed Changelog
* **`util/wct.sh`**: Added `sed` commands to patch `node_modules/wct-browser-legacy/browser.js` before running tests:
    - Wrapped `this.iframe.contentWindow.WCT` access in a check that safely handles `SecurityError`.
    - Wrapped `target.removeEventListener` in a `try/catch` block to ignore errors when removing listeners from cross-origin frames.
