### PR TITLE
Fix bogus "duplicate" results from common basenames in archives

### DIFF
--- a/results-processor/processor.py
+++ b/results-processor/processor.py
@@ -20,6 +20,7 @@ import requests
 from google.cloud import datastore
 from typing_extensions import Self
 from werkzeug.datastructures.structures import MultiDict
+from werkzeug.http import parse_options_header
 
 import config
 import gsutil
@@ -136,10 +137,24 @@ class Processor(object):
     def _github_token(self) -> str:
         return self._secret('github-wpt-fyi-bot-token')
 
+    def _make_temp_file(
+        self, name: str, ext: Optional[str]
+    ) -> Tuple[int, str]:
+        """Creates a temporary file whose name is based on name and ext.
+
+        `name` is used as mkstemp's prefix, so it must be one path component;
+        `ext` moves to the suffix to stay at the end of the filename, where
+        load_file() looks for '.gz'.
+        """
+        if ext:
+            name = name.removesuffix(ext)
+        return tempfile.mkstemp(prefix=name + '-' if name else None,
+                                suffix=ext, dir=self._temp_dir)
+
     def _download_gcs(self, gcs: str) -> str:
         assert gcs.startswith('gs://')
-        ext = self.known_extension(gcs)
-        fd, path = tempfile.mkstemp(suffix=ext, dir=self._temp_dir)
+        name = posixpath.basename(urlsplit(gcs).path)
+        fd, path = self._make_temp_file(name, self.known_extension(gcs))
         os.close(fd)
         # gsutil will log itself.
         gsutil.copy(gcs, path)
@@ -179,13 +194,18 @@ class Processor(object):
             except requests.HTTPError:
                 _log.error("Failed to fetch (%d): %s", r.status_code, url)
                 return None
-        ext = (self.known_extension(r.headers.get('Content-Disposition', ''))
-               or self.known_extension(url))
-        fd, path = tempfile.mkstemp(suffix=ext, dir=self._temp_dir)
+        disposition = r.headers.get('Content-Disposition', '')
+        filename = posixpath.basename(
+            parse_options_header(disposition)[1].get('filename')
+            or urlsplit(url).path)
+        fd, path = self._make_temp_file(
+            filename,
+            self.known_extension(filename) or self.known_extension(url))
         with os.fdopen(fd, mode='wb') as f:
             for chunk in r.iter_content(chunk_size=512*1024):
                 f.write(chunk)
         # Closing f will automatically close the underlying fd.
+        _log.info('Downloaded %s to %s', url, path)
         return path
 
     def _download_single(self, uri: str) -> Optional[str]:
@@ -197,16 +217,27 @@ class Processor(object):
         artifact = self._download_http(archive_url)
         if artifact is None:
             return
+        name = os.path.basename(artifact)
+        ext = self.known_extension(name)
+        if ext:
+            name = name.removesuffix(ext)
+        dest = os.path.join(self._temp_dir, name)
+        try:
+            os.mkdir(dest, 0o700)
+        except FileExistsError:
+            dest = tempfile.mkdtemp(prefix=name + '-' if name else None,
+                                    dir=self._temp_dir)
+        _log.info('Extracting %s into %s', archive_url, dest)
         with zipfile.ZipFile(artifact, mode='r') as z:
             for f in z.infolist():
                 if f.is_dir():
                     continue
                 basename = posixpath.basename(f.filename)
                 if fnmatch.fnmatchcase(basename, 'wpt_report*.json'):
-                    path = z.extract(f, path=self._temp_dir)
+                    path = z.extract(f, path=dest)
                     self.results.append(path)
                 elif fnmatch.fnmatchcase(basename, 'wpt_screenshot*.txt'):
