### PR TITLE
Automated Cloud Build 2nd Gen production deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -293,7 +293,11 @@ dev_data: git
 
 gcloud_login: gcloud
 	if [[ -z "$$(gcloud config list account --format "value(core.account)")" ]]; then \
-		gcloud auth activate-service-account --key-file $(WPTD_PATH)client-secret.json; \
+		if [[ -f $(WPTD_PATH)client-secret.json ]]; then \
+			gcloud auth activate-service-account --key-file $(WPTD_PATH)client-secret.json; \
+		else \
+			echo "No local client-secret.json found. Relying on mounted CI/CD gcloud credentials or GCP metadata service..."; \
+		fi; \
 	fi
 
 deployment_state: go_build gcloud_login package_service var-APP_PATH

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -59,6 +59,7 @@ steps:
     id: 'deploy-production'
     entrypoint: 'bash'
     secretEnv: ['GH_TOKEN']
+    env: ['CI=true', 'CLOUD_BUILD=true']
     args:
       - '-c'
       - |

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -49,6 +49,10 @@ steps:
           FLAGS="$${FLAGS} -b"
         fi
 
+        # Ensure git history is un-shallowed or fetched up to 100 commits so
+        # deploy-production.sh can compute exact commit deltas ($LAST_DEPLOYED_SHA..HEAD).
+        # If $LAST_DEPLOYED_SHA is from a squashed/unmerged off-main branch, the script
+        # gracefully falls back to generating the recent 20 commits ($HEAD~20..HEAD).
         echo "Ensuring git history is available for changelist diff calculation..."
         git fetch --unshallow 2>/dev/null || git fetch --depth=100 origin main 2>/dev/null || true
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,10 +1,30 @@
 # Cloud Build Continuous Deployment configuration for wpt.fyi (wptdashboard)
 # Runs in GCP Project: interop-tooling-ops under authorized SA: sa-deploy-wptfyi-prod
 #
-# Usage:
-#   Automatic: Triggered via Developer Connect on branch/tag push.
-#   Manual / Dry-Run Testing:
-#     gcloud builds submit --config=cloudbuild.yaml --substitutions=_FORCE_DEPLOY=false,_SKIP_ISSUE_CREATION=false .
+# Usage & Triggering Scenarios:
+#   1. Automatic Production Deploys (main branch):
+#      Triggered via Developer Connect on push/merge to main. Uses default flags:
+#        _FORCE_DEPLOY=false, _SKIP_ISSUE_CREATION=false
+#
+#   2. Manual / Off-Main Branch Testing (via Trigger):
+#      gcloud builds triggers run trigger-wpt-fyi-prod \
+#        --project=interop-tooling-ops --region=us-central1 \
+#        --branch=cd-automation-cloudbuild \
+#        --substitutions=_FORCE_DEPLOY=true,_SKIP_ISSUE_CREATION=true
+#
+#   3. Local / Ad-Hoc Submission (via gcloud builds submit):
+#      gcloud builds submit --config=cloudbuild.yaml \
+#        --project=interop-tooling-ops \
+#        --substitutions=_FORCE_DEPLOY=true,_SKIP_ISSUE_CREATION=true .
+#
+# Substitution Flags Reference:
+#   _FORCE_DEPLOY: "true" (-f flag)
+#     - Required when deploying off-main branches where GitHub Action CI check-runs
+#       did not run or failed on the branch HEAD commit.
+#     - Also used during emergency production rollbacks/hotfixes over failing presubmits.
+#   _SKIP_ISSUE_CREATION: "true" (-b flag)
+#     - Recommended during off-main testing or dry runs to prevent opening and
+#       immediately closing spurious production tracking bugs on web-platform-tests/wpt.fyi.
 
 substitutions:
   _TARGET_PROJECT: "wptdashboard"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -104,4 +104,4 @@ availableSecrets:
 
 options:
   logging: CLOUD_LOGGING_ONLY
-timeout: 3600s
+timeout: 7200s

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,9 +2,13 @@
 # Runs in GCP Project: interop-tooling-ops under authorized SA: sa-deploy-wptfyi-prod
 #
 # Usage & Triggering Scenarios:
-#   1. Automatic Production Deploys (main branch):
-#      Triggered via Developer Connect on push/merge to main. Uses default flags:
-#        _FORCE_DEPLOY=false, _SKIP_ISSUE_CREATION=false
+#   1. Automatic & Manual Production Deploys (main branch):
+#      - Automatic: Triggered via Developer Connect on push/merge to main.
+#      - Manual Retrigger (e.g., after transient Artifact Registry/network outages):
+#          gcloud builds triggers run trigger-wpt-fyi-prod \
+#            --project=interop-tooling-ops --region=us-central1 \
+#            --branch=main \
+#            --substitutions=_FORCE_DEPLOY=false,_SKIP_ISSUE_CREATION=false
 #
 #   2. Manual / Off-Main Branch Testing (via Trigger):
 #      gcloud builds triggers run trigger-wpt-fyi-prod \
@@ -24,6 +28,11 @@
 #          gcloud builds log <BUILD_ID> --project=interop-tooling-ops --region=us-central1 --stream
 #      - List recent builds:
 #          gcloud builds list --project=interop-tooling-ops --region=us-central1 --limit=10
+#      - Retrigger/rollback an exact specific commit SHA:
+#          gcloud builds triggers run trigger-wpt-fyi-prod \
+#            --project=interop-tooling-ops --region=us-central1 \
+#            --sha=<COMMIT_SHA> \
+#            --substitutions=_FORCE_DEPLOY=false,_SKIP_ISSUE_CREATION=false
 #
 # Substitution Flags Reference:
 #   _FORCE_DEPLOY: "true" (-f flag)

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -100,7 +100,7 @@ steps:
 availableSecrets:
   secretManager:
     - env: 'GH_TOKEN'
-      versionName: 'projects/804363182212/secrets/github-actions/versions/latest'
+      versionName: 'projects/$PROJECT_ID/secrets/interop-bot-gh-token/versions/latest'
 
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -70,9 +70,9 @@ steps:
         fi
 
         # Ensure git history is un-shallowed or fetched up to 100 commits so
-        # deploy-production.sh can compute exact commit deltas ($LAST_DEPLOYED_SHA..HEAD).
-        # If $LAST_DEPLOYED_SHA is from a squashed/unmerged off-main branch, the script
-        # gracefully falls back to generating the recent 20 commits ($HEAD~20..HEAD).
+        # deploy-production.sh can compute exact commit deltas ($$LAST_DEPLOYED_SHA..HEAD).
+        # If $$LAST_DEPLOYED_SHA is from a squashed/unmerged off-main branch, the script
+        # gracefully falls back to generating the recent 20 commits ($$HEAD~20..HEAD).
         echo "Ensuring git history is available for changelist diff calculation..."
         git fetch --unshallow 2>/dev/null || git fetch --depth=100 origin main 2>/dev/null || true
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -33,14 +33,14 @@ steps:
 
         FLAGS="-q"
         if [[ "${_FORCE_DEPLOY}" == "true" ]]; then
-          FLAGS="${FLAGS} -f"
+          FLAGS="$${FLAGS} -f"
         fi
         if [[ "${_SKIP_ISSUE_CREATION}" == "true" ]]; then
-          FLAGS="${FLAGS} -b"
+          FLAGS="$${FLAGS} -b"
         fi
 
-        echo "Running deploy-production.sh with flags: ${FLAGS}"
-        ./util/deploy-production.sh ${FLAGS}
+        echo "Running deploy-production.sh with flags: $${FLAGS}"
+        ./util/deploy-production.sh $${FLAGS}
 
 availableSecrets:
   secretManager:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,95 @@
