### PR TITLE
Results processor failed downloads

### DIFF
--- a/results-processor/main.py
+++ b/results-processor/main.py
@@ -115,7 +115,12 @@ def task_handler() -> ResponseReturnValue:
 
     task_id = flask.request.headers.get('X-AppEngine-TaskName')
     app.logger.info('Processing task %s', task_id)
-    resp = processor.process_report(task_id, flask.request.form)
+    try:
+        resp = processor.process_report(task_id, flask.request.form)
+    except processor.RequiredDownloadError as error:
+        app.logger.error('Required artifact download failed: %s', error)
+        # Cloud Tasks retries requests that return a non-success response.
+        return (str(error), HTTPStatus.SERVICE_UNAVAILABLE)
     status = HTTPStatus.CREATED if resp else HTTPStatus.NO_CONTENT
     if resp:
         app.logger.info(resp)

--- a/results-processor/main_test.py
+++ b/results-processor/main_test.py
@@ -1,0 +1,41 @@
+# Copyright 2026 The WPT Dashboard Project. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import unittest
+from http import HTTPStatus
+from unittest.mock import patch
+
+import processor
+from main import app
+
+
+class TaskHandlerTest(unittest.TestCase):
+    @patch('main._atomic_write')
+    @patch('main.processor.process_report')
+    def test_required_download_failure_is_retried(
+        self, process_report, _atomic_write
+    ):
+        error = processor.RequiredDownloadError(
+            'result files',
+            expected=2,
+            downloaded=1,
+            failed_uris=['https://example.com/result-2.json'],
+        )
+        process_report.side_effect = [error, 'processed']
+        headers = {
+            'X-AppEngine-QueueName': 'results-arrival',
+            'X-AppEngine-TaskName': '12345',
+        }
+
+        with app.test_client() as client:
+            first = client.post('/api/results/process', headers=headers)
+            second = client.post('/api/results/process', headers=headers)
+
+        self.assertEqual(first.status_code, HTTPStatus.SERVICE_UNAVAILABLE)
+        self.assertEqual(second.status_code, HTTPStatus.CREATED)
+        self.assertEqual(process_report.call_count, 2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/results-processor/processor.py
+++ b/results-processor/processor.py
@@ -7,13 +7,14 @@ import logging
 import os
 import posixpath
 import shutil
+import subprocess
 import sys
 import tempfile
 import time
 import traceback
 import zipfile
 from types import TracebackType
-from typing import Callable, List, Optional, Tuple, Type
+from typing import Callable, List, Optional, Tuple, Type, TypeVar
 from urllib.parse import urlparse, urlsplit
 
 import requests
@@ -27,6 +28,36 @@ import wptreport
 from wptscreenshot import WPTScreenshot
 
 _log = logging.getLogger(__name__)
+
+DownloadResult = TypeVar('DownloadResult')
+
+
+class ArtifactDownloadError(Exception):
+    """An individual artifact could not be downloaded."""
+
+    def __init__(self, uri: str, cause: Exception) -> None:
+        self.uri = uri
+        self.cause = cause
+        super().__init__('Failed to download {}: {}'.format(uri, cause))
+
+
+class RequiredDownloadError(Exception):
+    """One or more required artifacts could not be downloaded."""
+
+    def __init__(
+        self,
+        artifact_kind: str,
+        expected: int,
+        downloaded: int,
+        failed_uris: List[str],
+    ) -> None:
+        self.artifact_kind = artifact_kind
+        self.expected = expected
+        self.downloaded = downloaded
+        self.failed_uris = failed_uris
+        super().__init__(
+            'Downloaded {} of {} {}; failed URLs: {}'.format(
+                downloaded, expected, artifact_kind, ', '.join(failed_uris)))
 
 
 class Processor(object):
@@ -142,10 +173,13 @@ class Processor(object):
         fd, path = tempfile.mkstemp(suffix=ext, dir=self._temp_dir)
         os.close(fd)
         # gsutil will log itself.
-        gsutil.copy(gcs, path)
+        try:
+            gsutil.copy(gcs, path)
+        except (OSError, subprocess.SubprocessError) as error:
+            raise ArtifactDownloadError(gcs, error) from error
         return path
 
-    def _download_http(self, url: str) -> Optional[str]:
+    def _download_http(self, url: str) -> str:
         assert url.startswith('http://') or url.startswith('https://')
         _log.debug('Downloading %s', url)
         extra_headers = None
@@ -173,30 +207,27 @@ class Processor(object):
                     timeout=self.TIMEOUT_WAIT,
                 )
                 r.raise_for_status()
