### PR TITLE
Update the score for the JPEG XL investigation area

### DIFF
--- a/webapp/components/interop-data.js
+++ b/webapp/components/interop-data.js
@@ -1827,7 +1827,9 @@ export const interopData = {
       {
         'name': 'JPEG XL',
         'url': 'https://github.com/web-platform-tests/interop-jpegxl',
-        'scores_over_time': []
+        'scores_over_time': [
+          { 'date': '2026-06-01', 'score': 783 }
+        ]
       },
       {
         'name': 'Mobile testing',

--- a/webapp/static/interop-data.json
+++ b/webapp/static/interop-data.json
@@ -1796,7 +1796,9 @@
       {
         "name": "JPEG XL",
         "url": "https://github.com/web-platform-tests/interop-jpegxl",
-        "scores_over_time": []
+        "scores_over_time": [
+          { "date": "2026-06-01", "score": 783 }
+        ]
       },
       {
         "name": "Mobile testing",


### PR DESCRIPTION
## Description

Closes https://github.com/web-platform-tests/interop/issues/1293

## Changes

This updates the score for the JPEG XL investigation area (in both files needing it) based on the info provided by the team in https://github.com/web-platform-tests/interop/issues/1293