-                    path = z.extract(f, path=self._temp_dir)
+                    path = z.extract(f, path=dest)
                     self.screenshots.append(path)
 
     def download(

--- a/results-processor/processor_test.py
+++ b/results-processor/processor_test.py
@@ -3,7 +3,10 @@
 # found in the LICENSE file.
 
 import json
+import os
+import tempfile
 import unittest
+import zipfile
 from unittest.mock import call, patch
 
 from werkzeug.datastructures import MultiDict
@@ -15,13 +18,49 @@ from test_server import AUTH_CREDENTIALS
 
 
 class ProcessorTest(unittest.TestCase):
-    def fake_download(self, expected_path, response):
+    def fake_downloads(self, mapping):
         def _download(path):
-            if expected_path is None:
-                self.fail('Unexpected download:' + path)
-            self.assertEqual(expected_path, path)
-            return response
+            if path not in mapping:
+                self.fail('Unexpected download: ' + path)
+            return mapping[path]
         return _download
+
+    def fake_download(self, expected_path, response):
+        if expected_path is None:
+            return self.fake_downloads({})
+        return self.fake_downloads({expected_path: response})
+
+    def make_zip(self, members):
+        fd, path = tempfile.mkstemp(suffix='.zip')
+        os.close(fd)
+        self.addCleanup(os.remove, path)
+        with zipfile.ZipFile(path, mode='w') as z:
+            for name, data in members.items():
+                z.writestr(name, data)
+        return path
+
+    def test_make_temp_file(self):
+        cases = [
+            # name, ext, expected prefix
+            ('wpt_report.json.gz', '.json.gz', 'wpt_report-'),
+            ('safari-preview-results-testharness-15.zip', '.zip',
+             'safari-preview-results-testharness-15-'),
+            ('wpt_report_1', None, 'wpt_report_1-'),
+            ('', None, 'tmp'),
+        ]
+        with Processor() as p:
+            for name, ext, expected in cases:
+                fd, path = p._make_temp_file(name, ext)
+                os.close(fd)
+                self.assertEqual(os.path.dirname(path), p._temp_dir)
+                basename = os.path.basename(path)
+                self.assertTrue(basename.startswith(expected),
+                                f'{basename!r} should start with {expected!r}')
+                if ext is not None:
+                    self.assertTrue(basename.endswith(ext))
+
+            with self.assertRaises(OSError):
+                p._make_temp_file('x' * 500 + '.json', '.json')
 
     def test_known_extension(self):
         self.assertEqual(
@@ -114,6 +153,80 @@ class ProcessorTest(unittest.TestCase):
             self.assertEqual(len(p.screenshots), 1)
             self.assertTrue(p.screenshots[0].endswith(
                 '/wpt_screenshot.txt'))
+
+    def test_download_archives_colliding_names(self):
+        with Processor() as p:
+            p._download_gcs = self.fake_download(None, None)
+            p._download_http = self.fake_downloads({
+                'https://wpt.fyi/a.zip': self.make_zip({
+                    'wpt_report_1.json': b'report-a',
+                    'wpt_screenshot_1.txt': b'shot-a',
+                }),
+                'https://wpt.fyi/b.zip': self.make_zip({
+                    'wpt_report_1.json': b'report-b',
+                    'wpt_screenshot_1.txt': b'shot-b',
+                }),
+            })
+
+            p.download(
+                [], [], ['https://wpt.fyi/a.zip', 'https://wpt.fyi/b.zip'])
+
+            reports = []
+            for path in p.results:
+                with open(path, 'rb') as f:
+                    reports.append(f.read())
+            self.assertEqual(reports, [b'report-a', b'report-b'])
+
+            screenshots = []
+            for path in p.screenshots:
+                with open(path, 'rb') as f:
+                    screenshots.append(f.read())
+            self.assertEqual(screenshots, [b'shot-a', b'shot-b'])
+
+    def test_download_archive_duplicate_basenames(self):
+        with Processor() as p:
+            p._download_gcs = self.fake_download(None, None)
+            p._download_http = self.fake_download(
+                'https://wpt.fyi/artifact.zip', self.make_zip({
+                    'a/wpt_report_1.json': b'report-a',
+                    'a/wpt_screenshot_1.txt': b'shot-a',
+                    'b/wpt_report_1.json': b'report-b',
+                    'b/wpt_screenshot_1.txt': b'shot-b',
+                }))
+
+            p.download([], [], ['https://wpt.fyi/artifact.zip'])
+
+            reports = []
+            for path in p.results:
+                with open(path, 'rb') as f:
+                    reports.append(f.read())
+            self.assertEqual(reports, [b'report-a', b'report-b'])
+
+            screenshots = []
+            for path in p.screenshots:
+                with open(path, 'rb') as f:
+                    screenshots.append(f.read())
+            self.assertEqual(screenshots, [b'shot-a', b'shot-b'])
+
+    def test_download_archive_path_traversal(self):
+        with Processor() as p:
+            p._download_gcs = self.fake_download(None, None)
+            p._download_http = self.fake_download(
+                'https://wpt.fyi/artifact.zip', self.make_zip({
+                    '../../wpt_report_1.json': b'traversal-1',
+                    '/etc/wpt_report_2.json': b'traversal-2',
+                }))
+
+            p.download([], [], ['https://wpt.fyi/artifact.zip'])
+
+            self.assertEqual(len(p.results), 2)
+            temp_dir = os.path.realpath(p._temp_dir)
+            for path in p.results:
+                self.assertEqual(
+                    os.path.commonpath([temp_dir, os.path.realpath(path)]),
+                    temp_dir)
+            self.assertTrue(p.results[0].endswith('/wpt_report_1.json'))
+            self.assertTrue(p.results[1].endswith('/etc/wpt_report_2.json'))
 
 
 class MockProcessorTest(unittest.TestCase):
@@ -249,7 +362,7 @@ class ProcessorDownloadServerTest(unittest.TestCase):
             p.TIMEOUT_WAIT = 0.1  # to speed up tests
             url_404 = self.url + '/404'
             url_timeout = self.url + '/slow'
-            with self.assertLogs() as lm:
+            with self.assertLogs(level='ERROR') as lm:
                 p.download(
                     [self.url + '/download/test.txt', url_timeout],
                     [url_404],


### PR DESCRIPTION


<!--
Thanks for the PR, you probably worked hard on it! Before you submit it for review, please make sure you read our guidelines for contributing to this repository. 

Try to make the job easy for your reviewer! Below is a template you can use as a guide for what context your reviewer might need.  
If you changed any dev procedures, consider also updating the README.
-->

## Description
Fixes https://github.com/web-platform-tests/wpt.fyi/issues/5070.

Every archive was extracted into the same temporary directory, thus if each shard produces identical filenames, the files overwrote each other while self.results gained duplicates. `load_report()` then merged one report N times and `summarize()` raised `ConflictingDataError`, marking the run `INVALID`.

<!-- A detailed description explaining what your code accomplishes, and why this work is taking place. If this affects an open issue, please make sure to properly reference it. -->

## Review Information
See `tox.ini` in `results-processor`
<!-- Provide detailed instructions for how to run the code. -->

## Changes
We now extract each archive into a directory of its own, named after the archive rather than `mkstemp`'s `tmpXXXXXXXX`, so a path says where it came from. We also start using from `Content-Disposition`'s filename; parsing that header also allows `known_extension()` to function as intended for GitHub Actions.
<!-- Highlight the files that have changed and group them into concepts, or issues being solved -->

## Requirements
Unchanged.
<!-- Describe any special configurations, environment requirements, or dependencies. -->