-            except requests.Timeout:
-                _log.error("Timed out fetching: %s", url)
-                return None
-            except requests.HTTPError:
-                _log.error("Failed to fetch (%d): %s", r.status_code, url)
-                return None
+            except requests.RequestException as error:
+                raise ArtifactDownloadError(url, error) from error
         ext = (self.known_extension(r.headers.get('Content-Disposition', ''))
                or self.known_extension(url))
         fd, path = tempfile.mkstemp(suffix=ext, dir=self._temp_dir)
-        with os.fdopen(fd, mode='wb') as f:
-            for chunk in r.iter_content(chunk_size=512*1024):
-                f.write(chunk)
+        try:
+            with os.fdopen(fd, mode='wb') as f:
+                for chunk in r.iter_content(chunk_size=512*1024):
+                    f.write(chunk)
+        except requests.RequestException as error:
+            raise ArtifactDownloadError(url, error) from error
         # Closing f will automatically close the underlying fd.
         return path
 
-    def _download_single(self, uri: str) -> Optional[str]:
+    def _download_single(self, uri: str) -> str:
         if uri.startswith('gs://'):
             return self._download_gcs(uri)
         return self._download_http(uri)
 
     def _download_archive(self, archive_url: str) -> None:
         artifact = self._download_http(archive_url)
-        if artifact is None:
-            return
         with zipfile.ZipFile(artifact, mode='r') as z:
             for f in z.infolist():
                 if f.is_dir():
@@ -209,6 +240,48 @@ class Processor(object):
                     path = z.extract(f, path=self._temp_dir)
                     self.screenshots.append(path)
 
+    def _download_many(
+        self,
+        uris: List[str],
+        artifact_kind: str,
+        required: bool,
+        download_one: Callable[[str], DownloadResult],
+    ) -> List[DownloadResult]:
+        downloaded = []
+        failed_uris = []
+        for uri in uris:
+            try:
+                downloaded.append(download_one(uri))
+            except ArtifactDownloadError as error:
+                failed_uris.append(error.uri)
+                _log.warning('%s', error)
+
+        if failed_uris:
+            log = _log.error if required else _log.warning
+            log(
+                'Downloaded %d of %d %s; failed URLs: %s',
+                len(downloaded),
+                len(uris),
+                artifact_kind,
+                ', '.join(failed_uris),
+            )
+        else:
+            _log.info(
+                'Downloaded %d of %d %s',
+                len(downloaded),
+                len(uris),
+                artifact_kind,
+            )
+
+        if required and failed_uris:
+            raise RequiredDownloadError(
+                artifact_kind,
+                len(uris),
+                len(downloaded),
+                failed_uris,
+            )
+        return downloaded
+
     def download(
         self, results: List[str], screenshots: List[str], archives: List[str]
     ) -> None:
@@ -218,19 +291,33 @@ class Processor(object):
             results: A list of results URIs (gs:// or https?://).
             screenshots: A list of screenshots URIs (gs:// or https?://).
             archives: A list of archive URIs (https?://).
+
+        Raises:
+            RequiredDownloadError: If any result or archive cannot be
+                downloaded.
         """
         if archives:
             assert not results
             assert not screenshots
-            for archive_url in archives:
-                self._download_archive(archive_url)
+            self._download_many(
+                archives,
+                'archives',
+                required=True,
+                download_one=self._download_archive,
+            )
             return
-        self.results = [
-            p for p in (self._download_single(i) for i in results)
-            if p is not None]
-        self.screenshots = [
-            p for p in (self._download_single(i) for i in screenshots)
-            if p is not None]
+        self.results = self._download_many(
+            results,
+            'result files',
+            required=True,
+            download_one=self._download_single,
+        )
+        self.screenshots = self._download_many(
+            screenshots,
+            'screenshot files',
+            required=False,
+            download_one=self._download_single,
+        )
 
     def load_report(self) -> None:
         """Loads and merges all downloaded results."""

--- a/results-processor/processor_test.py
+++ b/results-processor/processor_test.py
@@ -10,7 +10,12 @@ from werkzeug.datastructures import MultiDict
 
 import test_util
 import wptreport
-from processor import Processor, process_report
+from processor import (
+    ArtifactDownloadError,
+    Processor,
+    RequiredDownloadError,
+    process_report,
+)
 from test_server import AUTH_CREDENTIALS
 
 
@@ -20,6 +25,8 @@ class ProcessorTest(unittest.TestCase):
             if expected_path is None:
                 self.fail('Unexpected download:' + path)
             self.assertEqual(expected_path, path)
+            if isinstance(response, Exception):
+                raise response
             return response
         return _download
 
@@ -81,8 +88,14 @@ class ProcessorTest(unittest.TestCase):
                            [],
                            ['https://wpt.fyi/artifact.zip'])
 
-            # Download failure: no exceptions should be raised.
-            p.download([], [], ['https://wpt.fyi/artifact.zip'])
+            # Archive download failures are fatal because archives contain
+            # result reports.
+            error = ArtifactDownloadError(
+                'https://wpt.fyi/artifact.zip', RuntimeError('failed'))
+            p._download_http = self.fake_download(
+                'https://wpt.fyi/artifact.zip', error)
+            with self.assertRaises(RequiredDownloadError):
+                p.download([], [], ['https://wpt.fyi/artifact.zip'])
             self.assertEqual(len(p.results), 0)
 
     def test_download_github(self):
@@ -202,6 +215,34 @@ class MockProcessorTest(unittest.TestCase):
         mock.create_run.assert_not_called()
 
     @patch('processor.Processor')
+    def test_params_plumbing_download_error(self, MockProcessor):
+        # Set up mock context manager to return self.
+        mock = MockProcessor.return_value
+        mock.__enter__.return_value = mock
+        mock.download.side_effect = RequiredDownloadError(
+            'result files',
+            expected=2,
+            downloaded=1,
+            failed_uris=['https://wpt.fyi/wpt_report_2.json.gz'],
+        )
+
+        params = MultiDict({
+            'uploader': 'blade-runner',
+            'id': '654321',
+            'results': [
+                'https://wpt.fyi/wpt_report_1.json.gz',
+                'https://wpt.fyi/wpt_report_2.json.gz',
+            ],
+        })
+        with self.assertRaises(RequiredDownloadError):
+            process_report('12345', params)
+
+        mock.load_report.assert_not_called()
+        mock.upload_raw.assert_not_called()
+        mock.upload_split.assert_not_called()
+        mock.create_run.assert_not_called()
+
+    @patch('processor.Processor')
     def test_params_plumbing_duplicate(self, MockProcessor):
         # Set up mock context manager to return self.
         mock = MockProcessor.return_value
@@ -244,23 +285,40 @@ class ProcessorDownloadServerTest(unittest.TestCase):
             with open(path, 'rb') as f:
                 self.assertEqual(f.read(), b'Hello, world!')
 
-    def test_download(self):
+    def test_result_download_failure(self):
         with Processor() as p:
             p.TIMEOUT_WAIT = 0.1  # to speed up tests
-            url_404 = self.url + '/404'
             url_timeout = self.url + '/slow'
-            with self.assertLogs() as lm:
+            with self.assertLogs() as logs:
+                with self.assertRaises(RequiredDownloadError) as cm:
+                    p.download(
+                        [self.url + '/download/test.txt', url_timeout],
+                        [],
+                        [])
+            self.assertEqual(cm.exception.expected, 2)
+            self.assertEqual(cm.exception.downloaded, 1)
+            self.assertListEqual(cm.exception.failed_uris, [url_timeout])
+            self.assertEqual(len(p.results), 0)
+            self.assertIn(
+                'Downloaded 1 of 2 result files; failed URLs: ' + url_timeout,
+                logs.output[-1],
+            )
+
+    def test_screenshot_download_failure(self):
+        with Processor() as p:
+            url_404 = self.url + '/404'
+            with self.assertLogs() as logs:
                 p.download(
-                    [self.url + '/download/test.txt', url_timeout],
+                    [self.url + '/download/test.txt'],
                     [url_404],
                     [])
             self.assertEqual(len(p.results), 1)
             self.assertTrue(p.results[0].endswith('.txt'))
             self.assertEqual(len(p.screenshots), 0)
-            self.assertListEqual(
-                lm.output,
-                ['ERROR:processor:Timed out fetching: ' + url_timeout,
-                 'ERROR:processor:Failed to fetch (404): ' + url_404])
+            self.assertIn(
+                'Downloaded 0 of 1 screenshot files; failed URLs: ' + url_404,
+                logs.output[-1],
+            )
 
     def test_download_content_disposition(self):
         with Processor() as p:


### PR DESCRIPTION
## Description

The processor had a single attempt at downloading individual chunks and filtered out any that failed because of any error, such as an inadvertent HTTP 403 or 500. The entire result was still considered valid, causing large amounts of subtests to go missing as [can be seen in this diff](https://wpt.fyi/results/?diff&filter=ADC&run_id=5988259300900864&run_id=5186126913732608).

I've made it so the result chunks are considered required downloads that are attempted again if an error occurs. Screenshots are still allowed to fail, matching what d23aeddc168ba15ae0a2d451d4ed44476d0afe76 was originally trying to do.

Relates to #4043 (I think).

## Review Information

Run the processor manually on a historical submission and let it download the chunks. To see its failure mode, intentionally cause a networking failure during the downloads.