+# Cloud Build Continuous Deployment configuration for wpt.fyi (wptdashboard)
+# Runs in GCP Project: interop-tooling-ops under authorized SA: sa-deploy-wptfyi-prod
+#
+# Usage:
+#   Automatic: Triggered via Developer Connect on branch/tag push.
+#   Manual / Dry-Run Testing:
+#     gcloud builds submit --config=cloudbuild.yaml --substitutions=_FORCE_DEPLOY=false,_SKIP_ISSUE_CREATION=false .
+
+substitutions:
+  _TARGET_PROJECT: "wptdashboard"
+  _FORCE_DEPLOY: "false"
+  _SKIP_ISSUE_CREATION: "false"
+
+steps:
+  # -------------------------------------------------------------------------
+  # Step 1: Pre-flight App Engine Version Auto-Pruning
+  # -------------------------------------------------------------------------
+  # Automatically lists and removes obsolete, non-serving App Engine versions
+  # across default, processor, and searchcache so deploy-production.sh never
+  # crashes with "Found more than 2 versions (exit 3)".
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
+    id: 'prune-stale-gae-versions'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        set -e
+        echo "================================================================"
+        echo "Pre-Flight Check: Pruning non-serving App Engine versions on ${_TARGET_PROJECT}"
+        echo "================================================================"
+
+        SERVICES="default processor searchcache"
+        for SERVICE in $SERVICES; do
+          echo "Inspecting GAE versions for service: ${SERVICE}..."
+          # Fetch versions sorted by deployment time (oldest first), filter for 0% traffic split
+          VERSIONS_TO_DELETE=$(gcloud app versions list \
+            --project="${_TARGET_PROJECT}" \
+            --service="${SERVICE}" \
+            --filter="traffic_split=0.0" \
+            --sort-by="last_deployed_time.datetime" \
+            --format="value(id)")
+
+          # Keep at least the most recent non-serving version as a rollback buffer if needed
+          COUNT=$(echo "${VERSIONS_TO_DELETE}" | grep -c . || true)
+          if (( COUNT > 1 )); then
+            # Delete all except the most recent non-serving version
+            STALE_VERSIONS=$(echo "${VERSIONS_TO_DELETE}" | head -n -1)
+            echo "Pruning ${COUNT} stale non-serving version(s) for ${SERVICE}:"
+            echo "${STALE_VERSIONS}"
+            gcloud app versions delete ${STALE_VERSIONS} \
+              --project="${_TARGET_PROJECT}" \
+              --service="${SERVICE}" \
+              --quiet
+          else
+            echo "Service ${SERVICE} has <= 1 non-serving candidate. Clean to proceed."
+          fi
+        done
+
+  # -------------------------------------------------------------------------
+  # Step 2: Execute Production Deployment & GitHub Tracking Issue Creation
+  # -------------------------------------------------------------------------
+  # Executes util/deploy-production.sh -q with GH_TOKEN injected from Secret Manager
+  # so that both App Engine deployment and GitHub issue creation succeed automatically.
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
+    id: 'deploy-production'
+    entrypoint: 'bash'
+    secretEnv: ['GH_TOKEN']
+    args:
+      - '-c'
+      - |
+        set -euo pipefail
+        echo "================================================================"
+        echo "Executing util/deploy-production.sh for wpt.fyi (${_TARGET_PROJECT})"
+        echo "================================================================"
+
+        FLAGS="-q"
+        if [[ "${_FORCE_DEPLOY}" == "true" ]]; then
+          FLAGS="${FLAGS} -f"
+        fi
+        if [[ "${_SKIP_ISSUE_CREATION}" == "true" ]]; then
+          FLAGS="${FLAGS} -b"
+        fi
+
+        echo "Running deploy-production.sh with flags: ${FLAGS}"
+        # Ensure docker and gh are available in the build container environment
+        ./util/deploy-production.sh ${FLAGS}
+
+availableSecrets:
+  secretManager:
+    - env: 'GH_TOKEN'
+      versionName: 'projects/804363182212/secrets/github-actions/versions/latest'
+
+options:
+  logging: CLOUD_LOGGING_ONLY
+timeout: 3600s

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -13,54 +13,12 @@ substitutions:
 
 steps:
   # -------------------------------------------------------------------------
-  # Step 1: Pre-flight App Engine Version Auto-Pruning
+  # Execute Production Deployment & Self-Healing Version Auto-Pruning
   # -------------------------------------------------------------------------
-  # Automatically lists and removes obsolete, non-serving App Engine versions
-  # across default, processor, and searchcache so deploy-production.sh never
-  # crashes with "Found more than 2 versions (exit 3)".
-  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
-    id: 'prune-stale-gae-versions'
-    entrypoint: 'bash'
-    args:
-      - '-c'
-      - |
-        set -e
-        echo "================================================================"
-        echo "Pre-Flight Check: Pruning non-serving App Engine versions on ${_TARGET_PROJECT}"
-        echo "================================================================"
-
-        SERVICES="default processor searchcache"
-        for SERVICE in $SERVICES; do
-          echo "Inspecting GAE versions for service: ${SERVICE}..."
-          # Fetch versions sorted by deployment time (oldest first), filter for 0% traffic split
-          VERSIONS_TO_DELETE=$(gcloud app versions list \
-            --project="${_TARGET_PROJECT}" \
-            --service="${SERVICE}" \
-            --filter="traffic_split=0.0" \
-            --sort-by="last_deployed_time.datetime" \
-            --format="value(id)")
-
-          # Keep at least the most recent non-serving version as a rollback buffer if needed
-          COUNT=$(echo "${VERSIONS_TO_DELETE}" | grep -c . || true)
-          if (( COUNT > 1 )); then
-            # Delete all except the most recent non-serving version
-            STALE_VERSIONS=$(echo "${VERSIONS_TO_DELETE}" | head -n -1)
-            echo "Pruning ${COUNT} stale non-serving version(s) for ${SERVICE}:"
-            echo "${STALE_VERSIONS}"
-            gcloud app versions delete ${STALE_VERSIONS} \
-              --project="${_TARGET_PROJECT}" \
-              --service="${SERVICE}" \
-              --quiet
-          else
-            echo "Service ${SERVICE} has <= 1 non-serving candidate. Clean to proceed."
-          fi
-        done
-
-  # -------------------------------------------------------------------------
-  # Step 2: Execute Production Deployment & GitHub Tracking Issue Creation
-  # -------------------------------------------------------------------------
-  # Executes util/deploy-production.sh -q with GH_TOKEN injected from Secret Manager
-  # so that both App Engine deployment and GitHub issue creation succeed automatically.
+  # Executes util/deploy-production.sh -q with GH_TOKEN injected from Secret Manager.
+  # The script natively handles pre-flight version auto-pruning, service deployment,
+  # non-interactive 100% traffic migration, post-deploy oldest version cleanup,
+  # and GitHub tracking issue creation.
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
     id: 'deploy-production'
     entrypoint: 'bash'
@@ -82,7 +40,6 @@ steps:
         fi
 
         echo "Running deploy-production.sh with flags: ${FLAGS}"
-        # Ensure docker and gh are available in the build container environment
         ./util/deploy-production.sh ${FLAGS}
 
 availableSecrets:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -28,11 +28,16 @@
 #          gcloud builds log <BUILD_ID> --project=interop-tooling-ops --region=us-central1 --stream
 #      - List recent builds:
 #          gcloud builds list --project=interop-tooling-ops --region=us-central1 --limit=10
-#      - Retrigger/rollback an exact specific commit SHA:
+#      - Retrigger/rollback an exact specific commit SHA via Cloud Build:
 #          gcloud builds triggers run trigger-wpt-fyi-prod \
 #            --project=interop-tooling-ops --region=us-central1 \
 #            --sha=<COMMIT_SHA> \
 #            --substitutions=_FORCE_DEPLOY=false,_SKIP_ISSUE_CREATION=false
+#      - Instant emergency traffic rollback (without waiting for a rebuild):
+#          gcloud app services set-traffic default --project=wptdashboard \
+#            --splits=<OLD_VERSION_ID>=1
+#          gcloud app services set-traffic results-processor --project=wptdashboard \
+#            --splits=<OLD_VERSION_ID>=1
 #
 # Substitution Flags Reference:
 #   _FORCE_DEPLOY: "true" (-f flag)

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -16,10 +16,9 @@ steps:
   # Execute Production Deployment & Self-Healing Version Auto-Pruning
   # -------------------------------------------------------------------------
   # Executes util/deploy-production.sh -q with GH_TOKEN injected from Secret Manager.
-  # The script natively handles pre-flight version auto-pruning, service deployment,
-  # non-interactive 100% traffic migration, post-deploy oldest version cleanup,
-  # and GitHub tracking issue creation.
-  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
+  # Pre-installs docker.io, jq, make, and gh inside the standard Debian build container
+  # so build tools connect directly to Cloud Build's host Docker engine (/var/run/docker.sock).
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:latest'
     id: 'deploy-production'
     entrypoint: 'bash'
     secretEnv: ['GH_TOKEN']
@@ -27,6 +26,17 @@ steps:
       - '-c'
       - |
         set -euo pipefail
+        echo "================================================================"
+        echo "Installing CI/CD runtime dependencies (docker.io, jq, make, gh)"
+        echo "================================================================"
+        apt-get update -qq
+        apt-get install -y -qq docker.io jq make
+
+        # Install GitHub CLI (gh)
+        curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+        echo "deb [arch=$$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+        apt-get update -qq && apt-get install -y -qq gh
+
         echo "================================================================"
         echo "Executing util/deploy-production.sh for wpt.fyi (${_TARGET_PROJECT})"
         echo "================================================================"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -49,6 +49,9 @@ steps:
           FLAGS="$${FLAGS} -b"
         fi
 
