### PR TITLE
Recognize Taskcluster infrastructure/ task names in webhook

### DIFF
--- a/api/taskcluster/webhook.go
+++ b/api/taskcluster/webhook.go
@@ -34,6 +34,12 @@ var (
 	// TaskNameRegex is based on task names in
 	// https://github.com/web-platform-tests/wpt/blob/master/tools/ci/tc/tasks/test.yml.
 	TaskNameRegex = regexp.MustCompile(`^wpt-([a-z_]+-[a-z]+)-([a-z]+(?:-[a-z]+)*|test262)(?:-\d+)?$`)
+	// infraTaskNameRegex matches the wptrunner infrastructure smoketest tasks,
+	// also defined in test.yml, e.g. "infrastructure/ tests (chrome)". Unlike
+	// TaskNameRegex there is no channel/suite segment: each browser currently
+	// only runs infra tests on a single channel, so the browser name alone is
+	// a sufficiently unique product key.
+	infraTaskNameRegex = regexp.MustCompile(`^infrastructure/ tests \(([a-z_]+)\)$`)
 	// Taskcluster has used different forms of URLs in their Check & Status
 	// updates in history. We accept all of them.
 	// See TestExtractTaskGroupID for examples.
@@ -531,21 +537,26 @@ func ExtractArtifactURLs(rootURL string, log shared.Logger, group *TaskGroupInfo
 			continue
 		}
 
-		matches := TaskNameRegex.FindStringSubmatch(task.Name)
-		if len(matches) != 3 { // full match, browser-channel, test type
+		var product string
+		if matches := TaskNameRegex.FindStringSubmatch(task.Name); len(matches) == 3 {
+			// full match, browser-channel, test type
+			product = matches[1]
+			switch matches[2] {
+			case "stability":
+				// Skip stability checks.
+				continue
+			case "results":
+				product += "-" + shared.PRHeadLabel
+			case "results-without-changes":
+				product += "-" + shared.PRBaseLabel
+			}
+		} else if matches := infraTaskNameRegex.FindStringSubmatch(task.Name); len(matches) == 2 {
+			// full match, browser
+			product = matches[1]
+		} else {
 			log.Infof("Ignoring unrecognized task: %s", task.Name)
 
 			continue
-		}
-		product := matches[1]
-		switch matches[2] {
-		case "stability":
-			// Skip stability checks.
-			continue
-		case "results":
-			product += "-" + shared.PRHeadLabel
-		case "results-without-changes":
-			product += "-" + shared.PRBaseLabel
 		}
 
 		if task.State != completedState {

--- a/api/taskcluster/webhook_test.go
+++ b/api/taskcluster/webhook_test.go
@@ -249,6 +249,61 @@ func TestExtractArtifactURLs_with_failures(t *testing.T) {
 	assert.Contains(t, urls, "chrome-dev")
 }
 
+func TestExtractArtifactURLs_infrastructure(t *testing.T) {
+	group := &tc.TaskGroupInfo{Tasks: make([]tc.TaskInfo, 3)}
+	group.Tasks[0].Name = "infrastructure/ tests (chrome)"
+	group.Tasks[1].Name = "infrastructure/ tests (firefox)"
+	group.Tasks[2].Name = "infrastructure/ tests (firefox_android)"
+	for i := 0; i < len(group.Tasks); i++ {
+		group.Tasks[i].State = "completed"
+		group.Tasks[i].TaskID = fmt.Sprint(i)
+	}
+
+	urls, err := tc.ExtractArtifactURLs("https://tc.example.com", shared.NewNilLogger(), group, "")
+	assert.Nil(t, err)
+	assert.Equal(t, map[string]tc.ArtifactURLs{
+		"chrome": {
+			Results: []string{
+				"https://tc.example.com/api/queue/v1/task/0/artifacts/public/results/wpt_report.json.gz",
+			},
+			Screenshots: []string{
+				"https://tc.example.com/api/queue/v1/task/0/artifacts/public/results/wpt_screenshot.txt.gz",
+			},
+		},
+		"firefox": {
+			Results: []string{
+				"https://tc.example.com/api/queue/v1/task/1/artifacts/public/results/wpt_report.json.gz",
+			},
+			Screenshots: []string{
+				"https://tc.example.com/api/queue/v1/task/1/artifacts/public/results/wpt_screenshot.txt.gz",
+			},
+		},
+		"firefox_android": {
+			Results: []string{
+				"https://tc.example.com/api/queue/v1/task/2/artifacts/public/results/wpt_report.json.gz",
+			},
+			Screenshots: []string{
+				"https://tc.example.com/api/queue/v1/task/2/artifacts/public/results/wpt_screenshot.txt.gz",
+			},
+		},
+	}, urls)
+}
+
+func TestExtractArtifactURLs_infrastructure_with_failure(t *testing.T) {
+	group := &tc.TaskGroupInfo{Tasks: make([]tc.TaskInfo, 2)}
+	group.Tasks[0].Name = "infrastructure/ tests (chrome)"
+	group.Tasks[0].State = "failed"
+	group.Tasks[0].TaskID = "foo"
+	group.Tasks[1].Name = "infrastructure/ tests (firefox)"
+	group.Tasks[1].State = "completed"
+	group.Tasks[1].TaskID = "bar"
+
+	urls, err := tc.ExtractArtifactURLs("https://tc.example.com", shared.NewNilLogger(), group, "")
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(urls))
+	assert.Contains(t, urls, "firefox")
+}
+
 func TestCreateAllRuns_success(t *testing.T) {
 	var requested uint32
 	requested = 0


### PR DESCRIPTION
These are named "infrastructure/ tests (<browser>)", rather than the
usual wpt-<browser>-<channel>-<suite> pattern, so ExtractArtifactURLs
was dropping them as unrecognized and their results never reached
wpt.fyi.

See also: https://github.com/web-platform-tests/wpt/pull/61844