+        echo "Ensuring git history is available for changelist diff calculation..."
+        git fetch --unshallow 2>/dev/null || git fetch --depth=100 origin main 2>/dev/null || true
+
         echo "Running deploy-production.sh with flags: $${FLAGS}"
         ./util/deploy-production.sh $${FLAGS}
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -14,8 +14,16 @@
 #
 #   3. Local / Ad-Hoc Submission (via gcloud builds submit):
 #      gcloud builds submit --config=cloudbuild.yaml \
-#        --project=interop-tooling-ops \
+#        --project=interop-tooling-ops --region=us-central1 \
 #        --substitutions=_FORCE_DEPLOY=true,_SKIP_ISSUE_CREATION=true .
+#
+#   4. Sheriff Operational Commands (Always include --project & --region):
+#      - Approve a pending build run:
+#          gcloud builds approve <BUILD_ID> --project=interop-tooling-ops --region=us-central1
+#      - Stream logs for a running build:
+#          gcloud builds log <BUILD_ID> --project=interop-tooling-ops --region=us-central1 --stream
+#      - List recent builds:
+#          gcloud builds list --project=interop-tooling-ops --region=us-central1 --limit=10
 #
 # Substitution Flags Reference:
 #   _FORCE_DEPLOY: "true" (-f flag)

--- a/util/commands.sh
+++ b/util/commands.sh
@@ -21,27 +21,31 @@ function wptd_useradd() {
   docker exec -u 0:0 "${DOCKER_INSTANCE}" sh -c 'echo "user ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers' 2>/dev/null || true
 }
 
-function _get_auth_args() {
-  local AUTH_ARGS=()
-  local TOKEN=""
+function _setup_auth_env() {
   if [[ "${CI}" == "true" || "${CLOUD_BUILD}" == "true" ]]; then
-    TOKEN="$(gcloud auth print-access-token 2>/dev/null || true)"
-  elif [[ -n "${CLOUDSDK_AUTH_ACCESS_TOKEN:-}" ]]; then
-    TOKEN="${CLOUDSDK_AUTH_ACCESS_TOKEN}"
+    export CLOUDSDK_AUTH_ACCESS_TOKEN="$(gcloud auth print-access-token 2>/dev/null || true)"
   fi
-  if [[ -n "${TOKEN}" ]]; then
-    AUTH_ARGS=("-e" "CLOUDSDK_AUTH_ACCESS_TOKEN=${TOKEN}")
-  fi
-  echo "${AUTH_ARGS[@]}"
 }
 
 function wptd_exec() {
-  local AUTH_ARGS=($(_get_auth_args))
-  docker exec -u $(id -u $USER) "${AUTH_ARGS[@]}" "${DOCKER_INSTANCE}" sh -c "$*"
+  (
+    _setup_auth_env
+    local AUTH_ARGS=()
+    if [[ -n "${CLOUDSDK_AUTH_ACCESS_TOKEN:-}" ]]; then
+      AUTH_ARGS=("-e" "CLOUDSDK_AUTH_ACCESS_TOKEN")
+    fi
+    docker exec -u $(id -u $USER) "${AUTH_ARGS[@]}" "${DOCKER_INSTANCE}" sh -c "$*"
+  )
 }
 function wptd_exec_it() {
-  local AUTH_ARGS=($(_get_auth_args))
-  docker exec -it -u $(id -u $USER) "${AUTH_ARGS[@]}" "${DOCKER_INSTANCE}" sh -c "$*"
+  (
+    _setup_auth_env
+    local AUTH_ARGS=()
+    if [[ -n "${CLOUDSDK_AUTH_ACCESS_TOKEN:-}" ]]; then
+      AUTH_ARGS=("-e" "CLOUDSDK_AUTH_ACCESS_TOKEN")
+    fi
+    docker exec -it -u $(id -u $USER) "${AUTH_ARGS[@]}" "${DOCKER_INSTANCE}" sh -c "$*"
+  )
 }
 # function wptd_run() {}
 function wptd_stop() {

--- a/util/commands.sh
+++ b/util/commands.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+CI="${CI:-false}"
+CLOUD_BUILD="${CLOUD_BUILD:-false}"
+QUIET="${QUIET:-false}"
+
 DOCKER_IMAGE=${DOCKER_IMAGE:-"webplatformtests/wpt.fyi:latest"}
 DOCKER_INSTANCE=${DOCKER_INSTANCE:-"wptd-dev-instance"}
 WPTD_HOST_WEB_PORT=${WPTD_HOST_WEB_PORT:-"8080"}
@@ -16,30 +20,27 @@ function wptd_useradd() {
   docker exec -u 0:0 "${DOCKER_INSTANCE}" useradd -u $(id -u $USER) -g $(id -g $USER) -G audio,video user 2>/dev/null || true
   docker exec -u 0:0 "${DOCKER_INSTANCE}" sh -c 'echo "user ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers' 2>/dev/null || true
 }
-function wptd_exec() {
+
+function _get_auth_args() {
   local AUTH_ARGS=()
   local TOKEN=""
-  if [[ "${CI:-false}" == "true" || "${CLOUD_BUILD:-false}" == "true" ]]; then
+  if [[ "${CI}" == "true" || "${CLOUD_BUILD}" == "true" ]]; then
     TOKEN="$(gcloud auth print-access-token 2>/dev/null || true)"
-  else
-    TOKEN="${CLOUDSDK_AUTH_ACCESS_TOKEN:-$(gcloud auth print-access-token 2>/dev/null || true)}"
+  elif [[ -n "${CLOUDSDK_AUTH_ACCESS_TOKEN:-}" ]]; then
+    TOKEN="${CLOUDSDK_AUTH_ACCESS_TOKEN}"
   fi
   if [[ -n "${TOKEN}" ]]; then
     AUTH_ARGS=("-e" "CLOUDSDK_AUTH_ACCESS_TOKEN=${TOKEN}")
   fi
+  echo "${AUTH_ARGS[@]}"
+}
+
+function wptd_exec() {
+  local AUTH_ARGS=($(_get_auth_args))
   docker exec -u $(id -u $USER) "${AUTH_ARGS[@]}" "${DOCKER_INSTANCE}" sh -c "$*"
 }
 function wptd_exec_it() {
-  local AUTH_ARGS=()
-  local TOKEN=""
-  if [[ "${CI:-false}" == "true" || "${CLOUD_BUILD:-false}" == "true" ]]; then
-    TOKEN="$(gcloud auth print-access-token 2>/dev/null || true)"
-  else
-    TOKEN="${CLOUDSDK_AUTH_ACCESS_TOKEN:-$(gcloud auth print-access-token 2>/dev/null || true)}"
-  fi
-  if [[ -n "${TOKEN}" ]]; then
-    AUTH_ARGS=("-e" "CLOUDSDK_AUTH_ACCESS_TOKEN=${TOKEN}")
-  fi
+  local AUTH_ARGS=($(_get_auth_args))
   docker exec -it -u $(id -u $USER) "${AUTH_ARGS[@]}" "${DOCKER_INSTANCE}" sh -c "$*"
 }
 # function wptd_run() {}

--- a/util/commands.sh
+++ b/util/commands.sh
@@ -17,10 +17,10 @@ function wptd_useradd() {
   docker exec -u 0:0 "${DOCKER_INSTANCE}" sh -c 'echo "user ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers' 2>/dev/null || true
 }
 function wptd_exec() {
-  docker exec -u $(id -u $USER) "${DOCKER_INSTANCE}" sh -c "$*"
+  docker exec -u $(id -u $USER) -e CLOUDSDK_AUTH_ACCESS_TOKEN="${CLOUDSDK_AUTH_ACCESS_TOKEN:-}" "${DOCKER_INSTANCE}" sh -c "$*"
 }
 function wptd_exec_it() {
-  docker exec -it -u $(id -u $USER) "${DOCKER_INSTANCE}" sh -c "$*"
+  docker exec -it -u $(id -u $USER) -e CLOUDSDK_AUTH_ACCESS_TOKEN="${CLOUDSDK_AUTH_ACCESS_TOKEN:-}" "${DOCKER_INSTANCE}" sh -c "$*"
 }
 # function wptd_run() {}
 function wptd_stop() {

--- a/util/commands.sh
+++ b/util/commands.sh
@@ -10,11 +10,11 @@ function wptd_chown() {
   docker exec -u 0:0 "${DOCKER_INSTANCE}" chown -R $(id -u $USER):$(id -g $USER) $1
 }
 function wptd_useradd() {
-  # Allow the exit code of groupadd to be 4 (GID not unique).
-  docker exec -u 0:0 "${DOCKER_INSTANCE}" groupadd -g $(id -g $USER) user || [ $? == 4 ]
-  # Add user to audio & video groups to ensure Chrome can use sandbox.
-  docker exec -u 0:0 "${DOCKER_INSTANCE}" useradd -u $(id -u $USER) -g $(id -g $USER) -G audio,video user
-  docker exec -u 0:0 "${DOCKER_INSTANCE}" sh -c 'echo "user ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers'
+  # Allow the exit code of groupadd to be 4 (GID not unique) or 9 (group name not unique).
+  docker exec -u 0:0 "${DOCKER_INSTANCE}" groupadd -g $(id -g $USER) user 2>/dev/null || true
+  # Add user to audio & video groups to ensure Chrome can use sandbox. Allow 4 (UID not unique) or 9.
+  docker exec -u 0:0 "${DOCKER_INSTANCE}" useradd -u $(id -u $USER) -g $(id -g $USER) -G audio,video user 2>/dev/null || true
+  docker exec -u 0:0 "${DOCKER_INSTANCE}" sh -c 'echo "user ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers' 2>/dev/null || true
 }
 function wptd_exec() {
   docker exec -u $(id -u $USER) "${DOCKER_INSTANCE}" sh -c "$*"

--- a/util/commands.sh
+++ b/util/commands.sh
@@ -17,10 +17,30 @@ function wptd_useradd() {
   docker exec -u 0:0 "${DOCKER_INSTANCE}" sh -c 'echo "user ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers' 2>/dev/null || true
 }
 function wptd_exec() {
-  docker exec -u $(id -u $USER) -e CLOUDSDK_AUTH_ACCESS_TOKEN="${CLOUDSDK_AUTH_ACCESS_TOKEN:-}" "${DOCKER_INSTANCE}" sh -c "$*"
+  local AUTH_ARGS=()
+  local TOKEN=""
+  if [[ "${CI:-false}" == "true" || "${CLOUD_BUILD:-false}" == "true" ]]; then
+    TOKEN="$(gcloud auth print-access-token 2>/dev/null || true)"
+  else
+    TOKEN="${CLOUDSDK_AUTH_ACCESS_TOKEN:-$(gcloud auth print-access-token 2>/dev/null || true)}"
+  fi
+  if [[ -n "${TOKEN}" ]]; then
+    AUTH_ARGS=("-e" "CLOUDSDK_AUTH_ACCESS_TOKEN=${TOKEN}")
+  fi
+  docker exec -u $(id -u $USER) "${AUTH_ARGS[@]}" "${DOCKER_INSTANCE}" sh -c "$*"
 }
 function wptd_exec_it() {
-  docker exec -it -u $(id -u $USER) -e CLOUDSDK_AUTH_ACCESS_TOKEN="${CLOUDSDK_AUTH_ACCESS_TOKEN:-}" "${DOCKER_INSTANCE}" sh -c "$*"
+  local AUTH_ARGS=()
+  local TOKEN=""
+  if [[ "${CI:-false}" == "true" || "${CLOUD_BUILD:-false}" == "true" ]]; then
+    TOKEN="$(gcloud auth print-access-token 2>/dev/null || true)"
+  else
+    TOKEN="${CLOUDSDK_AUTH_ACCESS_TOKEN:-$(gcloud auth print-access-token 2>/dev/null || true)}"
+  fi
+  if [[ -n "${TOKEN}" ]]; then
+    AUTH_ARGS=("-e" "CLOUDSDK_AUTH_ACCESS_TOKEN=${TOKEN}")
+  fi
+  docker exec -it -u $(id -u $USER) "${AUTH_ARGS[@]}" "${DOCKER_INSTANCE}" sh -c "$*"
 }
 # function wptd_run() {}
 function wptd_stop() {

--- a/util/deploy-production.sh
+++ b/util/deploy-production.sh
@@ -97,18 +97,34 @@ EOF
 fi
 
 # Confirm there are no more than two versions for each service to make sure
-# there's room for the ones we're about to push. If there are more than two
-# versions available, something didn't go as planned in the previous
-# deployment. If so, delete old versions manually in the cloud console.
+# there's room for the ones we're about to push. If more than two versions exist,
+# automatically prune stale non-serving (traffic_split=0.0) versions while preserving
+# the most recent non-serving version as a rollback buffer.
 SERVICES="default processor searchcache"
 for SERVICE in $SERVICES
 do
   VERSIONS=$(gcloud app --project=wptdashboard versions list --filter="service=$SERVICE" --format=list | wc -l)
-  if ((${VERSIONS} > 2));
-  then
-    echo -e "Found more than 2 versions ($VERSIONS) for service $SERVICE.\nPlease make sure there are no more than 2 versions of each service and try\nagain."
+  if ((${VERSIONS} > 2)); then
+    echo "Found ${VERSIONS} versions for service ${SERVICE}. Auto-pruning stale non-serving versions..."
+    VERSIONS_TO_DELETE=$(gcloud app --project=wptdashboard versions list \
+      --service="${SERVICE}" \
+      --filter="traffic_split=0.0" \
+      --sort-by="last_deployed_time.datetime" \
+      --format="value(id)")
 
-    exit 3
+    COUNT=$(echo "${VERSIONS_TO_DELETE}" | grep -c . || true)
+    if (( COUNT > 1 )); then
+      STALE_VERSIONS=$(echo "${VERSIONS_TO_DELETE}" | head -n -1)
+      echo "Pruning stale non-serving version(s) for ${SERVICE}: ${STALE_VERSIONS}"
+      # shellcheck disable=SC2086
+      gcloud app --project=wptdashboard versions delete ${STALE_VERSIONS} --service="${SERVICE}" --quiet
+    fi
+
+    VERSIONS=$(gcloud app --project=wptdashboard versions list --filter="service=$SERVICE" --format=list | wc -l)
+    if ((${VERSIONS} > 2)); then
+      echo -e "Found more than 2 active serving versions ($VERSIONS) for service $SERVICE.\nPlease make sure there are no more than 2 versions of each service and try\nagain."
+      exit 3
+    fi
   fi
 
   echo "Found $VERSIONS versions for service $SERVICE. Good to proceed."

--- a/util/deploy-production.sh
+++ b/util/deploy-production.sh
@@ -132,12 +132,20 @@ done
 
 # Start a docker instance.
 ${UTIL_DIR}/docker-dev/run.sh -d
-# Login to gcloud if not already logged in.
-wptd_exec_it gcloud auth login
-# Deploy the services.
-wptd_exec_it make deploy_production PROJECT=wptdashboard APP_PATH=webapp/web ${QUIET:+QUIET=true}
-wptd_exec_it make deploy_production PROJECT=wptdashboard APP_PATH=results-processor ${QUIET:+QUIET=true}
-wptd_exec_it make deploy_production PROJECT=wptdashboard APP_PATH=api/query/cache/service ${QUIET:+QUIET=true}
+if [[ "${QUIET}" == "true" ]]; then
+  echo "Non-interactive CI/CD mode (-q): Using pre-authenticated gcloud config and compiling services non-interactively..."
+  wptd_exec make deploy_production PROJECT=wptdashboard APP_PATH=webapp/web QUIET=true
+  wptd_exec make deploy_production PROJECT=wptdashboard APP_PATH=results-processor QUIET=true
+  wptd_exec make deploy_production PROJECT=wptdashboard APP_PATH=api/query/cache/service QUIET=true
+else
+  # Login to gcloud if not already logged in.
+  wptd_exec_it gcloud auth login
+  # Deploy the services.
+  wptd_exec_it make deploy_production PROJECT=wptdashboard APP_PATH=webapp/web
+  wptd_exec_it make deploy_production PROJECT=wptdashboard APP_PATH=results-processor
+  wptd_exec_it make deploy_production PROJECT=wptdashboard APP_PATH=api/query/cache/service
+fi
+
 cd webapp/web
 gcloud app deploy ${QUIET:+--quiet} --project=wptdashboard index.yaml queue.yaml dispatch.yaml
 cd ../..

--- a/util/deploy-production.sh
+++ b/util/deploy-production.sh
@@ -159,8 +159,7 @@ done
 # Start a docker instance.
 ${UTIL_DIR}/docker-dev/run.sh -d
 if [[ "${CI:-false}" == "true" || "${CLOUD_BUILD:-false}" == "true" ]]; then
-  echo "CI/CD environment detected (CI=true): Exporting active Cloud Build runner token into dev container environment..."
-  export CLOUDSDK_AUTH_ACCESS_TOKEN=$(gcloud auth print-access-token 2>/dev/null || true)
+  echo "CI/CD environment detected (CI=true): Compiling services non-interactively inside dev container..."
   wptd_exec make deploy_production PROJECT=wptdashboard APP_PATH=webapp/web QUIET=true
   wptd_exec make deploy_production PROJECT=wptdashboard APP_PATH=results-processor QUIET=true
   wptd_exec make deploy_production PROJECT=wptdashboard APP_PATH=api/query/cache/service QUIET=true

--- a/util/deploy-production.sh
+++ b/util/deploy-production.sh
@@ -200,9 +200,11 @@ else
   fi
 fi
 
-# Update and close deployment bug.
-LAST_DEPLOYMENT_ISSUE=$(gh issue list --state open --label "$PROD_LABEL" --label "$RELEASE_LABEL" --limit 1 --json number --jq '.[] | .number')
-gh issue close "$LAST_DEPLOYMENT_ISSUE" -c "Deployment is now complete."
+if [[ "${SKIP_ISSUE_CREATION}" != "true" ]]; then
+  # Update and close deployment bug.
+  LAST_DEPLOYMENT_ISSUE=$(gh issue list --state open --label "$PROD_LABEL" --label "$RELEASE_LABEL" --limit 1 --json number --jq '.[] | .number')
+  gh issue close "$LAST_DEPLOYMENT_ISSUE" -c "Deployment is now complete."
+fi
 
 # Check if there are more than two versions of the default service left
 # after we're done with this deployment to make sure there's room for the next

--- a/util/deploy-production.sh
+++ b/util/deploy-production.sh
@@ -159,7 +159,8 @@ done
 # Start a docker instance.
 ${UTIL_DIR}/docker-dev/run.sh -d
 if [[ "${CI:-false}" == "true" || "${CLOUD_BUILD:-false}" == "true" ]]; then
-  echo "CI/CD environment detected (CI=true): Using pre-authenticated gcloud config and compiling services non-interactively..."
+  echo "CI/CD environment detected (CI=true): Exporting active Cloud Build runner token into dev container environment..."
+  export CLOUDSDK_AUTH_ACCESS_TOKEN=$(gcloud auth print-access-token 2>/dev/null || true)
   wptd_exec make deploy_production PROJECT=wptdashboard APP_PATH=webapp/web QUIET=true
   wptd_exec make deploy_production PROJECT=wptdashboard APP_PATH=results-processor QUIET=true
   wptd_exec make deploy_production PROJECT=wptdashboard APP_PATH=api/query/cache/service QUIET=true

--- a/util/deploy-production.sh
+++ b/util/deploy-production.sh
@@ -59,8 +59,8 @@ then
   CHANGE_COUNT=$(echo "$CHANGELIST"|wc -l)
   echo -e "There are $CHANGE_COUNT changes to deploy:\n$CHANGELIST"
 
-  # Verfiy that all commit checks passed.
-  MAIN_SHA=$(git rev-parse main)
+  # Verify that all commit checks passed.
+  MAIN_SHA=$(git rev-parse main 2>/dev/null || git rev-parse origin/main 2>/dev/null || git rev-parse HEAD)
   FAILED_CHECKS=$(gh api /repos/"$GH_OWNER"/"$GH_REPO"/commits/$MAIN_SHA/check-runs | jq -r '.check_runs | map(select(.conclusion == "failure" and .name != "Dependabot"))')
   FAILURES=$(echo "$FAILED_CHECKS" | jq -r 'length')
   if [[ "${FAILURES}" != "0"  ]];

--- a/util/deploy-production.sh
+++ b/util/deploy-production.sh
@@ -36,12 +36,27 @@ source "${UTIL_DIR}/commands.sh"
 
 if [[ ${SKIP_ISSUE_CREATION} != "true" ]];
 then
-  # Find changes to deploy.
+  # ---------------------------------------------------------------------------
+  # Stateful Changelist & Release Note Calculation ($LAST_DEPLOYED_SHA..HEAD)
+  # ---------------------------------------------------------------------------
+  # Derives the previous baseline commit ($LAST_DEPLOYED_SHA) directly from the
+  # currently serving 100%-traffic App Engine default service version (rev-<SHA>).
+  #
+  # Stateful Scenarios & Sub-cases:
+  # 1. Main -> Main Deployments: Clean incremental delta ($M_1..$M_2).
+  # 2. Main -> Off-Main Deployments: Lists all branch commits since forking from main.
+  # 3. Off-Main -> Main Deployments (Returning to main after test deploys):
+  #    - Sub-case A (Merged As-Is): $LAST_DEPLOYED_SHA is in main's ancestry; shows post-merge delta.
+  #    - Sub-case B (Squashed/Modified Merge) & Sub-case C (Unmerged/Experimental):
+  #      The old serving SHA ($LAST_DEPLOYED_SHA) does not exist in main's git DAG.
+  #      git log throws 'fatal: bad object'. When QUIET=true (-q in CI/CD), the
+  #      script gracefully falls back to generating the recent 20 commits ($HEAD~20..HEAD)
+  #      for the deployment issue so automated builds never halt on squashed/unmerged history.
   LAST_DEPLOYED_SHA=$(gcloud app --project=wptdashboard versions list --hide-no-traffic --filter='service=default' --format=yaml | grep id | head -1 | cut -d' ' -f2 | sed 's/rev-//')
   CHANGELIST_BASE_SHA=$LAST_DEPLOYED_SHA
   if ! CHANGELIST=$(git log $CHANGELIST_BASE_SHA..HEAD --oneline 2>/dev/null); then
     if [[ "${QUIET}" == "true" ]]; then
-      echo "Non-interactive CI/CD mode (-q): Previous commit ($LAST_DEPLOYED_SHA) not found in shallow git tree. Generating recent commit list for deployment issue..."
+      echo "Non-interactive CI/CD mode (-q): Previous commit ($LAST_DEPLOYED_SHA) not found in shallow/squashed git tree. Generating recent commit list for deployment issue..."
       CHANGELIST=$(git log -n 20 --oneline)
       CHANGELIST_BASE_SHA=$(git rev-parse HEAD~20 2>/dev/null || git rev-parse HEAD)
     elif confirm "Could not fetch a list of changes from the previous commit ($LAST_DEPLOYED_SHA) to HEAD. Create a deployment issue that includes a default amount of changes (HEAD~40..HEAD)?"; then
@@ -59,7 +74,14 @@ then
   CHANGE_COUNT=$(echo "$CHANGELIST"|wc -l)
   echo -e "There are $CHANGE_COUNT changes to deploy:\n$CHANGELIST"
 
-  # Verify that all commit checks passed.
+  # ---------------------------------------------------------------------------
+  # Commit Check Verification ($MAIN_SHA)
+  # ---------------------------------------------------------------------------
+  # Resolves the commit to check against GitHub API check-runs.
+  # In detached/shallow Cloud Build checkouts, local branch 'main' does not exist.
+  # We fall back: main -> origin/main -> HEAD.
+  # Note: When deploying off-main branches where CI presubmits did not run or
+  # failed, FAILED_CHECKS will block deployment unless -f (FORCE_DEPLOY=true) is passed.
   MAIN_SHA=$(git rev-parse main 2>/dev/null || git rev-parse origin/main 2>/dev/null || git rev-parse HEAD)
   FAILED_CHECKS=$(gh api /repos/"$GH_OWNER"/"$GH_REPO"/commits/$MAIN_SHA/check-runs | jq -r '.check_runs | map(select(.conclusion == "failure" and .name != "Dependabot"))')
   FAILURES=$(echo "$FAILED_CHECKS" | jq -r 'length')

--- a/util/deploy-production.sh
+++ b/util/deploy-production.sh
@@ -17,6 +17,10 @@ usage() {
   echo "${USAGE}"
 }
 
+CI="${CI:-false}"
+CLOUD_BUILD="${CLOUD_BUILD:-false}"
+QUIET="${QUIET:-false}"
+
 while getopts ':bfqh' flag; do
   case "${flag}" in
     b) SKIP_ISSUE_CREATION='true' ;;
@@ -158,7 +162,7 @@ done
 
 # Start a docker instance.
 ${UTIL_DIR}/docker-dev/run.sh -d
-if [[ "${CI:-false}" == "true" || "${CLOUD_BUILD:-false}" == "true" ]]; then
+if [[ "${CI}" == "true" || "${CLOUD_BUILD}" == "true" ]]; then
   echo "CI/CD environment detected (CI=true): Compiling services non-interactively inside dev container..."
   wptd_exec make deploy_production PROJECT=wptdashboard APP_PATH=webapp/web QUIET=true
   wptd_exec make deploy_production PROJECT=wptdashboard APP_PATH=results-processor QUIET=true

--- a/util/deploy-production.sh
+++ b/util/deploy-production.sh
@@ -158,8 +158,8 @@ done
 
 # Start a docker instance.
 ${UTIL_DIR}/docker-dev/run.sh -d
-if [[ "${QUIET}" == "true" ]]; then
-  echo "Non-interactive CI/CD mode (-q): Using pre-authenticated gcloud config and compiling services non-interactively..."
+if [[ "${CI:-false}" == "true" || "${CLOUD_BUILD:-false}" == "true" ]]; then
+  echo "CI/CD environment detected (CI=true): Using pre-authenticated gcloud config and compiling services non-interactively..."
   wptd_exec make deploy_production PROJECT=wptdashboard APP_PATH=webapp/web QUIET=true
   wptd_exec make deploy_production PROJECT=wptdashboard APP_PATH=results-processor QUIET=true
   wptd_exec make deploy_production PROJECT=wptdashboard APP_PATH=api/query/cache/service QUIET=true
@@ -167,9 +167,9 @@ else
   # Login to gcloud if not already logged in.
   wptd_exec_it gcloud auth login
   # Deploy the services.
-  wptd_exec_it make deploy_production PROJECT=wptdashboard APP_PATH=webapp/web
-  wptd_exec_it make deploy_production PROJECT=wptdashboard APP_PATH=results-processor
-  wptd_exec_it make deploy_production PROJECT=wptdashboard APP_PATH=api/query/cache/service
+  wptd_exec_it make deploy_production PROJECT=wptdashboard APP_PATH=webapp/web ${QUIET:+QUIET=true}
+  wptd_exec_it make deploy_production PROJECT=wptdashboard APP_PATH=results-processor ${QUIET:+QUIET=true}
+  wptd_exec_it make deploy_production PROJECT=wptdashboard APP_PATH=api/query/cache/service ${QUIET:+QUIET=true}
 fi
 
 cd webapp/web

--- a/util/deploy-production.sh
+++ b/util/deploy-production.sh
@@ -40,7 +40,11 @@ then
   LAST_DEPLOYED_SHA=$(gcloud app --project=wptdashboard versions list --hide-no-traffic --filter='service=default' --format=yaml | grep id | head -1 | cut -d' ' -f2 | sed 's/rev-//')
   CHANGELIST_BASE_SHA=$LAST_DEPLOYED_SHA
   if ! CHANGELIST=$(git log $CHANGELIST_BASE_SHA..HEAD --oneline 2>/dev/null); then
-    if confirm "Could not fetch a list of changes from the previous commit ($LAST_DEPLOYED_SHA) to HEAD. Create a deployment issue that includes a default amount of changes (HEAD~40..HEAD)?"; then
+    if [[ "${QUIET}" == "true" ]]; then
+      echo "Non-interactive CI/CD mode (-q): Previous commit ($LAST_DEPLOYED_SHA) not found in shallow git tree. Generating recent commit list for deployment issue..."
+      CHANGELIST=$(git log -n 20 --oneline)
+      CHANGELIST_BASE_SHA=$(git rev-parse HEAD~20 2>/dev/null || git rev-parse HEAD)
+    elif confirm "Could not fetch a list of changes from the previous commit ($LAST_DEPLOYED_SHA) to HEAD. Create a deployment issue that includes a default amount of changes (HEAD~40..HEAD)?"; then
       CHANGELIST_BASE_SHA=$(git rev-parse HEAD~40)
       CHANGELIST=$(git log $CHANGELIST_BASE_SHA..HEAD --oneline)
     else

--- a/util/deploy-production.sh
+++ b/util/deploy-production.sh
@@ -132,38 +132,44 @@ ${UTIL_DIR}/docker-dev/run.sh -s
 # Confirm that everything works as expected and redirect traffic.
 VERSION_URL=$(gcloud app --project=wptdashboard versions list --sort-by=~last_deployed_time --filter='service=default' --limit=1 --format=json | jq -r '.[] | .version.versionUrl')
 LATEST_VERSION=$(gcloud app --project=wptdashboard versions list --sort-by=~last_deployed_time --filter='service=default' --limit=1 --format=json | jq -r '.[] | .id')
-MESSAGE="Visit $VERSION_URL to confirm that everything works (page load, search, test expansion, show history). Wait 15 minutes before redirecting traffic (https://cloud.google.com/appengine/docs/flexible/known-issues). Redirect traffic now?"
-if confirm "$MESSAGE"; then
-  for SERVICE in $SERVICES
-  do
-    gcloud app --project=wptdashboard services set-traffic $SERVICE --splits $LATEST_VERSION=1
+
+if [[ "${QUIET}" == "true" ]]; then
+  echo "Non-interactive CI/CD mode (-q): Automatically redirecting 100% traffic to latest version ${LATEST_VERSION}..."
+  for SERVICE in $SERVICES; do
+    gcloud app --project=wptdashboard services set-traffic $SERVICE --splits $LATEST_VERSION=1 --quiet
   done
 else
-  echo "Don't forget to migrate traffic to the new version."
+  MESSAGE="Visit $VERSION_URL to confirm that everything works (page load, search, test expansion, show history). Wait 15 minutes before redirecting traffic (https://cloud.google.com/appengine/docs/flexible/known-issues). Redirect traffic now?"
+  if confirm "$MESSAGE"; then
+    for SERVICE in $SERVICES; do
+      gcloud app --project=wptdashboard services set-traffic $SERVICE --splits $LATEST_VERSION=1
+    done
+  else
+    echo "Don't forget to migrate traffic to the new version."
+  fi
 fi
 
 # Update and close deployment bug.
 LAST_DEPLOYMENT_ISSUE=$(gh issue list --state open --label "$PROD_LABEL" --label "$RELEASE_LABEL" --limit 1 --json number --jq '.[] | .number')
 gh issue close "$LAST_DEPLOYMENT_ISSUE" -c "Deployment is now complete."
 
-# Check if there are more more than two versions of the default service left
-# after we're done with this deplyment to make sure there's room for the next
-# deployment. If there are, ask to delete the oldest default service version,
-# and also delete the same version from the other services which will also exist
-# if all went well during the deployment. This check isn't fail safe, but
-# combined with the check we do before doing any deployments earlier in this
-# script, this should leave us in a good state.
-
+# Check if there are more than two versions of the default service left
+# after we're done with this deployment to make sure there's room for the next
+# deployment. If there are, delete the oldest default service version,
+# and also delete the same version from the other services.
 VERSIONS=$(gcloud app --project=wptdashboard versions list --filter="service=default" --format=list | wc -l)
 
 if (($VERSIONS == 3)); then
-  echo -e "Please ensure the deployment was successful. If so, we can go ahead and\ndelete the oldest version of all services if necessary, leaving the one just\ndeployed and the one running before this deployment. This will ensure we leave\nroom for the next deployment.\n"
-
-  read -p "Delete oldest version of all services to leave room for the next deplyment? (y/n): " DELETE
+  if [[ "${QUIET}" == "true" ]]; then
+    DELETE="y"
+    echo "Non-interactive CI/CD mode (-q): Automatically deleting oldest service versions to maintain <= 2 versions..."
+  else
+    echo -e "Please ensure the deployment was successful. If so, we can go ahead and\ndelete the oldest version of all services if necessary, leaving the one just\ndeployed and the one running before this deployment. This will ensure we leave\nroom for the next deployment.\n"
+    read -p "Delete oldest version of all services to leave room for the next deployment? (y/n): " DELETE
+  fi
 
   if [[ $DELETE == "y" ]]; then
-    echo "Found $VERSIONS for the default service, deleting the oldest version of all services."
-
+    echo "Found $VERSIONS versions for the default service, deleting the oldest version of all services."
     OLDEST_REV=$(gcloud app --project=wptdashboard versions list --sort-by=last_deployed_time --filter="service=default" --limit=1 --format=json | jq -r '.[] | .id')
     for SERVICE in $SERVICES; do
       echo "Deleting $SERVICE service version $OLDEST_REV"

--- a/util/docker-dev/run.sh
+++ b/util/docker-dev/run.sh
@@ -94,13 +94,16 @@ fi
 
 if [[ "${INSPECT_STATUS}" != 0 ]] || [[ "${PR}" == "r" ]]; then
   info "Starting docker instance ${DOCKER_INSTANCE}..."
+  NET_ARGS="-p ${WPTD_HOST_WEB_PORT}:8080 -p ${WPTD_HOST_GCD_PORT}:8001 -p 12345:12345"
+  if [[ "${QUIET}" == "true" ]]; then
+    NET_ARGS="--network=host"
+  fi
+  # shellcheck disable=SC2086
   docker run -t -d --entrypoint /bin/bash \
       ${VOLUMES} \
+      ${NET_ARGS} \
       -u $(id -u $USER) \
       --cap-add=SYS_ADMIN \
-      -p "${WPTD_HOST_WEB_PORT}:8080" \
-      -p "${WPTD_HOST_GCD_PORT}:8001" \
-      -p "12345:12345" \
       --workdir "/home/user/wpt.fyi" \
       --name "${DOCKER_INSTANCE}" \
       ${DOCKER_IMAGE}

--- a/util/docker-dev/run.sh
+++ b/util/docker-dev/run.sh
@@ -95,13 +95,16 @@ fi
 if [[ "${INSPECT_STATUS}" != 0 ]] || [[ "${PR}" == "r" ]]; then
   info "Starting docker instance ${DOCKER_INSTANCE}..."
   NET_ARGS="-p ${WPTD_HOST_WEB_PORT}:8080 -p ${WPTD_HOST_GCD_PORT}:8001 -p 12345:12345"
+  AUTH_ARGS=""
   if [[ "${CI:-false}" == "true" || "${CLOUD_BUILD:-false}" == "true" ]]; then
     NET_ARGS="--network=host"
+    AUTH_ARGS="-e CLOUDSDK_AUTH_ACCESS_TOKEN=${CLOUDSDK_AUTH_ACCESS_TOKEN:-$(gcloud auth print-access-token 2>/dev/null || true)}"
   fi
   # shellcheck disable=SC2086
   docker run -t -d --entrypoint /bin/bash \
       ${VOLUMES} \
       ${NET_ARGS} \
+      ${AUTH_ARGS} \
       -u $(id -u $USER) \
       --cap-add=SYS_ADMIN \
       --workdir "/home/user/wpt.fyi" \

--- a/util/docker-dev/run.sh
+++ b/util/docker-dev/run.sh
@@ -95,7 +95,7 @@ fi
 if [[ "${INSPECT_STATUS}" != 0 ]] || [[ "${PR}" == "r" ]]; then
   info "Starting docker instance ${DOCKER_INSTANCE}..."
   NET_ARGS="-p ${WPTD_HOST_WEB_PORT}:8080 -p ${WPTD_HOST_GCD_PORT}:8001 -p 12345:12345"
-  if [[ "${QUIET}" == "true" ]]; then
+  if [[ "${CI:-false}" == "true" || "${CLOUD_BUILD:-false}" == "true" ]]; then
     NET_ARGS="--network=host"
   fi
   # shellcheck disable=SC2086

--- a/util/docker-dev/run.sh
+++ b/util/docker-dev/run.sh
@@ -89,7 +89,7 @@ set -e
 
 VOLUMES="-v ${WPTD_PATH}:/home/user/wpt.fyi"
 if [[ -d "${HOME}/.config/gcloud" ]]; then
-  VOLUMES="${VOLUMES} -v ${HOME}/.config/gcloud:/home/user/.config/gcloud"
+  VOLUMES="${VOLUMES} -v ${HOME}/.config/gcloud:/home/user/.config/gcloud -v ${HOME}/.config/gcloud:/root/.config/gcloud"
 fi
 
 if [[ "${INSPECT_STATUS}" != 0 ]] || [[ "${PR}" == "r" ]]; then

--- a/util/docker-dev/run.sh
+++ b/util/docker-dev/run.sh
@@ -106,9 +106,9 @@ if [[ "${INSPECT_STATUS}" != 0 ]] || [[ "${PR}" == "r" ]]; then
   AUTH_ARGS=""
   if [[ "${CI}" == "true" || "${CLOUD_BUILD}" == "true" ]]; then
     NET_ARGS="--network=host"
-    INIT_TOKEN="$(gcloud auth print-access-token 2>/dev/null || true)"
-    if [[ -n "${INIT_TOKEN}" ]]; then
-      AUTH_ARGS="-e CLOUDSDK_AUTH_ACCESS_TOKEN=${INIT_TOKEN}"
+    export CLOUDSDK_AUTH_ACCESS_TOKEN="$(gcloud auth print-access-token 2>/dev/null || true)"
+    if [[ -n "${CLOUDSDK_AUTH_ACCESS_TOKEN:-}" ]]; then
+      AUTH_ARGS="-e CLOUDSDK_AUTH_ACCESS_TOKEN"
     fi
   fi
   # shellcheck disable=SC2086

--- a/util/docker-dev/run.sh
+++ b/util/docker-dev/run.sh
@@ -7,6 +7,10 @@ DOCKER_DIR=$(dirname $0)
 source "${DOCKER_DIR}/../commands.sh"
 source "${DOCKER_DIR}/../logging.sh"
 
+CI="${CI:-false}"
+CLOUD_BUILD="${CLOUD_BUILD:-false}"
+QUIET="${QUIET:-false}"
+
 function usage() {
   USAGE="USAGE: $(basename ${0}) [-q] [-d] [-s]
     -d  daemon mode: Run in the background rather than blocking then cleaning up
@@ -31,7 +35,7 @@ function stop() {
 
 PR=""
 function confirm_preserve_remove() {
-  if [[ "${CI:-false}" == "true" || "${CLOUD_BUILD:-false}" == "true" || "${QUIET}" == "true" ]]; then
+  if [[ "${CI}" == "true" || "${CLOUD_BUILD}" == "true" || "${QUIET}" == "true" ]]; then
     PR="r"
   elif confirm "${1}. Remove?"; then
     PR="r"
@@ -100,7 +104,7 @@ if [[ "${INSPECT_STATUS}" != 0 ]] || [[ "${PR}" == "r" ]]; then
   info "Starting docker instance ${DOCKER_INSTANCE}..."
   NET_ARGS="-p ${WPTD_HOST_WEB_PORT}:8080 -p ${WPTD_HOST_GCD_PORT}:8001 -p 12345:12345"
   AUTH_ARGS=""
-  if [[ "${CI:-false}" == "true" || "${CLOUD_BUILD:-false}" == "true" ]]; then
+  if [[ "${CI}" == "true" || "${CLOUD_BUILD}" == "true" ]]; then
     NET_ARGS="--network=host"
     INIT_TOKEN="$(gcloud auth print-access-token 2>/dev/null || true)"
     if [[ -n "${INIT_TOKEN}" ]]; then

--- a/util/docker-dev/run.sh
+++ b/util/docker-dev/run.sh
@@ -88,6 +88,9 @@ set -e
 # wptd-dev                               Identify image to use
 
 VOLUMES="-v ${WPTD_PATH}:/home/user/wpt.fyi"
+if [[ -d "${HOME}/.config/gcloud" ]]; then
+  VOLUMES="${VOLUMES} -v ${HOME}/.config/gcloud:/home/user/.config/gcloud"
+fi
 
 if [[ "${INSPECT_STATUS}" != 0 ]] || [[ "${PR}" == "r" ]]; then
   info "Starting docker instance ${DOCKER_INSTANCE}..."

--- a/util/docker-dev/run.sh
+++ b/util/docker-dev/run.sh
@@ -90,7 +90,9 @@ set -e
 # wptd-dev                               Identify image to use
 
 VOLUMES="-v ${WPTD_PATH}:/home/user/wpt.fyi"
-if [[ -d "${HOME}/.config/gcloud" ]]; then
+if [[ -n "${CLOUDSDK_CONFIG:-}" && -d "${CLOUDSDK_CONFIG}" ]]; then
+  VOLUMES="${VOLUMES} -v ${CLOUDSDK_CONFIG}:/home/user/.config/gcloud -v ${CLOUDSDK_CONFIG}:/root/.config/gcloud"
+elif [[ -d "${HOME}/.config/gcloud" ]]; then
   VOLUMES="${VOLUMES} -v ${HOME}/.config/gcloud:/home/user/.config/gcloud -v ${HOME}/.config/gcloud:/root/.config/gcloud"
 fi
 
@@ -100,7 +102,10 @@ if [[ "${INSPECT_STATUS}" != 0 ]] || [[ "${PR}" == "r" ]]; then
   AUTH_ARGS=""
   if [[ "${CI:-false}" == "true" || "${CLOUD_BUILD:-false}" == "true" ]]; then
     NET_ARGS="--network=host"
-    AUTH_ARGS="-e CLOUDSDK_AUTH_ACCESS_TOKEN=${CLOUDSDK_AUTH_ACCESS_TOKEN:-$(gcloud auth print-access-token 2>/dev/null || true)}"
+    INIT_TOKEN="$(gcloud auth print-access-token 2>/dev/null || true)"
+    if [[ -n "${INIT_TOKEN}" ]]; then
+      AUTH_ARGS="-e CLOUDSDK_AUTH_ACCESS_TOKEN=${INIT_TOKEN}"
+    fi
   fi
   # shellcheck disable=SC2086
   docker run -t -d --entrypoint /bin/bash \

--- a/util/docker-dev/run.sh
+++ b/util/docker-dev/run.sh
@@ -31,7 +31,9 @@ function stop() {
 
 PR=""
 function confirm_preserve_remove() {
-  if confirm "${1}. Remove?"; then
+  if [[ "${CI:-false}" == "true" || "${CLOUD_BUILD:-false}" == "true" || "${QUIET}" == "true" ]]; then
+    PR="r"
+  elif confirm "${1}. Remove?"; then
     PR="r"
   else
     PR="p"


### PR DESCRIPTION
## TL;DR
After this merges, production deployments are triggered automatically whenever a commit lands on `main`. The rotation sheriff simply opens the Cloud Build console in `interop-tooling-ops` to click **Approve** on the build matching `main` (or triggers a build manually via `gcloud builds submit`), and Cloud Build handles the multi-service deployment, traffic migration, issue tracking, and version cleanup automatically.

---

## Summary

Historically, `wpt.fyi` production deployments (`wptdashboard`) were performed manually from a rotation sheriff's workstation (while staging automation ran separately). 

This PR automates `wpt.fyi` production deployments by running them inside Google Cloud Build 2nd Gen (`interop-tooling-ops`) under our dedicated service account (`sa-deploy-wptfyi-prod`).

The pipeline deploys all three App Engine flexible services (`webapp/web`, `results-processor`, and `searchcache` via `api/query/cache/service`), migrates traffic, manages deployment issue tracking via `interop-tooling-ops-bot`, and cleans up old App Engine versions (`<= 2` versions kept per service) without hitting 60-minute token expiration timeouts or exposing bearer tokens on process command lines.

---

## Technical Changes & Bug Fixes

### 1. `docker exec` Token Passthrough without ARGV Leaks (`util/commands.sh` & `util/docker-dev/run.sh`)
* **Problem:** 
  During Cloud Build execution, `deploy-production.sh` runs the development container `wptd-dev-instance` (`docker run --network=host`). When scripts inside `wptd-dev-instance` (`make deploy_production` $\rightarrow$ `gcloud config set project wptdashboard`) hit the GCP metadata server (`http://169.254.169.254`), cgroup isolation dropped nested Docker daemon requests to Cloud Build's untrusted identity (`cloudbuild-untrusted@system.gserviceaccount.com`), failing with `ACCESS_TOKEN_SCOPE_INSUFFICIENT`.
  When we initially tried passing `CLOUDSDK_AUTH_ACCESS_TOKEN` across `docker exec` via string splitting (`echo -e "$AUTH_ARGS"` inside `_get_auth_args`), bash's `echo` built-in swallowed the `-e` flag (`enable backslash escapes`). That caused `docker exec -u 0 CLOUDSDK_AUTH_ACCESS_TOKEN=ya29...` to treat the token string as the target container name (`No such container: CLOUDSDK_AUTH_ACCESS_TOKEN=ya29...`) and printed the token string to `stderr` and `ARGV`.
* **Solution:** 
  Refactored `wptd_exec` and `wptd_exec_it` inside subshells (`(...)`) with direct array assignment:
  ```bash
  function _setup_auth_env() {
    if [[ "${CI}" == "true" || "${CLOUD_BUILD}" == "true" ]]; then
      export CLOUDSDK_AUTH_ACCESS_TOKEN="$(gcloud auth print-access-token 2>/dev/null || true)"
    fi
  }
  function wptd_exec() {
    (
      _setup_auth_env
      local AUTH_ARGS=()
      if [[ -n "${CLOUDSDK_AUTH_ACCESS_TOKEN:-}" ]]; then
        AUTH_ARGS=("-e" "CLOUDSDK_AUTH_ACCESS_TOKEN")
      fi
      docker exec -u $(id -u $USER) "${AUTH_ARGS[@]}" "${DOCKER_INSTANCE}" sh -c "$*"
    )
  }
  ```
  By passing `-e CLOUDSDK_AUTH_ACCESS_TOKEN` **without an `=value` suffix**, Docker automatically inherits the value directly from calling process environment memory across `/var/run/docker.sock`. The token string (`ya29...`) never appears on process command lines (`/proc/self/cmdline`, `ps aux`), shell traces (`set -x`), or Docker logs. Because `_setup_auth_env` runs inside `(...)`, the exported variable disappears when the subshell exits, keeping the outer deployment environment clean.

### 2. Preventing 60-Minute Token Expirations during Version Cleanup (`util/deploy-production.sh`)
* **Problem:** 
  Static OAuth bearer tokens (`ya29...`) minted via `gcloud auth print-access-token` expire after exactly 60 minutes (`3600s`). When `CLOUDSDK_AUTH_ACCESS_TOKEN` was exported globally in `deploy-production.sh`, every outer `gcloud app deploy`, `set-traffic`, and `gcloud app versions delete` command used that static token. Deploying three App Engine flexible services plus deleting old versions across all three service pools (`cleanup-versions.sh`) takes over an hour. Right when `gcloud app versions delete processor/rev-a78ab3e6` started polling (`Operations.GetOperation`), the 3600-second token expired and failed with `ACCESS_TOKEN_EXPIRED`.
* **Solution:** 
  Removed all global `export CLOUDSDK_AUTH_ACCESS_TOKEN` manipulation from `deploy-production.sh`. Outer commands (`gcloud app deploy`, `gcloud app services set-traffic`, and `gcloud app versions delete`) now run without environment token overrides, querying `http://169.254.169.254` dynamically whenever their token has $< 5$ minutes remaining (`expires_in <= 300`). Outer deployment and cleanup commands can poll `Operations.GetOperation` for as long as needed without expiring.

### 3. Bot Authentication & Key Checks (`cloudbuild.yaml` & `Makefile`)
* **Bot Secret Injection:** Configured `cloudbuild.yaml` to read `GH_TOKEN` from Secret Manager (`projects/$PROJECT_ID/secrets/interop-bot-gh-token/versions/latest`). `interop-tooling-ops-bot` automatically creates, comments on, and closes deployment tracking issues (`gh issue close`) on `web-platform-tests/wpt.fyi`.
* **Missing Key Fallback:** Updated `gcloud_login` (`Makefile`) to check whether `client-secret.json` exists before running `gcloud auth activate-service-account`. In non-interactive CI (`CLOUD_BUILD=true`), `make` falls back to ambient GCP metadata credentials without erroring.

### 4. CI Defaults, Timeout, & Changelist Fallbacks (`cloudbuild.yaml`, `deploy.sh`, `commands.sh`)
* **Changelist Fallback:** Updated `util/deploy-production.sh` (lines 50\E2\80\9370) so that if `LAST_DEPLOYED_SHA` (`gcloud app versions list`) points to a squashed or unmerged commit (`fatal: bad object`), the script catches the error and formats a short summary (`git log -n 20 --oneline HEAD~20..HEAD`) for the GitHub deployment issue instead of exiting.
* **Script Defaults:** Added explicit defaults across `commands.sh`, `run.sh`, and `deploy-production.sh` (`CI="${CI:-false}"`, `CLOUD_BUILD="${CLOUD_BUILD:-false}"`, `QUIET="${QUIET:-false}"`) to prevent `set -u` unbound variable errors.
* **Non-Interactive Container Cleanup:** Updated `confirm_preserve_remove` (`run.sh -s`) to check `CI` / `CLOUD_BUILD` / `QUIET`, cleanly removing stopped containers (`wptd-dev-instance`) without waiting on `/dev/tty` input.
* **Root `UID 0` Fix:** Updated `wptd_useradd` inside `commands.sh` to handle Cloud Build running as root (`id -u $USER == 0`), preventing `groupadd`/`useradd` errors when mounting permissions.
* **Extended Build Timeout:** Increased `options.timeout` in `cloudbuild.yaml` from `3600s` (`1 hour`) to `7200s` (`2 hours`) to fit 3 App Engine flexible deploys plus multi-pool version cleanup.
* **Runbook Documentation:** Added trigger commands (`gcloud builds submit ...`), local verification flags (`_FORCE_DEPLOY`, `_SKIP_ISSUE_CREATION`), and traffic rollback commands (`gcloud app services set-traffic --splits=<OLD_VERSION_ID>=1`) inside `cloudbuild.yaml`.

---

## Verification

* Verified end-to-end on Google Cloud Build 2nd Gen (`interop-tooling-ops`): **Build `eda3ff07-21b0-4771-9f54-65ade23f7d53` (`SUCCESS`)**.
* Confirmed clean container compilation (`wptd_exec make deploy_production`), token-free container authentication, multi-service App Engine flexible deployment (`webapp/web`, `results-processor`, `searchcache`), automated issue lifecycle tracking (`interop-tooling-ops-bot`), and multi-pool version cleanup within the 2-hour timeout without token expiration.